### PR TITLE
Fix Open Campaign dialog filter and error message

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2303,6 +2303,7 @@ public class AppActions {
           JFileChooser chooser = new CampaignPreviewFileChooser();
           chooser.setDialogTitle(I18N.getText("msg.title.loadCampaign"));
           chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+          chooser.setFileFilter(MapTool.getFrame().getCmpgnFileFilter());
 
           if (chooser.showOpenDialog(MapTool.getFrame()) == JFileChooser.APPROVE_OPTION) {
             File campaignFile = chooser.getSelectedFile();

--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -458,6 +458,11 @@ public class PersistenceUtil {
     } catch (OutOfMemoryError oom) {
       MapTool.showError("Out of memory while reading campaign.", oom);
       return null;
+    } catch (ClassCastException cce) {
+      MapTool.showWarning(
+          I18N.getText(
+              "PersistenceUtil.warn.campaignWrongFileType",
+              pakFile.getContent().getClass().getSimpleName()));
     } catch (RuntimeException rte) {
       MapTool.showError("PersistenceUtil.error.campaignRead", rte);
     } catch (Error e) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -170,7 +170,8 @@ PersistenceUtil.error.mapVersion                = This map file is not readable 
 PersistenceUtil.error.tableRead                 = Error while reading table data from file.
 PersistenceUtil.error.tableVersion              = This table file is not readable by this version of MapTool.
 PersistenceUtil.warn.campaignNotLoaded          = Cannot determine campaign file format; not loaded.
-PersistenceUtil.warn.importWrongFileType        = File is not a MapTool map file.  File is {0}
+PersistenceUtil.warn.campaignWrongFileType      = File is not a MapTool campaign file. File is {0}.
+PersistenceUtil.warn.importWrongFileType        = File is not a MapTool map file.  File is {0}.
 
 ServerDialog.error.port                = You must enter a numeric port.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?!  Web server bug?


### PR DESCRIPTION
- Fix cmpgn filter not set as default in the Open Campaign dialog
- Change error message when opening a wrong maptool element as a campaign file
- Close #225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/605)
<!-- Reviewable:end -->
