### PR TITLE
Add parameters token id & mapname to token sight functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
@@ -37,7 +37,7 @@ public class TokenSightFunctions extends AbstractFunction {
   private static final TokenSightFunctions instance = new TokenSightFunctions();
 
   private TokenSightFunctions() {
-    super(0, 2, "hasSight", "setHasSight", "getSightType", "setSightType", "canSeeToken");
+    super(0, 3, "hasSight", "setHasSight", "getSightType", "setSightType", "canSeeToken");
   }
 
   public static TokenSightFunctions getInstance() {
@@ -55,106 +55,50 @@ public class TokenSightFunctions extends AbstractFunction {
   @Override
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException {
+    MapToolVariableResolver resolver = (MapToolVariableResolver) parser.getVariableResolver();
     Token token;
-
-    // For functions no parameters except option tokenID
+    // For functions no parameters except option tokenID and mapname
     if (functionName.equals("hasSight") || functionName.equals("getSightType")) {
-      if (parameters.size() == 1) {
-        token = FindTokenFunctions.findToken(parameters.get(0).toString(), null);
-        if (token == null) {
-          throw new ParserException(
-              I18N.getText(
-                  "macro.function.general.unknownToken",
-                  functionName,
-                  parameters.get(0).toString()));
-        }
-      } else if (parameters.size() == 0) {
-        token = ((MapToolVariableResolver) parser.getVariableResolver()).getTokenInContext();
-        if (token == null) {
-          throw new ParserException(
-              I18N.getText("macro.function.general.noImpersonated", functionName));
-        }
-      } else {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.tooManyParam", functionName, 1, parameters.size()));
-      }
-
+      checkNumberOfParameters(functionName, parameters, 0, 2);
+      token = getTokenFromParam(resolver, functionName, parameters, 0, 1);
       if (functionName.equals("hasSight"))
         return token.getHasSight() ? BigDecimal.ONE : BigDecimal.ZERO;
 
       if (functionName.equals("getSightType")) return token.getSightType();
     }
 
-    // For functions with only 1 parameter and optional second parameter of tokenID
-    if (parameters.size() > 2)
-      throw new ParserException(
-          I18N.getText("macro.function.general.tooManyParam", functionName, 1, parameters.size()));
-
-    if (parameters.isEmpty())
-      throw new ParserException(
-          I18N.getText(
-              "macro.function.general.notenoughparms", functionName, 1, parameters.size()));
-
-    if (parameters.size() == 2) {
-      token = FindTokenFunctions.findToken(parameters.get(1).toString(), null);
-
-      if (token == null) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.unknownToken", functionName, parameters.get(0).toString()));
-      }
-    } else {
-      token = ((MapToolVariableResolver) parser.getVariableResolver()).getTokenInContext();
-
-      if (token == null) {
-        throw new ParserException(
-            I18N.getText("macro.function.general.noImpersonated", functionName));
-      }
-    }
-
-    ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
-    Zone zone = renderer.getZone();
+    // For functions with only 1 parameter and optional second parameter of tokenID & mapname
+    checkNumberOfParameters(functionName, parameters, 1, 3);
+    token = getTokenFromParam(resolver, functionName, parameters, 1, 2);
 
     if (functionName.equals("setHasSight")) {
-      token.setHasSight(!parameters.get(0).equals(BigDecimal.ZERO));
-      zone.putToken(token);
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      renderer.flushLight();
-      return "";
+      MapTool.serverCommand()
+          .updateTokenProperty(token, "setHasSight", !parameters.get(0).equals(BigDecimal.ZERO));
+      token.getZoneRenderer().flushLight();
+      return token.getHasSight() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     if (functionName.equals("setSightType")) {
-      token.setSightType(parameters.get(0).toString());
-      zone.putToken(token);
-      MapTool.serverCommand().putToken(zone.getId(), token);
-      renderer.flushLight();
-      return "";
+      MapTool.serverCommand()
+          .updateTokenProperty(token, "setSightType", parameters.get(0).toString());
+      token.getZoneRenderer().flushLight();
+      return token.getSightType();
     }
 
     if (functionName.equals("canSeeToken")) {
       if (!token.getHasSight()) {
         return "[]";
       }
-      Area tokensVisibleArea = renderer.getZoneView().getVisibleArea(token);
+      ZoneRenderer zoneRenderer = token.getZoneRenderer();
+      Area tokensVisibleArea = zoneRenderer.getZoneView().getVisibleArea(token);
       if (tokensVisibleArea == null) {
         return "[]";
       }
-      Token target = null;
-      try {
-        target = FindTokenFunctions.findToken(parameters.get(0).toString(), zone.getName());
-      } catch (Exception e) {
-        if (e instanceof ClassCastException || token == null) {
-          throw new ParserException(
-              I18N.getText("macro.function.general.argumentTypeT", 2, functionName));
-        }
-      }
-      if (target == null) {
-        return "[]";
-      }
+      Token target = getTokenFromParam(resolver, functionName, parameters, 0, 2);
       if (!target.isVisible() || (target.isVisibleOnlyToOwner() && !AppUtil.playerOwns(target))) {
         return "[]";
       }
+      Zone zone = zoneRenderer.getZone();
       Grid grid = zone.getGrid();
 
       Rectangle bounds =
@@ -213,5 +157,76 @@ public class TokenSightFunctions extends AbstractFunction {
     }
 
     return "";
+  }
+
+  /**
+   * Checks that the number of objects in the list <code>parameters</code> is within given bounds
+   * (inclusive). Throws a <code>ParserException</code> if the check fails.
+   *
+   * @param functionName this is used in the exception message
+   * @param parameters a list of parameters
+   * @param min the minimum amount of parameters (inclusive)
+   * @param max the maximum amount of parameters (inclusive)
+   * @throws ParserException if there were more or less parameters than allowed
+   */
+  private void checkNumberOfParameters(
+      String functionName, List<Object> parameters, int min, int max) throws ParserException {
+    int numberOfParameters = parameters.size();
+    if (numberOfParameters < min) {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.general.notEnoughParam", functionName, min, numberOfParameters));
+    } else if (numberOfParameters > max) {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.general.tooManyParam", functionName, max, numberOfParameters));
+    }
+  }
+
+  /**
+   * Gets the token from the specified index or returns the token in context. This method will check
+   * the list size before trying to retrieve the token so it is safe to use for functions that have
+   * the token as a optional argument.
+   *
+   * @param res the variable resolver
+   * @param functionName The function name (used for generating exception messages).
+   * @param param The parameters for the function.
+   * @param indexToken The index to find the token at.
+   * @param indexMap The index to find the map name at. If -1, use current map instead.
+   * @return the token.
+   * @throws ParserException if a token is specified but the macro is not trusted, or the specified
+   *     token can not be found, or if no token is specified and no token is impersonated.
+   */
+  private Token getTokenFromParam(
+      MapToolVariableResolver res,
+      String functionName,
+      List<Object> param,
+      int indexToken,
+      int indexMap)
+      throws ParserException {
+
+    String mapName =
+        indexMap >= 0 && param.size() > indexMap ? param.get(indexMap).toString() : null;
+    Token token;
+    if (param.size() > indexToken) {
+      if (!MapTool.getParser().isMacroTrusted()) {
+        throw new ParserException(I18N.getText("macro.function.general.noPermOther", functionName));
+      }
+      token = FindTokenFunctions.findToken(param.get(indexToken).toString(), mapName);
+      if (token == null) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.general.unknownToken",
+                functionName,
+                param.get(indexToken).toString()));
+      }
+    } else {
+      token = res.getTokenInContext();
+      if (token == null) {
+        throw new ParserException(
+            I18N.getText("macro.function.general.noImpersonated", functionName));
+      }
+    }
+    return token;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -47,7 +47,6 @@ import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.JSONMacroFunctions;
-import net.rptools.maptool.client.ui.zone.FogUtil;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer.SelectionSet;
 import net.rptools.maptool.language.I18N;
@@ -2064,18 +2063,18 @@ public class Token extends BaseModel implements Cloneable {
         break;
       case "clearLightSources":
         clearLightSources();
-        FogUtil.exposeVisibleArea(zoneRenderer, Collections.singleton(getId()), true); // update FoW
-        zoneRenderer.repaint();
         break;
       case "removeLightSource":
         removeLightSource((LightSource) parameters[0]);
-        FogUtil.exposeVisibleArea(zoneRenderer, Collections.singleton(getId()), true); // update FoW
-        zoneRenderer.repaint();
         break;
       case "addLightSource":
         addLightSource((LightSource) parameters[0], (Direction) parameters[1]);
-        FogUtil.exposeVisibleArea(zoneRenderer, Collections.singleton(getId()), true); // update FoW
-        zoneRenderer.repaint();
+        break;
+      case "setHasSight":
+        setHasSight((boolean) parameters[0]);
+        break;
+      case "setSightType":
+        setSightType((String) parameters[0]);
         break;
     }
     fireModelChangeEvent(


### PR DESCRIPTION
- Add parameters token id & mapname to setHasSight() and hasSight()
- Add parameter mapname to canSeeToken(), getSightType() and setSightType()
- Change so setHasSight() and setSightType() send only the relevant information to the other clients instead of whole function
-  Close #578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/579)
<!-- Reviewable:end -->
