### PR TITLE
Multiline and bugs

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -87,8 +87,11 @@ public class MapToolVariableResolver extends MapVariableResolver {
 
 	private Token tokenInContext;
 
+	private boolean autoPrompt;
+
 	public MapToolVariableResolver(Token tokenInContext) {
 		this.tokenInContext = tokenInContext;
+		autoPrompt = true;
 		// Set the default macro.args to "" so that it is always present.
 		try {
 			this.setVariable("macro.args", "");
@@ -129,6 +132,14 @@ public class MapToolVariableResolver extends MapVariableResolver {
 		for (Runnable r : delayedActionList) {
 			r.run();
 		}
+	}
+
+	public void setAutoPrompt(boolean value) {
+		autoPrompt = value;
+	}
+
+	public boolean getAutoPrompt() {
+		return autoPrompt;
 	}
 
 	@Override
@@ -214,7 +225,7 @@ public class MapToolVariableResolver extends MapVariableResolver {
 		}
 
 		// Prompt
-		if (result == null || mods == VariableModifiers.Prompt) {
+		if ((result == null && autoPrompt == true) || mods == VariableModifiers.Prompt) {
 			String DialogTitle = I18N.getText("lineParser.dialogTitleNoToken");
 			if (tokenInContext != null && tokenInContext.getGMName() != null && MapTool.getPlayer().isGM()) {
 				DialogTitle = I18N.getText("lineParser.dialogTitle", tokenInContext.getGMName());

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1533,25 +1533,30 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
 							int lineCount = 0;
 							for (String line : entry.getValue().split("\n")) {
-								// For each value, make the iterator need and stash data about it
-								AttributedString text = new AttributedString(line);
-								text.addAttribute(TextAttribute.FONT, font);
-								AttributedCharacterIterator paragraph = text.getIterator();
-								int paragraphStart = paragraph.getBeginIndex();
-								int paragraphEnd = paragraph.getEndIndex();
-								// Make and initialize LineBreakMeasurer
-								LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
-								lineMeasurer.setPosition(paragraphStart);
-								// Get each line from the measurer and find the widest one;
-								while (lineMeasurer.getPosition() < paragraphEnd) {
-									TextLayout layout = lineMeasurer.nextLayout(layoutWidth);
-									lineLayouts.add(layout);
-									height += rowHeight;
-									float tmpValueWidth = layout.getPixelBounds(null, 0, 0).width;
-									lineCount++;
-									if (valueWidth < 0 || tmpValueWidth > valueWidth) {
-										valueWidth = tmpValueWidth;
+								if (line.length() > 0) {
+									// For each value, make the iterator need and stash data about it
+									AttributedString text = new AttributedString(line);
+									text.addAttribute(TextAttribute.FONT, font);
+									AttributedCharacterIterator paragraph = text.getIterator();
+									int paragraphStart = paragraph.getBeginIndex();
+									int paragraphEnd = paragraph.getEndIndex();
+									// Make and initialize LineBreakMeasurer
+									LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
+									lineMeasurer.setPosition(paragraphStart);
+									// Get each line from the measurer and find the widest one;
+									while (lineMeasurer.getPosition() < paragraphEnd) {
+										TextLayout layout = lineMeasurer.nextLayout(layoutWidth);
+										lineLayouts.add(layout);
+										height += rowHeight;
+										float tmpValueWidth = layout.getPixelBounds(null, 0, 0).width;
+										lineCount++;
+										if (valueWidth < 0 || tmpValueWidth > valueWidth) {
+											valueWidth = tmpValueWidth;
+										}
 									}
+								} else {
+									height += rowHeight;
+									lineCount++;
 								}
 							}
 							propertyLineCount.put(entry.getKey(), lineCount);
@@ -1592,19 +1597,25 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 
 							// Draw Value
 							for (String line : entry.getValue().split("\n")) {
-								// For each value, make the iterator need and stash data about it
-								AttributedString text = new AttributedString(line);
-								text.addAttribute(TextAttribute.FONT, font);
-								AttributedCharacterIterator paragraph = text.getIterator();
-								int paragraphStart = paragraph.getBeginIndex();
-								int paragraphEnd = paragraph.getEndIndex();
-								// Make and initialize LineBreakMeasurer
-								LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
-								lineMeasurer.setPosition(paragraphStart);
-								// Get each line from the measurer and find the widest one;
-								while (lineMeasurer.getPosition() < paragraphEnd) {
-									TextLayout layout = lineMeasurer.nextLayout(layoutWidth);
-									layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getPixelBounds(null, 0, 0).width, y);
+								if(line.length() > 0) {
+									// For each value, make the iterator need and stash data about it
+									AttributedString text = new AttributedString(line);
+									text.addAttribute(TextAttribute.FONT, font);
+									AttributedCharacterIterator paragraph = text.getIterator();
+									int paragraphStart = paragraph.getBeginIndex();
+									int paragraphEnd = paragraph.getEndIndex();
+									// Make and initialize LineBreakMeasurer
+									LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
+									lineMeasurer.setPosition(paragraphStart);
+									// Get each line from the measurer and find the widest one;
+									while (lineMeasurer.getPosition() < paragraphEnd) {
+										TextLayout layout = lineMeasurer.nextLayout(layoutWidth);
+										layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getPixelBounds(null, 0, 0).width, y);
+										y += rowHeight;
+									}
+								}
+								else
+								{
 									y += rowHeight;
 								}
 							}

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -137,6 +137,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 	private Token tokenOnStatSheet;
 
 	private static int PADDING = 7;
+	private static int STATSHEET_EXTERIOR_PADDING = 5;
 
 	// Offset from token's X,Y when dragging. Values are in zone coordinates.
 	private int dragOffsetX;
@@ -1474,8 +1475,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 				int bm = AppStyle.miniMapBorder.getBottomMargin();
 
 				// Stats
-				//My math is off here somewhere or I don't undestand something about the viewport. My math says I should only need to subtract off PADDING * 3, but that wasn't working. I subtract off PADDING * 7 to correct, but it's a hack.
-				int maxStatsWidth = viewSize.width - lm - rm - imgSize.width - PADDING * 7;
+				int maxStatsWidth = viewSize.width - lm - rm * 2 - imgSize.width - PADDING * 3 - STATSHEET_EXTERIOR_PADDING * 2;
 				Map<String, String> propertyMap = new LinkedHashMap<String, String>();
 				Map<String, Integer> propertyLineCount = new LinkedHashMap<String, Integer>();
 				LinkedList<TextLayout> lineLayouts = new LinkedList<TextLayout>();
@@ -1513,12 +1513,12 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 					FontMetrics valueFM = g.getFontMetrics(font);
 					FontMetrics keyFM = g.getFontMetrics(boldFont);
 					int rowHeight = Math.max(valueFM.getHeight(), keyFM.getHeight());
+					int keyWidth = -1;
+					float valueWidth = -1;
 					if (!propertyMap.isEmpty()) {
 						// Figure out size requirements
 						//int height = propertyMap.size() * (rowHeight + PADDING);
 						int height = 0;
-						int keyWidth = -1;
-						float valueWidth = -1;
 						//Iterate over keys to reserve room for key column
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
 							int tempKeyWidth = SwingUtilities.computeStringWidth(keyFM, entry.getKey());
@@ -1600,7 +1600,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 								lineMeasurer.setPosition(paragraphStart);
 								//Get each line from the measurer and find the widest one;
 								while (lineMeasurer.getPosition() < paragraphEnd) {
-									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth);
+									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth - keyWidth);
 									layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getAdvance(), y);
 									y += rowHeight;
 								}
@@ -1641,7 +1641,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 
 		// Jamz: Statsheet was still showing on drag, added other tests to hide statsheet as well
 		if (statSheet != null && !isDraggingToken && !mouseButtonDown) {
-			g.drawImage(statSheet, 5, viewSize.height - statSheet.getHeight() - 5, this);
+			g.drawImage(statSheet, STATSHEET_EXTERIOR_PADDING, viewSize.height - statSheet.getHeight() - STATSHEET_EXTERIOR_PADDING, this);
 		}
 
 		// Hovers

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -29,13 +29,21 @@ import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.awt.font.FontRenderContext;
+import java.awt.font.LineBreakMeasurer;
+import java.awt.font.TextAttribute;
+import java.awt.font.TextLayout;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.io.IOException;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1378,6 +1386,28 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 		}
 	}
 
+	/*class WrappedText
+	{
+		int lineCount;
+		String[] lines;
+		stringWidth[] widths;
+	}*/
+
+	/*private WrappedText wrapText(string text)
+	{
+		StringBuilder currentLine;
+		WrappedText wrappedText = new WrappedText();
+		for(int I = 0;I<text.length();I++){
+			if(text.charAt(I) == '\n'){
+				wrappedText.lines 
+			}
+				
+				currentLine.append(text.charAt(I));
+			
+		}
+		String[] firstPass = text.split('\n');
+	}*/
+
 	// //
 	// ZoneOverlay
 	/*
@@ -1388,6 +1418,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 	public void paintOverlay(final ZoneRenderer renderer, Graphics2D g) {
 		Dimension viewSize = renderer.getSize();
 		renderer.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		FontRenderContext fontRenderContext = g.getFontRenderContext();
 
 		Composite composite = g.getComposite();
 		if (selectionBoundBox != null) {
@@ -1436,8 +1467,18 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 					SwingUtil.constrainTo(imgSize, AppPreferences.getPortraitSize());
 				}
 
+				Dimension statSize = null;
+				int rm = AppStyle.miniMapBorder.getRightMargin();
+				int lm = AppStyle.miniMapBorder.getLeftMargin();
+				int tm = AppStyle.miniMapBorder.getTopMargin();
+				int bm = AppStyle.miniMapBorder.getBottomMargin();
+
 				// Stats
+				//My math is off here somewhere or I don't undestand something about the viewport. My math says I should only need to subtract off PADDING * 3, but that wasn't working. I subtract off PADDING * 7 to correct, but it's a hack.
+				int maxStatsWidth = viewSize.width - lm - rm - imgSize.width - PADDING * 7;
 				Map<String, String> propertyMap = new LinkedHashMap<String, String>();
+				Map<String, Integer> propertyLineCount = new LinkedHashMap<String, Integer>();
+				LinkedList<TextLayout> lineLayouts = new LinkedList<TextLayout>();
 				if (AppPreferences.getShowStatSheet()) {
 					for (TokenProperty property : MapTool.getCampaign().getTokenPropertyList(tokenUnderMouse.getPropertyType())) {
 						if (property.isShowOnStatSheet()) {
@@ -1467,11 +1508,6 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 						}
 					}
 				}
-				Dimension statSize = null;
-				int rm = AppStyle.miniMapBorder.getRightMargin();
-				int lm = AppStyle.miniMapBorder.getLeftMargin();
-				int tm = AppStyle.miniMapBorder.getTopMargin();
-				int bm = AppStyle.miniMapBorder.getBottomMargin();
 				if (tokenUnderMouse.getPortraitImage() != null || !propertyMap.isEmpty()) {
 					Font font = AppStyle.labelFont;
 					FontMetrics valueFM = g.getFontMetrics(font);
@@ -1479,15 +1515,46 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 					int rowHeight = Math.max(valueFM.getHeight(), keyFM.getHeight());
 					if (!propertyMap.isEmpty()) {
 						// Figure out size requirements
-						int height = propertyMap.size() * (rowHeight + PADDING);
-						int width = -1;
+						//int height = propertyMap.size() * (rowHeight + PADDING);
+						int height = 0;
+						int keyWidth = -1;
+						float valueWidth = -1;
+						//Iterate over keys to reserve room for key column
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
-							int lineWidth = SwingUtilities.computeStringWidth(keyFM, entry.getKey()) + SwingUtilities.computeStringWidth(valueFM, "  " + entry.getValue());
-							if (width < 0 || lineWidth > width) {
-								width = lineWidth;
+							int tempKeyWidth = SwingUtilities.computeStringWidth(keyFM, entry.getKey());
+							if (keyWidth < 0 || tempKeyWidth > keyWidth) {
+								keyWidth = tempKeyWidth;
 							}
 						}
-						statSize = new Dimension(width + PADDING * 3, height);
+						//Iterate over values, break then into lines as necessary. Figure out longest value length.
+						for (Entry<String, String> entry : propertyMap.entrySet()) {
+							int lineCount = 0;
+							for (String line : entry.getValue().split("\n")) {
+								//For each value, make the iterator need and stash data about it
+								AttributedString text = new AttributedString(line);
+								text.addAttribute(TextAttribute.FONT, font);
+								AttributedCharacterIterator paragraph = text.getIterator();
+								int paragraphStart = paragraph.getBeginIndex();
+								int paragraphEnd = paragraph.getEndIndex();
+								//Make and initialize LineBreakMeasurer
+								LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
+								lineMeasurer.setPosition(paragraphStart);
+								//Get each line from the measurer and find the widest one;
+								while (lineMeasurer.getPosition() < paragraphEnd) {
+									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth - keyWidth);
+									lineLayouts.add(layout);
+									height += rowHeight;
+									float tmpValueWidth = layout.getAdvance();
+									lineCount++;
+									if (valueWidth < 0 || tmpValueWidth > valueWidth) {
+										valueWidth = tmpValueWidth;
+									}
+								}
+							}
+							propertyLineCount.put(entry.getKey(), lineCount);
+							height += PADDING;
+						}
+						statSize = new Dimension((int) (keyWidth + valueWidth + PADDING * 3), height);
 					}
 					// Create the space for the image
 					int width = imgSize.width + (statSize != null ? statSize.width + rm : 0) + lm + rm;
@@ -1511,19 +1578,40 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
 							// Box
 							statsG.setColor(new Color(249, 241, 230, 140));
-							statsG.fillRect(bounds.x, y - keyFM.getAscent(), bounds.width - PADDING / 2, rowHeight);
+							statsG.fillRect(bounds.x, y - keyFM.getAscent(), bounds.width - PADDING / 2, rowHeight * propertyLineCount.get(entry.getKey()));
 							statsG.setColor(new Color(175, 163, 149));
-							statsG.drawRect(bounds.x, y - keyFM.getAscent(), bounds.width - PADDING / 2, rowHeight);
+							statsG.drawRect(bounds.x, y - keyFM.getAscent(), bounds.width - PADDING / 2, rowHeight * propertyLineCount.get(entry.getKey()));
 
-							// Values
+							// Draw Key
 							statsG.setColor(Color.black);
 							statsG.setFont(boldFont);
 							statsG.drawString(entry.getKey(), bounds.x + PADDING * 2, y);
+
+							// Draw Value
+							for (String line : entry.getValue().split("\n")) {
+								//For each value, make the iterator need and stash data about it
+								AttributedString text = new AttributedString(line);
+								text.addAttribute(TextAttribute.FONT, font);
+								AttributedCharacterIterator paragraph = text.getIterator();
+								int paragraphStart = paragraph.getBeginIndex();
+								int paragraphEnd = paragraph.getEndIndex();
+								//Make and initialize LineBreakMeasurer
+								LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
+								lineMeasurer.setPosition(paragraphStart);
+								//Get each line from the measurer and find the widest one;
+								while (lineMeasurer.getPosition() < paragraphEnd) {
+									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth);
+									layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getAdvance(), y);
+									y += rowHeight;
+								}
+							}
+							/*
 							statsG.setFont(font);
 							int strw = SwingUtilities.computeStringWidth(valueFM, entry.getValue());
 							statsG.drawString(entry.getValue(), bounds.x + bounds.width - strw - PADDING, y);
+							*/
 
-							y += PADDING + rowHeight;
+							y += PADDING;
 						}
 					}
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1544,7 +1544,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth - keyWidth);
 									lineLayouts.add(layout);
 									height += rowHeight;
