### PR TITLE
Feature: Issue #185 - Sorting artpacks

### DIFF
--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -166,6 +166,11 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		});
 	}
 
+	/**
+	 * Takes a size in bytes and produces a readable string with a unit (byte/kb/mb) attached
+	 * @param size the size in bytes
+	 * @return String containing a human readable file size
+	 */
 	private String getSizeString(int size) {
 		NumberFormat format = NumberFormat.getNumberInstance();
 		if (size < 1000) {
@@ -416,6 +421,9 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		}
 	}
 
+	/**
+	 * Model, passed to the table in the RPTools tab. Doesn't do much, besides displaying a message in a single cell
+	 */
 	private class MessageTableModel extends AbstractTableModel {
 		private final String message;
 
@@ -439,6 +447,10 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		}
 	}
 
+	/**
+	 * Model, passed to the table in the RPTools tab.
+	 * This model displays all the information from the downloaded list of art packs
+	 */
 	private class LibraryTableModel extends AbstractTableModel {
 
 		private final int COLUMN_INDEX_ARTIST = 0;
@@ -530,6 +542,11 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		}
 	}
 
+	/**
+	 * A renderer for the "size" cell in the RPTools JTable.
+	 * This is done, so we can sort by a simple integer size, but still render a size in kb/mb/etc
+	 * @see LibraryTableModel
+	 */
 	private class SizeCellRenderer extends DefaultTableCellRenderer {
 		@Override
 		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -43,8 +43,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 	private static final Logger log = Logger.getLogger(AddResourceDialog.class);
 
 	private static final String LIBRARY_URL = "http://library.rptools.net/1.3";
-	//private static final String LIBRARY_LIST_URL = LIBRARY_URL + "/listArtPacks";
-	private static final String LIBRARY_LIST_URL = "http://test.lukasjacobs.de/lib.txt";
+	private static final String LIBRARY_LIST_URL = LIBRARY_URL + "/listArtPacks";
 
 	public enum Tab {
 		LOCAL, WEB, RPTOOLS
@@ -92,12 +91,12 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		return (JTextField) getComponent("@localDirectory");
 	}
 
-	public JTable getLibraryList() {
+	public JTable getLibraryTable() {
 		return (JTable) getComponent("@rptoolsList");
 	}
 
 	public void initLibraryList() {
-		JTable list = getLibraryList();
+		JTable list = getLibraryTable();
 		list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 
 		list.setModel(new MessageTableModel(I18N.getText("dialog.addresource.downloading")));
@@ -225,11 +224,11 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
 					//Add a TableRowSorter
 					TableRowSorter<LibraryTableModel> sorter = new TableRowSorter<>();
-					getLibraryList().setRowSorter(sorter);
+					getLibraryTable().setRowSorter(sorter);
 					sorter.setModel((LibraryTableModel) model);
 
 					//Set the custom renderer for size
-					getLibraryList().setDefaultRenderer(Integer.class, new SizeCellRenderer());
+					getLibraryTable().setDefaultRenderer(Integer.class, new SizeCellRenderer());
 
 				} catch (Throwable t) {
 					log.error("unable to parse library list", t);
@@ -241,8 +240,8 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
 			@Override
 			protected void done() {
-				getLibraryList().setModel(model);
-				getLibraryList().repaint();
+				getLibraryTable().setModel(model);
+				getLibraryTable().repaint();
 			}
 		}.execute();
 	}
@@ -296,20 +295,20 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 				MapTool.showMessage("dialog.addresource.warn.invalidurl", "Error", JOptionPane.ERROR_MESSAGE, model.getUrl());
 				return false;
 			}
-			rowList.add(new LibraryRow("unknown", model.getUrlName(), model.getUrl(), -1)); //TODO: Don't default to "Unknow" artist
+			rowList.add(new LibraryRow("unknown", model.getUrlName(), model.getUrl(), -1));
 			break;
 
 		case RPTOOLS:
-			if (getLibraryList().getSelectedRowCount() == 0) {
+			if (getLibraryTable().getSelectedRowCount() == 0) {
 				MapTool.showMessage("dialog.addresource.warn.mustselectone", "Error", JOptionPane.ERROR_MESSAGE);
 				return false;
 			}
 
 			ArrayList<LibraryRow> selectedRows = new ArrayList<>();
-			LibraryTableModel model = (LibraryTableModel) getLibraryList().getModel();
-			int[] selectedRowIndices = getLibraryList().getSelectedRows();
-			for (int i = 0; i < getLibraryList().getSelectedRowCount(); i++) {
-				int modelRowIndex = getLibraryList().convertRowIndexToModel(selectedRowIndices[i]);
+			LibraryTableModel model = (LibraryTableModel) getLibraryTable().getModel();
+			int[] selectedRowIndices = getLibraryTable().getSelectedRows();
+			for (int i = 0; i < getLibraryTable().getSelectedRowCount(); i++) {
+				int modelRowIndex = getLibraryTable().convertRowIndexToModel(selectedRowIndices[i]);
 				selectedRows.add(model.getRow(modelRowIndex));
 			}
 
@@ -417,22 +416,6 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		}
 	}
 
