### PR TITLE
Nearest vertex from nerps

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
@@ -238,6 +238,10 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
 			return;
 		}
 		drawable.setLayer(selectedLayer);
+		if (MapTool.getPlayer().isGM())
+			drawable.setLayer(selectedLayer);
+		else
+			drawable.setLayer(Layer.TOKEN);
 
 		// Send new textures
 		MapToolUtil.uploadTexture(pen.getPaint());

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -31,6 +31,16 @@ import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.client.walker.astar.AStarHorizHexEuclideanWalker;
 import net.rptools.maptool.model.TokenFootprint.OffsetTranslator;
 
+/*
+ * @formatter:off
+ * Horizontal Hex grids produce rows of hexes
+ * and have their points at the top
+ *  /\ /\ /\ /\ /\ /\
+ * |  |  |  |  |  |  |
+ *  \/ \/ \/ \/ \/ \/
+ *  
+ * @formatter:on
+ */
 public class HexGridHorizontal extends HexGrid {
 
 	/*
@@ -235,4 +245,22 @@ public class HexGridHorizontal extends HexGrid {
 	protected OffsetTranslator getOffsetTranslator() {
 		return OFFSET_TRANSLATOR;
 	}
+	
+  /**
+   * Returns the cell centre as well as nearest vertex
+   */
+	@Override
+	public ZonePoint getNearestVertex(ZonePoint point) {
+	  double heightHalf = getURadius() / 2;
+	  //
+	  double isoX = ((point.x - getOffsetX()) / getVRadius() + (point.y - getOffsetY()) / heightHalf) / 2;
+	  double isoY = ((point.y - getOffsetY()) / heightHalf - (point.x - getOffsetX()) / getVRadius()) / 2;
+	  int newX = (int) Math.floor(isoX);
+	  int newY = (int) Math.floor(isoY);
+	  //
+	  double mapX = (newX - newY) * getVRadius();
+	  double mapY = ((newX + newY) * heightHalf) + heightHalf;
+	  return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
+	}
+
 }

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -29,6 +29,18 @@ import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.client.walker.astar.AStarVertHexEuclideanWalker;
 import net.rptools.maptool.model.TokenFootprint.OffsetTranslator;
 
+/*
+ * @formatter:off
+ * Vertical Hex grids produce columns of hexes
+ * and have their points at the side
+ *  \_/ \
+ *  / \_/
+ *  \_/ \
+ *  / \_/
+ *  \_/ \
+ *  
+ * @formatter:on
+ */
 public class HexGridVertical extends HexGrid {
 
 	private static final int[] ALL_ANGLES = new int[] { -150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180 };
@@ -206,4 +218,22 @@ public class HexGridVertical extends HexGrid {
 	protected OffsetTranslator getOffsetTranslator() {
 		return OFFSET_TRANSLATOR;
 	}
+	
+  /**
+   * Returns the cell centre as well as nearest vertex
+   */
+	@Override
+	public ZonePoint getNearestVertex(ZonePoint point) {
+	  double heightHalf = getURadius() / 2;
+	  //
+	  double isoY = ((point.y - getOffsetY()) / getVRadius() + (point.x - getOffsetX()) / heightHalf) / 2;
+	  double isoX = ((point.x - getOffsetX()) / heightHalf - (point.y - getOffsetY()) / getVRadius()) / 2;
+	  int newX = (int) Math.floor(isoX);
+	  int newY = (int) Math.floor(isoY);
+	  //
+	  double mapY = (newY - newX) * getVRadius();
+	  double mapX = ((newX + newY) * heightHalf) + heightHalf;
+	  return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
+	}
+
 }


### PR DESCRIPTION
Repeat of RP 193 & 195
Adds nearest vertex function for hex grids to improve line drawing,
Prevents players drawing on any layer but token - issue 194

These were in the 1.4.1-dev-branch but missing from the Nerp branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/230)
<!-- Reviewable:end -->