-									float tmpValueWidth = layout.getAdvance();
+									float tmpValueWidth = layout.getPixelBounds(null, 0, 0).width;
 									lineCount++;
 									if (valueWidth < 0 || tmpValueWidth > valueWidth) {
 										valueWidth = tmpValueWidth;
@@ -1601,7 +1601,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 								//Get each line from the measurer and find the widest one;
 								while (lineMeasurer.getPosition() < paragraphEnd) {
 									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth - keyWidth);
-									layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getAdvance(), y);
+									layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getPixelBounds(null, 0, 0).width, y);
 									y += rowHeight;
 								}
 							}

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1387,27 +1387,27 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 		}
 	}
 
-	/*class WrappedText
-	{
-		int lineCount;
-		String[] lines;
-		stringWidth[] widths;
-	}*/
+	// class WrappedText
+	// {
+	// int lineCount;
+	// String[] lines;
+	// stringWidth[] widths;
+	// }
 
-	/*private WrappedText wrapText(string text)
-	{
-		StringBuilder currentLine;
-		WrappedText wrappedText = new WrappedText();
-		for(int I = 0;I<text.length();I++){
-			if(text.charAt(I) == '\n'){
-				wrappedText.lines 
-			}
-				
-				currentLine.append(text.charAt(I));
-			
-		}
-		String[] firstPass = text.split('\n');
-	}*/
+	// private WrappedText wrapText(string text)
+	// {
+	// StringBuilder currentLine;
+	// WrappedText wrappedText = new WrappedText();
+	// for(int I = 0;I<text.length();I++){
+	// if(text.charAt(I) == '\n'){
+	// wrappedText.lines
+	// }
+	//
+	// currentLine.append(text.charAt(I));
+	//
+	// }
+	// String[] firstPass = text.split('\n');
+	// }
 
 	// //
 	// ZoneOverlay
