### PR TITLE
Fix #534, getMatchingProperties now take a third argument

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -152,7 +152,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      * String names = getMatchingProperties(String pattern, String delim: ",", String tokenId: currentToken())
      */
     if (functionName.equals("getMatchingProperties")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
       Token token = getTokenFromParam(resolver, functionName, parameters, 2);
       String pattern = parameters.get(0).toString();
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";


### PR DESCRIPTION
Bug was caused by the function being artificially restricted to 2 parameters, now fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/535)
<!-- Reviewable:end -->
