### PR TITLE
Fix minimized frames don't retain their title

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -82,12 +82,20 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * @return The HTMLFrame that is displayed.
    */
   public static HTMLFrame showFrame(
-      String name, String title, int width, int height, boolean temp, Object val, String html) {
+      String name,
+      String title,
+      String tabTitle,
+      int width,
+      int height,
+      boolean temp,
+      Object val,
+      String html) {
     HTMLFrame frame;
 
     if (frames.containsKey(name)) {
       frame = frames.get(name);
       frame.setTitle(title);
+      frame.setTabTitle(tabTitle);
       frame.updateContents(html, temp, val);
       if (!frame.isVisible()) {
         frame.setVisible(true);
@@ -102,6 +110,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       frames.put(name, frame);
       frame.updateContents(html, temp, val);
       frame.getDockingManager().showFrame(name);
+      frame.setTabTitle(tabTitle);
       // Jamz: why undock frames to center them?
       if (!frame.isDocked()) center(name);
     }
@@ -307,7 +316,9 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       macroCallbacks.put(rmae.getType(), rmae.getMacro());
     }
     if (e instanceof HTMLPane.ChangeTitleActionEvent) {
-      this.setTitle(((HTMLPane.ChangeTitleActionEvent) e).getNewTitle());
+      String newTitle = ((HTMLPane.ChangeTitleActionEvent) e).getNewTitle();
+      this.setTitle(newTitle);
+      this.setTabTitle(newTitle);
     }
     if (e instanceof HTMLPane.MetaTagActionEvent) {
       HTMLPane.MetaTagActionEvent mtae = (HTMLPane.MetaTagActionEvent) e;

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -46,6 +46,7 @@ public class HTMLFrameFactory {
     int width = -1;
     int height = -1;
     String title = name;
+    String tabTitle = null;
     Object frameValue = null;
     boolean hasFrame = true;
     boolean closeButton = true;
@@ -112,11 +113,14 @@ public class HTMLFrameFactory {
           }
         } else if (keyLC.equals("value")) {
           frameValue = value;
+        } else if (keyLC.equals("tabtitle")) {
+          tabTitle = value;
         }
       }
     }
+    if (tabTitle == null) tabTitle = title; // if tabTitle not set, make it same as title
     if (isFrame) {
-      HTMLFrame.showFrame(name, title, width, height, temporary, frameValue, html);
+      HTMLFrame.showFrame(name, title, tabTitle, width, height, temporary, frameValue, html);
     } else {
       HTMLDialog.showDialog(
           name, title, width, height, hasFrame, input, temporary, closeButton, frameValue, html);


### PR DESCRIPTION
- Fix: minimized frames now retain their title instead of reverting to the frame name
- Add new frame parameter "tabtitle" to specify the tabbed title of a frame
- HTML tag "<title>" ovverides both the title and the tabtitle
- Close #434

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/602)
<!-- Reviewable:end -->