@@ -1489,7 +1489,8 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 								continue;
 							}
 							MapToolVariableResolver resolver = new MapToolVariableResolver(tokenUnderMouse);
-							//TODO: is the double resolution of properties necessary here. I kept it, but it seems wasteful and I can't figure out any reason that the first resolution can't be used below.
+							// TODO: is the double resolution of properties necessary here. I kept it, but it seems wasteful and I can't figure out any reason that the first resolution can't be used
+							// below.
 							resolver.initialize();
 							resolver.setAutoPrompt(false);
 							Object propertyValue = tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
@@ -1515,33 +1516,35 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 					int rowHeight = Math.max(valueFM.getHeight(), keyFM.getHeight());
 					int keyWidth = -1;
 					float valueWidth = -1;
+					int layoutWidth = 1;
 					if (!propertyMap.isEmpty()) {
 						// Figure out size requirements
-						//int height = propertyMap.size() * (rowHeight + PADDING);
+						// int height = propertyMap.size() * (rowHeight + PADDING);
 						int height = 0;
-						//Iterate over keys to reserve room for key column
+						// Iterate over keys to reserve room for key column
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
 							int tempKeyWidth = SwingUtilities.computeStringWidth(keyFM, entry.getKey());
 							if (keyWidth < 0 || tempKeyWidth > keyWidth) {
 								keyWidth = tempKeyWidth;
 							}
 						}
