### PR TITLE
Add getFrameProperties() and getDialogProperties() functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.client.functions;
 
 import java.math.BigDecimal;
 import java.util.List;
+import net.rptools.maptool.client.ui.htmlframe.HTMLDialog;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrame;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrameFactory;
 import net.rptools.parser.Parser;
@@ -26,7 +27,16 @@ public class MacroDialogFunctions extends AbstractFunction {
   private static final MacroDialogFunctions instance = new MacroDialogFunctions();
 
   private MacroDialogFunctions() {
-    super(1, 1, "isDialogVisible", "isFrameVisible", "closeDialog", "resetFrame", "closeFrame");
+    super(
+        1,
+        1,
+        "isDialogVisible",
+        "isFrameVisible",
+        "closeDialog",
+        "resetFrame",
+        "closeFrame",
+        "getFrameProperties",
+        "getDialogProperties");
   }
 
   public static MacroDialogFunctions getInstance() {
@@ -57,6 +67,12 @@ public class MacroDialogFunctions extends AbstractFunction {
     if (functionName.equals("resetFrame")) {
       HTMLFrame.center(parameters.get(0).toString());
       return "";
+    }
+    if (functionName.equals("getFrameProperties")) {
+      return HTMLFrame.getFrameProperties(parameters.get(0).toString());
+    }
+    if (functionName.equals("getDialogProperties")) {
+      return HTMLDialog.getDialogProperties(parameters.get(0).toString());
     }
     return null;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLDialog.java
@@ -20,6 +20,7 @@ import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import javax.swing.JDialog;
@@ -27,6 +28,7 @@ import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
 import net.rptools.maptool.model.Token;
+import net.sf.json.JSONObject;
 
 @SuppressWarnings("serial")
 public class HTMLDialog extends JDialog implements HTMLPanelContainer {
@@ -147,6 +149,32 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       dialog.setVisible(true);
     }
     return dialog;
+  }
+
+  private boolean getTemporary() {
+    return this.temporary;
+  }
+
+  /**
+   * Return a json with the width, height, temporary variable and title of the dialog
+   *
+   * @param name The name of the frame.
+   * @return A json with the width, height, temporary and title of dialog
+   */
+  public static Object getDialogProperties(String name) {
+    if (dialogs.containsKey(name)) {
+      HTMLDialog dialog = dialogs.get(name);
+      JSONObject dialogProperties = new JSONObject();
+
+      dialogProperties.put("width", dialog.getWidth());
+      dialogProperties.put("height", dialog.getHeight());
+      dialogProperties.put("temporary", dialog.getTemporary() ? BigDecimal.ONE : BigDecimal.ZERO);
+      dialogProperties.put("title", dialog.getTitle());
+
+      return dialogProperties;
+    } else {
+      return "";
+    }
   }
 
   /** The selected token list has changed. */

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -28,6 +28,7 @@ import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
 import net.rptools.maptool.model.Token;
+import net.sf.json.JSONObject;
 
 @SuppressWarnings("serial")
 public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
@@ -207,6 +208,27 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
           frame.tokenChanged(token);
         }
       }
