### PR TITLE
Bug Fix - Tools not hiding FoW

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Zone.java
@@ -827,7 +827,7 @@ public class Zone extends BaseModel {
 		if (getVisionType() == VisionType.OFF) {
 			exposedArea.subtract(area);
 		}
-		if (selectedToks != null && !selectedToks.isEmpty() && MapTool.getServerPolicy().isUseIndividualFOW()) {
+		if (selectedToks != null && !selectedToks.isEmpty() && (MapTool.getServerPolicy().isUseIndividualFOW() || MapTool.isPersonalServer())) {
 			List<Token> allToks = new ArrayList<Token>();
 
 			for (GUID guid : selectedToks) {

--- a/maptool/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/maptool/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -635,7 +635,7 @@ panel.MapExplorer.View.CLIPBOARD=Clipboard
 panel.MapExplorer.View.LIGHT_SOURCES=Light Sources
 panel.Asset.ImageModel.checkbox.searchSubDir1=Search subdirectories?
 panel.Asset.ImageModel.checkbox.searchSubDir2=results
-panel.Asset.ImageModel.slider.toolTip=Slide to adjust the preview thumbnail size...
+panel.Asset.ImageModel.slider.toolTip=Slide to adjust the thumbnail preview size...
 
 # DrawExplorer panel
 panel.DrawExplorer.Unknown.Shape=Unknown Shape
@@ -1305,8 +1305,8 @@ To see the current values, use the <b>{1}</b> option of the <b>{0}</b> menu.<p>\
 Attempt connection anyway?
 
 CoordinateStatusBar.mapCoordinates=Map Coordinates
-AssetCacheStatusBar.toolTip=Current size of Asset cache directory.
-ImageCacheStatusBar.toolTip=Current size of Image thumbs cache directory.
+AssetCacheStatusBar.toolTip=Current size of Asset cache directory, Double-Click to clear this cache.
+ImageCacheStatusBar.toolTip=Current size of Image thumbs cache directory, Double-Click to clear this cache.
 AppHomeDiskSpaceStatusBar.toolTip=Current free space in users home directory.
 
 EditLookupTablePanel.error.noName=Table must have a name.


### PR DESCRIPTION
 - Squashed outstanding issue with manual FoW tools. If no server is
running, tools Exposed FoW at individual level but Hide FoW at the
global level. Hide FoW fixed so it hides at the same level as Expose FoW
now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/101)
<!-- Reviewable:end -->
