### PR TITLE
Change Functions to only send relevant data instead of whole token 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientCommand.java
+++ b/src/main/java/net/rptools/maptool/client/ClientCommand.java
@@ -28,7 +28,7 @@ public class ClientCommand {
     getAsset,
     removeAsset,
     putToken,
-    setTokenProperty,
+    updateTokenProperty,
     removeToken,
     draw,
     clearAllDrawings,

--- a/src/main/java/net/rptools/maptool/client/ClientCommand.java
+++ b/src/main/java/net/rptools/maptool/client/ClientCommand.java
@@ -28,6 +28,7 @@ public class ClientCommand {
     getAsset,
     removeAsset,
     putToken,
+    setTokenProperty,
     removeToken,
     draw,
     clearAllDrawings,

--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -230,6 +230,17 @@ public class ClientMethodHandler extends AbstractMethodHandler {
                 MapTool.getFrame().refresh();
                 return;
 
+              case setTokenProperty:
+                zoneGUID = (GUID) parameters[0];
+                ZoneRenderer zoneRenderer = MapTool.getFrame().getZoneRenderer(zoneGUID);
+                if (zoneRenderer == null) return;
+
+                Token mytoken = zoneRenderer.getZone().getToken((GUID) parameters[1]);
+                if (mytoken != null) {
+                  mytoken.setProperty(parameters[2].toString(), parameters[3].toString());
+                }
+                return;
+
               case removeToken:
                 zoneGUID = (GUID) parameters[0];
                 zone = MapTool.getCampaign().getZone(zoneGUID);

--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -239,7 +239,8 @@ public class ClientMethodHandler extends AbstractMethodHandler {
 
                 Token mytoken = zoneRenderer.getZone().getToken((GUID) parameters[1]);
                 if (mytoken != null) {
-                  mytoken.updateProperty(parameters[2].toString(), (Object[]) parameters[3]);
+                  mytoken.updateProperty(
+                      zoneRenderer, parameters[2].toString(), (Object[]) parameters[3]);
                 }
                 return;
 

--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -18,6 +18,7 @@ import java.awt.EventQueue;
 import java.awt.Point;
 import java.awt.geom.Area;
 import java.io.IOException;
+import java.lang.reflect.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -230,14 +231,15 @@ public class ClientMethodHandler extends AbstractMethodHandler {
                 MapTool.getFrame().refresh();
                 return;
 
-              case setTokenProperty:
+              case updateTokenProperty: // select token from sent zoneGUID & tokenGUID, then call
+                // Token.updateProperty()
                 zoneGUID = (GUID) parameters[0];
                 ZoneRenderer zoneRenderer = MapTool.getFrame().getZoneRenderer(zoneGUID);
                 if (zoneRenderer == null) return;
 
                 Token mytoken = zoneRenderer.getZone().getToken((GUID) parameters[1]);
                 if (mytoken != null) {
-                  mytoken.setProperty(parameters[2].toString(), parameters[3].toString());
+                  mytoken.updateProperty(parameters[2].toString(), (Object[]) parameters[3]);
                 }
                 return;
 

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import net.rptools.lib.MD5Key;
+import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Campaign;
@@ -149,10 +150,11 @@ public class ServerCommandClientImpl implements ServerCommand {
    * @param Object[] an array of parameters
    */
   public void updateTokenProperty(Token token, String methodName, Object... parameters) {
+    ZoneRenderer zoneRenderer = token.getZoneRenderer();
     GUID tokenGUID = token.getId();
-    GUID zoneGUID = token.getZoneRenderer().getZone().getId();
+    GUID zoneGUID = zoneRenderer.getZone().getId();
 
-    token.updateProperty(methodName, parameters);
+    token.updateProperty(zoneRenderer, methodName, parameters); // update locally right away
     updateTokenProperty(zoneGUID, tokenGUID, methodName, parameters);
   }
 

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -127,6 +127,10 @@ public class ServerCommandClientImpl implements ServerCommand {
     makeServerCall(COMMAND.removeToken, zoneGUID, tokenGUID);
   }
 
+  public void setTokenProperty(GUID zoneGUID, GUID tokenGUID, String property, String value) {
+    makeServerCall(COMMAND.setTokenProperty, zoneGUID, tokenGUID, property, value);
+  }
+
   public void putLabel(GUID zoneGUID, Label label) {
     makeServerCall(COMMAND.putLabel, zoneGUID, label);
   }

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -127,8 +127,33 @@ public class ServerCommandClientImpl implements ServerCommand {
     makeServerCall(COMMAND.removeToken, zoneGUID, tokenGUID);
   }
 
-  public void setTokenProperty(GUID zoneGUID, GUID tokenGUID, String property, String value) {
-    makeServerCall(COMMAND.setTokenProperty, zoneGUID, tokenGUID, property, value);
+  /**
+   * Send the command updateTokenProperty to the server. The method doesn't send the whole Token,
+   * greatly reducing lag.
+   *
+   * @param zoneGUID the GUID of the zone the token is on
+   * @param tokenGUID the GUID of the token
+   * @param methodName the string with the setter for the token
+   * @param Object[] an array of parameters
+   */
+  public void updateTokenProperty(
+      GUID zoneGUID, GUID tokenGUID, String methodName, Object[] parameters) {
+    makeServerCall(COMMAND.updateTokenProperty, zoneGUID, tokenGUID, methodName, parameters);
+  }
+
+  /**
+   * Simplifies the arguments for the method above.
+   *
+   * @param Token the token to be updated
+   * @param methodName the method to be used
+   * @param Object[] an array of parameters
+   */
+  public void updateTokenProperty(Token token, String methodName, Object... parameters) {
+    GUID tokenGUID = token.getId();
+    GUID zoneGUID = token.getZoneRenderer().getZone().getId();
+
+    token.updateProperty(methodName, parameters);
+    updateTokenProperty(zoneGUID, tokenGUID, methodName, parameters);
   }
 
   public void putLabel(GUID zoneGUID, Label label) {

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -104,11 +104,9 @@ public class TokenLocationFunctions extends AbstractFunction {
                 1,
                 parameters.get(0).toString()));
       }
-      token.setZOrder(((BigDecimal) parameters.get(0)).intValue());
+      MapTool.serverCommand()
+          .updateTokenProperty(token, "setZOrder", ((BigDecimal) parameters.get(0)).intValue());
       ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
-      Zone zone = renderer.getZone();
-      zone.putToken(token);
-      MapTool.serverCommand().putToken(zone.getId(), token);
       renderer.flushLight();
       return BigDecimal.valueOf(token.getZOrder());
     }
@@ -552,17 +550,20 @@ public class TokenLocationFunctions extends AbstractFunction {
    */
   public void moveToken(Token token, int x, int y, boolean units) {
     Grid grid = MapTool.getFrame().getCurrentZoneRenderer().getZone().getGrid();
+    int newX;
+    int newY;
 
     if (units) {
       ZonePoint zp = new ZonePoint(x, y);
-      token.setX(zp.x);
-      token.setY(zp.y);
+      newX = zp.x;
+      newY = zp.y;
     } else {
       CellPoint cp = new CellPoint(x, y);
       ZonePoint zp = grid.convert(cp);
-      token.setX(zp.x);
-      token.setY(zp.y);
+      newX = zp.x;
+      newY = zp.y;
     }
+    MapTool.serverCommand().updateTokenProperty(token, "setXY", newX, newY);
   }
 
   /**
@@ -608,8 +609,6 @@ public class TokenLocationFunctions extends AbstractFunction {
     moveToken(token, x, y, useDistance);
     ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
     Zone zone = renderer.getZone();
-    zone.putToken(token);
-    MapTool.serverCommand().putToken(zone.getId(), token);
     renderer.flushLight();
     return "";
   }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -201,6 +201,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, functionName);
+      ZoneRenderer zoneR = token.getZoneRenderer();
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return "";
@@ -213,6 +214,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, functionName);
+      ZoneRenderer zoneR = token.getZoneRenderer();
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return "";
@@ -325,7 +327,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       String property = parameters.get(0).toString();
       String value = parameters.get(1).toString();
 
-      Token token = getTokenFromParam(resolver, functionName, parameters, 2,3);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 2, 3);
       MapTool.serverCommand().updateTokenProperty(token, "setProperty", property, value);
       return "";
     }
@@ -470,6 +472,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("bringToFront")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      Zone zone = token.getZoneRenderer().getZone();
       MapTool.serverCommand().updateTokenProperty(token, "setZOrder", zone.getLargestZOrder() + 1);
       return BigDecimal.valueOf(token.getZOrder());
     }
@@ -480,6 +483,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("sendToBack")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      Zone zone = token.getZoneRenderer().getZone();
       MapTool.serverCommand().updateTokenProperty(token, "setZOrder", zone.getSmallestZOrder() - 1);
       return BigDecimal.valueOf(token.getZOrder());
     }
@@ -603,6 +607,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       BigDecimal facing = getBigDecimalFromParam(functionName, parameters, 0);
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       MapTool.serverCommand().updateTokenProperty(token, "setFacing", facing.intValue());
+      ZoneRenderer zoneR = token.getZoneRenderer();
       zoneR
           .flushLight(); // FJE This isn't needed unless the token had a light source, right? Should
       // we check for that?
@@ -616,6 +621,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, "setFacing", (Integer) null);
+      ZoneRenderer zoneR = token.getZoneRenderer();
       zoneR.flushLight();
       return "";
     }
@@ -799,21 +805,9 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("setTokenSnapToGrid")) {
       checkNumberOfParameters(functionName, parameters, 1, 3);
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      Object toGrid = parameters.get(0);
-      MapTool.serverCommand()
-          .updateTokenProperty(
-              token, "setSnapToGrid", AbstractTokenAccessorFunction.getBooleanValue(toGrid));
-      return "";
-    }
-    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
-  }
->>>>>>> Change functions in TokenPropertyFunctions.java to only send modified data
-
-      // Faster to not update clients through MapTool.serverCommand().putToken(token)
-      return param;
+      Boolean toGrid = AbstractTokenAccessorFunction.getBooleanValue((Object) parameters.get(0));
+      MapTool.serverCommand().updateTokenProperty(token, "setSnapToGrid", toGrid);
+      return toGrid;
     }
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -334,12 +334,13 @@ public class TokenPropertyFunctions extends AbstractFunction {
      */
     if (functionName.equals("setProperty")) {
       checkNumberOfParameters(functionName, parameters, 2, 4);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 2, 3);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setProperty(parameters.get(0).toString(), parameters.get(1).toString());
-      MapTool.serverCommand().putToken(zone.getId(), token);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 2,3);
+      MapTool.serverCommand()
+          .setTokenProperty(
+              zone.getId(),
+              token.getId(),
+              parameters.get(0).toString(),
+              parameters.get(1).toString());
       return "";
     }
 

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -126,11 +126,8 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("setPropertyType")) {
       checkNumberOfParameters(functionName, parameters, 1, 3);
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setPropertyType(parameters.get(0).toString());
-      MapTool.serverCommand().putToken(zone.getId(), token);
+      MapTool.serverCommand()
+          .updateTokenProperty(token, functionName, parameters.get(0).toString());
       return "";
     }
 
@@ -203,11 +200,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("setPC")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setType(Token.Type.PC);
-      MapTool.serverCommand().putToken(zone.getId(), token);
+      MapTool.serverCommand().updateTokenProperty(token, functionName);
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return "";
@@ -219,11 +212,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("setNPC")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setType(Token.Type.NPC);
-      MapTool.serverCommand().putToken(zone.getId(), token);
+      MapTool.serverCommand().updateTokenProperty(token, functionName);
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return "";
@@ -252,7 +241,6 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       String layer = setLayer(token, parameters.get(0).toString(), forceShape);
-      MapTool.serverCommand().putToken(zone.getId(), token);
       zoneR.flushLight();
       MapTool.getFrame().updateTokenTree();
       return layer;
@@ -334,13 +322,11 @@ public class TokenPropertyFunctions extends AbstractFunction {
      */
     if (functionName.equals("setProperty")) {
       checkNumberOfParameters(functionName, parameters, 2, 4);
+      String property = parameters.get(0).toString();
+      String value = parameters.get(1).toString();
+
       Token token = getTokenFromParam(resolver, functionName, parameters, 2,3);
-      MapTool.serverCommand()
-          .setTokenProperty(
-              zone.getId(),
-              token.getId(),
-              parameters.get(0).toString(),
-              parameters.get(1).toString());
+      MapTool.serverCommand().updateTokenProperty(token, "setProperty", property, value);
       return "";
     }
 
@@ -453,11 +439,8 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("setGMNotes")) {
       checkNumberOfParameters(functionName, parameters, 1, 3);
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setGMNotes(parameters.get(0).toString());
-      // Faster to not update clients through MapTool.serverCommand().putToken(token)
+      MapTool.serverCommand()
+          .updateTokenProperty(token, "setGMNotes", parameters.get(0).toString());
       return token.getGMNotes();
     }
 
@@ -477,11 +460,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("setNotes")) {
       checkNumberOfParameters(functionName, parameters, 1, 3);
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setNotes(parameters.get(0).toString());
-      // Faster to not update clients through MapTool.serverCommand().putToken(token)
+      MapTool.serverCommand().updateTokenProperty(token, "setNotes", parameters.get(0).toString());
       return token.getNotes();
     }
 
@@ -491,13 +470,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("bringToFront")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setZOrder(zone.getLargestZOrder() + 1);
-
-      MapTool.serverCommand().putToken(zone.getId(), token);
-
+      MapTool.serverCommand().updateTokenProperty(token, "setZOrder", zone.getLargestZOrder() + 1);
       return BigDecimal.valueOf(token.getZOrder());
     }
 
@@ -507,13 +480,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("sendToBack")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setZOrder(zone.getSmallestZOrder() - 1);
-
-      MapTool.serverCommand().putToken(zone.getId(), token);
-
+      MapTool.serverCommand().updateTokenProperty(token, "setZOrder", zone.getSmallestZOrder() - 1);
       return BigDecimal.valueOf(token.getZOrder());
     }
 
