### PR TITLE
Initialise visibleTokenSet with empty set to avoid NPEs

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -198,7 +198,7 @@ public class ZoneRenderer extends JComponent
   private Area visibleScreenArea;
   private final List<ItemRenderer> itemRenderList = new LinkedList<ItemRenderer>();
   private PlayerView lastView;
-  private Set<GUID> visibleTokenSet; // = new HashSet<GUID>();
+  private Set<GUID> visibleTokenSet = new HashSet<>();
   private CodeTimer timer;
 
   private boolean autoResizeStamp = false;


### PR DESCRIPTION
Initialise the visibleTokenSet in ZoneRenderer so that if it used before the renderer modifies it in the render loop it wont thrown an NPE and correctly reflect there are no visible tokens.

Fixes #250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/285)
<!-- Reviewable:end -->