+    }
+  }
+
+  /**
+   * Return a json with the width, height and title of the frame
+   *
+   * @param name The name of the frame.
+   * @return A json with the width, height and title of the frame
+   */
+  public static Object getFrameProperties(String name) {
+    if (frames.containsKey(name)) {
+      HTMLFrame frame = frames.get(name);
+      JSONObject frameProperties = new JSONObject();
+
+      frameProperties.put("width", frame.getWidth());
+      frameProperties.put("height", frame.getHeight());
+      frameProperties.put("title", frame.getTitle());
+
+      return frameProperties;
+    } else {
+      return "";
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -21,6 +21,7 @@ import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import javax.swing.ImageIcon;
@@ -35,6 +36,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
   private static final Map<String, HTMLFrame> frames = new HashMap<String, HTMLFrame>();
   private final Map<String, String> macroCallbacks = new HashMap<String, String>();
 
+  private Object value;
   private final HTMLPanel panel;
 
   /**
@@ -70,16 +72,18 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * @param title The title of the frame.
    * @param width The width of the frame in pixels.
    * @param height The height of the frame in pixels.
+   * @param val A value that can be returned by getFrameProperties().
    * @param html The html to display in the frame.
    * @return The HTMLFrame that is displayed.
    */
-  public static HTMLFrame showFrame(String name, String title, int width, int height, String html) {
+  public static HTMLFrame showFrame(
+      String name, String title, int width, int height, Object val, String html) {
     HTMLFrame frame;
 
     if (frames.containsKey(name)) {
       frame = frames.get(name);
       frame.setTitle(title);
-      frame.updateContents(html);
+      frame.updateContents(html, val);
       if (!frame.isVisible()) {
         frame.setVisible(true);
         frame.getDockingManager().showFrame(name);
@@ -91,7 +95,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
 
       frame = new HTMLFrame(MapTool.getFrame(), name, title, width, height);
       frames.put(name, frame);
-      frame.updateContents(html);
+      frame.updateContents(html, val);
       frame.getDockingManager().showFrame(name);
       // Jamz: why undock frames to center them?
       if (!frame.isDocked()) center(name);
@@ -99,14 +103,22 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
     return frame;
   }
 
+  public void setValue(Object val) {
+    this.value = val;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
   /**
    * Creates a new HTMLFrame.
    *
    * @param parent The parent of this frame.
-   * @param name the name of the frame.
+   * @param name The name of the frame.
    * @param title The title of the frame.
-   * @param width
-   * @param height
+   * @param width The width of the frame.
+   * @param height The height of the frame.
    */
   private HTMLFrame(Frame parent, String name, String title, int width, int height) {
     super(title, new ImageIcon(AppStyle.chatPanelImage));
@@ -138,10 +150,12 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * Updates the html contents of the frame.
    *
    * @param html the html contents.
+   * @param val the value of the frame.
    */
-  public void updateContents(String html) {
+  public void updateContents(String html, Object val) {
     macroCallbacks.clear();
     panel.updateContents(html, false);
+    setValue(val);
   }
 
   /** The selected token list has changed. */
@@ -215,7 +229,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * Return a json with the width, height and title of the frame
    *
    * @param name The name of the frame.
-   * @return A json with the width, height and title of the frame
+   * @return A json with the width, height, title, and value of the frame
    */
   public static Object getFrameProperties(String name) {
     if (frames.containsKey(name)) {
@@ -225,6 +239,20 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       frameProperties.put("width", frame.getWidth());
       frameProperties.put("height", frame.getHeight());
       frameProperties.put("title", frame.getTitle());
+
+      Object frameValue = frame.getValue();
+      if (frameValue == null) {
+        frameValue = "";
+      } else {
+        if (frameValue instanceof String) {
+          // try to convert to a number
+          try {
+            frameValue = new BigDecimal(frameValue.toString());
+          } catch (Exception e) {
+          }
+        }
+      }
+      frameProperties.put("value", frameValue);
 
       return frameProperties;
     } else {

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -121,8 +121,9 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * @param height The height of the frame.
    */
   private HTMLFrame(Frame parent, String name, String title, int width, int height) {
-    super(title, new ImageIcon(AppStyle.chatPanelImage));
+    super(name, new ImageIcon(AppStyle.chatPanelImage));
 
+    setTitle(title);
     setPreferredSize(new Dimension(width, height));
     panel = new HTMLPanel(this, true, true); // closeOnSubmit is true so we don't get close button
     add(panel);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -46,6 +46,7 @@ public class HTMLFrameFactory {
     int width = -1;
     int height = -1;
     String title = name;
+    Object frameValue = null;
     boolean hasFrame = true;
     boolean closeButton = true;
 
@@ -109,14 +110,16 @@ public class HTMLFrameFactory {
           } catch (NumberFormatException e) {
             // Ignoring the value; shouldn't we warn the user?
           }
+        } else if (keyLC.equals("value")) {
+          frameValue = value;
         }
       }
     }
     if (isFrame) {
-      HTMLFrame.showFrame(name, title, width, height, html);
+      HTMLFrame.showFrame(name, title, width, height, frameValue, html);
     } else {
       HTMLDialog.showDialog(
-          name, title, width, height, hasFrame, input, temporary, closeButton, html);
+          name, title, width, height, hasFrame, input, temporary, closeButton, frameValue, html);
     }
   }
 


### PR DESCRIPTION
- Add new parameter "value" to frame() and dialog()
- Add getFrameProperties(name) and getDialogProperties(name) functions
- Functions returns json with "width", "height", "temporary" (dialog only), "title", and "value"
- Fix Fix frame() bug with "title" parameter on frame creation
- Implements #584, Close #587
- Example: 

[frame("Frame Test", "value=Bob"): {test}]
[getFrameProperties("Frame Test")]
{"width":400,"height":200,"title":"Frame Test","value":"Bob"}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/586)
<!-- Reviewable:end -->
