### PR TITLE
Fixes #210 - Non-snap-to-grid Tokens have bad last path info

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -30,6 +30,7 @@ Bug Fixes
 * [#23][i23] - Fixed sendToBack & bringToFront macros broke states and bar changes in the macro. This was an OLD one going back to 1.3b63! You can now safely use these functions in your macro now!
 * [#30][i30] - Players see NPC movement when there are no lights no more! This was another old bug going back to 1.3b-something and only showed itself if you had NO lights (including personal lights, aka darkvision).
 * [#232][i232] - Mouse pointer incorrectly changing to Hand pointer was an oversight which has been corrected, hands down the best bug fix!
+* [#210][i210] - *Non-snap-to-grid Tokens have bad last path info* Tokens now walk the straight and narrow again, no more drunken paths shown.
 
 Enhancements
 -----
@@ -63,6 +64,7 @@ A new shift+ctrl+spacebar command along with a new pointer image is now availabl
 * [#239][i239] - MapToolScriptTokenMaker now handles function names with . notation and dynamically pulls in all functions names. TokenMakerMaker no longer needs to be ran upon changes to MTScript.
 * [#240][i240] - Macro Editor now has Auto-Completion for macro functions! A brief description and summary can be displayed (these will be added as time permits)
 
+[i210]: https://github.com/RPTools/maptool/issues/210
 [i113]: https://github.com/JamzTheMan/MapTool/issues/113
 [i108]: https://github.com/JamzTheMan/MapTool/issues/108
 [i92]: https://github.com/JamzTheMan/MapTool/issues/92

--- a/src/main/java/net/rptools/maptool/model/Path.java
+++ b/src/main/java/net/rptools/maptool/model/Path.java
@@ -168,72 +168,100 @@ public class Path<T extends AbstractPoint> {
       }
 
     } else {
-      // Lee: solo movement
-      if (keyToken.isSnapToGrid()) {
-        for (T cp : cellList) {
-          T np = (T) cp.clone();
-          np.x -= cellOffsetX;
-          np.y -= cellOffsetY;
-          path.addPathCell(np);
-        }
-
-        for (T cp : waypointList) {
-          T np = (T) cp.clone();
-          np.x -= cellOffsetX;
-          np.y -= cellOffsetY;
-          path.addWayPoint(np);
-        }
-      } else {
-        Path<CellPoint> reflectedPath = new Path<CellPoint>();
-        NaiveWalker nw = new NaiveWalker(zone);
-        Path<ZonePoint> wpl = set.getGridlessPath();
-
-        if (cellList.size() > 2) {
-
-          CellPoint prevPoint = grid.convert(new ZonePoint(startPoint.x, startPoint.y));
-          CellPoint terminalPoint = grid.convert(endPoint);
-          CellPoint convPoint;
-
-          // Lee: since we already have the start point
-          ((List<T>) cellList).remove(0);
-
-          for (T p : cellList) {
-            convPoint = grid.convert((ZonePoint) p);
-            reflectedPath.addAllPathCells(nw.calculatePath(prevPoint, convPoint));
-            prevPoint = convPoint;
-          }
-
-        } else {
-          reflectedPath.addAllPathCells(
-              nw.calculatePath(grid.convert(startPoint), grid.convert(endPoint)));
-        }
-
-        ZonePoint buildVal = startPoint;
-        Path<ZonePoint> processPath = new Path<ZonePoint>();
-
-        for (CellPoint p : reflectedPath.getCellPath()) {
-          ZonePoint tempPoint = (ZonePoint) buildVal.clone();
-          processPath.addPathCell(tempPoint);
-
-          if (buildVal.x < endPoint.x) buildVal.x += 100;
-          else if (buildVal.x > endPoint.x) buildVal.x -= 100;
-          if (buildVal.y < endPoint.y) buildVal.y += 100;
-          else if (buildVal.y > endPoint.y) buildVal.y -= 100;
-        }
-
-        // processPath.addWayPoint(startPoint);
-        for (T cp : waypointList) {
-          ZonePoint np = (ZonePoint) cp;
-          if (np != startPoint && np != endPoint) processPath.addWayPoint(np);
-        }
-
-        processPath.addWayPoint(endPoint);
-
-        // Lee: replacing the last point in derived path for the more
-        // accurate landing point
-        processPath.replaceLastPoint(endPoint);
-        path = (Path<T>) processPath;
+      for (T cp : cellList) {
+        T np = (T) cp.clone();
+        np.x -= cellOffsetX;
+        np.y -= cellOffsetY;
+        path.addPathCell(np);
       }
+
+      for (T cp : waypointList) {
+        T np = (T) cp.clone();
+        np.x -= cellOffsetX;
+        np.y -= cellOffsetY;
+        path.addWayPoint(np);
+      }
+
+      /*
+       * Not exactly sure what Lee was trying to do here?
+       * I believe he was trying to return all the "cells" a non-STG token moved though?
+       * I'll leave the code below in case someone wants to clean it up later.
+       * For now, I've restored partial logic back to 1.4.0.5 above.
+       */
+
+      /*
+      	// Lee: solo movement
+      	if (keyToken.isSnapToGrid()) {
+      		for (T cp : cellList) {
+      			T np = (T) cp.clone();
+      			np.x -= cellOffsetX;
+      			np.y -= cellOffsetY;
+      			path.addPathCell(np);
+      		}
+
+      		for (T cp : waypointList) {
+      			T np = (T) cp.clone();
+      			np.x -= cellOffsetX;
+      			np.y -= cellOffsetY;
+      			path.addWayPoint(np);
+      		}
+      	} else {
+      		Path<CellPoint> reflectedPath = new Path<CellPoint>();
+      		NaiveWalker nw = new NaiveWalker(zone);
+      		Path<ZonePoint> wpl = set.getGridlessPath();
+
+      		if (cellList.size() > 2) {
+
+      			CellPoint prevPoint = grid.convert(new ZonePoint(startPoint.x, startPoint.y));
+      			CellPoint terminalPoint = grid.convert(endPoint);
+      			CellPoint convPoint;
+
+      			// Lee: since we already have the start point
+      			((List<T>) cellList).remove(0);
+
+      			for (T p : cellList) {
+      				convPoint = grid.convert((ZonePoint) p);
+      				reflectedPath.addAllPathCells(nw.calculatePath(prevPoint, convPoint));
+      				prevPoint = convPoint;
+      			}
+
+      		} else {
+      			reflectedPath.addAllPathCells(
+      					nw.calculatePath(grid.convert(startPoint), grid.convert(endPoint)));
+      		}
+
+      		ZonePoint buildVal = startPoint;
+      		Path<ZonePoint> processPath = new Path<ZonePoint>();
+
+      		for (CellPoint p : reflectedPath.getCellPath()) {
+      			ZonePoint tempPoint = (ZonePoint) buildVal.clone();
+      			processPath.addPathCell(tempPoint);
+
+      			if (buildVal.x < endPoint.x)
+      				buildVal.x += 100;
+      			else if (buildVal.x > endPoint.x)
+      				buildVal.x -= 100;
+      			if (buildVal.y < endPoint.y)
+      				buildVal.y += 100;
+      			else if (buildVal.y > endPoint.y)
+      				buildVal.y -= 100;
+      		}
+
+      		// processPath.addWayPoint(startPoint);
+      		for (T cp : waypointList) {
+      			ZonePoint np = (ZonePoint) cp;
+      			if (np != startPoint && np != endPoint)
+      				processPath.addWayPoint(np);
+      		}
+
+      		processPath.addWayPoint(endPoint);
+
+      		// Lee: replacing the last point in derived path for the more
+      		// accurate landing point
+      		processPath.replaceLastPoint(endPoint);
+      		path = (Path<T>) processPath;
+      	}
+      */
     }
     return path;
   }


### PR DESCRIPTION
 * Non-snap-to-grid tokens now return just the start/end points + way
points. Functions as 1.4.0.5 once again.

Signed-off-by: Jamz <Jamz@Nerps.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/281)
<!-- Reviewable:end -->