@@ -545,6 +512,9 @@ public class TokenPropertyFunctions extends AbstractFunction {
      */
     if (functionName.equals("setLibProperty")) {
       checkNumberOfParameters(functionName, parameters, 2, 3);
+      String property = parameters.get(0).toString();
+      String value = parameters.get(1).toString();
+
       String location;
       if (parameters.size() > 2) {
         location = parameters.get(2).toString();
@@ -552,10 +522,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
         location = MapTool.getParser().getMacroSource();
       }
       Token token = MapTool.getParser().getTokenMacroLib(location);
-      token.setProperty(parameters.get(0).toString(), parameters.get(1).toString());
-      Zone z = MapTool.getParser().getTokenMacroLibZone(location);
-      // Note: not `zone' since we want only the zone this particular token came from
-      MapTool.serverCommand().putToken(z.getId(), token);
+      MapTool.serverCommand().updateTokenProperty(token, "setProperty", property, value);
       return "";
     }
 
@@ -635,11 +602,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       checkNumberOfParameters(functionName, parameters, 1, 3);
       BigDecimal facing = getBigDecimalFromParam(functionName, parameters, 0);
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setFacing(facing.intValue());
-      MapTool.serverCommand().putToken(zone.getId(), token);
+      MapTool.serverCommand().updateTokenProperty(token, "setFacing", facing.intValue());
       zoneR
           .flushLight(); // FJE This isn't needed unless the token had a light source, right? Should
       // we check for that?
@@ -652,11 +615,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equals("removeTokenFacing")) {
       checkNumberOfParameters(functionName, parameters, 0, 2);
       Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
-
-      token.setFacing(null);
-      MapTool.serverCommand().putToken(zone.getId(), token);
+      MapTool.serverCommand().updateTokenProperty(token, "setFacing", (Integer) null);
       zoneR.flushLight();
       return "";
     }
