### PR TITLE
Update SysInfo.java

### DIFF
--- a/src/main/java/net/rptools/maptool/util/SysInfo.java
+++ b/src/main/java/net/rptools/maptool/util/SysInfo.java
@@ -147,7 +147,6 @@ public class SysInfo {
     appendInfo("Java Vendor.: " + p.getProperty("java.vendor"));
     appendInfo("Java Home...: " + p.getProperty("java.home"));
     appendInfo("Java Version: " + p.getProperty("java.version"));
-    appendInfo(getJavaVersionInfo());
   }
 
   private void getLocaleInfo() {
@@ -245,21 +244,6 @@ public class SysInfo {
     } catch (SocketException se) {
       appendInfo("*** Could net get list of network interfaces ***");
     }
-  }
-
-  private String getJavaVersionInfo() {
-    String info = "Result of executing 'java -version':\n";
-    try {
-      Process result = Runtime.getRuntime().exec("java -version");
-
-      BufferedReader output = new BufferedReader(new InputStreamReader(result.getErrorStream()));
-
-      String line = output.readLine();
-      while ((line = output.readLine()) != null) info = info.concat("............: " + line + "\n");
-    } catch (Exception e) {
-      MapTool.showError("Exception running 'java -version' to get version number information", e);
-    }
-    return info;
   }
 
   private void getDisplayInfo() {


### PR DESCRIPTION
Removed method to get the command line java -version info as it is no longer needed since all MT versions going forward are 64-bit.  Issue #386

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/387)
<!-- Reviewable:end -->
