### PR TITLE
Catch abort

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1312,19 +1312,20 @@ public class MapToolLineParser {
                 String callName = result.getValue().toString();
                 result = parseExpression(resolver, tokenInContext, rollBranch);
                 String macroArgs = result.getValue().toString();
-                
+
                 try {
-                	output_text = runMacro(resolver, tokenInContext, callName, macroArgs);
+                  output_text = runMacro(resolver, tokenInContext, callName, macroArgs);
                 } catch (AbortFunctionException e) {
-                    // required to catch abort that are not 
-                	// in a (UDF)function call
-                	// but in a real "macro(...)" call
-                	log.debug(e);
-                    boolean catchAbort = BigDecimal.ONE.equals(resolver.getVariable("macro.catchAbort"));
-                    if (!catchAbort) throw e;
-                    output_text = "";
+                  // required to catch abort that are not
+                  // in a (UDF)function call
+                  // but in a real "macro(...)" call
+                  log.debug(e);
+                  boolean catchAbort =
+                      BigDecimal.ONE.equals(resolver.getVariable("macro.catchAbort"));
+                  if (!catchAbort) throw e;
+                  output_text = "";
                 }
-                
+
                 if (output != Output.NONE) {
                   expressionBuilder.append(output_text);
                 }
@@ -1437,7 +1438,7 @@ public class MapToolLineParser {
       log.debug(e);
       boolean catchAbort = BigDecimal.ONE.equals(resolver.getVariable("macro.catchAbort"));
       if (!catchAbort) throw e;
-      
+
       // return an empty result to not collide with tooltips
       // when catching an abort
       Result result = new Result("");

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1460,7 +1460,7 @@ public class MapToolLineParser {
       boolean catchAssert = BigDecimal.ONE.equals(resolver.getVariable("macro.catchAssert"));
       if (!catchAssert) throw e;
       MapTool.addLocalMessage(e.getMessage());
-      
+
       // return an empty result to not collide with tooltips
       // when catching an assert`
       Result result = new Result("");

--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -93,6 +93,7 @@ public class MapToolVariableResolver extends MapVariableResolver {
     try {
       this.setVariable("macro.args", "");
       this.setVariable("macro.catchAbort", BigDecimal.ZERO);
+      this.setVariable("macro.catchAssert", BigDecimal.ZERO);
       this.setVariable("macro.args.num", BigDecimal.ZERO);
       this.setVariable("tokens.denyMove", 0);
       this.setVariable("tokens.moveCount", 1);


### PR DESCRIPTION
Ensure catchAbort for UDF, straight macros and roll options Issue #287
As discussed with Azhrei I deleted the nerps fork, so cannot reuse the old PR.

Previous catchAbort ignored direct macro calls and had an issue with
some roll options. This fixes that.

Sample of calls (with raiseAbort@this being a macro doing an abort(0)
and raiseAbort, raiseAbortNotIgnoreOutput 2 UDFs pointing to the macro
wit/without output ignored):

`[h: var = 0]
[h: macro.catchAbort = 1]
[h: result = "default value"]
abort_r: [r: result = abort(var)]

result_r: [r: result]
abort_t: [t: result = abort(var)]

result_t: [r: result]
abort_t_code: [t, code: {
[result = abort(var)]
}]

result_t_code: [r: result]
abort_r_code: [r, code: {
[result = abort(var)]
}]

result_r_code: [r: result]
abort_f: [raiseAbort()]

result_f: [r: result]
abort_f_with_output: [raiseAbortNotIgnoreOutput()]

result_f_with_output: [r: result]
abort_macro: [macro("raiseAbort@this"): ""]

result_macro_code: [r: result]
More text...`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/294)
<!-- Reviewable:end -->
