### PR TITLE
Added ability to insert newline into command text area Fixes #237

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -60,6 +60,7 @@ A new shift+ctrl+spacebar command along with a new pointer image is now availabl
 * New function exportData exportData(FilePath file, String data, boolean appendToFile) which saves string data to external file.
 * New function getEnvironmentVariable(String name), Returns the value stored in the Environment Variable.
 * New menu option added to the "Connections" window. Right clicking a player will offer a "Whisper" command that prepopulates the chat window with a whisper macro.  
+* [#237][i237] - Added support to use shift-enter to insert newlines into the command entry box (also known as the chat entry box)
 
 [i113]: https://github.com/JamzTheMan/MapTool/issues/113
 [i108]: https://github.com/JamzTheMan/MapTool/issues/108
@@ -101,3 +102,4 @@ A new shift+ctrl+spacebar command along with a new pointer image is now availabl
 [i54]: https://github.com/JamzTheMan/MapTool/issues/54
 [i59]: https://github.com/JamzTheMan/MapTool/issues/59
 [i125]: https://github.com/JamzTheMan/MapTool/issues/125
+[i237]: https://github.com/RPTools/maptool/issues/237

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1438,6 +1438,22 @@ public class AppActions {
 		}
 	};
 
+	/**
+	 * Action to insert a newline into the chat input field
+	 */
+	public static final String NEWLINE_COMMAND_ID = "action.newlineCommand";
+
+	public static final Action NEWLINE_COMMAND = new DefaultClientAction() {
+		{
+			init(NEWLINE_COMMAND_ID);
+		}
+
+		@Override
+		public void execute(ActionEvent e) {
+			MapTool.getFrame().getCommandPanel().insertNewline();
+		}
+	};
+
 	public static final Action ADJUST_GRID = new ZoneAdminClientAction() {
 		{
 			init("action.adjustGrid");

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -22,6 +22,7 @@ import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.KeyAdapter;
@@ -380,12 +381,14 @@ public class CommandPanel extends JPanel implements Observer {
 			actions.put(AppActions.CANCEL_COMMAND_ID, AppActions.CANCEL_COMMAND);
 			actions.put(AppActions.COMMAND_UP_ID, new CommandHistoryUpAction());
 			actions.put(AppActions.COMMAND_DOWN_ID, new CommandHistoryDownAction());
+			actions.put(AppActions.NEWLINE_COMMAND_ID, AppActions.NEWLINE_COMMAND);
 
 			InputMap inputs = commandTextArea.getInputMap();
 			inputs.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), AppActions.CANCEL_COMMAND_ID);
 			inputs.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), AppActions.COMMIT_COMMAND_ID);
 			inputs.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), AppActions.COMMAND_UP_ID);
 			inputs.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), AppActions.COMMAND_DOWN_ID);
+			inputs.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK), AppActions.NEWLINE_COMMAND_ID);
 
 			// Resize on demand
 			MapTool.getEventDispatcher().addListener(MapTool.PreferencesEvent.Changed, new AppEventListener() {
@@ -479,7 +482,7 @@ public class CommandPanel extends JPanel implements Observer {
 			closeDivCount++;
 		}
 		if (closeDivCount > divCount) {
-			MapTool.addServerMessage(TextMessage.me(null, "You have too many &lt;/div&gt;."));
+			MapTool.addServerMessage(TextMessage.me(null, "Unexpected &lt;/div&gt; tag without matching &lt;div&gt;."));
 			commandTextArea.setText("");
 			return;
 		}
@@ -503,6 +506,14 @@ public class CommandPanel extends JPanel implements Observer {
 		commandTextArea.setText("");
 		validate();
 		MapTool.getFrame().hideCommandPanel();
+	}
+
+	/**
+	 * Inserts a newline into the chat input box.
+	 */
+	public void insertNewline() {
+		String text = commandTextArea.getText();
+		commandTextArea.setText(text + "\n");
 	}
 
 	public void startMacro() {


### PR DESCRIPTION
Added the ability to use shift-enter to insert newlines into the command text area.

Also changed an error message to be clearer.

Fixes #237 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/236)
<!-- Reviewable:end -->
