### PR TITLE
Reverse change that causes facing arrows to only show when the "Force…

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -2802,8 +2802,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 					if (AppPreferences.getForceFacingArrow() == false)
 						break;
 				case CIRCLE:
-					if (AppPreferences.getForceFacingArrow() == false)
-						break;
 					arrow = getCircleFacingArrow(token.getFacing(), footprintBounds.width / 2);
 					if (zone.getGrid().isIsometric())
 						arrow = getFigureFacingArrow(token.getFacing(), footprintBounds.width / 2);
@@ -2819,8 +2817,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 					clippedG.translate(-cx, -cy);
 					break;
 				case SQUARE:
-					if (AppPreferences.getForceFacingArrow() == false)
-						break;
 
 					if (zone.getGrid().isIsometric()) {
 						arrow = getFigureFacingArrow(token.getFacing(), footprintBounds.width / 2);


### PR DESCRIPTION
https://github.com/RPTools/maptool/issues/164
Correct behaviour is:
* Facing Arrows should appear when a facing is set for Circle, Square and Figure tokens (without Image tables).
* Facing arrows should not appear on topdown tokens or Figure tokens with image tables.
* Facing arrows should always show if the "Force token facing arrow" preference is set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/177)
<!-- Reviewable:end -->