@@ -683,7 +642,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       // keep the
       // ownership there.
       String myself = MapTool.getPlayer().getName();
-      token.clearAllOwners();
+      MapTool.serverCommand().updateTokenProperty(token, "clearAllOwners");
       String s = parameters.get(0).toString();
       if (StringUtil.isEmpty(s)) {
         // Do nothing when trusted, since all ownership should be turned off for an empty string
@@ -692,16 +651,18 @@ public class TokenPropertyFunctions extends AbstractFunction {
         Object json = JSONMacroFunctions.asJSON(parameters.get(0));
         if (json != null && json instanceof JSONArray) {
           for (Object o : (JSONArray) json) {
-            token.addOwner(o.toString());
+            MapTool.serverCommand().updateTokenProperty(token, "addOwner", o.toString());
           }
         } else {
-          token.addOwner(s);
+          MapTool.serverCommand().updateTokenProperty(token, "addOwner", s);
         }
       }
       if (!trusted)
-        token.addOwner(
-            myself); // If not trusted we must have been in the owner list -- keep us there.
-      MapTool.serverCommand().putToken(zone.getId(), token);
+        MapTool.serverCommand()
+            .updateTokenProperty(
+                token,
+                "addOwner",
+                myself); // If not trusted we must have been in the owner list -- keep us there.
       return "";
     }
 