-						//Iterate over values, break then into lines as necessary. Figure out longest value length.
+						layoutWidth = Math.max(1, maxStatsWidth - keyWidth);
+						// Iterate over values, break then into lines as necessary. Figure out longest value length.
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
 							int lineCount = 0;
 							for (String line : entry.getValue().split("\n")) {
-								//For each value, make the iterator need and stash data about it
+								// For each value, make the iterator need and stash data about it
 								AttributedString text = new AttributedString(line);
 								text.addAttribute(TextAttribute.FONT, font);
 								AttributedCharacterIterator paragraph = text.getIterator();
 								int paragraphStart = paragraph.getBeginIndex();
 								int paragraphEnd = paragraph.getEndIndex();
-								//Make and initialize LineBreakMeasurer
+								// Make and initialize LineBreakMeasurer
 								LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
 								lineMeasurer.setPosition(paragraphStart);
-								//Get each line from the measurer and find the widest one;
+								// Get each line from the measurer and find the widest one;
 								while (lineMeasurer.getPosition() < paragraphEnd) {
-									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth - keyWidth);
+									TextLayout layout = lineMeasurer.nextLayout(layoutWidth);
 									lineLayouts.add(layout);
 									height += rowHeight;
 									float tmpValueWidth = layout.getPixelBounds(null, 0, 0).width;
@@ -1589,27 +1592,26 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 
 							// Draw Value
 							for (String line : entry.getValue().split("\n")) {
-								//For each value, make the iterator need and stash data about it
+								// For each value, make the iterator need and stash data about it
 								AttributedString text = new AttributedString(line);
 								text.addAttribute(TextAttribute.FONT, font);
 								AttributedCharacterIterator paragraph = text.getIterator();
 								int paragraphStart = paragraph.getBeginIndex();
 								int paragraphEnd = paragraph.getEndIndex();
-								//Make and initialize LineBreakMeasurer
+								// Make and initialize LineBreakMeasurer
 								LineBreakMeasurer lineMeasurer = new LineBreakMeasurer(paragraph, BreakIterator.getLineInstance(), fontRenderContext);
 								lineMeasurer.setPosition(paragraphStart);
-								//Get each line from the measurer and find the widest one;
+								// Get each line from the measurer and find the widest one;
 								while (lineMeasurer.getPosition() < paragraphEnd) {
-									TextLayout layout = lineMeasurer.nextLayout(maxStatsWidth - keyWidth);
+									TextLayout layout = lineMeasurer.nextLayout(layoutWidth);
 									layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getPixelBounds(null, 0, 0).width, y);
 									y += rowHeight;
 								}
 							}
