### PR TITLE
Resize free size figure tokens

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -1950,6 +1950,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 					double th = token.getHeight() * Double.valueOf(footprintBounds.width) / token.getWidth();
 					iso_ho = footprintBounds.height - th;
 					footprintBounds = new Rectangle(footprintBounds.x, footprintBounds.y - (int) iso_ho, footprintBounds.width, (int) th);
+					iso_ho = iso_ho * getScale();
 				}
 				SwingUtil.constrainTo(imgSize, footprintBounds.width, footprintBounds.height);
 
@@ -1958,7 +1959,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 				if (token.isSnapToScale()) {
 					offsetx = (int) (imgSize.width < footprintBounds.width ? (footprintBounds.width - imgSize.width) / 2 * getScale() : 0);
 					offsety = (int) (imgSize.height < footprintBounds.height ? (footprintBounds.height - imgSize.height) / 2 * getScale() : 0);
-					iso_ho = iso_ho * getScale();
 				}
 				int tx = x + offsetx;
 				int ty = y + offsety + (int) iso_ho;
@@ -1973,7 +1973,11 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 					at.scale((double) imgSize.width / workImage.getWidth(), (double) imgSize.height / workImage.getHeight());
 					at.scale(getScale(), getScale());
 				} else {
-					at.scale((double) scaledWidth / workImage.getWidth(), (double) scaledHeight / workImage.getHeight());
+					if (token.getShape() == TokenShape.FIGURE) {
+						at.scale((double) scaledWidth / workImage.getWidth(), (double) scaledWidth / workImage.getWidth());
+					} else {
+						at.scale((double) scaledWidth / workImage.getWidth(), (double) scaledHeight / workImage.getHeight());
+					}
 				}
 				g.drawImage(workImage, at, this);
 
@@ -2617,7 +2621,11 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 				at.scale(((double) imgSize.width) / workImage.getWidth(), ((double) imgSize.height) / workImage.getHeight());
 				at.scale(getScale(), getScale());
 			} else {
-				at.scale((scaledWidth) / workImage.getWidth(), (scaledHeight) / workImage.getHeight());
+				if (token.getShape() == TokenShape.FIGURE) {
+					at.scale((double) scaledWidth / workImage.getWidth(), (double) scaledWidth / workImage.getWidth());
+				} else {
+					at.scale((double) scaledWidth / workImage.getWidth(), (double) scaledHeight / workImage.getHeight());
+				}
 			}
 			timer.stop("tokenlist-6");
 

--- a/maptool/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1416,6 +1416,7 @@ public class Zone extends BaseModel {
 	private Zone getZone() {
 		return this;
 	}
+
 	/** @return Getter for initiativeList */
 	public InitiativeList getInitiativeList() {
 		return initiativeList;

--- a/maptool/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1386,10 +1386,10 @@ public class Zone extends BaseModel {
 					 * if either token is a figure, get the footprint and find the lowest point but if the same, 
 					 * return the smallest, else use normal z order
 					 */
-					Rectangle b1 = o1.getFootprint(getGrid()).getBounds(getGrid());
-					Rectangle b2 = o2.getFootprint(getGrid()).getBounds(getGrid());
-					int v1 = o1.getY() + b1.y + b1.height;
-					int v2 = o2.getY() + b2.y + b2.height;
+					Rectangle b1 = o1.getBounds(getZone());
+					Rectangle b2 = o2.getBounds(getZone());
+					int v1 = o1.getY() + b1.height;
+					int v2 = o2.getY() + b2.height;
 					if ((v1 - v2) != 0)
 						return v1 - v2;
 					if (o1.isStamp() && o2.isToken())
@@ -1413,6 +1413,9 @@ public class Zone extends BaseModel {
 		};
 	}
 
+	private Zone getZone() {
+		return this;
+	}
 	/** @return Getter for initiativeList */
 	public InitiativeList getInitiativeList() {
 		return initiativeList;


### PR DESCRIPTION
I didn't really consider "Figure" type tokens or stamps every being "free size" since all the logic is based around the grid cell they are "standing" in. When you free size an image, there is no strong relationship to a grid cell.

However I have made some changes to make tokens or stamps that are both "Figure" types and "free size" behave a bit more consistently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/93)
<!-- Reviewable:end -->
