### PR TITLE
Fix opening&closing Edit Token Dialog turning on Visible over FoW

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -289,7 +289,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     if (MapTool.getPlayer().isGM()) {
       tabbedPane.setEnabledAt(tabbedPane.indexOfTab("VBL"), true);
       getTokenVblPanel().setToken(token);
-      getAlwaysVisibleButton().setSelected(token.isAlwaysVisible());
       getAlphaSensitivitySpinner().setValue(getTokenVblPanel().getAlphaSensitivity());
       getVisibilityToleranceSpinner().setValue(token.getAlwaysVisibleTolerance());
     } else {
@@ -297,6 +296,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       if (tabbedPane.getSelectedIndex() == tabbedPane.indexOfTab("VBL"))
         tabbedPane.setSelectedIndex(0);
     }
+    getAlwaysVisibleButton().setSelected(token.isAlwaysVisible());
 
     // Jamz: Init the Hero Lab tab...
     heroLabData = token.getHeroLabData();


### PR DESCRIPTION
Fix so that opening and closing the Edit Token dialog on Player Client no longer turns on Visible over FoW for that token.

Close #551.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/554)
<!-- Reviewable:end -->
