### PR TITLE
SENTRY MAPTOOL-20 fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
@@ -156,7 +156,10 @@ public class DrawablesPanel extends JComponent {
       if (bounds == null) bounds = drawnBounds;
       else bounds.add(drawnBounds);
     }
-    if (bounds != null) return bounds;
+    // Fix for Sentry MAPTOOL-20
+    if (bounds != null && bounds.getWidth() > 0 && bounds.getHeight() > 0) {
+      return bounds;
+    }
     return new Rectangle(0, 0, -1, -1);
   }
 }


### PR DESCRIPTION
I was only able to recreate this error by deliberately coding a bounds object with a width of 0.
So I do don't know how the error was created, but this should catch future examples cleanly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/360)
<!-- Reviewable:end -->