@@ -720,12 +681,10 @@ public class TokenPropertyFunctions extends AbstractFunction {
       BigDecimal ownedByAll = getBigDecimalFromParam(functionName, parameters, 0);
 
       if (ownedByAll.compareTo(BigDecimal.ZERO) == 0) {
-        token.setOwnedByAll(false);
+        MapTool.serverCommand().updateTokenProperty(token, "setOwnedByAll", false);
       } else {
-        token.setOwnedByAll(true);
+        MapTool.serverCommand().updateTokenProperty(token, "setOwnedByAll", true);
       }
-
-      MapTool.serverCommand().putToken(zone.getId(), token);
       return token.isOwnedByAll() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
@@ -746,17 +705,13 @@ public class TokenPropertyFunctions extends AbstractFunction {
      * See Token.TokenShape for shape values. Currently "Top down", "Top_down", "Circle", and "Square".
      */
     if (functionName.equals("setTokenShape")) {
-      checkNumberOfParameters(functionName, parameters, 0, 3);
-      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      ZoneRenderer zoneR = token.getZoneRenderer();
-      Zone zone = zoneR.getZone();
+      checkNumberOfParameters(functionName, parameters, 1, 3);
 
+      Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Token.TokenShape newShape =
           Token.TokenShape.valueOf(
               parameters.get(0).toString().toUpperCase().trim().replace(" ", "_"));
-      token.setShape(newShape);
-
-      // Faster to not update clients through MapTool.serverCommand().putToken(token)
+      MapTool.serverCommand().updateTokenProperty(token, "setShape", newShape);
       return token.getShape().toString();
     }
 
@@ -817,21 +772,22 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       double magnitude = getBigDecimalFromParam(functionName, parameters, 0).doubleValue();
-
       Rectangle tokenBounds = token.getBounds(zone);
       double oldWidth = tokenBounds.width;
       double oldHeight = tokenBounds.height;
-      token.setSnapToScale(false);
+      MapTool.serverCommand().updateTokenProperty(token, "setSnapToScale", false);
 
+      double newScaleX;
+      double newScaleY;
       if (functionName.equals("setTokenWidth")) {
-        token.setScaleX(magnitude / token.getWidth());
-        token.setScaleY(oldHeight / token.getHeight());
+        newScaleX = magnitude / token.getWidth();
+        newScaleY = oldHeight / token.getHeight();
       } else { // it wasn't 'setTokenWidth' which means functionName equals 'setTokenHeight'
-        token.setScaleX(oldWidth / token.getWidth());
-        token.setScaleY(magnitude / token.getHeight());
+        newScaleX = oldWidth / token.getWidth();
+        newScaleY = magnitude / token.getHeight();
       }
-
-      // Faster to not update clients through MapTool.serverCommand().putToken(token)
+      MapTool.serverCommand().updateTokenProperty(token, "setScaleX", newScaleX);
+      MapTool.serverCommand().updateTokenProperty(token, "setScaleY", newScaleY);
       return magnitude;
     }
 
@@ -846,8 +802,15 @@ public class TokenPropertyFunctions extends AbstractFunction {
       ZoneRenderer zoneR = token.getZoneRenderer();
       Zone zone = zoneR.getZone();
 
-      Object param = parameters.get(0);
-      token.setSnapToGrid(AbstractTokenAccessorFunction.getBooleanValue(param));
+      Object toGrid = parameters.get(0);
+      MapTool.serverCommand()
+          .updateTokenProperty(
+              token, "setSnapToGrid", AbstractTokenAccessorFunction.getBooleanValue(toGrid));
+      return "";
+    }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
+  }
+>>>>>>> Change functions in TokenPropertyFunctions.java to only send modified data
 
       // Faster to not update clients through MapTool.serverCommand().putToken(token)
       return param;
