### PR TITLE
Fix minor bugs in setSnapToGrid() and getPropertyDefault()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -388,11 +388,15 @@ public class TokenPropertyFunctions extends AbstractFunction {
      */
     if (functionName.equals("getPropertyDefault")) {
       checkNumberOfParameters(functionName, parameters, 1, 2);
-      Token token = resolver.getTokenInContext();
       String name = parameters.get(0).toString();
-      String propType =
-          parameters.size() > 1 ? parameters.get(1).toString() : token.getPropertyType();
 
+      String propType;
+      if (parameters.size() > 1) {
+        propType = parameters.get(1).toString();
+      } else {
+        Token token = getTokenFromParam(resolver, functionName, parameters, 1, -1);
+        propType = token.getPropertyType();
+      }
       Object val = null;
 
       List<TokenProperty> propertyList =
@@ -800,7 +804,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Token token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Boolean toGrid = AbstractTokenAccessorFunction.getBooleanValue((Object) parameters.get(0));
       MapTool.serverCommand().updateTokenProperty(token, "setSnapToGrid", toGrid);
-      return toGrid;
+      return token.isSnapToGrid() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }


### PR DESCRIPTION
- Fix null exception error if getPropertyDefault() is used with one parameter and there is no current token.  Issue #569 
- Fix setTokenSnapToGrid() returning true/false instead of 1/0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/572)
<!-- Reviewable:end -->
