### PR TITLE
Add two new previous roll functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -163,6 +163,12 @@ public class MapToolLineParser {
   /** The dice rolls that occurred in the previous parse this one. */
   private List<Integer> rolled = new LinkedList<>();
 
+  /**
+   * The dice rolls that occurred since either start of the macro or the previous time {@link
+   * #getNewRolls()} was called.
+   */
+  private List<Integer> newRolls = new LinkedList<>();
+
   private enum Output { // Mutually exclusive output formats
     NONE,
     RESULT,
@@ -706,6 +712,7 @@ public class MapToolLineParser {
     lastRolled.clear();
     lastRolled.addAll(rolled);
     rolled.clear();
+    newRolls.clear();
 
     if (line == null) {
       return "";
@@ -1468,6 +1475,7 @@ public class MapToolLineParser {
       Result res =
           createParser(resolver, tokenInContext == null ? false : true).evaluate(expression);
       rolled.addAll(res.getRolled());
+      newRolls.addAll(res.getRolled());
 
       return res;
     } catch (AbortFunctionException e) {
@@ -2167,11 +2175,42 @@ public class MapToolLineParser {
     return contextStack.size();
   }
 
+  /**
+   * Returns the raw dice rolls that have occurred during this pars / execution.
+   *
+   * @return the raw dice rolls that have occurred during this parse / execution.
+   */
   public List<Integer> getRolled() {
     return List.copyOf(rolled);
   }
 
+  /**
+   * Returns the raw dice rolls that occurred during the last parse / execution.
+   *
+   * @return the raw dice rolls that occurred during the last parse / execution.
+   */
   public List<Integer> getLastRolled() {
     return List.copyOf(lastRolled);
+  }
+
+  /**
+   * Returns the raw dice rolls that have occurred during this parse since the last time <code>
+   * getNewRolls()</code> was called. If <code>getNewRolls()</code> has not yet been called during
+   * this parse / execution then all rolls since the start of the parse / execution will be
+   * returned.
+   *
+   * @return the raw dice rolls that occurred since last call to this funnction.
+   */
+  public List<Integer> getNewRolls() {
+    List<Integer> rolls = List.copyOf(newRolls);
+    newRolls.clear();
+    return rolls;
+  }
+
+  /** Resets all the lists of rolls that have occurred. */
+  public void clearRolls() {
+    newRolls.clear();
+    lastRolled.clear();
+    rolled.clear();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/LastRolledFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LastRolledFunction.java
@@ -25,7 +25,7 @@ public class LastRolledFunction extends AbstractFunction {
   private static final LastRolledFunction instance = new LastRolledFunction();
 
   private LastRolledFunction() {
-    super(0, 1, "lastRolled", "getRolled");
+    super(0, 1, "lastRolled", "getRolled", "clearRolls", "getNewRolls");
   }
 
   public static LastRolledFunction getInstance() {
@@ -38,8 +38,12 @@ public class LastRolledFunction extends AbstractFunction {
     JSONArray jarr = new JSONArray();
     if (functionName.equalsIgnoreCase("lastRolled")) {
       jarr.addAll(MapTool.getParser().getLastRolled());
-    } else {
+    } else if (functionName.equalsIgnoreCase("getRolled")) {
       jarr.addAll(MapTool.getParser().getRolled());
+    } else if (functionName.equalsIgnoreCase("clearRolls")) {
+      MapTool.getParser().clearRolls();
+    } else {
+      jarr.addAll(MapTool.getParser().getNewRolls());
     }
 
     return jarr;


### PR DESCRIPTION
Added
getNewRolls() which returns the raw dice rolls performed since the last call to getNewRolls() for the current macro parse. If no call has been made yet then all rolls for the current macro parse.
clearRolls() which will clear all roll lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/427)
<!-- Reviewable:end -->
