### PR TITLE
Fix MapTool not logging when ran from uberJar or installed versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,9 +151,9 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     // For Sentry bug reporting
-    annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.11.0'	// Bridges v1 to v2 for other code in other libs
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.2'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.2'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.11.2'	// Bridges v1 to v2 for other code in other libs
 
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -8,9 +8,7 @@
 			<PatternLayout pattern="%d{HH:mm:ss.SSS} (%F:%L) [%t] %-5level %logger{36} - %msg%n" />
 		</Console>
 		<RollingFile name="LogFile" fileName="${sys:appHome}/maptool.log" filePattern="${sys:appHome}/archive/maptool_%d{yyy-MM-dd_HH-mm-ss}.log.zip" ignoreExceptions="false">
-			<PatternLayout>
-				<Pattern>%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
-			</PatternLayout>
+			<PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n" />
 			<Policies>
 				<OnStartupTriggeringPolicy />
 				<SizeBasedTriggeringPolicy size="10 MB" />
@@ -23,9 +21,7 @@
 			</DefaultRolloverStrategy>
 		</RollingFile>
 		<JTextAreaAppender name="jtextarea-log" maxLines="5000">
-			<PatternLayout>
-				<pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
-			</PatternLayout>
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger - %msg%n" />
 		</JTextAreaAppender>
 	</Appenders>
 	<Loggers>


### PR DESCRIPTION
 * annotationProcessor no long picked up in uberjar, switched log4j-core
back to implementation
 * slight adjustments to patternlayouts, only console logs FQCN, file &
appenders no longer log any class location info for faster logging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/447)
<!-- Reviewable:end -->
