### PR TITLE
Add mapName as optional parameter to functions in TokenPropertyFunction.java

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -131,8 +131,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
 
       token.setPropertyType(parameters.get(0).toString());
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(
-          token); // TODO: FJE Should this be here? Added because other places have it...?!
       return "";
     }
 
@@ -210,7 +208,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
 
       token.setType(Token.Type.PC);
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return "";
@@ -227,7 +224,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
 
       token.setType(Token.Type.NPC);
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return "";
@@ -257,7 +253,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
 
       String layer = setLayer(token, parameters.get(0).toString(), forceShape);
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return layer;
@@ -331,7 +326,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
 
       token.resetProperty(parameters.get(0).toString());
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       return "";
     }
 
@@ -346,7 +340,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
 
       token.setProperty(parameters.get(0).toString(), parameters.get(1).toString());
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       return "";
     }
 
@@ -463,8 +456,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       token.setGMNotes(parameters.get(0).toString());
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
+      // Faster to not update clients through MapTool.serverCommand().putToken(token)
       return token.getGMNotes();
     }
 
@@ -488,8 +480,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       token.setNotes(parameters.get(0).toString());
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
+      // Faster to not update clients through MapTool.serverCommand().putToken(token)
       return token.getNotes();
     }
 
@@ -505,7 +496,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
       token.setZOrder(zone.getLargestZOrder() + 1);
 
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
 
       return BigDecimal.valueOf(token.getZOrder());
     }
@@ -522,7 +512,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
       token.setZOrder(zone.getSmallestZOrder() - 1);
 
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
 
       return BigDecimal.valueOf(token.getZOrder());
     }
@@ -564,9 +553,8 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Token token = MapTool.getParser().getTokenMacroLib(location);
       token.setProperty(parameters.get(0).toString(), parameters.get(1).toString());
       Zone z = MapTool.getParser().getTokenMacroLibZone(location);
+      // Note: not `zone' since we want only the zone this particular token came from
       MapTool.serverCommand().putToken(z.getId(), token);
-      z.putToken(
-          token); // Note: not `zone' since we want only the zone this particular token came from
       return "";
     }
 
@@ -654,7 +642,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
       zoneR
           .flushLight(); // FJE This isn't needed unless the token had a light source, right? Should
       // we check for that?
-      zone.putToken(token);
       return "";
     }
 
@@ -670,7 +657,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
       token.setFacing(null);
       MapTool.serverCommand().putToken(zone.getId(), token);
       zoneR.flushLight();
-      zone.putToken(token);
       return "";
     }
 
@@ -715,7 +701,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
         token.addOwner(
             myself); // If not trusted we must have been in the owner list -- keep us there.
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       return "";
     }
 
@@ -740,7 +725,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
       }
 
       MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
       return token.isOwnedByAll() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
@@ -771,8 +755,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
               parameters.get(0).toString().toUpperCase().trim().replace(" ", "_"));
       token.setShape(newShape);
 
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
+      // Faster to not update clients through MapTool.serverCommand().putToken(token)
       return token.getShape().toString();
     }
 
@@ -847,8 +830,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
         token.setScaleY(magnitude / token.getHeight());
       }
 
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
+      // Faster to not update clients through MapTool.serverCommand().putToken(token)
       return magnitude;
     }
 
@@ -866,8 +848,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Object param = parameters.get(0);
       token.setSnapToGrid(AbstractTokenAccessorFunction.getBooleanValue(param));
 
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      zone.putToken(token);
+      // Faster to not update clients through MapTool.serverCommand().putToken(token)
       return param;
     }
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
@@ -914,7 +895,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
         renderer.flush(token);
         renderer.repaint();
         MapTool.serverCommand().putToken(zone.getId(), token);
-        zone.putToken(token);
         MapTool.getFrame().updateTokenTree();
         return getSize(token);
       }
@@ -934,9 +914,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     Zone zone = renderer.getZone();
     Grid grid = zone.getGrid();
     token.setFootprint(grid, grid.getDefaultFootprint());
