### PR TITLE
Z order violation

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -1228,7 +1228,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 			// and figure tokens need sorting via alternative logic.
 			List<Token> tokens = zone.getFigureTokens();
 			List<Token> sortedTokens = new ArrayList<Token>(tokens);
-		    Collections.sort(sortedTokens, zone.getFigureZOrderComparator());
+			Collections.sort(sortedTokens, zone.getFigureZOrderComparator());
 			if (!tokens.isEmpty()) {
 				timer.start("tokens - figures");
 				renderTokens(g2d, sortedTokens, view, true);

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -1225,10 +1225,13 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 			}
 
 			// if there is fog or vision we may need to re-render figure type tokens
+			// and figure tokens need sorting via alternative logic.
 			List<Token> tokens = zone.getFigureTokens();
+			List<Token> sortedTokens = new ArrayList<Token>(tokens);
+		    Collections.sort(sortedTokens, zone.getFigureZOrderComparator());
 			if (!tokens.isEmpty()) {
 				timer.start("tokens - figures");
-				renderTokens(g2d, tokens, view, true);
+				renderTokens(g2d, sortedTokens, view, true);
 				timer.stop("tokens - figures");
 			}
 

--- a/maptool/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1561,8 +1561,12 @@ public class Zone extends BaseModel {
 			@Override
 			public int compare(Token o1, Token o2) {
 				/**
-				 * If either token is a figure, get the footprint and find the lowest point but if the same, 
-				 * return the smallest, else use normal z order
+				 * It is an assumption of this comparator that all tokens are being sorted using isometric logic.
+				 * 
+				 * Get the footprint (dependent on Grid) and find the centre of the footprint.
+				 * If the same, place tokens above objects.
+				 * Otherwise use height to place the smallest in front.
+				 * If still equal use normal z order.
 				 */
 				int v1 = getFigureZOrder(o1);
 				int v2 = getFigureZOrder(o2);

--- a/maptool/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1572,9 +1572,9 @@ public class Zone extends BaseModel {
 				int v2 = getFigureZOrder(o2);
 				if ((v1 - v2) != 0)
 					return v1 - v2;
-				if (o1.isStamp() && o2.isToken())
+				if (!o1.isToken() && o2.isToken())
 					return -1;
-				if (o2.isStamp() && o1.isToken())
+				if (!o2.isToken() && o1.isToken())
 					return +1;
 				if (o1.getHeight() != o2.getHeight()) {
 					// Larger tokens at the same position, go behind

--- a/maptool/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/maptool/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1111,7 +1111,7 @@ public class Zone extends BaseModel {
 		// LATER: optimize this
 		tokenOrderedList.remove(token);
 		tokenOrderedList.add(token);
-		Collections.sort(tokenOrderedList, getZOrderComparator());
+		Collections.sort(tokenOrderedList, TOKEN_Z_ORDER_COMPARATOR);
 
 		if (newToken) {
 			fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_ADDED, token));
@@ -1151,7 +1151,7 @@ public class Zone extends BaseModel {
 		}
 		tokenOrderedList.removeAll(tokens);
 		tokenOrderedList.addAll(tokens);
-		Collections.sort(tokenOrderedList, getZOrderComparator());
+		Collections.sort(tokenOrderedList, TOKEN_Z_ORDER_COMPARATOR);
 
 		if (!addedTokens.isEmpty())
 			fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_ADDED, addedTokens));
@@ -1536,7 +1536,6 @@ public class Zone extends BaseModel {
 		public boolean matchToken(Token t);
 	}
 
-	@Deprecated
 	public static final Comparator<Token> TOKEN_Z_ORDER_COMPARATOR = new TokenZOrderComparator();
 
 	public static class TokenZOrderComparator implements Comparator<Token> {
@@ -1554,10 +1553,10 @@ public class Zone extends BaseModel {
 	}
 
 	/**
-	 * Need to replace static TOKEN_Z_ORDER_COMPARATOR comparator with instantiated version so that grid is available
-	 * and can access token footprint
+	 * Replaces the static TOKEN_Z_ORDER_COMPARATOR comparator with instantiated version so that grid is available
+	 * and can access token footprint. Only used when Rendering just Figure Tokens.
 	 **/
-	public Comparator<Token> getZOrderComparator() {
+	public Comparator<Token> getFigureZOrderComparator() {
 		return new Comparator<Token>() {
 			@Override
 			public int compare(Token o1, Token o2) {
@@ -1565,19 +1564,17 @@ public class Zone extends BaseModel {
 				 * If either token is a figure, get the footprint and find the lowest point but if the same, 
 				 * return the smallest, else use normal z order
 				 */
-				if (o1.getShape() == Token.TokenShape.FIGURE || o2.getShape() == Token.TokenShape.FIGURE) {
-					int v1 = getFigureZOrder(o1);
-					int v2 = getFigureZOrder(o2);
-					if ((v1 - v2) != 0)
-						return v1 - v2;
-					if (o1.isStamp() && o2.isToken())
-						return -1;
-					if (o2.isStamp() && o1.isToken())
-						return +1;
-					if (o1.getHeight() != o2.getHeight()) {
-						// Larger tokens at the same position, go behind
-						return o2.getHeight() - o1.getHeight();
-					}
+				int v1 = getFigureZOrder(o1);
+				int v2 = getFigureZOrder(o2);
+				if ((v1 - v2) != 0)
+					return v1 - v2;
+				if (o1.isStamp() && o2.isToken())
+					return -1;
+				if (o2.isStamp() && o1.isToken())
+					return +1;
+				if (o1.getHeight() != o2.getHeight()) {
+					// Larger tokens at the same position, go behind
+					return o2.getHeight() - o1.getHeight();
 				}
 				int lval = o1.getZOrder();
 				int rval = o2.getZOrder();

--- a/maptool/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/maptool/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -282,7 +282,7 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
 				}
 			}
 			// Arrange
-			Collections.sort(tokenList, zone.getZOrderComparator());
+			Collections.sort(tokenList, Zone.TOKEN_Z_ORDER_COMPARATOR);
 
 			// Update
 			int z = zone.getLargestZOrder() + 1;
@@ -487,7 +487,7 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
 				}
 			}
 			// Arrange
-			Collections.sort(tokenList, zone.getZOrderComparator());
+			Collections.sort(tokenList, Zone.TOKEN_Z_ORDER_COMPARATOR);
 
 			// Update
 			int z = zone.getSmallestZOrder() - 1;


### PR DESCRIPTION
This solves the ZOrder sort violation problem by restoring the original comparator and only using the new figure comparator when sorting figure only.

Difficult to say this absolutely solves the problem as we have never been able to reliably trigger the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/179)
<!-- Reviewable:end -->
