### PR TITLE
Fix exception when loading wrong MapTool file as campaign properties

### DIFF
--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -805,9 +805,14 @@ public class PersistenceUtil {
         props = (CampaignProperties) pakFile.getContent();
         loadAssets(props.getAllImageAssets(), pakFile);
       } catch (ConversionException ce) {
-        MapTool.showError("PersistenceUtil.error.campaignPropertiesVersion", ce);
+        MapTool.showError(I18N.getText("PersistenceUtil.error.campaignPropertiesVersion"), ce);
       } catch (IOException ioe) {
-        MapTool.showError("Could not load campaign properties", ioe);
+        MapTool.showError(I18N.getText("PersistenceUtil.error.campaignPropertiesRead"), ioe);
+      } catch (ClassCastException cce) {
+        MapTool.showWarning(
+            I18N.getText(
+                "PersistenceUtil.warn.campaignProperties.importWrongFileType",
+                pakFile.getContent().getClass().getSimpleName()));
       }
       return props;
     } catch (IOException e) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -153,8 +153,11 @@ MapToolEventQueue.stackOverflow.title = Error: Stack Overflow
 MapToolEventQueue.unexpectedError     = An unexpected error has occurred.
 MapToolEventQueue.warning.title       = Warning
 
-PersistenceUtil.error.campaignPropertiesLegacy  = This campaign properties file is not a legacy format file readable by this version of MapTool.
-PersistenceUtil.error.campaignPropertiesVersion = This campaign properties file is not readable by this version of MapTool.
+PersistenceUtil.error.campaignPropertiesLegacy               = This campaign properties file is not a legacy format file readable by this version of MapTool.
+PersistenceUtil.error.campaignPropertiesVersion              = This campaign properties file is not readable by this version of MapTool.
+PersistenceUtil.error.campaignPropertiesRead                 = Error while reading campaign properties data from file.
+PersistenceUtil.warn.campaignProperties.importWrongFileType  = File is not a MapTool campaign properties file.  File is {0}.
+
 PersistenceUtil.error.campaignRead              = Error while reading campaign file.
 PersistenceUtil.error.campaignVersion           = This campaign file is not readable by this version of MapTool.<br>We will attempt to load using the legacy format...
 # The keys ending with "Read" are for reporting IOExceptions.


### PR DESCRIPTION
- Add error message: File is not a MapTool campaign properties file.  File is {simple class name}.
- Add proper i18n support for ioe and conversion exception errors
- Close #603

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/604)
<!-- Reviewable:end -->
