### PR TITLE
Add to frame() partial support for "temporary"

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -116,7 +116,7 @@ public class HTMLFrameFactory {
       }
     }
     if (isFrame) {
-      HTMLFrame.showFrame(name, title, width, height, frameValue, html);
+      HTMLFrame.showFrame(name, title, width, height, temporary, frameValue, html);
     } else {
       HTMLDialog.showDialog(
           name, title, width, height, hasFrame, input, temporary, closeButton, frameValue, html);


### PR DESCRIPTION
- Fix behavior with temporary=1 when the frame is closed through closeFrame()
- Add field "temporary" to the json returned by getFrameProperties()
- Does not fix behavior when clicking on the close button - I don't know how to setup the WindowListener properly
- Partially fix #585

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/593)
<!-- Reviewable:end -->
