### PR TITLE
Changes to get the Java FX up and running in Mac OS

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -10,8 +10,6 @@ package net.rptools.maptool.client.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
-import java.awt.Desktop;
 import java.awt.EventQueue;
 import java.awt.GraphicsConfiguration;
 import java.awt.GridBagConstraints;
@@ -20,13 +18,6 @@ import java.awt.GridLayout;
 import java.awt.IllegalComponentStateException;
 import java.awt.Image;
 import java.awt.Rectangle;
-import java.awt.desktop.AboutEvent;
-import java.awt.desktop.AboutHandler;
-import java.awt.desktop.PreferencesEvent;
-import java.awt.desktop.PreferencesHandler;
-import java.awt.desktop.QuitEvent;
-import java.awt.desktop.QuitHandler;
-import java.awt.desktop.QuitResponse;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -49,7 +40,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
-import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
@@ -59,7 +49,6 @@ import javax.swing.JLabel;
 import javax.swing.JLayeredPane;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -74,7 +63,6 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
-import javax.xml.parsers.ParserConfigurationException;
 
 import net.rptools.lib.AppEvent;
 import net.rptools.lib.AppEventListener;
@@ -87,13 +75,11 @@ import net.rptools.lib.swing.PositionalLayout;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.lib.swing.preference.WindowPreferences;
 import net.rptools.maptool.client.AppActions;
-import net.rptools.maptool.client.AppActions.ClientAction;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.AppUtil;
-import net.rptools.maptool.client.ServerDisconnectHandler;
 import net.rptools.maptool.client.swing.AppHomeDiskSpaceStatusBar;
 import net.rptools.maptool.client.swing.AssetCacheStatusBar;
 import net.rptools.maptool.client.swing.CoordinateStatusBar;
@@ -142,19 +128,17 @@ import net.rptools.maptool.model.drawing.Pen;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool_fx.MapTool;
 
+import net.rptools.maptool_fx.stub.DockingManagerStub;
 import org.apache.commons.collections.map.LinkedMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.xml.sax.SAXException;
 
-import com.jidesoft.docking.DefaultDockableHolder;
 import com.jidesoft.docking.DockableFrame;
 
-import javafx.scene.control.ButtonType;
 
 /**
  */
-public class MapToolFrame extends DefaultDockableHolder implements WindowListener, AppEventListener {
+public class MapToolFrame extends JFrame implements WindowListener, AppEventListener {
 	private static final Logger log = LogManager.getLogger(MapToolFrame.class);
 	// private static final String INITIAL_LAYOUT_XML = "net/rptools/maptool/client/ui/ilayout.xml";
 	private static final String MAPTOOL_LOGO_IMAGE = "net/rptools/maptool/client/image/maptool-logo.png";
@@ -871,6 +855,10 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
 	public void hideCommandPanel() {
 		getDockingManager().hideFrame(MTFrame.CHAT.name());
+	}
+
+	public DockingManagerStub getDockingManager() {
+		return new DockingManagerStub();
 	}
 
 	public ColorPicker getColorPicker() {

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
@@ -264,7 +264,9 @@ public class AssetPanel extends JComponent {
 			thumbnailPreviewSlider.setOrientation(SwingConstants.VERTICAL);
 			thumbnailPreviewSlider.setToolTipText(I18N.getString("panel.Asset.ImageModel.slider.toolTip"));
 
-			thumbnailPreviewSlider.setUI(new MetalSliderUI() {
+			// TODO: Remove
+			//  MetalSliderUI has a problem with unset default value under Mac OS
+			/*thumbnailPreviewSlider.setUI(new MetalSliderUI() {
 				protected void scrollDueToClickInTrack(int direction) {
 					int value = thumbnailPreviewSlider.getValue();
 
@@ -275,7 +277,7 @@ public class AssetPanel extends JComponent {
 					}
 					thumbnailPreviewSlider.setValue(value);
 				}
-			});
+			});*/
 
 			thumbnailPreviewSlider.addChangeListener(new ChangeListener() {
 				@Override

--- a/src/main/java/net/rptools/maptool_fx/stub/DockingManagerStub.java
+++ b/src/main/java/net/rptools/maptool_fx/stub/DockingManagerStub.java
@@ -1,0 +1,58 @@
+package net.rptools.maptool_fx.stub;
+
+import com.jidesoft.docking.DockableFrame;
+import javafx.scene.control.Alert;
+import net.rptools.maptool.client.ui.htmlframe.HTMLFrame;
+
+import java.awt.*;
+
+public class DockingManagerStub {
+    public void hideFrame(String name) {
+        Alert dialog = new Alert(Alert.AlertType.INFORMATION);
+        dialog.setTitle("Docking Manager Stub");
+        dialog.setHeaderText("DockingManagerStub.hideFrame()");
+        dialog.setContentText("Frame Name = " + name);
+        dialog.showAndWait();
+    }
+
+    public void showFrame(String name) {
+        Alert dialog = new Alert(Alert.AlertType.INFORMATION);
+        dialog.setTitle("Docking Manager Stub");
+        dialog.setHeaderText("DockingManagerStub.showFrame()");
+        dialog.setContentText("Frame Name = " + name);
+        dialog.showAndWait();
+    }
+
+    public void resetToDefault() {
+        Alert dialog = new Alert(Alert.AlertType.INFORMATION);
+        dialog.setTitle("Docking Manager Stub");
+        dialog.setHeaderText("DockingManagerStub.resetToDefault()");
+        dialog.showAndWait();
+    }
+
+    public void addFrame(HTMLFrame htmlFrame) {
+        Alert dialog = new Alert(Alert.AlertType.INFORMATION);
+        dialog.setTitle("Docking Manager Stub");
+        dialog.setHeaderText("DockingManagerStub.addFrame()");
+        dialog.setContentText("HTML Frame Name = " + htmlFrame.getName());
+        dialog.showAndWait();
+    }
+
+    public void floatFrame(String key, Rectangle rect, boolean b) {
+        Alert dialog = new Alert(Alert.AlertType.INFORMATION);
+        dialog.setTitle("Docking Manager Stub");
+        dialog.setHeaderText("DockingManagerStub.floatFrame()");
+        dialog.setContentText("key = " + key);
+        dialog.showAndWait();
+    }
+
+    public DockableFrame getFrame(String name) {
+        Alert dialog = new Alert(Alert.AlertType.INFORMATION);
+        dialog.setTitle("Docking Manager Stub");
+        dialog.setHeaderText("DockingManagerStub.getFrame()");
+        dialog.setContentText("Name = " + name);
+        dialog.showAndWait();
+
+        return null;
+    }
+}


### PR DESCRIPTION
**Changes to get the Java FX up and running in Mac OS**

JIDE DockManager fails on Mac OS as there is no WindowLookAndFeel class available, so MapToolFrame no longer extends JIDE DockingManager. All calls to DockingManager class are now routed to a temporary stub class which will pop up a dialog as all this functionality will be replaced as part of the JavaFX port anyway.

Also removed the MetalSliderUI look and feel for the slider in the AssetPanel as this causes a null pointer violation under Mac OS as the apple settings for look and feel do not provide all the required default values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/215)
<!-- Reviewable:end -->
