### PR TITLE
Fix mouse drag issues: non snap-to-grid on square maps, snap-to-grid on gridless maps

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -910,7 +910,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
       zonePoint = grid.convert(grid.convert(zonePoint));
     } else {
       // Non-snapped while dragging.  Snaps when mouse-button released.
-      if (!(grid instanceof SquareGrid)) {
+      if (!(grid instanceof SquareGrid) || !tokenBeingDragged.isSnapToGrid()) {
         zonePoint.translate(-dragOffsetX, -dragOffsetY);
       }
     }

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -562,7 +562,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
         ZonePoint pos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
         Rectangle tokenBounds = token.getBounds(renderer.getZone());
 
-        if (token.isSnapToGrid()) {
+        if (token.isSnapToGrid() && getZone().getGrid().getCapabilities().isSnapToGridSupported()) {
           dragOffsetX = (pos.x - tokenBounds.x) - (tokenBounds.width / 2);
           dragOffsetY = (pos.y - tokenBounds.y) - (tokenBounds.height / 2);
         } else {


### PR DESCRIPTION
- Fix drag from upper left corner instead of mouse point for non snap-to-grid tokens on square maps
- Remove drag offset (left and up) for snap-to-grid tokens on gridless maps
- Close #540

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/567)
<!-- Reviewable:end -->
