### PR TITLE
GM Notes & Name now hidden on Player tokens

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -185,6 +185,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     bind(token);
 
     getRootPane().setDefaultButton(getOKButton());
+    ((JTextArea)getComponent("@GMNotes")).setEnabled(MapTool.getPlayer().isGM());
+    ((JTextField)getComponent("@GMName")).setEnabled(MapTool.getPlayer().isGM());
     dialog.showDialog();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -185,8 +185,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     bind(token);
 
     getRootPane().setDefaultButton(getOKButton());
-    ((JTextArea)getComponent("@GMNotes")).setEnabled(MapTool.getPlayer().isGM());
-    ((JTextField)getComponent("@GMName")).setEnabled(MapTool.getPlayer().isGM());
+    ((JTextArea) getComponent("@GMNotes")).setEnabled(MapTool.getPlayer().isGM());
+    ((JTextField) getComponent("@GMName")).setEnabled(MapTool.getPlayer().isGM());
     dialog.showDialog();
   }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -468,9 +468,9 @@ public class Token extends BaseModel implements Cloneable {
 
   public String getGMNotes() {
     if (MapTool.getPlayer().isGM()) {
-        return gmNotes;
+      return gmNotes;
     } else {
-        return "";
+      return "";
     }
   }
 
@@ -480,9 +480,9 @@ public class Token extends BaseModel implements Cloneable {
 
   public String getGMName() {
     if (MapTool.getPlayer().isGM()) {
-        return gmName;
+      return gmName;
     } else {
-        return "";
+      return "";
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -467,7 +467,11 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public String getGMNotes() {
-    return gmNotes;
+    if (MapTool.getPlayer().isGM()) {
+        return gmNotes;
+    } else {
+        return "";
+    }
   }
 
   public void setGMNotes(String notes) {
@@ -475,7 +479,11 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public String getGMName() {
-    return gmName;
+    if (MapTool.getPlayer().isGM()) {
+        return gmName;
+    } else {
+        return "";
+    }
   }
 
   public void setGMName(String name) {


### PR DESCRIPTION
For issue #461, GM Notes and Name are now hidden from players on player-owned tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/462)
<!-- Reviewable:end -->
