### PR TITLE
Fixes missing default resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,9 +151,9 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     // For Sentry bug reporting
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.2'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.2'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.11.2'	// Bridges v1 to v2 for other code in other libs
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.12.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.12.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.12.0'	// Bridges v1 to v2 for other code in other libs
 
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'

--- a/src/main/java/net/rptools/maptool/client/AppSetup.java
+++ b/src/main/java/net/rptools/maptool/client/AppSetup.java
@@ -14,19 +14,13 @@
  */
 package net.rptools.maptool.client;
 
-import java.awt.EventQueue;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.awt.*;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
 import java.util.regex.Pattern;
-import javax.swing.JOptionPane;
-import javax.swing.JTextPane;
+import javax.swing.*;
 import net.rptools.lib.FileUtil;
 import net.rptools.maptool.model.AssetManager;
 import org.apache.commons.io.FileUtils;
@@ -43,7 +37,8 @@ public class AppSetup {
 
   public static void install() {
     try {
-      installDefaultTokens();
+      // Only init once
+      if (!new File(AppConstants.UNZIP_DIR, "README").exists()) installDefaultTokens();
     } catch (IOException ioe) {
       log.error(ioe);
     }
@@ -52,9 +47,6 @@ public class AppSetup {
   }
 
   public static void installDefaultTokens() throws IOException {
-    // Only init once
-    if (AppUtil.getAppHome().listFiles().length > 0) return;
-
     installLibrary("Default", AppSetup.class.getClassLoader().getResource("default_images.zip"));
   }
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,37 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO" packages="net.rptools.maptool.client.ui.logger">
-	<Properties>
-		<Property name="log-path">log</Property>
-	</Properties>
-	<Appenders>
-		<Console name="Console" target="SYSTEM_OUT">
-			<PatternLayout pattern="%d{HH:mm:ss.SSS} (%F:%L) [%t] %-5level %logger{36} - %msg%n" />
-		</Console>
-		<RollingFile name="LogFile" fileName="${sys:appHome}/maptool.log" filePattern="${sys:appHome}/archive/maptool_%d{yyy-MM-dd_HH-mm-ss}.log.zip" ignoreExceptions="false">
-			<PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n" />
-			<Policies>
-				<OnStartupTriggeringPolicy />
-				<SizeBasedTriggeringPolicy size="10 MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="10">
-				<Delete basePath="${sys:appHome}/archive">
-					<IfFileName glob="maptool_*.log.zip" />
-					<IfLastModified age="14d" />
-				</Delete>
-			</DefaultRolloverStrategy>
-		</RollingFile>
-		<JTextAreaAppender name="jtextarea-log" maxLines="5000">
-			<PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger - %msg%n" />
-		</JTextAreaAppender>
-	</Appenders>
-	<Loggers>
-		<Logger name="MapToolConsole" level="INFO" additivity="false">
-			<AppenderRef ref="jtextarea-log" level="debug" />
-		</Logger>
-		<Root level="INFO">
-			<AppenderRef ref="Console" level="DEBUG" />
-			<AppenderRef ref="LogFile" />
-			<AppenderRef ref="jtextarea-log" level="debug" />
-		</Root>
-	</Loggers>
+    <Properties>
+        <Property name="log-path">log</Property>
+    </Properties>
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} (%F:%L) [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile
+                name="LogFile"
+                fileName="${sys:appHome}/maptool.log"
+                filePattern="${sys:appHome}/archive/maptool_%d{yyyy-MM-dd_HH-mm-ss}.log.zip"
+                ignoreExceptions="false">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10">
+                <Delete basePath="${sys:appHome}/archive">
+                    <IfFileName glob="maptool_*.log.zip"/>
+                    <IfLastModified age="14d"/>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+        <JTextAreaAppender name="jtextarea-log" maxLines="5000">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger - %msg%n"/>
+        </JTextAreaAppender>
+    </Appenders>
+    <Loggers>
+        <Logger name="MapToolConsole" level="INFO" additivity="false">
+            <AppenderRef ref="jtextarea-log" level="debug"/>
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="Console" level="DEBUG"/>
+            <AppenderRef ref="LogFile"/>
+            <AppenderRef ref="jtextarea-log" level="debug"/>
+        </Root>
+    </Loggers>
 </Configuration>


### PR DESCRIPTION
 * Fixes bug introduced by adding additional default resources (themes for syntax highlighter). Default resources now properly install once again on fresh installs/run of MapTool.
 * Rolling log timestamps were sticking and not properly keeping 14 days worth of logs.
   Updated log4j2 dependencies to fix the issue.
   Note: Every start of MapTool should archive the previous maptool.log file as a zip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/497)
<!-- Reviewable:end -->
