### PR TITLE
Fix to TokenLightFunctions, Add parameters id & mapname

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
@@ -17,14 +17,14 @@ package net.rptools.maptool.client.functions;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
-import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Direction;
+import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.LightSource;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.model.Zone;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
@@ -34,7 +34,7 @@ public class TokenLightFunctions extends AbstractFunction {
   private static final TokenLightFunctions instance = new TokenLightFunctions();
 
   private TokenLightFunctions() {
-    super(0, 3, "hasLightSource", "clearLights", "setLight", "getLights");
+    super(0, 5, "hasLightSource", "clearLights", "setLight", "getLights");
   }
 
   public static TokenLightFunctions getInstance() {
@@ -44,28 +44,24 @@ public class TokenLightFunctions extends AbstractFunction {
   @Override
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException {
-    final Token tokenInContext =
-        ((MapToolVariableResolver) parser.getVariableResolver()).getTokenInContext();
-    if (tokenInContext == null) {
-      throw new ParserException(
-          I18N.getText("macro.function.general.noImpersonated", functionName));
-    }
+    MapToolVariableResolver resolver = (MapToolVariableResolver) parser.getVariableResolver();
+
     if (functionName.equals("hasLightSource")) {
-      return hasLightSource(tokenInContext, parameters) ? BigDecimal.ONE : BigDecimal.ZERO;
+      checkNumberOfParameters(functionName, parameters, 0, 4);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 2, 3);
+      return hasLightSource(token, parameters) ? BigDecimal.ONE : BigDecimal.ZERO;
     }
     if (functionName.equals("clearLights")) {
-      tokenInContext.clearLightSources();
-      MapTool.serverCommand()
-          .putToken(MapTool.getFrame().getCurrentZoneRenderer().getZone().getId(), tokenInContext);
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
+      MapTool.serverCommand().updateTokenProperty(token, "clearLightSources");
       MapTool.getFrame().updateTokenTree();
       return "";
     }
     if (functionName.equals("setLight")) {
-      if (parameters.size() < 3) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.notEnoughParam", functionName, 3, parameters.size()));
-      }
+      checkNumberOfParameters(functionName, parameters, 3, 5);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 3, 4);
+
       if (!(parameters.get(2) instanceof BigDecimal)) {
         throw new ParserException(
             I18N.getText(
@@ -75,15 +71,17 @@ public class TokenLightFunctions extends AbstractFunction {
                 parameters.get(2).toString()));
       }
       return setLight(
-          tokenInContext,
+          token,
           parameters.get(0).toString(),
           parameters.get(1).toString(),
           (BigDecimal) parameters.get(2));
     }
     if (functionName.equals("getLights")) {
+      checkNumberOfParameters(functionName, parameters, 0, 4);
+      Token token = getTokenFromParam(resolver, functionName, parameters, 2, 3);
+
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
-      return getLights(
-          tokenInContext, parameters.size() > 0 ? parameters.get(0).toString() : null, delim);
+      return getLights(token, parameters.size() > 0 ? parameters.get(0).toString() : null, delim);
     }
     return null;
   }
@@ -97,22 +95,29 @@ public class TokenLightFunctions extends AbstractFunction {
    * @param delim the delimiter for the list.
    * @return a string list containing the lights that are on.
    */
-  private String getLights(Token token, String category, String delim) {
+  private String getLights(Token token, String category, String delim) throws ParserException {
     ArrayList<String> lightList = new ArrayList<String>();
+    Map<String, Map<GUID, LightSource>> lightSourcesMap =
+        MapTool.getCampaign().getLightSourcesMap();
 
     if (category == null || category.equals("*")) {
-      for (String catName : MapTool.getCampaign().getLightSourcesMap().keySet()) {
-        for (LightSource ls : MapTool.getCampaign().getLightSourcesMap().get(catName).values()) {
+      for (String catName : lightSourcesMap.keySet()) {
+        for (LightSource ls : lightSourcesMap.get(catName).values()) {
           if (token.hasLightSource(ls)) {
             lightList.add(ls.getName());
           }
         }
       }
     } else {
-      for (LightSource ls : MapTool.getCampaign().getLightSourcesMap().get(category).values()) {
-        if (token.hasLightSource(ls)) {
-          lightList.add(ls.getName());
+      if (lightSourcesMap.containsKey(category)) {
+        for (LightSource ls : lightSourcesMap.get(category).values()) {
+          if (token.hasLightSource(ls)) {
+            lightList.add(ls.getName());
+          }
         }
+      } else {
+        throw new ParserException(
+            I18N.getText("macro.function.tokenLight.unknownLightType", "getLights", category));
       }
     }
     if ("json".equals(delim)) {
@@ -135,23 +140,27 @@ public class TokenLightFunctions extends AbstractFunction {
   private BigDecimal setLight(Token token, String category, String name, BigDecimal val)
       throws ParserException {
     boolean found = false;
+    Map<String, Map<GUID, LightSource>> lightSourcesMap =
+        MapTool.getCampaign().getLightSourcesMap();
 
-    for (LightSource ls : MapTool.getCampaign().getLightSourcesMap().get(category).values()) {
-      if (ls.getName().equals(name)) {
-        found = true;
-        if (val.equals(BigDecimal.ZERO)) {
-          token.removeLightSource(ls);
-        } else {
-          token.addLightSource(ls, Direction.CENTER);
+    if (lightSourcesMap.containsKey(category)) {
+      for (LightSource ls : lightSourcesMap.get(category).values()) {
+        if (ls.getName().equals(name)) {
+          found = true;
+          if (val.equals(BigDecimal.ZERO)) {
+            MapTool.serverCommand().updateTokenProperty(token, "removeLightSource", ls);
+          } else {
+            MapTool.serverCommand()
+                .updateTokenProperty(token, "addLightSource", ls, Direction.CENTER);
+          }
         }
       }
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.tokenLight.unknownLightType", "setLights", category));
     }
-    ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
-    Zone zone = renderer.getZone();
-    zone.putToken(token);
-    MapTool.serverCommand().putToken(zone.getId(), token);
     MapTool.getFrame().updateTokenTree();
-    renderer.flushLight();
+    token.getZoneRenderer().flushLight();
 
     return found ? BigDecimal.ONE : BigDecimal.ZERO;
   }
@@ -167,29 +176,113 @@ public class TokenLightFunctions extends AbstractFunction {
    *     checked to see if it has a light source with the name in the second parameter from the
    *     category in the first parameter.
    */
-  private boolean hasLightSource(Token token, List<Object> parameters) {
-    if (parameters.size() < 1) {
+  private boolean hasLightSource(Token token, List<Object> parameters) throws ParserException {
+    String category = (parameters.size() > 0) ? parameters.get(0).toString() : "*";
+    String name = (parameters.size() > 1) ? parameters.get(1).toString() : "*";
+
+    if (category.equals("*") && name.equals("*")) {
       return token.hasLightSources();
     }
-    String category = parameters.get(0).toString();
 
-    if (parameters.size() < 2) {
-      for (LightSource ls : MapTool.getCampaign().getLightSourcesMap().get(category).values()) {
-        if (token.hasLightSource(ls)) {
-          return true;
+    Map<String, Map<GUID, LightSource>> lightSourcesMap =
+        MapTool.getCampaign().getLightSourcesMap();
+
+    if (category.equals("*")) {
+      for (String catName : lightSourcesMap.keySet()) {
+        for (LightSource ls : lightSourcesMap.get(catName).values()) {
+          if (ls.getName().equals(name) || name.equals("*")) {
+            if (token.hasLightSource(ls)) {
+              return true;
+            }
+          }
         }
       }
-      return false;
-    }
-    String name = parameters.get(1).toString();
-
-    for (LightSource ls : MapTool.getCampaign().getLightSourcesMap().get(category).values()) {
-      if (ls.getName().equals(name)) {
-        if (token.hasLightSource(ls)) {
-          return true;
+    } else {
+      if (lightSourcesMap.containsKey(category)) {
+        for (LightSource ls : lightSourcesMap.get(category).values()) {
+          if (ls.getName().equals(name) || name.equals("*")) {
+            if (token.hasLightSource(ls)) {
+              return true;
+            }
+          }
         }
+      } else {
+        throw new ParserException(
+            I18N.getText("macro.function.tokenLight.unknownLightType", "hasLightSource", category));
       }
     }
+
     return false;
+  }
+
+  /**
+   * Checks that the number of objects in the list <code>parameters</code> is within given bounds
+   * (inclusive). Throws a <code>ParserException</code> if the check fails.
+   *
+   * @param functionName this is used in the exception message
+   * @param parameters a list of parameters
+   * @param min the minimum amount of parameters (inclusive)
+   * @param max the maximum amount of parameters (inclusive)
+   * @throws ParserException if there were more or less parameters than allowed
+   */
+  private void checkNumberOfParameters(
+      String functionName, List<Object> parameters, int min, int max) throws ParserException {
+    int numberOfParameters = parameters.size();
+    if (numberOfParameters < min) {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.general.notEnoughParam", functionName, min, numberOfParameters));
+    } else if (numberOfParameters > max) {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.general.tooManyParam", functionName, max, numberOfParameters));
+    }
+  }
+
+  /**
+   * Gets the token from the specified index or returns the token in context. This method will check
+   * the list size before trying to retrieve the token so it is safe to use for functions that have
+   * the token as a optional argument.
+   *
+   * @param res the variable resolver
+   * @param functionName The function name (used for generating exception messages).
+   * @param param The parameters for the function.
+   * @param indexToken The index to find the token at.
+   * @param indexMap The index to find the map name at. If -1, use current map instead.
+   * @return the token.
+   * @throws ParserException if a token is specified but the macro is not trusted, or the specified
+   *     token can not be found, or if no token is specified and no token is impersonated.
+   */
+  private Token getTokenFromParam(
+      MapToolVariableResolver res,
+      String functionName,
+      List<Object> param,
+      int indexToken,
+      int indexMap)
+      throws ParserException {
+
+    String mapName =
+        indexMap >= 0 && param.size() > indexMap ? param.get(indexMap).toString() : null;
+    Token token;
+    if (param.size() > indexToken) {
+      if (!MapTool.getParser().isMacroTrusted()) {
+        throw new ParserException(I18N.getText("macro.function.general.noPermOther", functionName));
+      }
+      token = FindTokenFunctions.findToken(param.get(indexToken).toString(), mapName);
+      if (token == null) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.general.unknownToken",
+                functionName,
+                param.get(indexToken).toString()));
+      }
+    } else {
+      token = res.getTokenInContext();
+      if (token == null) {
+        throw new ParserException(
+            I18N.getText("macro.function.general.noImpersonated", functionName));
+      }
+    }
+    return token;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -47,6 +47,7 @@ import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.JSONMacroFunctions;
+import net.rptools.maptool.client.ui.zone.FogUtil;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer.SelectionSet;
 import net.rptools.maptool.language.I18N;
@@ -2060,6 +2061,21 @@ public class Token extends BaseModel implements Cloneable {
         setX((int) parameters[0]);
         setY((int) parameters[1]);
         MapTool.getFrame().refresh();
+        break;
+      case "clearLightSources":
+        clearLightSources();
+        FogUtil.exposeVisibleArea(zoneRenderer, Collections.singleton(getId()), true); // update FoW
+        zoneRenderer.repaint();
+        break;
+      case "removeLightSource":
+        removeLightSource((LightSource) parameters[0]);
+        FogUtil.exposeVisibleArea(zoneRenderer, Collections.singleton(getId()), true); // update FoW
+        zoneRenderer.repaint();
+        break;
+      case "addLightSource":
+        addLightSource((LightSource) parameters[0], (Direction) parameters[1]);
+        FogUtil.exposeVisibleArea(zoneRenderer, Collections.singleton(getId()), true); // update FoW
+        zoneRenderer.repaint();
         break;
     }
     fireModelChangeEvent(

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -920,6 +920,8 @@ macro.function.strLst.incorrectParamExact          = "{0}" requires exactly {1} 
 macro.function.strLst.incorrectParamType           = Argument number {1} to function "{0}" must be type "{2}", but was passed "{3}" of type "{4}".
 macro.function.strPropFromVar.wrongArgs            = strPropFromVars second parameter "{0}" is invalid.
 macro.function.syrinscape.inactive                 = This client has not enabled Syrinscape integration in preference.
+# TokenLightFunctions
+macro.function.tokenLight.unknownLightType         = Unknown light type "{1}" in function "{0}".
 # name setting functions
 macro.function.tokenName.emptyTokenNameForbidden   = Error executing "{0}": the token name cannot be empty.
 # TokenPropertyFunctions


### PR DESCRIPTION
- Fix hasLightSource(), setLight(), and getLights() to give error message instead of NPE if the light type entered doesn't exist
- Fix FoW to update automatically after running clearLights() & setLight()
- Change so only the property of interest is sent by clearLights() & setLight()
- Add parameters token id and mapname
- Close #574
- Functions affected:
hasLightSource()
setLight()
getLights()
clearLights()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/575)
<!-- Reviewable:end -->