-	private class MessageListModel extends AbstractListModel {
-		private final String message;
-
-		public MessageListModel(String message) {
-			this.message = message;
-		}
-
-		public Object getElementAt(int index) {
-			return message;
-		}
-
-		public int getSize() {
-			return 1;
-		}
-	}
-
 	private class MessageTableModel extends AbstractTableModel {
 		private final String message;
 
@@ -458,6 +441,10 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
 	private class LibraryTableModel extends AbstractTableModel {
 
+	    private final int COLUMN_INDEX_ARTIST    = 0;
+        private final int COLUMN_INDEX_NAME      = 1;
+        private final int COLUMN_INDEX_SIZE      = 2;
+
 		private ArrayList<LibraryRow> rows;
 
 		LibraryTableModel() {
@@ -467,13 +454,13 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		@Override
 		public String getColumnName(int column) {
 			switch (column) {
-				case 0: //Artist
+				case COLUMN_INDEX_ARTIST: //Artist
 					return I18N.getText("dialog.addresource.artist");
 
-				case 1: //Name
+				case COLUMN_INDEX_NAME: //Name
 					return I18N.getText("dialog.addresource.artpackname");
 
-				case 2: //Size
+				case COLUMN_INDEX_SIZE: //Size
 					return I18N.getText("dialog.addresource.size");
 
 				default:
@@ -496,13 +483,13 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 			LibraryRow row = rows.get(rowIndex);
 
 			switch (columnIndex) {
-				case 0: //Author
+				case COLUMN_INDEX_ARTIST: //Artist
 					return row.artist;
 
-				case 1: //Name
+				case COLUMN_INDEX_NAME: //Name
 					return row.name;
 
-				case 2: //Size
+				case COLUMN_INDEX_SIZE: //Size
 					return row.size;
 
 				default:
@@ -513,13 +500,13 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		@Override
 		public Class<?> getColumnClass(int columnIndex) {
 			switch (columnIndex) {
-				case 0: //Author
+				case COLUMN_INDEX_ARTIST: //Artist
 					return String.class;
 
-				case 1: //Name
+				case COLUMN_INDEX_NAME: //Name
 					return String.class;
 
-				case 2: //Size
+				case COLUMN_INDEX_SIZE: //Size
 					return Integer.class;
 
 				default:

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -362,11 +362,6 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 			size = Integer.parseInt(data[3]);
 		}
 
-		@Override
-		public String toString() {
-			return "<html><b>" + name + "</b> <i>(" + getSizeString() + ")</i>";
-		}
-
 		private String getSizeString() {
 			NumberFormat format = NumberFormat.getNumberInstance();
 			if (size < 1000) {

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -110,16 +110,16 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 			public void stateChanged(ChangeEvent e) {
 				// Hmmm, this is fragile (breaks if the order changes) rethink this later
 				switch (tabPane.getSelectedIndex()) {
-				case 0:
-					model.tab = Tab.LOCAL;
-					break;
-				case 1:
-					model.tab = Tab.WEB;
-					break;
-				case 2:
-					model.tab = Tab.RPTOOLS;
-					downloadLibraryList();
-					break;
+					case 0:
+						model.tab = Tab.LOCAL;
+						break;
+					case 1:
+						model.tab = Tab.WEB;
+						break;
+					case 2:
+						model.tab = Tab.RPTOOLS;
+						downloadLibraryList();
+						break;
 				}
 			}
 		});
@@ -256,77 +256,77 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		final List<LibraryRow> rowList = new ArrayList<LibraryRow>();
 
 		switch (model.getTab()) {
-		case LOCAL:
-			if (StringUtils.isEmpty(model.getLocalDirectory())) {
-				MapTool.showMessage("dialog.addresource.warn.filenotfound", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
-				return false;
-			}
-			File root = new File(model.getLocalDirectory());
-			if (!root.exists()) {
-				MapTool.showMessage("dialog.addresource.warn.filenotfound", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
-				return false;
-			}
-			if (!root.isDirectory()) {
-				MapTool.showMessage("dialog.addresource.warn.directoryrequired", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
-				return false;
-			}
-			try {
-				AppSetup.installLibrary(FileUtil.getNameWithoutExtension(root), root);
-			} catch (MalformedURLException e) {
-				log.error("Bad path url: " + root.getPath(), e);
-				MapTool.showMessage("dialog.addresource.warn.badpath", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
-				return false;
-			} catch (IOException e) {
-				log.error("IOException adding local root: " + root.getPath(), e);
-				MapTool.showMessage("dialog.addresource.warn.badpath", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
-				return false;
-			}
-			return true;
-
-		case WEB:
-			if (StringUtils.isEmpty(model.getUrlName())) {
-				MapTool.showMessage("dialog.addresource.warn.musthavename", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
-				return false;
-			}
-			// validate the url format so that we don't hit it later
-			try {
-				new URL(model.getUrl());
-			} catch (MalformedURLException e) {
-				MapTool.showMessage("dialog.addresource.warn.invalidurl", "Error", JOptionPane.ERROR_MESSAGE, model.getUrl());
-				return false;
-			}
-			rowList.add(new LibraryRow("unknown", model.getUrlName(), model.getUrl(), -1));
-			break;
-
-		case RPTOOLS:
-			if (getLibraryTable().getSelectedRowCount() == 0) {
-				MapTool.showMessage("dialog.addresource.warn.mustselectone", "Error", JOptionPane.ERROR_MESSAGE);
-				return false;
-			}
-
-			ArrayList<LibraryRow> selectedRows = new ArrayList<>();
-			LibraryTableModel model = (LibraryTableModel) getLibraryTable().getModel();
-			int[] selectedRowIndices = getLibraryTable().getSelectedRows();
-			for (int i = 0; i < getLibraryTable().getSelectedRowCount(); i++) {
-				int modelRowIndex = getLibraryTable().convertRowIndexToModel(selectedRowIndices[i]);
-				selectedRows.add(model.getRow(modelRowIndex));
-			}
-
-			for (Object obj : selectedRows) {
-				LibraryRow row = (LibraryRow) obj;
-
-				//validate the url format
-				row.path = LIBRARY_URL + "/" + row.path;
-				try {
-					new URL(row.path);
-				} catch (MalformedURLException e) {
-					MapTool.showMessage("dialog.addresource.warn.invalidurl", "Error", JOptionPane.ERROR_MESSAGE, row.path);
+			case LOCAL:
+				if (StringUtils.isEmpty(model.getLocalDirectory())) {
+					MapTool.showMessage("dialog.addresource.warn.filenotfound", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
 					return false;
 				}
-				rowList.add(row);
-			}
+				File root = new File(model.getLocalDirectory());
+				if (!root.exists()) {
+					MapTool.showMessage("dialog.addresource.warn.filenotfound", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
+					return false;
+				}
+				if (!root.isDirectory()) {
+					MapTool.showMessage("dialog.addresource.warn.directoryrequired", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
+					return false;
+				}
+				try {
+					AppSetup.installLibrary(FileUtil.getNameWithoutExtension(root), root);
+				} catch (MalformedURLException e) {
+					log.error("Bad path url: " + root.getPath(), e);
+					MapTool.showMessage("dialog.addresource.warn.badpath", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
+					return false;
+				} catch (IOException e) {
+					log.error("IOException adding local root: " + root.getPath(), e);
+					MapTool.showMessage("dialog.addresource.warn.badpath", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
+					return false;
+				}
+				return true;
 
-			break;
+			case WEB:
+				if (StringUtils.isEmpty(model.getUrlName())) {
+					MapTool.showMessage("dialog.addresource.warn.musthavename", "Error", JOptionPane.ERROR_MESSAGE, model.getLocalDirectory());
+					return false;
+				}
+				// validate the url format so that we don't hit it later
+				try {
+					new URL(model.getUrl());
+				} catch (MalformedURLException e) {
+					MapTool.showMessage("dialog.addresource.warn.invalidurl", "Error", JOptionPane.ERROR_MESSAGE, model.getUrl());
+					return false;
+				}
+				rowList.add(new LibraryRow("unknown", model.getUrlName(), model.getUrl(), -1));
+				break;
+
+			case RPTOOLS:
+				if (getLibraryTable().getSelectedRowCount() == 0) {
+					MapTool.showMessage("dialog.addresource.warn.mustselectone", "Error", JOptionPane.ERROR_MESSAGE);
+					return false;
+				}
+
+				ArrayList<LibraryRow> selectedRows = new ArrayList<>();
+				LibraryTableModel model = (LibraryTableModel) getLibraryTable().getModel();
+				int[] selectedRowIndices = getLibraryTable().getSelectedRows();
+				for (int i = 0; i < getLibraryTable().getSelectedRowCount(); i++) {
+					int modelRowIndex = getLibraryTable().convertRowIndexToModel(selectedRowIndices[i]);
+					selectedRows.add(model.getRow(modelRowIndex));
+				}
+
+				for (Object obj : selectedRows) {
+					LibraryRow row = (LibraryRow) obj;
+
+					//validate the url format
+					row.path = LIBRARY_URL + "/" + row.path;
+					try {
+						new URL(row.path);
+					} catch (MalformedURLException e) {
+						MapTool.showMessage("dialog.addresource.warn.invalidurl", "Error", JOptionPane.ERROR_MESSAGE, row.path);
+						return false;
+					}
+					rowList.add(row);
+				}
+
+				break;
 		}
 
 		new SwingWorker<Object, Object>() {
@@ -441,9 +441,9 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
 	private class LibraryTableModel extends AbstractTableModel {
 
-	    private final int COLUMN_INDEX_ARTIST    = 0;
-        private final int COLUMN_INDEX_NAME      = 1;
-        private final int COLUMN_INDEX_SIZE      = 2;
+		private final int COLUMN_INDEX_ARTIST = 0;
+		private final int COLUMN_INDEX_NAME = 1;
+		private final int COLUMN_INDEX_SIZE = 2;
 
 		private ArrayList<LibraryRow> rows;
 
@@ -523,7 +523,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		}
 
 		public LibraryRow getRow(int rowIndex) {
-			if(rowIndex >= rows.size() || rowIndex < 0)
+			if (rowIndex >= rows.size() || rowIndex < 0)
 				return null;
 
 			return rows.get(rowIndex);

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -25,6 +25,7 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
@@ -166,6 +167,17 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		});
 	}
 
+	private String getSizeString(int size) {
+		NumberFormat format = NumberFormat.getNumberInstance();
+		if (size < 1000) {
+			return format.format(size) + " bytes";
+		}
+		if (size < 1000000) {
+			return format.format(size / 1000) + " k";
+		}
+		return format.format(size / 1000000) + " mb";
+	}
+
 	private void downloadLibraryList() {
 		if (downloadLibraryListInitiated) {
 			return;
@@ -215,6 +227,9 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 					TableRowSorter<LibraryTableModel> sorter = new TableRowSorter<>();
 					getLibraryList().setRowSorter(sorter);
 					sorter.setModel((LibraryTableModel) model);
+
+					//Set the custom renderer for size
+					getLibraryList().setDefaultRenderer(Integer.class, new SizeCellRenderer());
 
 				} catch (Throwable t) {
 					log.error("unable to parse library list", t);
@@ -361,17 +376,6 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 			path = data[2].trim();
 			size = Integer.parseInt(data[3]);
 		}
-
-		private String getSizeString() {
-			NumberFormat format = NumberFormat.getNumberInstance();
-			if (size < 1000) {
-				return format.format(size) + " bytes";
-			}
-			if (size < 1000000) {
-				return format.format(size / 1000) + " k";
-			}
-			return format.format(size / 1000000) + " mb";
-		}
 	}
 
 	public static class Model {
@@ -506,6 +510,23 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 			}
 		}
 
+		@Override
+		public Class<?> getColumnClass(int columnIndex) {
+			switch (columnIndex) {
+				case 0: //Author
+					return String.class;
+
+				case 1: //Name
+					return String.class;
+
+				case 2: //Size
+					return Integer.class;
+
+				default:
+					return null;
+			}
+		}
+
 		public void addElement(LibraryRow row) {
 			if (rows.contains(row))
 				return;
@@ -519,6 +540,17 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 				return null;
 
 			return rows.get(rowIndex);
+		}
+	}
+
+	private class SizeCellRenderer extends DefaultTableCellRenderer {
+		@Override
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+			super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+			Integer size = (Integer) value;
+			setText(getSizeString(size.intValue()));
+
+			return this;
 		}
 	}
 }

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -58,7 +58,8 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 	private static final Logger log = Logger.getLogger(AddResourceDialog.class);
 
 	private static final String LIBRARY_URL = "http://library.rptools.net/1.3";
-	private static final String LIBRARY_LIST_URL = LIBRARY_URL + "/listArtPacks";
+	//private static final String LIBRARY_LIST_URL = LIBRARY_URL + "/listArtPacks";
+	private static final String LIBRARY_LIST_URL = "http://test.lukasjacobs.de/lib.txt";
 
 	public enum Tab {
 		LOCAL, WEB, RPTOOLS
@@ -288,7 +289,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 				MapTool.showMessage("dialog.addresource.warn.invalidurl", "Error", JOptionPane.ERROR_MESSAGE, model.getUrl());
 				return false;
 			}
-			rowList.add(new LibraryRow(model.getUrlName(), model.getUrl(), -1));
+			rowList.add(new LibraryRow("unknown", model.getUrlName(), model.getUrl(), -1)); //TODO: Don't default to "Unknow" artist
 			break;
 
 		case RPTOOLS:
@@ -339,11 +340,13 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 	}
 
 	private static class LibraryRow {
+		private final String artist;
 		private final String name;
 		private String path;
 		private final int size;
 
-		public LibraryRow(String name, String path, int size) {
+		public LibraryRow(String artist, String name, String path, int size) {
+			this.artist = artist.trim();
 			this.name = name.trim();
 			this.path = path.trim();
 			this.size = size;
@@ -352,9 +355,10 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 		public LibraryRow(String row) {
 			String[] data = row.split("\\|");
 
-			name = data[0].trim();
-			path = data[1].trim();
-			size = Integer.parseInt(data[2]);
+			artist = data[0].trim();
+			name = data[1].trim();
+			path = data[2].trim();
+			size = Integer.parseInt(data[3]);
 		}
 
 		@Override

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -466,15 +466,15 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
 		@Override
 		public String getColumnName(int column) {
-			switch (column) { //TODO: Internationalize these Strings
+			switch (column) {
 				case 0: //Artist
-					return "Artist";
+					return I18N.getText("dialog.addresource.artist");
 
 				case 1: //Name
-					return "Name";
+					return I18N.getText("dialog.addresource.artpackname");
 
 				case 2: //Size
-					return "Size";
+					return I18N.getText("dialog.addresource.size");
 
 				default:
 					return null;

--- a/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
+++ b/maptool/src/main/java/net/rptools/maptool/client/ui/AddResourceDialog.java
@@ -11,41 +11,31 @@
 
 package net.rptools.maptool.client.ui;
 
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
+import com.jidesoft.swing.FolderChooser;
+import net.rptools.lib.FileUtil;
+import net.rptools.maptool.client.*;
+import net.rptools.maptool.client.swing.AbeillePanel;
+import net.rptools.maptool.client.swing.GenericDialog;
+import net.rptools.maptool.language.I18N;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.jdesktop.swingworker.SwingWorker;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
-
-import net.rptools.lib.FileUtil;
-import net.rptools.maptool.client.AppPreferences;
-import net.rptools.maptool.client.AppSetup;
-import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.RemoteFileDownloader;
-import net.rptools.maptool.client.WebDownloader;
-import net.rptools.maptool.client.swing.AbeillePanel;
-import net.rptools.maptool.client.swing.GenericDialog;
-import net.rptools.maptool.language.I18N;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.jdesktop.swingworker.SwingWorker;
-
-import com.jidesoft.swing.FolderChooser;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
@@ -220,10 +210,17 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 						tableModel.addElement(row);
 					}
 					model = tableModel;
+
+					//Add a TableRowSorter
+					TableRowSorter<LibraryTableModel> sorter = new TableRowSorter<>();
+					getLibraryList().setRowSorter(sorter);
+					sorter.setModel((LibraryTableModel) model);
+
 				} catch (Throwable t) {
 					log.error("unable to parse library list", t);
 					model = new MessageTableModel(I18N.getText("dialog.addresource.errorDownloading"));
 				}
+
 				return null;
 			}
 
@@ -295,8 +292,10 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 
 			ArrayList<LibraryRow> selectedRows = new ArrayList<>();
 			LibraryTableModel model = (LibraryTableModel) getLibraryList().getModel();
+			int[] selectedRowIndices = getLibraryList().getSelectedRows();
 			for (int i = 0; i < getLibraryList().getSelectedRowCount(); i++) {
-				selectedRows.add(model.getRow(i));
+				int modelRowIndex = getLibraryList().convertRowIndexToModel(selectedRowIndices[i]);
+				selectedRows.add(model.getRow(modelRowIndex));
 			}
 
 			for (Object obj : selectedRows) {
@@ -312,6 +311,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
 				}
 				rowList.add(row);
 			}
+
 			break;
 		}
 

--- a/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/addResourcesDialog.xml
+++ b/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/addResourcesDialog.xml
@@ -76,7 +76,7 @@
                <at name="classname">javax.swing.JButton</at>
                <at name="properties">
                 <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="text">Install &gt;&gt;</at>
+                 <at name="text">Install</at>
                  <at name="height">25</at>
                  <at name="width">97</at>
                  <at name="name">installButton</at>

--- a/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/addResourcesDialog.xml
+++ b/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/addResourcesDialog.xml
@@ -24,8 +24,8 @@
     </at>
     <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
    </super>
-   <at name="id">/Users/frank/Workspace/maptool/src/net/rptools/maptool/client/ui/forms/addResourcesDialog.jfrm</at>
-   <at name="path">net/rptools/maptool/client/ui/forms/addResourcesDialog.jfrm</at>
+   <at name="id">D:\Code\maptool\maptool\src\main\resources\net\rptools\maptool\client\ui\forms\addResourcesDialog.xml</at>
+   <at name="path">addResourcesDialog.xml</at>
    <at name="rowspecs">CENTER:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),CENTER:20DLU:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
    <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
    <at name="components">
@@ -47,7 +47,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.1227686960</at>
+        <at name="id">embedded.1503272721</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -76,11 +76,6 @@
                <at name="classname">javax.swing.JButton</at>
                <at name="properties">
                 <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="text">Install</at>
-                 <at name="height">25</at>
-                 <at name="width">97</at>
-                 <at name="name">installButton</at>
-                 <at name="actionCommand">Install &gt;&gt;</at>
                  <at name="border">
                   <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                    <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -101,6 +96,11 @@
                    </at>
                   </object>
                  </at>
+                 <at name="actionCommand">Install &gt;&gt;</at>
+                 <at name="name">installButton</at>
+                 <at name="width">64</at>
+                 <at name="text">Install</at>
+                 <at name="height">22</at>
                 </object>
                </at>
               </object>
@@ -132,11 +132,6 @@
                <at name="classname">javax.swing.JButton</at>
                <at name="properties">
                 <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="text">Cancel</at>
-                 <at name="height">25</at>
-                 <at name="width">97</at>
-                 <at name="name">cancelButton</at>
-                 <at name="actionCommand">Cancel</at>
                  <at name="border">
                   <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                    <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -157,6 +152,11 @@
                    </at>
                   </object>
                  </at>
+                 <at name="actionCommand">Cancel</at>
+                 <at name="name">cancelButton</at>
+                 <at name="width">64</at>
+                 <at name="text">Cancel</at>
+                 <at name="height">22</at>
                 </object>
                </at>
               </object>
@@ -171,7 +171,17 @@
           <at name="classname">com.jeta.forms.gui.form.GridView</at>
           <at name="properties">
            <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="name"></at>
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList"/>
+              </at>
+             </object>
+            </at>
+            <at name="name"/>
             <at name="fill">
              <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
               <at name="name">fill</at>
@@ -201,16 +211,6 @@
                  </object>
                 </at>
                </object>
-              </at>
-             </object>
-            </at>
-            <at name="border">
-             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-              <super classname="com.jeta.forms.store.properties.BorderProperty">
-               <at name="name">border</at>
-              </super>
-              <at name="borders">
-               <object classname="java.util.LinkedList"/>
               </at>
              </object>
             </at>
@@ -294,11 +294,6 @@
           <at name="classname">javax.swing.JTabbedPane</at>
           <at name="properties">
            <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="tabPlacement">2</at>
-            <at name="height">647</at>
-            <at name="componentCount">3</at>
-            <at name="width">1112</at>
-            <at name="name">tabPane</at>
             <at name="border">
              <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
               <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -319,6 +314,9 @@
               </at>
              </object>
             </at>
+            <at name="componentCount">3</at>
+            <at name="tabPlacement">2</at>
+            <at name="name">tabPane</at>
             <at name="tabs">
              <object classname="com.jeta.forms.store.properties.TabbedPaneProperties">
               <at name="name">tabs</at>
@@ -328,14 +326,13 @@
                  <at name="value">
                   <object classname="com.jeta.forms.store.properties.TabProperty">
                    <at name="name">tab</at>
-                   <at name="title"></at>
                    <at name="icon">
                     <object classname="com.jeta.forms.store.properties.IconProperty">
                      <at name="embedded">false</at>
-                     <at name="path">net/rptools/maptool/client/image/folder.png</at>
+                     <at name="path">net\rptools\maptool\client\image\folder.png</at>
                      <at name="description">folder.png</at>
-                     <at name="width">64</at>
-                     <at name="height">64</at>
+                     <at name="width">16</at>
+                     <at name="height">16</at>
                     </object>
                    </at>
                    <at name="form">
@@ -354,7 +351,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.1900711748</at>
+                     <at name="id">embedded.141313246</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:20DLU:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -383,11 +380,6 @@
                             <at name="classname">javax.swing.JButton</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">...</at>
-                              <at name="height">25</at>
-                              <at name="width">43</at>
-                              <at name="name">localDirectoryButton</at>
-                              <at name="actionCommand">...</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -408,6 +400,11 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="actionCommand">...</at>
+                              <at name="name">localDirectoryButton</at>
+                              <at name="width">44</at>
+                              <at name="text">...</at>
+                              <at name="height">22</at>
                              </object>
                             </at>
                            </object>
@@ -439,22 +436,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Local Directory</at>
-                              <at name="height">17</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">1</at>
-                                <at name="size">14</at>
-                               </object>
-                              </at>
-                              <at name="width">895</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -475,6 +456,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">1116</at>
+                              <at name="name"/>
+                              <at name="text">Local Directory</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">1</at>
+                                <at name="size">14</at>
+                               </object>
+                              </at>
+                              <at name="height">17</at>
                              </object>
                             </at>
                            </object>
@@ -506,22 +503,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Path:</at>
-                              <at name="height">14</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">1</at>
-                                <at name="size">11</at>
-                               </object>
-                              </at>
-                              <at name="width">30</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -542,6 +523,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">29</at>
+                              <at name="name"/>
+                              <at name="text">Path:</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">1</at>
+                                <at name="size">11</at>
+                               </object>
+                              </at>
+                              <at name="height">14</at>
                              </object>
                             </at>
                            </object>
@@ -573,10 +570,6 @@
                             <at name="classname">javax.swing.JTextField</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="height">19</at>
-                              <at name="width">845</at>
-                              <at name="name">@localDirectory</at>
-                              <at name="columns">30</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -597,6 +590,10 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="columns">30</at>
+                              <at name="name">@localDirectory</at>
+                              <at name="width">1067</at>
+                              <at name="height">20</at>
                              </object>
                             </at>
                            </object>
@@ -628,22 +625,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">(e.g. c:\data\cmpgn_images)</at>
-                              <at name="height">14</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">2</at>
-                                <at name="size">11</at>
-                               </object>
-                              </at>
-                              <at name="width">845</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -664,6 +645,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">1067</at>
+                              <at name="name"/>
+                              <at name="text">(e.g. c:\data\cmpgn_images)</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">2</at>
+                                <at name="size">11</at>
+                               </object>
+                              </at>
+                              <at name="height">14</at>
                              </object>
                             </at>
                            </object>
@@ -678,6 +675,16 @@
                        <at name="classname">com.jeta.forms.gui.form.GridView</at>
                        <at name="properties">
                         <object classname="com.jeta.forms.store.support.PropertyMap">
+                         <at name="border">
+                          <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                           <super classname="com.jeta.forms.store.properties.BorderProperty">
+                            <at name="name">border</at>
+                           </super>
+                           <at name="borders">
+                            <object classname="java.util.LinkedList"/>
+                           </at>
+                          </object>
+                         </at>
                          <at name="name"></at>
                          <at name="fill">
                           <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
@@ -719,16 +726,6 @@
                               </object>
                              </at>
                             </object>
-                           </at>
-                          </object>
-                         </at>
-                         <at name="border">
-                          <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                           <super classname="com.jeta.forms.store.properties.BorderProperty">
-                            <at name="name">border</at>
-                           </super>
-                           <at name="borders">
-                            <object classname="java.util.LinkedList"/>
                            </at>
                           </object>
                          </at>
@@ -785,14 +782,13 @@
                  <at name="value">
                   <object classname="com.jeta.forms.store.properties.TabProperty">
                    <at name="name">tab</at>
-                   <at name="title"></at>
                    <at name="icon">
                     <object classname="com.jeta.forms.store.properties.IconProperty">
                      <at name="embedded">false</at>
-                     <at name="path">net/rptools/maptool/client/image/download.png</at>
+                     <at name="path">net\rptools\maptool\client\image\download.png</at>
                      <at name="description">download.png</at>
-                     <at name="width">64</at>
-                     <at name="height">64</at>
+                     <at name="width">16</at>
+                     <at name="height">16</at>
                     </object>
                    </at>
                    <at name="form">
@@ -811,7 +807,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.294576878</at>
+                     <at name="id">embedded.157015194</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:20DLU:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -840,9 +836,6 @@
                             <at name="classname">javax.swing.JTextField</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="height">19</at>
-                              <at name="width">902</at>
-                              <at name="name">@url</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -863,6 +856,9 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="name">@url</at>
+                              <at name="width">1125</at>
+                              <at name="height">20</at>
                              </object>
                             </at>
                            </object>
@@ -894,22 +890,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">(e.g. http://myhost.com/cmpgn_images.zip)</at>
-                              <at name="height">14</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">2</at>
-                                <at name="size">11</at>
-                               </object>
-                              </at>
-                              <at name="width">902</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -930,6 +910,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">1125</at>
+                              <at name="name"/>
+                              <at name="text">(e.g. http://myhost.com/cmpgn_images.zip)</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">2</at>
+                                <at name="size">11</at>
+                               </object>
+                              </at>
+                              <at name="height">14</at>
                              </object>
                             </at>
                            </object>
@@ -961,22 +957,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">URL</at>
-                              <at name="height">17</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">1</at>
-                                <at name="size">14</at>
-                               </object>
-                              </at>
-                              <at name="width">958</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -997,6 +977,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">1180</at>
+                              <at name="name"/>
+                              <at name="text">URL</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">1</at>
+                                <at name="size">14</at>
+                               </object>
+                              </at>
+                              <at name="height">17</at>
                              </object>
                             </at>
                            </object>
@@ -1028,22 +1024,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">URL:</at>
-                              <at name="height">14</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">1</at>
-                                <at name="size">11</at>
-                               </object>
-                              </at>
-                              <at name="width">36</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1064,6 +1044,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">35</at>
+                              <at name="name"/>
+                              <at name="text">URL:</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">1</at>
+                                <at name="size">11</at>
+                               </object>
+                              </at>
+                              <at name="height">14</at>
                              </object>
                             </at>
                            </object>
@@ -1095,22 +1091,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Name:</at>
-                              <at name="height">14</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">1</at>
-                                <at name="size">11</at>
-                               </object>
-                              </at>
-                              <at name="width">36</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1131,6 +1111,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">35</at>
+                              <at name="name"/>
+                              <at name="text">Name:</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">1</at>
+                                <at name="size">11</at>
+                               </object>
+                              </at>
+                              <at name="height">14</at>
                              </object>
                             </at>
                            </object>
@@ -1162,9 +1158,6 @@
                             <at name="classname">javax.swing.JTextField</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="height">19</at>
-                              <at name="width">902</at>
-                              <at name="name">@urlName</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1185,6 +1178,9 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="name">@urlName</at>
+                              <at name="width">1125</at>
+                              <at name="height">20</at>
                              </object>
                             </at>
                            </object>
@@ -1216,22 +1212,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">(e.g. My Campaign Images)</at>
-                              <at name="height">14</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">2</at>
-                                <at name="size">11</at>
-                               </object>
-                              </at>
-                              <at name="width">902</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1252,6 +1232,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">1125</at>
+                              <at name="name"/>
+                              <at name="text">(e.g. My Campaign Images)</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">2</at>
+                                <at name="size">11</at>
+                               </object>
+                              </at>
+                              <at name="height">14</at>
                              </object>
                             </at>
                            </object>
@@ -1266,7 +1262,17 @@
                        <at name="classname">com.jeta.forms.gui.form.GridView</at>
                        <at name="properties">
                         <object classname="com.jeta.forms.store.support.PropertyMap">
-                         <at name="name"></at>
+                         <at name="border">
+                          <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                           <super classname="com.jeta.forms.store.properties.BorderProperty">
+                            <at name="name">border</at>
+                           </super>
+                           <at name="borders">
+                            <object classname="java.util.LinkedList"/>
+                           </at>
+                          </object>
+                         </at>
+                         <at name="name"/>
                          <at name="fill">
                           <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                            <at name="name">fill</at>
@@ -1307,16 +1313,6 @@
                               </object>
                              </at>
                             </object>
-                           </at>
-                          </object>
-                         </at>
-                         <at name="border">
-                          <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                           <super classname="com.jeta.forms.store.properties.BorderProperty">
-                            <at name="name">border</at>
-                           </super>
-                           <at name="borders">
-                            <object classname="java.util.LinkedList"/>
                            </at>
                           </object>
                          </at>
@@ -1382,14 +1378,13 @@
                  <at name="value">
                   <object classname="com.jeta.forms.store.properties.TabProperty">
                    <at name="name">tab</at>
-                   <at name="title"></at>
                    <at name="icon">
                     <object classname="com.jeta.forms.store.properties.IconProperty">
                      <at name="embedded">false</at>
-                     <at name="path">net/rptools/maptool/client/image/rptools_icon.png</at>
+                     <at name="path">net\rptools\maptool\client\image\rptools_icon.png</at>
                      <at name="description">rptools_icon.png</at>
-                     <at name="width">64</at>
-                     <at name="height">64</at>
+                     <at name="width">16</at>
+                     <at name="height">16</at>
                     </object>
                    </at>
                    <at name="form">
@@ -1408,7 +1403,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.1433844202</at>
+                     <at name="id">embedded.170272017</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -1437,22 +1432,6 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">RPTools Library</at>
-                              <at name="height">17</at>
-                              <at name="font">
-                               <object classname="com.jeta.forms.store.properties.FontProperty">
-                                <at name="family">Tahoma</at>
-                                <at name="style">1</at>
-                                <at name="size">14</at>
-                               </object>
-                              </at>
-                              <at name="width">958</at>
-                              <at name="name"></at>
-                              <at name="fill">
-                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                <at name="name">fill</at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1473,6 +1452,22 @@
                                 </at>
                                </object>
                               </at>
+                              <at name="width">1180</at>
+                              <at name="name"/>
+                              <at name="text">RPTools Library</at>
+                              <at name="fill">
+                               <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                <at name="name">fill</at>
+                               </object>
+                              </at>
+                              <at name="font">
+                               <object classname="com.jeta.forms.store.properties.FontProperty">
+                                <at name="family">Tahoma</at>
+                                <at name="style">1</at>
+                                <at name="size">14</at>
+                               </object>
+                              </at>
+                              <at name="height">17</at>
                              </object>
                             </at>
                            </object>
@@ -1498,49 +1493,12 @@
                            <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
                           </super>
                           <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-                          <at name="beanclass">javax.swing.JList</at>
+                          <at name="beanclass">javax.swing.JTable</at>
                           <at name="beanproperties">
                            <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-                            <at name="classname">javax.swing.JList</at>
+                            <at name="classname">javax.swing.JTable</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="scrollableTracksViewportWidth">true</at>
-                              <at name="height">518</at>
-                              <at name="items">
-                               <object classname="com.jeta.forms.store.properties.ItemsProperty">
-                                <at name="name">items</at>
-                               </object>
-                              </at>
-                              <at name="width">955</at>
-                              <at name="name">@rptoolsList</at>
-                              <at name="scollBars">
-                               <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
-                                <at name="name">scollBars</at>
-                                <at name="verticalpolicy">20</at>
-                                <at name="horizontalpolicy">31</at>
-                                <at name="scrollname"></at>
-                                <at name="border">
-                                 <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                                  <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                   <at name="name">border</at>
-                                  </super>
-                                  <at name="borders">
-                                   <object classname="java.util.LinkedList">
-                                    <item >
-                                     <at name="value">
-                                      <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                                       <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                        <at name="name">border</at>
-                                       </super>
-                                      </object>
-                                     </at>
-                                    </item>
-                                   </object>
-                                  </at>
-                                 </object>
-                                </at>
-                               </object>
-                              </at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1548,20 +1506,6 @@
                                 </super>
                                 <at name="borders">
                                  <object classname="java.util.LinkedList">
-                                  <item >
-                                   <at name="value">
-                                    <object classname="com.jeta.forms.store.properties.EmptyBorderProperty">
-                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                      <at name="name">border</at>
-                                      <at name="title"></at>
-                                     </super>
-                                     <at name="top">5</at>
-                                     <at name="left">5</at>
-                                     <at name="bottom">5</at>
-                                     <at name="right">5</at>
-                                    </object>
-                                   </at>
-                                  </item>
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
@@ -1575,7 +1519,16 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="scrollableTracksViewportHeight">true</at>
+                              <at name="name">@rptoolsList</at>
+                              <at name="width">1178</at>
+                              <at name="scollBars">
+                               <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
+                                <at name="name">scollBars</at>
+                                <at name="verticalpolicy">20</at>
+                                <at name="horizontalpolicy">30</at>
+                               </object>
+                              </at>
+                              <at name="height">32</at>
                              </object>
                             </at>
                            </object>
@@ -1590,7 +1543,17 @@
                        <at name="classname">com.jeta.forms.gui.form.GridView</at>
                        <at name="properties">
                         <object classname="com.jeta.forms.store.support.PropertyMap">
-                         <at name="name"></at>
+                         <at name="border">
+                          <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                           <super classname="com.jeta.forms.store.properties.BorderProperty">
+                            <at name="name">border</at>
+                           </super>
+                           <at name="borders">
+                            <object classname="java.util.LinkedList"/>
+                           </at>
+                          </object>
+                         </at>
+                         <at name="name"/>
                          <at name="fill">
                           <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                            <at name="name">fill</at>
@@ -1631,16 +1594,6 @@
                               </object>
                              </at>
                             </object>
-                           </at>
-                          </object>
-                         </at>
-                         <at name="border">
-                          <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                           <super classname="com.jeta.forms.store.properties.BorderProperty">
-                            <at name="name">border</at>
-                           </super>
-                           <at name="borders">
-                            <object classname="java.util.LinkedList"/>
                            </at>
                           </object>
                          </at>
@@ -1694,7 +1647,9 @@
               </at>
              </object>
             </at>
+            <at name="width">1277</at>
             <at name="tabCount">3</at>
+            <at name="height">863</at>
            </object>
           </at>
          </object>
@@ -1709,7 +1664,17 @@
      <at name="classname">com.jeta.forms.gui.form.GridView</at>
      <at name="properties">
       <object classname="com.jeta.forms.store.support.PropertyMap">
-       <at name="name"></at>
+       <at name="border">
+        <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+         <super classname="com.jeta.forms.store.properties.BorderProperty">
+          <at name="name">border</at>
+         </super>
+         <at name="borders">
+          <object classname="java.util.LinkedList"/>
+         </at>
+        </object>
+       </at>
+       <at name="name"/>
        <at name="fill">
         <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
          <at name="name">fill</at>
@@ -1739,16 +1704,6 @@
             </object>
            </at>
           </object>
-         </at>
-        </object>
-       </at>
-       <at name="border">
-        <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-         <super classname="com.jeta.forms.store.properties.BorderProperty">
-          <at name="name">border</at>
-         </super>
-         <at name="borders">
-          <object classname="java.util.LinkedList"/>
          </at>
         </object>
        </at>

--- a/maptool/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/maptool/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1256,6 +1256,9 @@ dialog.addresource.warn.couldnotload=Error while downloading library
 dialog.addresource.warn.badpath=Invalid path
 dialog.addresource.warn.musthavename=Must supply a name for the library
 dialog.addresource.warn.mustselectone=Must select at least one library to download
+dialog.addresource.artist=Artist
+dialog.addresource.artpackname=Name
+dialog.addresource.size=Size
 
 dialog.screenshot.error.failedExportingImage=Failed to export image.
 dialog.screenshot.error.failedImageGeneration=Failed to generate image.

--- a/maptool/src/main/resources/net/rptools/maptool/language/i18n_de.properties
+++ b/maptool/src/main/resources/net/rptools/maptool/language/i18n_de.properties
@@ -1196,6 +1196,9 @@ dialog.addresource.warn.couldnotload=Fehler beim Herunterladen der Bibliothek
 dialog.addresource.warn.badpath=Ung\u00fcltiger Pfad
 dialog.addresource.warn.musthavename=Es mu\u00df ein Name f\u00fcr die Bibliothek angegeben werden
 dialog.addresource.warn.mustselectone=Es mu\u00df mindestens eine Bibliothek zum Herunterladen ausgew\u00e4hlt werden
+dialog.addresource.artist=K\u00fcnstler
+dialog.addresource.artpackname=Name
+dialog.addresource.size=Gr\u00f6sse
 
 dialog.screenshot.error.failedExportingImage=Bildexport fehlgeschlagen.
 dialog.screenshot.error.failedImageGeneration=Bilderstellung fehlgeschlagen.


### PR DESCRIPTION
This addresses issue #185 
To accomplish sorting by author as well as by name, a new format for the listArtPacks file on the server is required. I recommend just using a second file, next to the "old" format and changing the `private static final String LIBRARY_LIST_URL` variable in `net.rptools.maptool.client.ui.AddResourceDialog` to point to the new index file. A gist, containing the new index file format can be found [here](https://gist.github.com/Mornielome/7fc77a142ee3e207fa48dbfa33cf2c8d)

Regarding a lot of the "changed" code that looks exactly the same: There seem to have been a lot of mixed tabs and spaces for indentation in the file. I settled with tabs, but if this is wrong I can easily change this to be spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/199)
<!-- Reviewable:end -->
