### PR TITLE
Fixed NPE when unmapping port

### DIFF
--- a/src/main/java/net/rptools/maptool/util/UPnPUtil.java
+++ b/src/main/java/net/rptools/maptool/util/UPnPUtil.java
@@ -219,10 +219,10 @@ public class UPnPUtil {
           // NewPortMappingDescription=MapTool
           boolean unmapped = gd.deletePortMapping(null, port, "TCP");
           if (unmapped) {
-            iter.remove();
             count++;
             if (log.isInfoEnabled())
               log.info("UPnP: Port unmapped from " + igds.get(gd).getDisplayName());
+            iter.remove();
           } else {
             if (log.isInfoEnabled())
               log.info("UPnP: Failed to unmap port from " + igds.get(gd).getDisplayName());


### PR DESCRIPTION
IGD was being removed from iterator while it was still being used.  Fixes NPE seen in #473.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/475)
<!-- Reviewable:end -->
