### PR TITLE
Revert "Change gradle root project name to match the case of the git hub project"

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,4 +15,4 @@ include 'api'
 include 'services:webservice'
 */
 
-rootProject.name = 'maptool'
+rootProject.name = 'MapTool'


### PR DESCRIPTION
Reverts RPTools/maptool#351
This was causing issues with the icons when running on file systems which are case sensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/373)
<!-- Reviewable:end -->
