### PR TITLE
Fixes #510 incorrect error message with goto()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -641,13 +641,13 @@ public class TokenLocationFunctions extends AbstractFunction {
       if (!(args.get(0) instanceof BigDecimal)) {
         throw new ParserException(
             I18N.getText(
-                "macro.function.general.argumentTypeN", "moveToken", 1, args.get(0).toString()));
+                "macro.function.general.argumentTypeN", "goto", 1, args.get(0).toString()));
       }
 
       if (!(args.get(1) instanceof BigDecimal)) {
         throw new ParserException(
             I18N.getText(
-                "macro.function.general.argumentTypeN", "moveToken", 2, args.get(1).toString()));
+                "macro.function.general.argumentTypeN", "goto", 2, args.get(1).toString()));
       }
 
       x = ((BigDecimal) args.get(0)).intValue();


### PR DESCRIPTION
Fixes two typos that give the wrong error message (moveToken is blamed) when goto() is called with incorrect arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/514)
<!-- Reviewable:end -->