-							/*
-							statsG.setFont(font);
-							int strw = SwingUtilities.computeStringWidth(valueFM, entry.getValue());
-							statsG.drawString(entry.getValue(), bounds.x + bounds.width - strw - PADDING, y);
-							*/
+
+							// statsG.setFont(font);
+							// int strw = SwingUtilities.computeStringWidth(valueFM, entry.getValue());
+							// statsG.drawString(entry.getValue(), bounds.x + bounds.width - strw -PADDING, y);
 
 							y += PADDING;
 						}

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1597,7 +1597,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 
 							// Draw Value
 							for (String line : entry.getValue().split("\n")) {
-								if(line.length() > 0) {
+								if (line.length() > 0) {
 									// For each value, make the iterator need and stash data about it
 									AttributedString text = new AttributedString(line);
 									text.addAttribute(TextAttribute.FONT, font);
@@ -1613,9 +1613,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 										layout.draw(statsG, bounds.x + bounds.width - PADDING - layout.getPixelBounds(null, 0, 0).width, y);
 										y += rowHeight;
 									}
-								}
-								else
-								{
+								} else {
 									y += rowHeight;
 								}
 							}

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -61,6 +61,7 @@ import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ScreenPoint;
+import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.swing.HTMLPanelRenderer;
 import net.rptools.maptool.client.tool.LayerSelectionDialog.LayerSelectionListener;
 import net.rptools.maptool.client.ui.*;
