### PR TITLE
Fix One-One-One Movement

### DIFF
--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarSquareEuclideanWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarSquareEuclideanWalker.java
@@ -14,12 +14,13 @@
  */
 package net.rptools.maptool.client.walker.astar;
 
-import java.util.Arrays;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Zone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
 
 public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
   private static final Logger log = LogManager.getLogger(AStarSquareEuclideanWalker.class);
@@ -83,7 +84,7 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
     int yDist = current.y - goal.y;
 
     double distance;
-    int crossProductTieBreaker = 0;
+    int crossProductTieBreaker;
 
     switch (metric) {
       case MANHATTAN:
@@ -91,6 +92,7 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
         distance = Math.abs(xDist) + Math.abs(yDist);
         break;
       default:
+      case ONE_ONE_ONE:
       case ONE_TWO_ONE:
         xDist = Math.abs(current.x - goal.x);
         yDist = Math.abs(current.y - goal.y);
@@ -99,9 +101,6 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
         } else {
           distance = Math.floor(diagonalMultiplier * xDist) + (yDist - xDist);
         }
-        break;
-      case ONE_ONE_ONE:
-        distance = Math.max(Math.abs(xDist), Math.abs(yDist));
         break;
     }
 
@@ -113,7 +112,9 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
       crossProductTieBreaker = Math.abs(xDist * crossY + crossX * yDist);
     }
 
-    return distance += crossProductTieBreaker * 0.001;
+    distance += crossProductTieBreaker * 0.001;
+
+    return distance;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarSquareEuclideanWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarSquareEuclideanWalker.java
@@ -14,13 +14,12 @@
  */
 package net.rptools.maptool.client.walker.astar;
 
+import java.util.Arrays;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Zone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.Arrays;
 
 public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
   private static final Logger log = LogManager.getLogger(AStarSquareEuclideanWalker.class);


### PR DESCRIPTION
 * Changed One-0ne-One Movement heueristic to use same tie breaker logic as One-Two-One heueristic.

Signed-off-by: Jamz <Jamz@Nerps.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/495)
<!-- Reviewable:end -->
