### PR TITLE
Change gradle root project name to match the case of the git hub project

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,4 +15,4 @@ include 'api'
 include 'services:webservice'
 */
 
-rootProject.name = 'MapTool'
+rootProject.name = 'maptool'


### PR DESCRIPTION
Title says it all.
Change needed to simplify Eclipse Gradle Import process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/351)
<!-- Reviewable:end -->
