### PR TITLE
Fix #513 Null Pointer Exception on apply change to token macro

### DIFF
--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -31,6 +31,7 @@ import net.rptools.maptool.client.ui.MacroButtonHotKeyManager;
 import net.rptools.maptool.client.ui.macrobuttons.buttons.MacroButton;
 import net.rptools.maptool.client.ui.macrobuttons.buttons.MacroButtonPrefs;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.util.StringUtil;
 import net.rptools.parser.ParserException;
 import org.apache.logging.log4j.LogManager;
@@ -325,7 +326,12 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
 
   public void save() {
     if (saveLocation.equals("Token") && tokenId != null) {
-      getToken().saveMacroButtonProperty(this);
+      Token token = getToken();
+      if (token != null) {
+        token.saveMacroButtonProperty(this);
+      } else {
+        MapTool.showError(I18N.getText("msg.error.macro.buttonNullToken", getLabel(), tokenId));
+      }
     } else if (saveLocation.equals("GlobalPanel")) {
       MacroButtonPrefs.savePreferences(this);
     } else if (saveLocation.equals("CampaignPanel")) {
@@ -468,8 +474,9 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     if (token == null) {
       List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
       for (ZoneRenderer zr : zrenderers) {
-        if (token == null) {
-          token = zr.getZone().getToken(this.tokenId);
+        token = zr.getZone().getToken(this.tokenId);
+        if (token != null) {
+          break;
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -462,7 +462,18 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
   }
 
   public Token getToken() {
-    return MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(this.tokenId);
+    Token token = MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(this.tokenId);
+
+    // If token not in current map, look for token in other maps.
+    if (token == null) {
+      List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
+      for (ZoneRenderer zr : zrenderers) {
+        if (token == null) {
+          token = zr.getZone().getToken(this.tokenId);
+        }
+      }
+    }
+    return token;
   }
 
   public void setTokenId(Token token) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -47,6 +47,7 @@ import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.JSONMacroFunctions;
+import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer.SelectionSet;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.util.ImageManager;
@@ -961,6 +962,22 @@ public class Token extends BaseModel implements Cloneable {
     return id;
   }
 
+  public ZoneRenderer getZoneRenderer() { // Returns the ZoneRenderer the token is on
+    ZoneRenderer zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
+    Token token = zoneRenderer.getZone().getToken(getId());
+
+    if (token == null) {
+      List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
+      for (ZoneRenderer zr : zrenderers) {
+        token = zr.getZone().getToken(getId());
+        if (token != null) {
+          zoneRenderer = zr;
+        }
+      }
+    }
+    return zoneRenderer;
+  }
+
   public void setId(GUID id) {
     this.id = id;
   }
@@ -1531,8 +1548,7 @@ public class Token extends BaseModel implements Cloneable {
   public void saveMacroButtonProperty(MacroButtonProperties prop) {
     getMacroPropertiesMap(false).put(prop.getIndex(), prop);
     MapTool.getFrame().resetTokenPanels();
-    MapTool.serverCommand()
-        .putToken(MapTool.getFrame().getCurrentZoneRenderer().getZone().getId(), this);
+    MapTool.serverCommand().putToken(getZoneRenderer().getZone().getId(), this);
 
     // Lets the token macro panels update only if a macro changes
     fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, id));

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1030,6 +1030,7 @@ msg.error.loadingIconImage                    = Could not load icon image.
 msg.error.loadingQuickMaps                    = Error loading quickmaps.
 msg.error.macro.buttonGroupDnDFail            = Drag & Drop problem
 msg.error.macro.buttonPropsAreNull            = Button properties are null.
+msg.error.macro.buttonNullToken               = Macro {0} cannot be saved; token {1} no longer valid.
 msg.error.macro.exportFail                    = <html><body>Macro could not be exported:<br><br>{0}</body></html>
 msg.error.macro.exportSetFail                 = <html><body>Macro set could not be exported:<br><br>{0}</body></html>
 msg.error.macro.importFail                    = <html><body>Macro could not be imported:<br><br>{0}</body></html>


### PR DESCRIPTION
Fix issue caused by two functions related to macro edit window that were looking for token only on current map.

Token macro edit window can remain open even if the token is no longer on the current map. Fix so applying changes works for a token regardless of the map it is on.

EDIT: second commit also fixes Null Pointer Exception when applying changes to a token macro after the token is deleted.

Close #513

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/518)
<!-- Reviewable:end -->
