### PR TITLE
Fix for tokens getting wrong size on hex maps.

### DIFF
--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -229,7 +229,8 @@ public abstract class HexGrid extends Grid {
     // don't use size. it has already been used to set the minorRadius
     // and will only introduce a rounding error.
     Area a = new Area(createShape(minorRadius, edgeProjection, edgeLength));
-//    System.out.println("HexGrid.createCellShape(): " + a.getBounds().width + ":" + a.getBounds().height);
+    //    System.out.println("HexGrid.createCellShape(): " + a.getBounds().width + ":" +
+    // a.getBounds().height);
     return a;
   }
 

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -228,7 +228,9 @@ public abstract class HexGrid extends Grid {
   protected Area createCellShape(int size) {
     // don't use size. it has already been used to set the minorRadius
     // and will only introduce a rounding error.
-    return new Area(createShape(minorRadius, edgeProjection, edgeLength));
+    Area a = new Area(createShape(minorRadius, edgeProjection, edgeLength));
+//    System.out.println("HexGrid.createCellShape(): " + a.getBounds().width + ":" + a.getBounds().height);
+    return a;
   }
 
   @Override
@@ -289,8 +291,6 @@ public abstract class HexGrid extends Grid {
 
   @Override
   public void setSize(int size) {
-    super.setSize(size);
-
     if (hexRatio == 0) {
       hexRatio = REGULAR_HEX_RATIO;
     }
@@ -308,6 +308,9 @@ public abstract class HexGrid extends Grid {
 
     // Cell offset gives the offset to apply to the cell zone coords to draw images/tokens
     cellOffset = setCellOffset();
+    // The call to the super.setSize() must be last as it calls createCellShape()
+    // which needs the values set above.
+    super.setSize(size);
   }
 
   protected void createShape(double scale) {


### PR DESCRIPTION
Fix for Issue #166 

Tokens dropped on hex maps were getting set to the default grid size instead of the actual grid size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/482)
<!-- Reviewable:end -->
