### PR TITLE
Fix #519, path not calculated right if A* timeouts

### DIFF
--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -209,7 +209,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
 
       // We now calculate paths off the main UI thread but only one at a time. If the token moves we
       // cancel the thread
-      // and restart so we're only caclulating the most recent path request. Clearing the list
+      // and restart so we're only calculating the most recent path request. Clearing the list
       // effectively finishes
       // this thread gracefully.
       if (Thread.interrupted()) {
@@ -226,8 +226,18 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
 
     // Jamz We don't need to "calculate" distance after the fact as it's already stored as the G
     // cost...
-    if (!ret.isEmpty()) distance = ret.get(0).getDistanceTraveled(zone);
-    else distance = 0;
+    if (!ret.isEmpty()) {
+      distance = ret.get(0).getDistanceTraveled(zone);
+    } else { // if pathfinding interrupted because of timeout
+      distance = 0;
+      AStarCellPoint goalCell = new AStarCellPoint(goal); // we allow reaching of target location
+      AStarCellPoint startCell = new AStarCellPoint(start);
+
+      goalCell.parent = startCell;
+
+      ret.add(goalCell);
+      ret.add(startCell);
+    }
 
     Collections.reverse(ret);
     timeOut = (System.currentTimeMillis() - timeOut);


### PR DESCRIPTION
The previous waypoint (or initial location if no waypoint) was ignored if the next move incurred a A* timeout.

Fix the behavior when a timeout of A* occurs so that a direct path between waypoint and goal is created. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/520)
<!-- Reviewable:end -->
