### PR TITLE
Fix token names showing under FoW when Vision or Auto-Reveal are off

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -3439,6 +3439,15 @@ public class ZoneRenderer extends JComponent
 
       // Token names and labels
       boolean showCurrentTokenLabel = AppState.isShowTokenNames() || token == tokenUnderMouse;
+
+      // if policy does not auto-reveal FoW, check if fog covers the token (slow)
+      if (showCurrentTokenLabel
+          && !isGMView
+          && (!zoneView.isUsingVision() || !MapTool.getServerPolicy().isAutoRevealOnMovement())) {
+        if (!zone.isTokenVisible(token)) {
+          showCurrentTokenLabel = false;
+        }
+      }
       if (showCurrentTokenLabel) {
         GUID tokId = token.getId();
         int offset = 3; // Keep it from tramping on the token border.


### PR DESCRIPTION
- Add a check with zone.isTokenVisible()
- The operation is slow, but only runs if "Show Token Names" is enabled or the token is under the mouse
- Only affects cases where either Vision or Auto-Reveal are off
- Close #553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/607)
<!-- Reviewable:end -->
