### PR TITLE
Fix new bug introduced by previous fix.

### DIFF
--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablePaint.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablePaint.java
@@ -33,16 +33,18 @@ public abstract class DrawablePaint implements Serializable {
       return null;
     }
     if (paint instanceof Color) {
+      // Colors from swatch/HSV/RGB pickers
       return new DrawableColorPaint((Color) paint);
+    }
+    if (paint instanceof AssetPaint) {
+      // Texture Picker
+      Asset asset = ((AssetPaint) paint).getAsset();
+      return new DrawableTexturePaint(asset);
     }
     if (paint instanceof TexturePaint) {
       //  This only happens if you select the top-left White swatch and only
-      //  this first click.  After that it always returns a Color.
+      //  the first click.  After that it always returns a Color.
       return new DrawableColorPaint(Color.WHITE);
-    }
-    if (paint instanceof AssetPaint) {
-      Asset asset = ((AssetPaint) paint).getAsset();
-      return new DrawableTexturePaint(asset);
     }
     throw new IllegalArgumentException("Invalid type of paint: " + paint.getClass().getName());
   }


### PR DESCRIPTION
Issue #261 - Was mistakenly capturing textures along with the bad paint from the white swatch.  Can select textures for map backgrounds again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/503)
<!-- Reviewable:end -->