@@ -883,19 +846,18 @@ public class TokenPropertyFunctions extends AbstractFunction {
    */
   private String setSize(Token token, String size) throws ParserException {
     if (size.equalsIgnoreCase("native") || size.equalsIgnoreCase("free")) {
-      token.setSnapToScale(false);
+      MapTool.serverCommand().updateTokenProperty(token, "setSnapToScale", false);
       return getSize(token);
     }
-    token.setSnapToScale(true);
+    MapTool.serverCommand().updateTokenProperty(token, "setSnapToScale", true);
     ZoneRenderer renderer = token.getZoneRenderer();
     Zone zone = renderer.getZone();
     Grid grid = zone.getGrid();
     for (TokenFootprint footprint : grid.getFootprints()) {
       if (footprint.getName().equalsIgnoreCase(size)) {
-        token.setFootprint(grid, footprint);
+        MapTool.serverCommand().updateTokenProperty(token, "setFootprint", grid, footprint);
         renderer.flush(token);
         renderer.repaint();
-        MapTool.serverCommand().putToken(zone.getId(), token);
         MapTool.getFrame().updateTokenTree();
         return getSize(token);
       }
@@ -910,12 +872,12 @@ public class TokenPropertyFunctions extends AbstractFunction {
    * @param token The token to reset the size of.
    */
   private void resetSize(Token token) {
-    token.setSnapToScale(true);
+    MapTool.serverCommand().updateTokenProperty(token, "setSnapToScale", true);
     ZoneRenderer renderer = token.getZoneRenderer();
     Zone zone = renderer.getZone();
     Grid grid = zone.getGrid();
-    token.setFootprint(grid, grid.getDefaultFootprint());
-    // Faster to not update clients through MapTool.serverCommand().putToken(token)
+    MapTool.serverCommand()
+        .updateTokenProperty(token, "setFootprint", grid, grid.getDefaultFootprint());
   }
 
   /**
@@ -944,22 +906,27 @@ public class TokenPropertyFunctions extends AbstractFunction {
       throw new ParserException(
           I18N.getText("macro.function.tokenProperty.unknownLayer", "setLayer", layerName));
     }
-    token.setLayer(layer);
+    MapTool.serverCommand().updateTokenProperty(token, "setLayer", layer);
     if (forceShape) {
+      Token.TokenShape tokenShape = null;
       switch (layer) {
         case BACKGROUND:
         case OBJECT:
-          token.setShape(Token.TokenShape.TOP_DOWN);
+          tokenShape = Token.TokenShape.TOP_DOWN;
           break;
         case GM:
         case TOKEN:
           Image image = ImageManager.getImage(token.getImageAssetId());
           if (image == null || image == ImageManager.TRANSFERING_IMAGE) {
-            token.setShape(Token.TokenShape.TOP_DOWN);
+
+            tokenShape = Token.TokenShape.TOP_DOWN;
           } else {
-            token.setShape(TokenUtil.guessTokenType(image));
+            tokenShape = TokenUtil.guessTokenType(image);
           }
           break;
+      }
+      if (tokenShape != null) {
+        MapTool.serverCommand().updateTokenProperty(token, "setShape", tokenShape);
       }
     }
     return layerName;

--- a/src/main/java/net/rptools/maptool/client/functions/TokenStateFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenStateFunction.java
@@ -177,10 +177,6 @@ public class TokenStateFunction extends AbstractFunction {
     val = args.get(1);
 
     setBooleanTokenState(token, stateName, val);
-    ((MapToolVariableResolver) parser.getVariableResolver())
-        .addDelayedAction(
-            new MapToolVariableResolver.PutTokenAction(
-                MapTool.getFrame().getCurrentZoneRenderer().getZone().getId(), token));
 
     return val;
   }
@@ -223,8 +219,6 @@ public class TokenStateFunction extends AbstractFunction {
     for (Object stateName : MapTool.getCampaign().getTokenStatesMap().keySet()) {
       setBooleanTokenState(token, stateName.toString(), val);
     }
-    MapTool.serverCommand()
-        .putToken(MapTool.getFrame().getCurrentZoneRenderer().getZone().getId(), token);
     return val;
   }
 
@@ -284,7 +278,7 @@ public class TokenStateFunction extends AbstractFunction {
       } catch (NumberFormatException e) {
         set = Boolean.parseBoolean(val.toString());
       }
-      token.setState(stateName, set);
+      MapTool.serverCommand().updateTokenProperty(token, "setState", stateName, set);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2027,6 +2027,19 @@ public class Token extends BaseModel implements Cloneable {
       case "setGMNotes":
         setGMNotes(parameters[0].toString());
         break;
+      case "setX":
+        setX((int) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setY":
+        setY((int) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setXY":
+        setX((int) parameters[0]);
+        setY((int) parameters[1]);
+        MapTool.getFrame().refresh();
+        break;
     }
     fireModelChangeEvent(
         new ModelChangeEvent(zone, Zone.Event.TOKEN_CHANGED, this)); // fire onChangeToken

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1948,4 +1948,83 @@ public class Token extends BaseModel implements Cloneable {
   public void setHeroLabData(HeroLabData heroLabData) {
     this.heroLabData = heroLabData;
   }
+
+  /**
+   * Call the relevant setter from methodName with an array of parameters Called by
+   * ClientMethodHandler to deal with sent change to token
+   *
+   * @param methodName the method to be used
+   * @param parameters an array of parameters
+   */
+  public void updateProperty(String methodName, Object[] parameters) {
+    Zone zone = getZoneRenderer().getZone();
+    switch (methodName) {
+      case "setPropertyType":
+        setPropertyType(parameters[0].toString());
+        break;
+      case "setPC":
+        setType(Type.PC);
+        break;
+      case "setNPC":
+        setType(Type.NPC);
+        break;
+      case "setLayer":
+        setLayer((Zone.Layer) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setShape":
+        setShape((TokenShape) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setSnapToScale":
+        setSnapToScale((Boolean) parameters[0]);
+        MapTool.getFrame().refresh(); // refresh change on map
+        break;
+      case "setSnapToGrid":
+        setSnapToGrid((Boolean) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setFootprint":
+        setFootprint((Grid) parameters[0], (TokenFootprint) parameters[1]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setProperty":
+        setProperty(parameters[0].toString(), parameters[1].toString());
+        break;
+      case "setZOrder":
+        setZOrder((int) parameters[0]);
+        zone.sortZOrder(); // update new ZOrder
+        MapTool.getFrame().refresh();
+        break;
+      case "setFacing":
+        setFacing((Integer) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "clearAllOwners":
+        clearAllOwners();
+        break;
+      case "setOwnedByAll":
+        setOwnedByAll((Boolean) parameters[0]);
+        break;
+      case "addOwner":
+        addOwner(parameters[0].toString());
+        break;
+      case "setScaleX":
+        setScaleX((double) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setScaleY":
+        setScaleY((double) parameters[0]);
+        MapTool.getFrame().refresh();
+        break;
+      case "setNotes":
+        setNotes(parameters[0].toString());
+        break;
+      case "setGMNotes":
+        setGMNotes(parameters[0].toString());
+        break;
+    }
+    fireModelChangeEvent(
+        new ModelChangeEvent(zone, Zone.Event.TOKEN_CHANGED, this)); // fire onChangeToken
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1954,11 +1954,15 @@ public class Token extends BaseModel implements Cloneable {
    * ClientMethodHandler to deal with sent change to token
    *
    * @param methodName the method to be used
+   * @param zoneRenderer the zone renderer where the token is
    * @param parameters an array of parameters
    */
-  public void updateProperty(String methodName, Object[] parameters) {
-    Zone zone = getZoneRenderer().getZone();
+  public void updateProperty(ZoneRenderer zoneRenderer, String methodName, Object[] parameters) {
+    Zone zone = zoneRenderer.getZone();
     switch (methodName) {
+      case "setState":
+        setState(parameters[0].toString(), parameters[1]);
+        MapTool.getFrame().refresh();
       case "setPropertyType":
         setPropertyType(parameters[0].toString());
         break;

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -944,6 +944,11 @@ public class Zone extends BaseModel {
     return tokenOrderedList.size() > 0 ? tokenOrderedList.get(0).getZOrder() : 0;
   }
 
+  /** Sort the tokens by their ZOrder */
+  public void sortZOrder() {
+    Collections.sort(tokenOrderedList, TOKEN_Z_ORDER_COMPARATOR);
+  }
+
   ///////////////////////////////////////////////////////////////////////////
   // labels
   ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -49,6 +49,7 @@ public interface ServerCommand {
     removeAsset,
     putToken,
     removeToken,
+    setTokenProperty,
     draw,
     updateDrawing,
     clearAllDrawings,
@@ -133,6 +134,8 @@ public interface ServerCommand {
   public void putToken(GUID zoneGUID, Token token);
 
   public void removeToken(GUID zoneGUID, GUID tokenGUID);
+
+  public void setTokenProperty(GUID zoneGUID, GUID tokenGUID, String property, String value);
 
   public void putLabel(GUID zoneGUID, Label label);
 

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -49,7 +49,7 @@ public interface ServerCommand {
     removeAsset,
     putToken,
     removeToken,
-    setTokenProperty,
+    updateTokenProperty,
     draw,
     updateDrawing,
     clearAllDrawings,
@@ -135,7 +135,10 @@ public interface ServerCommand {
 
   public void removeToken(GUID zoneGUID, GUID tokenGUID);
 
-  public void setTokenProperty(GUID zoneGUID, GUID tokenGUID, String property, String value);
+  public void updateTokenProperty(
+      GUID zoneGUID, GUID tokenGUID, String methodName, Object[] parameters);
+
+  public void updateTokenProperty(Token token, String methodName, Object... parameters);
 
   public void putLabel(GUID zoneGUID, Label label);
 

--- a/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -124,6 +124,11 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
         case putLabel:
           putLabel(context.getGUID(0), (Label) context.get(1));
           break;
+        case setTokenProperty:
+          setTokenProperty(
+              context.getGUID(0), context.getGUID(1), context.getString(2), context.getString(3));
+          break;
+
         case putToken:
           putToken(context.getGUID(0), (Token) context.get(1));
           break;
@@ -555,6 +560,10 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
         .getConnection()
         .broadcastCallMethod(
             ClientCommand.COMMAND.removeToken.name(), RPCContext.getCurrent().parameters);
+  }
+
+  public void setTokenProperty(GUID zoneGUID, GUID tokenGUID, String property, String value) {
+    forwardToAllClients();
   }
 
   public void removeZone(GUID zoneGUID) {

--- a/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -124,9 +124,9 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
         case putLabel:
           putLabel(context.getGUID(0), (Label) context.get(1));
           break;
-        case setTokenProperty:
-          setTokenProperty(
-              context.getGUID(0), context.getGUID(1), context.getString(2), context.getString(3));
+        case updateTokenProperty:
+          updateTokenProperty(
+              context.getGUID(0), context.getGUID(1), context.getString(2), context.getObjArray(3));
           break;
 
         case putToken:
@@ -562,9 +562,16 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
             ClientCommand.COMMAND.removeToken.name(), RPCContext.getCurrent().parameters);
   }
 
-  public void setTokenProperty(GUID zoneGUID, GUID tokenGUID, String property, String value) {
-    forwardToAllClients();
+  public void updateTokenProperty(
+      GUID zoneGUID, GUID tokenGUID, String methodName, Object[] parameters) {
+    forwardToClients();
   }
+
+  public void updateTokenProperty(
+      Token token,
+      String methodName,
+      Object...
+          parameters) {} // never actually called, but necessary to satisfy interface requirements
 
   public void removeZone(GUID zoneGUID) {
     server.getCampaign().removeZone(zoneGUID);
@@ -793,6 +800,10 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
 
     public Boolean getBool(int index) {
       return (Boolean) parameters[index];
+    }
+
+    public Object[] getObjArray(int index) {
+      return (Object[]) parameters[index];
     }
   }
 }


### PR DESCRIPTION
- Stop the functions in TokenPropertyFunctions from sending the entire token to other clients
- Same for setState and setAllStates
- Same for setTokenDrawOrder and moveToken
- Add server commands to update token properties by sending only the Token method to call and its new value
- Fix #552, and partially fullfill #555
- The following functions are affected:

    setPC
    setNPC
    setLayer
    setSize
    resetSize
    resetProperty
    setProperty
    sendToBack
    bringToFront
    setPropertyType
    setTokenFacing
    removeTokenFacing
    setOwner
    setOwnedByAll
    setTokenWidth
    setTokenHeight
    setTokenShape
    setGMNotes
    setNotes
    setTokenSnapToGrid
    setLibProperty
    setState
    setAllStates
    setTokenDrawOrder
    moveToken

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/556)
<!-- Reviewable:end -->