@@ -1446,14 +1447,20 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 							if (property.isOwnerOnly() && !AppUtil.playerOwns(tokenUnderMouse)) {
 								continue;
 							}
-							Object propertyValue = tokenUnderMouse.getEvaluatedProperty(property.getName());
+							MapToolVariableResolver resolver = new MapToolVariableResolver(tokenUnderMouse);
+							//TODO: is the double resolution of properties necessary here. I kept it, but it seems wasteful and I can't figure out any reason that the first resolution can't be used below.
+							resolver.initialize();
+							resolver.setAutoPrompt(false);
+							Object propertyValue = tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
+							resolver.flush();
 							if (propertyValue != null) {
 								if (propertyValue.toString().length() > 0) {
 									String propName = property.getName();
 									if (property.getShortName() != null) {
 										propName = property.getShortName();
 									}
-									Object value = tokenUnderMouse.getEvaluatedProperty(property.getName());
+									Object value = tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
+                  resolver.flush();
 									propertyMap.put(propName, value != null ? value.toString() : "");
 								}
 							}

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1529,7 +1529,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 							}
 						}
 						layoutWidth = Math.max(1, maxStatsWidth - keyWidth);
-						// Iterate over values, break then into lines as necessary. Figure out longest value length.
+						// Iterate over values, break them into lines as necessary. Figure out longest value length.
 						for (Entry<String, String> entry : propertyMap.entrySet()) {
 							int lineCount = 0;
 							for (String line : entry.getValue().split("\n")) {

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1460,7 +1460,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 										propName = property.getShortName();
 									}
 									Object value = tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
-                  resolver.flush();
+									resolver.flush();
 									propertyMap.put(propName, value != null ? value.toString() : "");
 								}
 							}

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -80,6 +80,7 @@ import com.jidesoft.grid.AbstractPropertyTableModel;
 import com.jidesoft.grid.Property;
 import com.jidesoft.grid.PropertyPane;
 import com.jidesoft.grid.PropertyTable;
