### PR TITLE
Add movedOverDrawing() function

### DIFF
--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -58,9 +58,16 @@ public class DrawablesGroup extends AbstractDrawing {
   public Area getArea() {
     Area area = null;
     for (DrawnElement element : drawableList) {
-      if (area == null) area = element.getDrawable().getArea();
-      else area.add(element.getDrawable().getArea());
-      ;
+      boolean isEraser = element.getPen().isEraser();
+      if (area == null) {
+        if (!isEraser) area = new Area(element.getDrawable().getArea());
+      } else {
+        if (isEraser) {
+          area.subtract(element.getDrawable().getArea());
+        } else {
+          area.add(element.getDrawable().getArea());
+        }
+      }
     }
     return area;
   }


### PR DESCRIPTION
Pull Request for Issue #416 

This creates a movedOverDrawing(mapName, drawingId, points) function.

`[h: lp = getLastPath()]<br><br>
[h: id = findDrawings(getCurrentMapName(),"fig5")]
[r: movedOverDrawing(getCurrentMapName(),id,lp)]`

This works as per the movedOverPoints() function and returns a JSON array with coordinates of all cells in the path that overlap with the area defined by the specified drawing. 

If the drawing happens to be a group, the function respects "cuts" and which won't be included in the drawing's area.

If the drawing is a fat line, the function triggers if the path point crosses the line's width.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/418)
<!-- Reviewable:end -->
