### PR TITLE
Fix broken Player Vision with Non Individual View

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -838,10 +838,15 @@ public class ZoneRenderer extends JComponent
           iter.remove();
         }
       }
-      if (selectedTokens.isEmpty())
-        selectedTokens = zone.getOwnedTokensWithSight(MapTool.getPlayer());
-    } else {
-      selectedTokens = zone.getOwnedTokensWithSight(MapTool.getPlayer());
+    }
+    if (selectedTokens == null || selectedTokens.isEmpty()) {
+      // if no selected token qualifying for view, use owned tokens or player tokens with sight
+      final boolean checkOwnership =
+          MapTool.getServerPolicy().isUseIndividualViews() || MapTool.isPersonalServer();
+      selectedTokens =
+          checkOwnership
+              ? zone.getOwnedTokensWithSight(MapTool.getPlayer())
+              : zone.getPlayerTokensWithSight();
     }
     return new PlayerView(role, selectedTokens);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -626,12 +626,8 @@ public class ZoneView implements ModelChangeListener {
           continue;
         }
       } else {
-        // If we're viewing the map as a player and the token is not a PC or we're not the GM, then
-        // skip it.
-        // This used to be the code:
-        // if ((token.getType() != Token.Type.PC && !view.isGMView() || (!view.isGMView() &&
-        // MapTool.getPlayer().getRole() == Role.GM))) {
-        if (!isGMview && (token.getType() != Token.Type.PC || MapTool.getPlayer().isGM())) {
+        // If we're viewing the map as a player and the token is not a PC, then skip it.
+        if (!isGMview && (token.getType() != Token.Type.PC)) {
           continue;
         }
       }


### PR DESCRIPTION
Previous code skipped all tokens if a GM had player view on, because of the incorrect code:

if (!isGMview && MapTool.getPlayer().isGM()){
   continue;
}

Additionally, previous code had getPlayerView() return the set of owned tokens (instead of all PC tokens) when individual views were disabled and no token were selected.

Fix both issues, and Close #357

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/550)
<!-- Reviewable:end -->
