### PR TITLE
Refactor SightType and Light to use same shape code from Grid class.

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Grid.java
@@ -272,13 +272,13 @@ public abstract class Grid implements Cloneable {
 	
 	/**
 	 * Called by SightType and Light class to return a vision area
-	 * based upon a specified distance.
+	 * based upon a specified distance
 	 * 
-	 * @param shape - CIRCLE, SQUARE or CONE
-	 * @param token - used to position the shape and to provide footprint
-	 * @param range - as specified in the vision or light definition
-	 * @param arcAngle - only used by cone
-	 * @param offsetAngle - arc distance from facing, only used by cone
+	 * @param shape CIRCLE, SQUARE or CONE
+	 * @param token Used to position the shape and to provide footprint
+	 * @param range As specified in the vision or light definition
+	 * @param arcAngle Only used by cone
+	 * @param offsetAngle Arc distance from facing, only used by cone
 	 * @return Area
 	 */
 	public Area getShapedArea(ShapeType shape, Token token, double range, double arcAngle, int offsetAngle) {

--- a/maptool/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Grid.java
@@ -14,7 +14,11 @@ package net.rptools.maptool.model;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Arc2D;
 import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
@@ -264,6 +268,55 @@ public abstract class Grid implements Cloneable {
 	 */
 	public int getSize() {
 		return size;
+	}
+	
+	/**
+	 * Called by SightType and Light class to return a vision area
+	 * based upon a specified distance.
+	 * 
+	 * @param shape - CIRCLE, SQUARE or CONE
+	 * @param token - used to position the shape and to provide footprint
+	 * @param range - as specified in the vision or light definition
+	 * @param arcAngle - only used by cone
+	 * @param offsetAngle - arc distance from facing, only used by cone
+	 * @return Area
+	 */
+	public Area getShapedArea(ShapeType shape, Token token, double range, double arcAngle, int offsetAngle) {
+		if (shape == null) {
+			shape = ShapeType.CIRCLE;
+		}
+		int visionDistance = zone.getTokenVisionInPixels();
+		double visionRange = (range == 0) ? visionDistance : range * getSize() / zone.getUnitsPerCell();
+		Area visibleArea = new Area();
+		switch (shape) {
+		case CIRCLE:
+			visibleArea = new Area(new Ellipse2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2));
+			break;
+		case SQUARE:
+			visibleArea = new Area(new Rectangle2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2));
+			break;
+		case CONE:
+			if (token.getFacing() == null) {
+				token.setFacing(0);
+			}
+			//TODO: confirm if we want the offset to be positive-counter-clockwise, negative-clockwise or vice versa
+			//simply a matter of changing the sign on offsetAngle
+			Area tempvisibleArea = new Area(new Arc2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2, 360.0 - (arcAngle / 2.0) + (offsetAngle * 1.0), arcAngle, Arc2D.PIE));
+			// Rotate
+			tempvisibleArea = tempvisibleArea.createTransformedArea(AffineTransform.getRotateInstance(-Math.toRadians(token.getFacing())));
+
+			Rectangle footprint = token.getFootprint(this).getBounds(this);
+			footprint.x = -footprint.width / 2;
+			footprint.y = -footprint.height / 2;
+			//footprint = footprint.createTransformedArea(AffineTransform.getTranslateInstance(-footprint.getBounds().getWidth() / 2, -footprint.getBounds().getHeight() / 2));
+			visibleArea.add(new Area(footprint));
+			visibleArea.add(tempvisibleArea);
+			break;
+		default:
+			visibleArea = new Area(new Ellipse2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2));
+			break;
+		}
+		return visibleArea;
 	}
 
 	private void fireGridChanged() {

--- a/maptool/src/main/java/net/rptools/maptool/model/Light.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Light.java
@@ -100,33 +100,7 @@ public class Light {
 	}
 
 	public Area getArea(Token token, Zone zone) {
-		double size = radius / zone.getUnitsPerCell() * zone.getGrid().getSize();
-		if (shape == null) {
-			shape = ShapeType.CIRCLE;
-		}
-		switch (shape) {
-		case SQUARE:
-			return new Area(new Rectangle2D.Double(-size, -size, size * 2, size * 2));
-
-		case CONE:
-			// Be sure we can always at least see our feet
-//			Lee: decoupling from dependence on grid and just use token-centric values. 
-//			Area footprint = new Area(token.getFootprint(zone.getGrid()).getBounds(zone.getGrid()));
-			double magnitude = (2.5 * token.getFootprint(zone.getGrid()).getScale()) / zone.getUnitsPerCell() * zone.getGrid().getSize();
-			Area footprint = new Area(new Ellipse2D.Double(-magnitude, -magnitude, magnitude * 2, magnitude * 2));
-//			footprint.transform(AffineTransform.getTranslateInstance(-footprint.getBounds().getWidth() / 2.0, -footprint.getBounds().getHeight() / 2.0));
-
-			Area area = new Area(new Arc2D.Double(-size, -size, size * 2, size * 2, 360.0 - (arcAngle / 2.0), arcAngle, Arc2D.PIE));
-			if (token.getFacing() != null) {
-				area = area.createTransformedArea(AffineTransform.getRotateInstance(-Math.toRadians(token.getFacing())));
-			}
-			area.add(footprint);
-			return area;
-
-		default:
-		case CIRCLE:
-			return new Area(new Ellipse2D.Double(-size, -size, size * 2, size * 2));
-		}
+		return zone.getGrid().getShapedArea(getShape(), token, getRadius(), getArcAngle(), (int)getFacingOffset());
 	}
 
 	public void setGM(boolean b) {

--- a/maptool/src/main/java/net/rptools/maptool/model/SightType.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/SightType.java
@@ -111,44 +111,6 @@ public class SightType {
 	}
 
 	public Area getVisionShape(Token token, Zone zone) {
-		float visionRange = getDistance();
-		int visionDistance = zone.getTokenVisionInPixels();
-		Area visibleArea = new Area();
-
-		// FIXME This next formula is identical to the one in zone.getTokenVisionInPixels() called two lines above!!
-		visionRange = (visionRange == 0) ? visionDistance : visionRange * zone.getGrid().getSize() / zone.getUnitsPerCell();
-
-		//now calculate the shape and return the shaped Area to the caller
-		switch (getShape()) {
-		case CIRCLE:
-			visibleArea = new Area(new Ellipse2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2));
-			break;
-		case SQUARE:
-			visibleArea = new Area(new Rectangle2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2));
-			break;
-		case CONE:
-			if (token.getFacing() == null) {
-				token.setFacing(0);
-			}
-			int offsetAngle = getOffset();
-			int arcAngle = getArc();
-			//TODO: confirm if we want the offset to be positive-counter-clockwise, negative-clockwise or vice versa
-			//simply a matter of changing the sign on offsetAngle
-			Area tempvisibleArea = new Area(new Arc2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2, 360.0 - (arcAngle / 2.0) + (offsetAngle * 1.0), arcAngle, Arc2D.PIE));
-			// Rotate
-			tempvisibleArea = tempvisibleArea.createTransformedArea(AffineTransform.getRotateInstance(-Math.toRadians(token.getFacing())));
-
-			Rectangle footprint = token.getFootprint(zone.getGrid()).getBounds(zone.getGrid());
-			footprint.x = -footprint.width / 2;
-			footprint.y = -footprint.height / 2;
-			//footprint = footprint.createTransformedArea(AffineTransform.getTranslateInstance(-footprint.getBounds().getWidth() / 2, -footprint.getBounds().getHeight() / 2));
-			visibleArea.add(new Area(footprint));
-			visibleArea.add(tempvisibleArea);
-			break;
-		default:
-			visibleArea = new Area(new Ellipse2D.Double(-visionRange, -visionRange, visionRange * 2, visionRange * 2));
-			break;
-		}
-		return visibleArea;
+		return zone.getGrid().getShapedArea(getShape(), token, getDistance(), getArc(), getOffset());
 	}
 }


### PR DESCRIPTION
Hi,

A relatively straight forward fix to issue 32.3 (http://forums.rptools.net/viewtopic.php?f=86&t=25968) I think.

SightType and Light classes shared the same code to produce circle, square and cone vision shapes, but a bug fix had been applied to SightType and missed from Light.  So I have refactored the two classes to get the shapes from the Grid class, which reduces code duplication and makes it more readable imo.

cheers