### PR TITLE
Fix #523 cheat exploit

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -441,7 +441,7 @@ public class CommandPanel extends JPanel implements Observer {
    * FIXME: this is insufficient for stopping faked rolls; the user can still do something like &{"laquo;"}.
    */
   public static final Pattern CHEATER_PATTERN =
-      Pattern.compile("\u00AB|\u00BB|&#171|&#187|&laquo|&raquo|\036|\037|&#xAB|&#xBB");
+      Pattern.compile("\u00AB|\u00BB|&#171;?|&#187;?|&laquo;?|&raquo;?|&#xAB;?|&#xBB;?|\036|\037");
 
   /** Execute the command in the command field. */
   public void commitCommand() {

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -441,7 +441,7 @@ public class CommandPanel extends JPanel implements Observer {
    * FIXME: this is insufficient for stopping faked rolls; the user can still do something like &{"laquo;"}.
    */
   public static final Pattern CHEATER_PATTERN =
-      Pattern.compile("\u00AB|\u00BB|&#171;|&#187;|&laquo;|&raquo;|\036|\037");
+      Pattern.compile("\u00AB|\u00BB|&#171|&#187|&laquo|&raquo|\036|\037|&#xAB|&#xBB");
 
   /** Execute the command in the command field. */
   public void commitCommand() {


### PR DESCRIPTION
MT allows you to not use ; for the entities, so remove it from cheating symbols. Also, include &#xAB and &#xBB as cheating symbols.

Thanks to aliasmask for identifying the two new symbols.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/521)
<!-- Reviewable:end -->