-
-    MapTool.serverCommand().putToken(zone.getId(), token);
-    zone.putToken(token);
+    // Faster to not update clients through MapTool.serverCommand().putToken(token)
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -111,25 +111,24 @@ public class TokenPropertyFunctions extends AbstractFunction {
       throws ParserException {
     MapToolVariableResolver resolver = (MapToolVariableResolver) parser.getVariableResolver();
 
-    // Cached for all those putToken() calls that are needed
-    ZoneRenderer zoneR = MapTool.getFrame().getCurrentZoneRenderer();
-    Zone zone = zoneR.getZone();
-
     /*
-     * String type = getPropertyType(String tokenId: currentToken())
+     * String type = getPropertyType(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getPropertyType")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getPropertyType();
     }
 
     /*
-     * String empty = setPropertyType(String propTypeName, String tokenId: currentToken())
+     * String empty = setPropertyType(String propTypeName, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setPropertyType")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setPropertyType(parameters.get(0).toString());
       MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(
@@ -138,22 +137,22 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String names = getPropertyNames(String delim: ",", String tokenId: currentToken())
+     * String names = getPropertyNames(String delim: ",", String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getPropertyNames") || functionName.equals("getPropertyNamesRaw")) {
-      checkNumberOfParameters(functionName, parameters, 0, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 0, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : ",";
       String pattern = ".*";
       return getPropertyNames(token, delim, pattern, functionName.equals("getPropertyNamesRaw"));
     }
 
     /*
-     * String names = getMatchingProperties(String pattern, String delim: ",", String tokenId: currentToken())
+     * String names = getMatchingProperties(String pattern, String delim: ",", String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getMatchingProperties")) {
-      checkNumberOfParameters(functionName, parameters, 1, 3);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 2);
+      checkNumberOfParameters(functionName, parameters, 1, 4);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 2, 3);
       String pattern = parameters.get(0).toString();
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
       return getPropertyNames(token, delim, pattern, false);
@@ -174,38 +173,41 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * Number zeroOne = hasProperty(String propName, String tokenId: currentToken())
+     * Number zeroOne = hasProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("hasProperty")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return hasProperty(token, parameters.get(0).toString()) ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     /*
-     * Number zeroOne = isNPC(String tokenId: currentToken())
+     * Number zeroOne = isNPC(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("isNPC")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getType() == Token.Type.NPC ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     /*
-     * Number zeroOne = isPC(String tokenId: currentToken())
+     * Number zeroOne = isPC(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("isPC")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getType() == Token.Type.PC ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     /*
-     * String empty = setPC(String tokenId: currentToken())
+     * String empty = setPC(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setPC")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setType(Token.Type.PC);
       MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
@@ -215,11 +217,14 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String empty = setNPC(String tokenId: currentToken())
+     * String empty = setNPC(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setNPC")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setType(Token.Type.NPC);
       MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
@@ -229,24 +234,27 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String layer = getLayer(String tokenId: currentToken())
+     * String layer = getLayer(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getLayer")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getLayer().name();
     }
 
     /*
-     * String layer = setLayer(String layer, String tokenId: currentToken(), boolean forceShape: true)
+     * String layer = setLayer(String layer, String tokenId: currentToken(), boolean forceShape: true, string mapName: current map)
      */
     if (functionName.equals("setLayer")) {
       boolean forceShape = true;
-      checkNumberOfParameters(functionName, parameters, 1, 3);
-      if (parameters.size() == 3) {
+      checkNumberOfParameters(functionName, parameters, 1, 4);
+      if (parameters.size() > 2) {
         forceShape = !BigDecimal.ZERO.equals(parameters.get(2));
       }
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 3);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       String layer = setLayer(token, parameters.get(0).toString(), forceShape);
       MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
@@ -256,36 +264,38 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String size = getSize(String tokenId: currentToken())
+     * String size = getSize(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getSize")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return getSize(token);
     }
 
     /*
-     * String size = setSize(String size, String tokenId: currentToken())
+     * String size = setSize(String size, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setSize")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+
       return setSize(token, parameters.get(0).toString());
     }
 
     if (functionName.equals("resetSize")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       resetSize(token);
+
       return "";
     }
 
     /*
-     * String owners = getOwners(String delim: ",", String tokenId: currentToken())
+     * String owners = getOwners(String delim: ",", String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getOwners")) {
-      checkNumberOfParameters(functionName, parameters, 0, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 0, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return getOwners(token, parameters.size() > 0 ? parameters.get(0).toString() : ",");
     }
 
@@ -293,17 +303,17 @@ public class TokenPropertyFunctions extends AbstractFunction {
      * Number zeroOne = isOwnedByAll(String tokenId: currentToken())
      */
     if (functionName.equals("isOwnedByAll")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isOwnedByAll() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     /*
-     * Number zeroOne = isOwner(String player: self, String tokenId: currentToken())
+     * Number zeroOne = isOwner(String player: self, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("isOwner")) {
-      checkNumberOfParameters(functionName, parameters, 0, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 0, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       if (parameters.size() > 0) {
         return token.isOwner(parameters.get(0).toString()) ? BigDecimal.ONE : BigDecimal.ZERO;
       }
@@ -311,11 +321,14 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String empty = resetProperty(String propName, String tokenId: currentToken())
+     * String empty = resetProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("resetProperty")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.resetProperty(parameters.get(0).toString());
       MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
@@ -323,11 +336,14 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String empty = setProperty(String propName, String value, String tokenId: currentToken())
+     * String empty = setProperty(String propName, String value, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setProperty")) {
-      checkNumberOfParameters(functionName, parameters, 2, 3);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 2);
+      checkNumberOfParameters(functionName, parameters, 2, 4);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 2, 3);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setProperty(parameters.get(0).toString(), parameters.get(1).toString());
       MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
@@ -335,11 +351,11 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * {String|Number} value = getRawProperty(String propName, String tokenId: currentToken())
+     * {String|Number} value = getRawProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getRawProperty")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Object val = token.getProperty(parameters.get(0).toString());
       if (val == null) {
         return "";
@@ -358,11 +374,11 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * {String|Number} value = getProperty(String propName, String tokenId: currentToken())
+     * {String|Number} value = getProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getProperty")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Object val = token.getEvaluatedProperty(parameters.get(0).toString());
 
       if (val instanceof String) {
@@ -378,11 +394,11 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * Number zeroOne = isPropertyEmpty(String propName, String tokenId: currentToken())
+     * Number zeroOne = isPropertyEmpty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("isPropertyEmpty")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return token.getProperty(parameters.get(0).toString()) == null
           ? BigDecimal.ONE
           : BigDecimal.ZERO;
@@ -428,67 +444,85 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String notes = getGMNotes(String tokenId: currentToken())
+     * String notes = getGMNotes(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getGMNotes")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       String notes = token.getGMNotes();
       return notes != null ? notes : "";
     }
 
     /*
-     * String notes = setGMNotes(String notes, String tokenId: currentToken())
+     * String notes = setGMNotes(String notes, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setGMNotes")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setGMNotes(parameters.get(0).toString());
+      MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
       return token.getGMNotes();
     }
 
     /*
-     * String notes = getNotes(String tokenId: currentToken())
+     * String notes = getNotes(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getNotes")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       String notes = token.getNotes();
       return notes != null ? notes : "";
     }
 
     /*
-     * String notes = setNotes(String notes, String tokenId: currentToken())
+     * String notes = setNotes(String notes, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setNotes")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setNotes(parameters.get(0).toString());
+      MapTool.serverCommand().putToken(zone.getId(), token);
       zone.putToken(token);
       return token.getNotes();
     }
 
     /*
-     * String empty = bringToFront(String tokenId: currentToken())
+     * String empty = bringToFront(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("bringToFront")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setZOrder(zone.getLargestZOrder() + 1);
+
       MapTool.serverCommand().putToken(zone.getId(), token);
+      zone.putToken(token);
 
       return BigDecimal.valueOf(token.getZOrder());
     }
 
     /*
-     * String empty = sendToBack(String tokenId: currentToken())
+     * String empty = sendToBack(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("sendToBack")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setZOrder(zone.getSmallestZOrder() - 1);
+
       MapTool.serverCommand().putToken(zone.getId(), token);
+      zone.putToken(token);
 
       return BigDecimal.valueOf(token.getZOrder());
     }
@@ -584,11 +618,11 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * Number facing = getTokenFacing(String tokenId: currentToken())
+     * Number facing = getTokenFacing(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getTokenFacing")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       if (token.getFacing() == null) {
         return ""; // XXX Should be -1 instead of a string?
       }
@@ -596,22 +630,25 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * Number degrees = getTokenRotation(String tokenId: currentToken())
+     * Number degrees = getTokenRotation(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("getTokenRotation")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
 
       return BigDecimal.valueOf(token.getFacingInDegrees());
     }
 
     /*
-     * String empty = setTokenFacing(Number facing, String tokenId: currentToken())
+     * String empty = setTokenFacing(Number facing, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setTokenFacing")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
       BigDecimal facing = getBigDecimalFromParam(functionName, parameters, 0);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setFacing(facing.intValue());
       MapTool.serverCommand().putToken(zone.getId(), token);
       zoneR
@@ -622,11 +659,14 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String empty = removeTokenFacing(String tokenId: currentToken())
+     * String empty = removeTokenFacing(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("removeTokenFacing")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       token.setFacing(null);
       MapTool.serverCommand().putToken(zone.getId(), token);
       zoneR.flushLight();
@@ -635,21 +675,23 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * Number zeroOne = isSnapToGrid(String tokenId: currentToken())
+     * Number zeroOne = isSnapToGrid(String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("isSnapToGrid")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 0);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isSnapToGrid() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     /*
-     * String empty = setOwner(String playerName | JSONArray playerNames, String tokenId: currentToken())
+     * String empty = setOwner(String playerName | JSONArray playerNames, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setOwner")) {
-      checkNumberOfParameters(functionName, parameters, 0, 2);
+      checkNumberOfParameters(functionName, parameters, 0, 3);
       boolean trusted = MapTool.getParser().isMacroTrusted();
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
       // Remove current owners, but if this macro is untrusted and the current player is an owner,
       // keep the
       // ownership there.
@@ -678,14 +720,17 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String empty = setOwner(0|1, String tokenId: currentToken())
+     * String empty = setOwnedByAll(0|1, String tokenId: currentToken(), string mapName: current map)
      */
     if (functionName.equals("setOwnedByAll")) {
       // If not trusted, do nothing and return -1 result
       if (!MapTool.getParser().isMacroTrusted()) return -1;
 
-      checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       BigDecimal ownedByAll = getBigDecimalFromParam(functionName, parameters, 0);
 
       if (ownedByAll.compareTo(BigDecimal.ZERO) == 0) {
@@ -700,67 +745,48 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String newShape = getTokenShape(String tokenId: currentToken())
+     * String newShape = getTokenShape(String tokenId: currentToken(), string mapName: current map)
      *
      * See Token.TokenShape for return values. Currently "Top down", "Circle", and "Square".
      */
     if (functionName.equals("getTokenShape")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
-
-      Token token;
-      token = getTokenFromContextOrParam(parser, functionName, parameters);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getShape().toString();
     }
 
     /*
-     * String newShape = setTokenShape(String shape, String tokenId: currentToken())
+     * String newShape = setTokenShape(String shape, String tokenId: currentToken(), string mapName: current map)
      *
      * See Token.TokenShape for shape values. Currently "Top down", "Top_down", "Circle", and "Square".
      */
     if (functionName.equals("setTokenShape")) {
-      checkNumberOfParameters(functionName, parameters, 0, 2);
+      checkNumberOfParameters(functionName, parameters, 0, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
 
-      Token token;
-      // TODO: should just call getTokenFromParam? This doesn't check if the macro is trusted
-      // though...
-      if (parameters.size() == 1) {
-        token = ((MapToolVariableResolver) parser.getVariableResolver()).getTokenInContext();
-        if (token == null)
-          throw new ParserException(
-              I18N.getText("macro.function.general.noImpersonated", functionName));
-      } else {
-        token =
-            getTokenFromParam(
-                (MapToolVariableResolver) parser.getVariableResolver(),
-                functionName,
-                parameters,
-                1);
-        if (token == null)
-          throw new ParserException(
-              I18N.getText(
-                  "macro.function.general.unknownToken",
-                  functionName,
-                  parameters.get(1).toString()));
-      }
       Token.TokenShape newShape =
           Token.TokenShape.valueOf(
               parameters.get(0).toString().toUpperCase().trim().replace(" ", "_"));
       token.setShape(newShape);
+
+      MapTool.serverCommand().putToken(zone.getId(), token);
+      zone.putToken(token);
       return token.getShape().toString();
     }
 
     /*
-     * String newShape = getTokenWidth(String tokenId: currentToken())
+     * String newShape = getTokenWidth(String tokenId: currentToken(), string mapName: current map)
      *
-     * String newShape = getTokenHeight(String tokenId: currentToken())
+     * String newShape = getTokenHeight(String tokenId: currentToken(), string mapName: current map)
      *
      * Returns pixel width/height for a given token. Useful for free size tokens.
      */
     if (functionName.equals("getTokenNativeWidth") || functionName.equals("getTokenNativeHeight")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
 
-      Token token;
-      token = getTokenFromContextOrParam(parser, functionName, parameters);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
 
       if (functionName.equals("getTokenNativeWidth")) {
         return BigDecimal.valueOf(token.getWidth());
@@ -770,17 +796,19 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
-     * String newShape = getTokenWidth(String tokenId: currentToken())
+     * String newShape = getTokenWidth(String tokenId: currentToken(), string mapName: current map)
      *
-     * String newShape = getTokenHeight(String tokenId: currentToken())
+     * String newShape = getTokenHeight(String tokenId: currentToken(), string mapName: current map)
      *
      * Returns pixel width/height for a given token. Useful for free size tokens.
      */
     if (functionName.equals("getTokenWidth") || functionName.equals("getTokenHeight")) {
-      checkNumberOfParameters(functionName, parameters, 0, 1);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
 
-      Token token;
-      token = getTokenFromContextOrParam(parser, functionName, parameters);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       // Get the pixel width or height of a given token
       Rectangle tokenBounds = token.getBounds(zone);
 
@@ -792,14 +820,20 @@ public class TokenPropertyFunctions extends AbstractFunction {
     }
 
     /*
+     * String newWidth   = setTokenWidth(String width, String tokenId: currentToken(), string mapName: current map)
+     *
+     * String newHeight  = setTokenHeight(String height, String tokenId: currentToken(), string mapName: current map)
+     *
      * Sets the width/height for a given token. Useful for free size tokens.
      */
     if (functionName.equals("setTokenWidth") || functionName.equals("setTokenHeight")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
+
       double magnitude = getBigDecimalFromParam(functionName, parameters, 0).doubleValue();
-      Token token =
-          getTokenFromParam(
-              (MapToolVariableResolver) parser.getVariableResolver(), functionName, parameters, 1);
+
       Rectangle tokenBounds = token.getBounds(zone);
       double oldWidth = tokenBounds.width;
       double oldHeight = tokenBounds.height;
@@ -812,41 +846,31 @@ public class TokenPropertyFunctions extends AbstractFunction {
         token.setScaleX(oldWidth / token.getWidth());
         token.setScaleY(magnitude / token.getHeight());
       }
-      return "";
+
+      MapTool.serverCommand().putToken(zone.getId(), token);
+      zone.putToken(token);
+      return magnitude;
     }
 
-    /* Sets whether the token should snap to the grid or not */
+    /*
+     * Number newSnapToGrid   = setTokenSnapToGrid(Bool snapToGrid, String tokenId: currentToken(), string mapName: current map)
+     *
+     * Sets whether the token should snap to the grid or not
+     */
     if (functionName.equals("setTokenSnapToGrid")) {
-      checkNumberOfParameters(functionName, parameters, 1, 2);
+      checkNumberOfParameters(functionName, parameters, 1, 3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
+      ZoneRenderer zoneR = token.getZoneRenderer();
+      Zone zone = zoneR.getZone();
 
       Object param = parameters.get(0);
-      Token token =
-          getTokenFromParam(
-              (MapToolVariableResolver) parser.getVariableResolver(), functionName, parameters, 1);
       token.setSnapToGrid(AbstractTokenAccessorFunction.getBooleanValue(param));
-      return "";
+
+      MapTool.serverCommand().putToken(zone.getId(), token);
+      zone.putToken(token);
+      return param;
     }
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
-  }
-
-  private Token getTokenFromContextOrParam(
-      Parser parser, String functionName, List<Object> parameters) throws ParserException {
-    Token token;
-    if (parameters.isEmpty()) {
-      token = ((MapToolVariableResolver) parser.getVariableResolver()).getTokenInContext();
-      if (token == null)
-        throw new ParserException(
-            I18N.getText("macro.function.general.noImpersonated", functionName));
-    } else {
-      token =
-          getTokenFromParam(
-              (MapToolVariableResolver) parser.getVariableResolver(), functionName, parameters, 0);
-      if (token == null)
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.unknownToken", functionName, parameters.get(0).toString()));
-    }
-    return token;
   }
 
   /**
@@ -856,7 +880,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
    * @return the size of the token.
    */
   private String getSize(Token token) {
-    Grid grid = MapTool.getFrame().getCurrentZoneRenderer().getZone().getGrid();
+    Grid grid = token.getZoneRenderer().getZone().getGrid();
     if (token.isSnapToScale()) {
       for (TokenFootprint footprint : grid.getFootprints()) {
         if (token.getFootprint(grid) == footprint) {
@@ -881,7 +905,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       return getSize(token);
     }
     token.setSnapToScale(true);
-    ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
+    ZoneRenderer renderer = token.getZoneRenderer();
     Zone zone = renderer.getZone();
     Grid grid = zone.getGrid();
     for (TokenFootprint footprint : grid.getFootprints()) {
@@ -906,10 +930,13 @@ public class TokenPropertyFunctions extends AbstractFunction {
    */
   private void resetSize(Token token) {
     token.setSnapToScale(true);
-    ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
+    ZoneRenderer renderer = token.getZoneRenderer();
     Zone zone = renderer.getZone();
     Grid grid = zone.getGrid();
     token.setFootprint(grid, grid.getDefaultFootprint());
+
+    MapTool.serverCommand().putToken(zone.getId(), token);
+    zone.putToken(token);
   }
 
   /**
@@ -1130,24 +1157,34 @@ public class TokenPropertyFunctions extends AbstractFunction {
    * @param res the variable resolver
    * @param functionName The function name (used for generating exception messages).
    * @param param The parameters for the function.
-   * @param index The index to find the token at.
+   * @param indexToken The index to find the token at.
+   * @param indexMap The index to find the map name at. If -1, use current map instead.
    * @return the token.
    * @throws ParserException if a token is specified but the macro is not trusted, or the specified
    *     token can not be found, or if no token is specified and no token is impersonated.
    */
   private Token getTokenFromParam(
-      MapToolVariableResolver res, String functionName, List<Object> param, int index)
+      MapToolVariableResolver res,
+      String functionName,
+      List<Object> param,
+      int indexToken,
+      int indexMap)
       throws ParserException {
+
+    String mapName =
+        indexMap >= 0 && param.size() > indexMap ? param.get(indexMap).toString() : null;
     Token token;
-    if (param.size() > index) {
+    if (param.size() > indexToken) {
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPermOther", functionName));
       }
-      token = FindTokenFunctions.findToken(param.get(index).toString(), null);
+      token = FindTokenFunctions.findToken(param.get(indexToken).toString(), mapName);
       if (token == null) {
         throw new ParserException(
             I18N.getText(
-                "macro.function.general.unknownToken", functionName, param.get(index).toString()));
+                "macro.function.general.unknownToken",
+                functionName,
+                param.get(indexToken).toString()));
       }
     } else {
       token = res.getTokenInContext();


### PR DESCRIPTION
Add mapName as optional parameter to these functions:

    getPropertyNames
    getPropertyNamesRaw
    hasProperty
    isNPC
    isPC
    setPC
    setNPC
    getLayer
    setLayer
    getSize
    setSize
    resetSize
    getOwners
    isOwnedByAll
    isOwner
    resetProperty
    getProperty
    setProperty
    isPropertyEmpty
    getPropertyDefault
    sendToBack
    bringToFront
    setPropertyType
    getPropertyType
    getRawProperty
    getTokenFacing
    setTokenFacing
    removeTokenFacing
    getTokenRotation
    getMatchingProperties
    isSnapToGrid
    setOwner
    setOwnedByAll
    getTokenNativeWidth
    getTokenNativeHeight
    getTokenWidth
    getTokenHeight
    setTokenWidth
    setTokenHeight
    getTokenShape
    setTokenShape
    getGMNotes
    setGMNotes
    getNotes
    setNotes
    setTokenSnapToGrid

Fix bug where functions would not propagate change to other clients:  setTokenShape, setTokenWidth, setTokenHeight, setTokenSnapToGrid

Close #545

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/546)
<!-- Reviewable:end -->
