### PR TITLE
Fix #522 UPnP tooltip in Preferences

### DIFF
--- a/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
@@ -8933,7 +8933,7 @@ Disabled (default): show tooltips for macroLinks</at>
                                           <at name="name">fill</at>
                                          </object>
                                         </at>
-                                        <at name="toolTipText">&lt;html&gt;Player-editable macros cannot call &lt;b&gt;trusted&lt;/b&gt; functions.  When developing a framework, this should be disabled.</at>
+                                        <at name="toolTipText">Timeout period in milliseconds to wait when looking for UPnP gateways.</at>
                                         <at name="height">14</at>
                                        </object>
                                       </at>


### PR DESCRIPTION
Change the UPnP tooltip from a duplicate of Macro Panels to the one suggested by Phergus.

Co-Authored-By: Phergus <phergus@users.noreply.github.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/524)
<!-- Reviewable:end -->