+import com.jidesoft.grid.MultilineStringCellEditor;
 import com.jidesoft.swing.CheckBoxListWithSelectable;
 import com.jidesoft.swing.DefaultSelectable;
 import com.jidesoft.swing.Selectable;
@@ -1371,6 +1372,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 			public EditTokenProperty(String key) {
 				super(key, key, String.class, (String) getPropertyTypeCombo().getSelectedItem());
 				this.key = key;
+				setCellEditor(new MultilineStringCellEditor());
 			}
 
 			@Override

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -150,7 +150,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 	}
 
 	public void initGMNotesTextArea() {
-		getGMNotesTextArea().addMouseListener(new MouseHandler(getGMNotesTextArea()));
+		if (MapTool.getPlayer().isGM())
+			getGMNotesTextArea().addMouseListener(new MouseHandler(getGMNotesTextArea()));
 		getComponent("@GMNotes").setEnabled(MapTool.getPlayer().isGM());
 	}
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -44,6 +44,7 @@ import net.rptools.lib.swing.SwingUtil;
 import net.rptools.lib.transferable.TokenTransferData;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.JSONMacroFunctions;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer.SelectionSet;
 import net.rptools.maptool.language.I18N;
@@ -1321,6 +1322,10 @@ public class Token extends BaseModel implements Cloneable {
 	}
 
 	public Object getEvaluatedProperty(String key) {
+		return getEvaluatedProperty(null, key);
+	}
+
+	public Object getEvaluatedProperty(MapToolVariableResolver resolver, String key) {
 		Object val = getProperty(key);
 		if (val == null) {
 			// Global default ?
@@ -1348,7 +1353,7 @@ public class Token extends BaseModel implements Cloneable {
 			if (log.isDebugEnabled()) {
 				log.debug("Evaluating property: '" + key + "' for token " + getName() + "(" + getId() + ")----------------------------------------------------------------------------------");
 			}
-			val = MapTool.getParser().parseLine(this, val.toString());
+			val = MapTool.getParser().parseLine(resolver, this, val.toString());
 		} catch (ParserException pe) {
 			// pe.printStackTrace();
 			val = val.toString();


### PR DESCRIPTION
Bugs:
Maptool won't throw up hundreds of errors dialogs or potentially crash when a calculated property encounters a unknown property.
"Send to..." is no longer available to players for GM notes

New Feature: Multiline properties
Statsheet now supports automatic word wrap at the edge of the zone rendering area.
Statsheet will also wrap properties at new lines.
Token property editor now has a button on the right side that opens up a multiline text editor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/246)
<!-- Reviewable:end -->
