### PR TITLE
Default the "Rename Map" input dialog to old name

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -125,18 +125,18 @@ import com.jidesoft.docking.DockableFrame;
  * used throughout the application. Most of these are added to the main frame
  * menu, but some are added dynamically as needed, sometimes to the frame menu
  * but also to the context menu (the "right-click menu").
- * 
+ *
  * Each object instantiated from {@link DefaultClientAction} should have an
  * initializer that calls {@link ClientAction#init(String)} and passes the base
  * message key from the properties file. This base message key will be used to
  * locate the text that should appear on the menu item as well as the
  * accelerator, mnemonic, and short description strings. (See the {@link I18N}
  * class for more details on how the key is used.
- * 
+ *
  * In addition, each object should override {@link ClientAction#isAvailable()}
  * and return true if the application is in a state where the Action should be
  * enabled. (The default is <code>true</code>.)
- * 
+ *
  * Last is the {@link ClientAction#execute(ActionEvent)} method. It is passed
  * the {@link ActionEvent} object that triggered this Action as a parameter. It
  * should perform the necessary work to accomplish the effect of the Action.
@@ -538,10 +538,11 @@ public class AppActions {
 
 		@Override
 		public void execute(ActionEvent e) {
-
 			Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
-			String msg = I18N.getText("msg.confirm.renameMap", zone.getName() != null ? zone.getName() : "");
-			String name = JOptionPane.showInputDialog(MapTool.getFrame(), msg);
+			String oldName = zone.getName();
+			if (oldName == null) oldName = "";
+			String msg = I18N.getText("msg.confirm.renameMap", oldName);
+			String name = JOptionPane.showInputDialog(MapTool.getFrame(), msg, oldName);
 			if (name != null) {
 				zone.setName(name);
 				MapTool.serverCommand().renameZone(zone.getId(), name);
@@ -697,24 +698,24 @@ public class AppActions {
 	 * public static final DefaultClientAction UNDO_DRAWING = new
 	 * DefaultClientAction() { { init("action.undoDrawing"); isAvailable(); //
 	 * XXX FJE Is this even necessary? }
-	 * 
+	 *
 	 * @Override public void execute(ActionEvent e) {
 	 * DrawableUndoManager.getInstance().undo(); isAvailable();
 	 * REDO_DRAWING.isAvailable(); // XXX FJE Calling these forces the update,
 	 * but won't the framework call them? }
-	 * 
+	 *
 	 * @Override public boolean isAvailable() {
 	 * setEnabled(DrawableUndoManager.getInstance().getUndoManager().canUndo());
 	 * return isEnabled(); } };
-	 * 
+	 *
 	 * public static final DefaultClientAction REDO_DRAWING = new
 	 * DefaultClientAction() { { init("action.redoDrawing"); isAvailable(); //
 	 * XXX Is this even necessary? }
-	 * 
+	 *
 	 * @Override public void execute(ActionEvent e) {
 	 * DrawableUndoManager.getInstance().redo(); isAvailable();
 	 * UNDO_DRAWING.isAvailable(); }
-	 * 
+	 *
 	 * @Override public boolean isAvailable() {
 	 * setEnabled(DrawableUndoManager.getInstance().getUndoManager().canRedo());
 	 * return isEnabled(); } };
@@ -774,7 +775,7 @@ public class AppActions {
 	 * <p>
 	 * If any tokens<i>are</i> deleted, then the selection set for the zone is
 	 * cleared.
-	 * 
+	 *
 	 * @param zone
 	 * @param tokenSet
 	 */
@@ -824,7 +825,7 @@ public class AppActions {
 	 * "clipboard") so that they can be pasted back in again later. This is the
 	 * highest level function in that it determines token ownership (only owners
 	 * can copy/cut tokens).
-	 * 
+	 *
 	 * @param tokenSet
 	 *            the set of tokens to copy; if empty, plays the
 	 *            {@link MapTool#SND_INVALID_OPERATION} sound.
@@ -873,7 +874,7 @@ public class AppActions {
 	 * <li>All tokens have their relative pixel offsets saved and reproduced
 	 * when pasted back in.
 	 * </ul>
-	 * 
+	 *
 	 * <li><b>Both maps have grids.</b><br>
 	 * This scheme will preserve proper spacing on the Token layer (for tokens)
 	 * and on the Object and Background layers (for stamps). The spacing will
@@ -889,7 +890,7 @@ public class AppActions {
 	 * <li>For all tokens that are not snapToGrid, their relative pixel offsets
 	 * should be saved and reproduced when the tokens are pasted.
 	 * </ul>
-	 * 
+	 *
 	 * <li><b>The source map is gridless and the destination has a grid.</b><br>
 	 * This one is essentially identical to the first case.
 	 * <ul>
@@ -898,7 +899,7 @@ public class AppActions {
 	 * tokens have the relative pixel offsets applied and then are "snapped"
 	 * into the correct cell location.
 	 * </ul>
-	 * 
+	 *
 	 * <li><b>The source map has a grid and the destination is gridless.</b><br>
 	 * This one is essentially identical to the first case.
 	 * <ul>
@@ -906,7 +907,7 @@ public class AppActions {
 	 * offsets are reproduced when pasted.
 	 * </ul>
 	 * </ol>
-	 * 
+	 *
 	 * @param tokenList
 	 *            the list of tokens to copy; if empty, plays the
 	 *            {@link MapTool#SND_INVALID_OPERATION} sound.
@@ -986,7 +987,7 @@ public class AppActions {
 	 * specified location on the given layer. See {@link #copyTokens(List)} for
 	 * details of how the copy/paste operations work with respect to grid type
 	 * on the source and destination zones.
-	 * 
+	 *
 	 * @param destination
 	 *            ZonePoint specifying where to paste; normally this is
 	 *            unchanged from the MouseEvent
@@ -1030,7 +1031,7 @@ public class AppActions {
 		for (Token origToken : tokenList) {
 			Token token = new Token(origToken);
 
-			// need this here to get around times when a token is copied and pasted into the 
+			// need this here to get around times when a token is copied and pasted into the
 			// same zone, such as a framework "template"
 			if (allTokensSet != null && allTokensSet.contains(token.getExposedAreaGUID())) {
 				GUID guid = new GUID();
@@ -1879,7 +1880,7 @@ public class AppActions {
 						 * in) is recreated. This means that only some items for
 						 * that campaign, zone(s), and token's are copied over
 						 * when you start a new server instance.
-						 * 
+						 *
 						 * You need to modify either Campaign(Campaign) or
 						 * Zone(Zone) to get any data you need to persist from
 						 * the pre-server campaign to the post server start up
@@ -2324,9 +2325,9 @@ public class AppActions {
 	 * stored map into the current campaign. This Action is only available when
 	 * the current application is either hosting a server or is not connected to
 	 * a server.
-	 * 
+	 *
 	 * Property used from <b>i18n.properties</b> is <code>action.loadMap</code>
-	 * 
+	 *
 	 * @author FJE
 	 */
 	public static final LoadMapAction LOAD_MAP = new LoadMapAction() {
@@ -2785,7 +2786,7 @@ public class AppActions {
 		 * <code>null</code> because not all Actions have an associated
 		 * accelerator key defined, but it is currently only called by methods
 		 * that reference the {CUT,COPY,PASTE}_TOKEN Actions.
-		 * 
+		 *
 		 * @return KeyStroke associated with the Action or <code>null</code>
 		 */
 		public final KeyStroke getKeyStroke() {


### PR DESCRIPTION
Small improvement here. When a user wants to change the name of a map using the Map>Rename... dialogue it now defaults to whatever the current name is.

It's not really something we have in our issue tracker but one poster mentioned it in this thread:
http://forums.rptools.net/viewtopic.php?f=26&t=24125