### PR TITLE
Use standard mathematics for token facing

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -46,10 +46,19 @@ public class TokenPropertyFunctions extends AbstractFunction {
 	private static final TokenPropertyFunctions instance = new TokenPropertyFunctions();
 
 	private TokenPropertyFunctions() {
-		super(0, 4, "getPropertyNames", "getAllPropertyNames", "getPropertyNamesRaw", "hasProperty", "isNPC", "isPC", "setPC", "setNPC", "getLayer", "setLayer", "getSize", "setSize", "getOwners",
-				"isOwnedByAll", "isOwner", "resetProperty", "getProperty", "setProperty", "isPropertyEmpty", "getPropertyDefault", "sendToBack", "bringToFront", "getLibProperty", "setLibProperty",
-				"getLibPropertyNames", "setPropertyType", "getPropertyType", "getRawProperty", "getTokenFacing", "setTokenFacing", "removeTokenFacing", "getMatchingProperties",
-				"getMatchingLibProperties", "isSnapToGrid", "setOwner", "getTokenWidth", "getTokenHeight", "setTokenWidth", "setTokenHeight", "getTokenShape", "setTokenShape",
+		super(0, 4, "getPropertyNames", "getAllPropertyNames",
+				"getPropertyNamesRaw", "hasProperty", "isNPC", "isPC", "setPC",
+				"setNPC", "getLayer", "setLayer", "getSize", "setSize",
+				"getOwners", "isOwnedByAll", "isOwner", "resetProperty",
+				"getProperty", "setProperty", "isPropertyEmpty",
+				"getPropertyDefault", "sendToBack", "bringToFront",
+				"getLibProperty", "setLibProperty", "getLibPropertyNames",
+				"setPropertyType", "getPropertyType", "getRawProperty",
+				"getTokenFacing", "getTokenAngle", "setTokenFacing",
+				"removeTokenFacing", "getMatchingProperties",
+				"getMatchingLibProperties", "isSnapToGrid", "setOwner",
+				"getTokenWidth", "getTokenHeight", "setTokenWidth",
+				"setTokenHeight", "getTokenShape", "setTokenShape",
 				"getGMNotes", "setGMNotes", "getNotes", "setNotes");
 	}
 
@@ -534,16 +543,29 @@ public class TokenPropertyFunctions extends AbstractFunction {
 			return getPropertyNames(token, delim, pattern, false);
 		}
 
+		if (functionName.equals("getTokenAngle")) {
+			checkNumberOfParameters(functionName, parameters, 0, 1);
+			Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+			if (!token.hasFacing()) {
+				return "";
+			}
+			return new BigDecimal(token.getFacing());
+		}
+
 		/*
 		 * Number facing = getTokenFacing(String tokenId: currentToken())
 		 */
 		if (functionName.equals("getTokenFacing")) {
 			checkNumberOfParameters(functionName, parameters, 0, 1);
 			Token token = getTokenFromParam(resolver, functionName, parameters, 0);
-			if (token.getFacing() == null) {
-				return ""; // XXX Should be -1 instead of a string?
+			if (!token.hasFacing()) {
+				return "";
 			}
-			return BigDecimal.valueOf(token.getFacing());
+			int facing = token.getFacing();
+			if (facing > 180) {
+				facing -= 360;
+			}
+			return new BigDecimal(facing);
 		}
 
 		/*

--- a/maptool/src/main/java/net/rptools/maptool/model/Token.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Token.java
@@ -93,6 +93,7 @@ public class Token extends BaseModel {
 	}
 
 	public static final Comparator<Token> NAME_COMPARATOR = new Comparator<Token>() {
+		@Override
 		public int compare(Token o1, Token o2) {
 			return o1.getName().compareToIgnoreCase(o2.getName());
 		}
@@ -215,10 +216,13 @@ public class Token extends BaseModel {
 		y = token.y;
 		z = token.z;
 
-		// These properties shouldn't be transferred, they are more transient and relate to token history, not to new tokens
-		//		lastX = token.lastX;
-		//		lastY = token.lastY;
-		//		lastPath = token.lastPath;
+		/*
+		 * These properties shouldn't be transferred, they are more transient
+		 * and relate to token history, not to new tokens:
+		 * lastX = token.lastX;
+		 * lastY = token.lastY;
+		 * lastPath = token.lastPath;
+		 */
 
 		snapToScale = token.snapToScale;
 		width = token.width;
@@ -357,7 +361,7 @@ public class Token extends BaseModel {
 	public int getHeight() {
 		return height;
 	}
-	
+
 	public boolean isMarker() {
 		return isStamp() && (!StringUtil.isEmpty(notes) || !StringUtil.isEmpty(gmNotes) || portraitImage != null);
 	}
@@ -490,9 +494,15 @@ public class Token extends BaseModel {
 	}
 
 	public void setFacing(Integer facing) {
-		while (facing != null && (facing > 180 || facing < -179)) {
-			facing += facing > 180 ? -360 : 0;
-			facing += facing < -179 ? 360 : 0;
+		/*
+		 * Only one or zero of these while loops will be executed each time the
+		 * method is called.
+		 */
+		while (facing < 0) {
+			facing += 360;
+		}
+		while (facing >= 360) {
+			facing -= 360;
 		}
 		this.facing = facing;
 	}
@@ -719,7 +729,7 @@ public class Token extends BaseModel {
 	 * this method: through repeated attempts to name a token they own to another name, they could determine which token
 	 * names the GM is already using. Fortunately, the showError() call makes this extremely unlikely due to the
 	 * interactive nature of a failure.
-	 * 
+	 *
 	 * @param name
 	 * @throws IOException
 	 */
@@ -962,7 +972,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Get a particular state property for this Token.
-	 * 
+	 *
 	 * @param property
 	 *            The name of the property being read.
 	 * @return Returns the current value of property.
@@ -973,7 +983,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Set the value of state for this Token.
-	 * 
+	 *
 	 * @param aState
 	 *            The property to set.
 	 * @param aValue
@@ -1049,7 +1059,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Returns all property names, all in lowercase.
-	 * 
+	 *
 	 * @return
 	 */
 	public Set<String> getPropertyNames() {
@@ -1058,7 +1068,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Returns all property names, preserving their case.
-	 * 
+	 *
 	 * @return
 	 */
 	public Set<String> getPropertyNamesRaw() {
@@ -1217,7 +1227,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Get a set containing the names of all set properties on this token.
-	 * 
+	 *
 	 * @return The set of state property names that have a value associated with them.
 	 */
 	public Set<String> getStatePropertyNames() {
@@ -1294,7 +1304,7 @@ public class Token extends BaseModel {
 	/**
 	 * Convert the token into a hash map. This is used to ship all of the properties for the token to other apps that do
 	 * need access to the <code>Token</code> class.
-	 * 
+	 *
 	 * @return A map containing the properties of the token.
 	 */
 	public TokenTransferData toTransferData() {
@@ -1338,7 +1348,7 @@ public class Token extends BaseModel {
 	/**
 	 * Constructor to create a new token from a transfer object containing its property values. This is used to read in
 	 * a new token from other apps that don't have access to the <code>Token</code> class.
-	 * 
+	 *
 	 * @param td
 	 *            Read the values from this transfer object.
 	 */
@@ -1421,7 +1431,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Get an integer value from the map or return the default value
-	 * 
+	 *
 	 * @param map
 	 *            Get the value from this map
 	 * @param propName
@@ -1439,7 +1449,7 @@ public class Token extends BaseModel {
 
 	/**
 	 * Get a boolean value from the map or return the default value
-	 * 
+	 *
 	 * @param map
 	 *            Get the value from this map
 	 * @param propName
@@ -1494,6 +1504,7 @@ public class Token extends BaseModel {
 	}
 
 	public static final Comparator<Token> COMPARE_BY_NAME = new Comparator<Token>() {
+		@Override
 		public int compare(Token o1, Token o2) {
 			if (o1 == null || o2 == null) {
 				return 0;
@@ -1502,6 +1513,7 @@ public class Token extends BaseModel {
 		}
 	};
 	public static final Comparator<Token> COMPARE_BY_ZORDER = new Comparator<Token>() {
+		@Override
 		public int compare(Token o1, Token o2) {
 			if (o1 == null || o2 == null) {
 				return 0;

--- a/maptool/src/test/java/net/rptools/maptool/model/TestToken.java
+++ b/maptool/src/test/java/net/rptools/maptool/model/TestToken.java
@@ -1,0 +1,111 @@
+/*
+ *  This software copyright by various authors including the RPTools.net
+ *  development team, and licensed under the LGPL Version 3 or, at your
+ *  option, any later version.
+ *
+ *  Portions of this software were originally covered under the Apache
+ *  Software License, Version 1.1 or Version 2.0.
+ *
+ *  See the file LICENSE elsewhere in this distribution for license details.
+ */
+
+package net.rptools.maptool.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Alexander "d4rkAlf" Johansson Werne
+ *
+ */
+public class TestToken {
+	Token token;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		token = new Token();
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+		token = null;
+	}
+
+	/**
+	 * Test method for {@link net.rptools.maptool.model.Token#hasFacing()}.
+	 */
+	@Test
+	public void testDoesNotHaveFacing() {
+		boolean hasFacing = token.hasFacing();
+		assertTrue("hasFacing should return false", hasFacing == false);
+	}
+
+	/**
+	 * Test method for {@link net.rptools.maptool.model.Token#hasFacing()}.
+	 */
+	@Test
+	public void testHasFacing() {
+		token.setFacing(0);
+		boolean hasFacing = token.hasFacing();
+		assertTrue("hasFacing should return true", hasFacing == true);
+	}
+
+	/**
+	 * Test method for
+	 * {@link net.rptools.maptool.model.Token#setFacing(Integer)} and
+	 * {@link net.rptools.maptool.model.Token#getFacing()}.
+	 */
+	@Test
+	public void testFacing() {
+		int facing;
+
+		token.setFacing(0);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 0", 0, facing);
+
+		token.setFacing(90);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 90", 90, facing);
+
+		token.setFacing(180);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 180", 180, facing);
+
+		token.setFacing(270);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 270", 270, facing);
+	}
+
+	/**
+	 * Test method for
+	 * {@link net.rptools.maptool.model.Token#setFacing(Integer)} and
+	 * {@link net.rptools.maptool.model.Token#getFacing()}.
+	 */
+	@Test
+	public void testFacingEdgeCases() {
+		int facing;
+
+		token.setFacing(-90);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 270", 270, facing);
+
+		token.setFacing(360);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 0", 0, facing);
+
+		token.setFacing(540);
+		facing = token.getFacing();
+		assertEquals("Token does not have facing 180", 180, facing);
+	}
+
+}


### PR DESCRIPTION
Token facing now follows standard mathematical definitions using
degrees. In other words the facing is always between 0 degrees
(inclusive) and 360 degrees (exclusive). 0° indicates the token is
facing towards the east, 90° towards north, 180° towards west and
270° towards south.

There is a new macro function (getTokenAngle) that gives scripters
access to these values. The old macro getTokenFacing still returns
values from -179° to 180°.
http://forums.rptools.net/viewtopic.php?f=86&t=25826