### PR TITLE
Fix not working syntax highlighting for new defined functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
@@ -24,6 +24,7 @@ import java.util.Stack;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.AbortFunction.AbortFunctionException;
+import net.rptools.maptool.client.ui.syntax.MapToolScriptSyntax;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.model.Player;
 import net.rptools.maptool.model.Token;
@@ -179,6 +180,8 @@ public class UserDefinedMacroFunctions implements Function {
       redefinedFunctions.put(name, fr);
     }
     userDefinedFunctions.put(name, new FunctionDefinition(macro, ignoreOutput, newVariableContext));
+
+    MapToolScriptSyntax.resetScriptSyntax();
   }
 
   public Object executeOldFunction(Parser parser, List<Object> parameters) throws ParserException {

--- a/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
+++ b/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
@@ -121,6 +121,10 @@ public class MapToolScriptSyntax extends MapToolScriptTokenMaker {
     super.addToken(array, start, end, tokenType, startOffset, hyperlink);
   }
 
+  public static void resetScriptSyntax() {
+    macroFunctionTokenMap = null;
+  }
+
   private TokenMap getMacroFunctionNames() {
     if (macroFunctionTokenMap == null) {
       macroFunctionTokenMap = new TokenMap(true);


### PR DESCRIPTION
If you use defineFunction these new functions to not get syntax
highlighted straight away when manually calling the onCampaignLoad
macro. Only when the campaign is reloaded. This fixes that behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/286)
<!-- Reviewable:end -->
