### PR TITLE
Debounce/throttle repaint() calls in ZoneRenderer

### DIFF
--- a/src/main/java/net/rptools/maptool/client/DebounceExecutor.java
+++ b/src/main/java/net/rptools/maptool/client/DebounceExecutor.java
@@ -1,0 +1,131 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.Date;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Manages throttling rapid successive attempts to execute a task.
+ *
+ * @see https://stackoverflow.com/a/18758408
+ * @see https://github.com/ThomasGirard/JDebounce
+ *
+ * @author Philip Nichols (philip.j.nichols@gmail.com)
+ * @version 1.5.3
+ * @since 2019-08-23
+ */
+public class DebounceExecutor {
+
+    /**
+     * The time, in milliseconds, during which to throttle subsequent requests
+     * to run the task.
+     */
+    private final long delay;
+
+    /**
+     * A {@link ScheduledExecutorService} that will be used to run the debounced
+     * task when the delay elapses.
+     */
+    private final ScheduledExecutorService executor
+            = Executors.newSingleThreadScheduledExecutor();
+
+    /**
+     * A {@link ScheduledFuture} that represents the debounced task.
+     */
+    private ScheduledFuture<?> future;
+
+    /**
+     * A {@link Runnable} representing the task to be managed.
+     */
+    private final Runnable task;
+
+    /**
+     * A wrapper to provide additional servicing for running the task.
+     */
+    private final Runnable taskWrapper;
+
+    /**
+     * A {@link long} indicating the time, in milliseconds, when the task last
+     * entered a pending state.
+     */
+    private long taskPendingSince = -1;
+    
+    /**
+     * A reference to the logging service.
+     */
+    private static final Logger log 
+            = LogManager.getLogger(DebounceExecutor.class);
+
+
+    /**
+     * Initializes a new instance of the {@link DebounceExecutor} class.
+     *
+     * Note that this class swallows later attempted invocations of its 
+     * managed task.  This makes it appropriate for repaint()-like tasks, where
+     * even an early-scheduled task will be working with the current backbuffer
+     * once it finally executes.  <i>It is not appropriate for tasks whose 
+     * correct execution relies on swallowing early invocations and running the 
+     * last-posted one.</i>
+     *
+     * @param delay The time, in milliseconds, during which the DebounceExecutor
+     * will wait before executing the <i>task</i> and throttle subsequent
+     * requests.
+     * @param task The task to be executed after the <i>delay</i> elapses.
+     */
+    public DebounceExecutor(long delay, Runnable task) {
+        this.delay = delay;
+        this.task = task;
+        this.taskWrapper = new Runnable() {
+
+            @Override
+            public void run() {
+                if (task != null) {
+                    task.run();
+                }
+            };
+        };
+
+    }
+
+    /**
+     * Dispatches a task to be executed by this {@link DebounceExecutor}
+     * instance.
+     */
+    public void dispatch() {
+        long now = (new Date()).getTime();
+        if (this.delay < 1) {
+            this.task.run();
+        } else if (this.taskPendingSince == -1
+                || now - this.taskPendingSince >= this.delay) {
+            this.taskPendingSince = now;
+            // With very particular timing, this could overwrite a running 
+            // _future_.  This should not be problematic when it does happen, 
+            // since _future_ is never read from.
+            this.future = this.executor.schedule(
+                    task,
+                    delay,
+                    TimeUnit.MILLISECONDS);
+        } else {
+            log.info("Task execution was debounced.");
+        }
+    }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -144,6 +144,8 @@ public class ZoneRenderer extends JComponent
     implements DropTargetListener, Comparable<ZoneRenderer> {
   private static final long serialVersionUID = 3832897780066104884L;
   private static final Logger log = LogManager.getLogger(ZoneRenderer.class);
+  
+  private static final long REPAINT_DEBOUNCE_INTERVAL = 34;
 
   private static final Color TRANSLUCENT_YELLOW =
       new Color(Color.yellow.getRed(), Color.yellow.getGreen(), Color.yellow.getBlue(), 50);
@@ -310,7 +312,7 @@ public class ZoneRenderer extends JComponent
 
   public void clearShowPaths() {
     showPathList.clear();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public Scale getZoneScale() {
@@ -332,7 +334,7 @@ public class ZoneRenderer extends JComponent
               // flushFog = true;
             }
             visibleScreenArea = null;
-            repaint();
+            repaint(REPAINT_DEBOUNCE_INTERVAL);
           }
         });
   }
@@ -358,7 +360,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
     tokenUnderMouse = token;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   @Override
@@ -375,7 +377,7 @@ public class ZoneRenderer extends JComponent
       }
     }
     selectionSetMap.put(keyToken, new SelectionSet(playerId, keyToken, tokenList));
-    repaint(); // Jamz: Seems to have no affect?
+    repaint(REPAINT_DEBOUNCE_INTERVAL); // Jamz: Seems to have no affect?
   }
 
   public boolean hasMoveSelectionSetMoved(GUID keyToken, ZonePoint point) {
@@ -397,7 +399,7 @@ public class ZoneRenderer extends JComponent
     }
     Token token = zone.getToken(keyToken);
     set.setOffset(offset.x - token.getX(), offset.y - token.getY());
-    repaint(); // Jamz: may cause flicker when using AI
+    repaint(REPAINT_DEBOUNCE_INTERVAL); // Jamz: may cause flicker when using AI
   }
 
   public void toggleMoveSelectionSetWaypoint(GUID keyToken, ZonePoint location) {
@@ -406,7 +408,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
     set.toggleWaypoint(location);
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public ZonePoint getLastWaypoint(GUID keyToken) {
@@ -422,7 +424,7 @@ public class ZoneRenderer extends JComponent
     if (set == null) {
       return;
     }
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void commitMoveSelectionSet(GUID keyTokenId) {
@@ -617,7 +619,7 @@ public class ZoneRenderer extends JComponent
 
     setViewOffset(x, y);
 
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void centerOn(CellPoint point) {
@@ -680,13 +682,13 @@ public class ZoneRenderer extends JComponent
     renderedLightMap = null;
     renderedAuraMap = null;
     zoneView.flush();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void flushFog() {
     flushFog = true;
     visibleScreenArea = null;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public Zone getZone() {
@@ -2718,7 +2720,7 @@ public class ZoneRenderer extends JComponent
     if (!keepSelectedTokenSet) selectedTokenSet.clear();
     else keepSelectedTokenSet = false; // Always reset it back, temp boolean only
 
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   /**
@@ -3620,7 +3622,7 @@ public class ZoneRenderer extends JComponent
     // flushFog = true; // could call flushFog() but also clears visibleScreenArea and I don't know
     // if we want
     // that...
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public boolean selectToken(GUID tokenGUID) {
@@ -3632,7 +3634,7 @@ public class ZoneRenderer extends JComponent
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
     // flushFog = true;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
     return true;
   }
 
@@ -3645,7 +3647,7 @@ public class ZoneRenderer extends JComponent
     }
     addToSelectionHistory(selectedTokenSet);
 
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
   }
@@ -3667,7 +3669,7 @@ public class ZoneRenderer extends JComponent
     selectedTokenSet.clear();
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void undoSelectToken() {
@@ -3700,7 +3702,7 @@ public class ZoneRenderer extends JComponent
     // disable the undo button.
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   private void addToSelectionHistory(Set<GUID> selectionSet) {
@@ -3871,7 +3873,7 @@ public class ZoneRenderer extends JComponent
 
   public void adjustGridSize(int delta) {
     zone.getGrid().setSize(Math.max(0, zone.getGrid().getSize() + delta));
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void moveGridBy(int dx, int dy) {
@@ -3888,7 +3890,7 @@ public class ZoneRenderer extends JComponent
       gridOffsetX = gridOffsetX - (int) zone.getGrid().getCellWidth();
     }
     zone.getGrid().setOffset(gridOffsetX, gridOffsetY);
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   /**
@@ -3927,7 +3929,7 @@ public class ZoneRenderer extends JComponent
   /** This makes sure that any image updates get refreshed. This could be a little smarter. */
   @Override
   public boolean imageUpdate(Image img, int infoflags, int x, int y, int w, int h) {
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
     return super.imageUpdate(img, infoflags, x, y, w, h);
   }
 
@@ -4434,7 +4436,7 @@ public class ZoneRenderer extends JComponent
     // Copy them to the clipboard so that we can quickly copy them onto the map
     AppActions.copyTokens(tokens);
     requestFocusInWindow();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   /**
@@ -4522,7 +4524,7 @@ public class ZoneRenderer extends JComponent
         flushFog = true;
       }
       MapTool.getFrame().updateTokenTree();
-      repaint();
+      repaint(REPAINT_DEBOUNCE_INTERVAL);
     }
   }
 
@@ -4544,7 +4546,7 @@ public class ZoneRenderer extends JComponent
 
   public void setHighlightCommonMacros(List<Token> affectedTokens) {
     highlightCommonMacros = affectedTokens;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   // End token common macro identification

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -147,6 +147,11 @@ public class ZoneRenderer extends JComponent
 
   private static final Color TRANSLUCENT_YELLOW =
       new Color(Color.yellow.getRed(), Color.yellow.getGreen(), Color.yellow.getBlue(), 50);
+  
+  /**
+   * Time period, in milliseconds, within which to wait for a repaint.
+   */
+  private static final long REPAINT_DEBOUNCE_INTERVAL = 34;
 
   public static final int MIN_GRID_SIZE = 10;
   private static LightSourceIconOverlay lightSourceIconOverlay = new LightSourceIconOverlay();
@@ -310,7 +315,7 @@ public class ZoneRenderer extends JComponent
 
   public void clearShowPaths() {
     showPathList.clear();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public Scale getZoneScale() {
@@ -332,7 +337,7 @@ public class ZoneRenderer extends JComponent
               // flushFog = true;
             }
             visibleScreenArea = null;
-            repaint();
+            repaint(REPAINT_DEBOUNCE_INTERVAL);
           }
         });
   }
@@ -358,7 +363,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
     tokenUnderMouse = token;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   @Override
@@ -375,7 +380,7 @@ public class ZoneRenderer extends JComponent
       }
     }
     selectionSetMap.put(keyToken, new SelectionSet(playerId, keyToken, tokenList));
-    repaint(); // Jamz: Seems to have no affect?
+    repaint(REPAINT_DEBOUNCE_INTERVAL); // Jamz: Seems to have no affect?
   }
 
   public boolean hasMoveSelectionSetMoved(GUID keyToken, ZonePoint point) {
@@ -397,7 +402,7 @@ public class ZoneRenderer extends JComponent
     }
     Token token = zone.getToken(keyToken);
     set.setOffset(offset.x - token.getX(), offset.y - token.getY());
-    repaint(); // Jamz: may cause flicker when using AI
+    repaint(REPAINT_DEBOUNCE_INTERVAL); // Jamz: may cause flicker when using AI
   }
 
   public void toggleMoveSelectionSetWaypoint(GUID keyToken, ZonePoint location) {
@@ -406,7 +411,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
     set.toggleWaypoint(location);
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public ZonePoint getLastWaypoint(GUID keyToken) {
@@ -422,7 +427,7 @@ public class ZoneRenderer extends JComponent
     if (set == null) {
       return;
     }
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void commitMoveSelectionSet(GUID keyTokenId) {
@@ -617,7 +622,7 @@ public class ZoneRenderer extends JComponent
 
     setViewOffset(x, y);
 
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void centerOn(CellPoint point) {
@@ -680,13 +685,13 @@ public class ZoneRenderer extends JComponent
     renderedLightMap = null;
     renderedAuraMap = null;
     zoneView.flush();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void flushFog() {
     flushFog = true;
     visibleScreenArea = null;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public Zone getZone() {
@@ -2718,7 +2723,7 @@ public class ZoneRenderer extends JComponent
     if (!keepSelectedTokenSet) selectedTokenSet.clear();
     else keepSelectedTokenSet = false; // Always reset it back, temp boolean only
 
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   /**
@@ -3620,7 +3625,7 @@ public class ZoneRenderer extends JComponent
     // flushFog = true; // could call flushFog() but also clears visibleScreenArea and I don't know
     // if we want
     // that...
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public boolean selectToken(GUID tokenGUID) {
@@ -3632,7 +3637,7 @@ public class ZoneRenderer extends JComponent
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
     // flushFog = true;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
     return true;
   }
 
@@ -3645,7 +3650,7 @@ public class ZoneRenderer extends JComponent
     }
     addToSelectionHistory(selectedTokenSet);
 
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
   }
@@ -3667,7 +3672,7 @@ public class ZoneRenderer extends JComponent
     selectedTokenSet.clear();
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void undoSelectToken() {
@@ -3700,7 +3705,7 @@ public class ZoneRenderer extends JComponent
     // disable the undo button.
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   private void addToSelectionHistory(Set<GUID> selectionSet) {
@@ -3871,7 +3876,7 @@ public class ZoneRenderer extends JComponent
 
   public void adjustGridSize(int delta) {
     zone.getGrid().setSize(Math.max(0, zone.getGrid().getSize() + delta));
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   public void moveGridBy(int dx, int dy) {
@@ -3888,7 +3893,7 @@ public class ZoneRenderer extends JComponent
       gridOffsetX = gridOffsetX - (int) zone.getGrid().getCellWidth();
     }
     zone.getGrid().setOffset(gridOffsetX, gridOffsetY);
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   /**
@@ -3927,7 +3932,7 @@ public class ZoneRenderer extends JComponent
   /** This makes sure that any image updates get refreshed. This could be a little smarter. */
   @Override
   public boolean imageUpdate(Image img, int infoflags, int x, int y, int w, int h) {
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
     return super.imageUpdate(img, infoflags, x, y, w, h);
   }
 
@@ -4434,7 +4439,7 @@ public class ZoneRenderer extends JComponent
     // Copy them to the clipboard so that we can quickly copy them onto the map
     AppActions.copyTokens(tokens);
     requestFocusInWindow();
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   /**
@@ -4522,7 +4527,7 @@ public class ZoneRenderer extends JComponent
         flushFog = true;
       }
       MapTool.getFrame().updateTokenTree();
-      repaint();
+      repaint(REPAINT_DEBOUNCE_INTERVAL);
     }
   }
 
@@ -4544,7 +4549,7 @@ public class ZoneRenderer extends JComponent
 
   public void setHighlightCommonMacros(List<Token> affectedTokens) {
     highlightCommonMacros = affectedTokens;
-    repaint();
+    repaint(REPAINT_DEBOUNCE_INTERVAL);
   }
 
   // End token common macro identification

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -144,8 +144,6 @@ public class ZoneRenderer extends JComponent
     implements DropTargetListener, Comparable<ZoneRenderer> {
   private static final long serialVersionUID = 3832897780066104884L;
   private static final Logger log = LogManager.getLogger(ZoneRenderer.class);
-  
-  private static final long REPAINT_DEBOUNCE_INTERVAL = 34;
 
   private static final Color TRANSLUCENT_YELLOW =
       new Color(Color.yellow.getRed(), Color.yellow.getGreen(), Color.yellow.getBlue(), 50);
@@ -312,7 +310,7 @@ public class ZoneRenderer extends JComponent
 
   public void clearShowPaths() {
     showPathList.clear();
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public Scale getZoneScale() {
@@ -334,7 +332,7 @@ public class ZoneRenderer extends JComponent
               // flushFog = true;
             }
             visibleScreenArea = null;
-            repaint(REPAINT_DEBOUNCE_INTERVAL);
+            repaint();
           }
         });
   }
@@ -360,7 +358,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
     tokenUnderMouse = token;
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   @Override
@@ -377,7 +375,7 @@ public class ZoneRenderer extends JComponent
       }
     }
     selectionSetMap.put(keyToken, new SelectionSet(playerId, keyToken, tokenList));
-    repaint(REPAINT_DEBOUNCE_INTERVAL); // Jamz: Seems to have no affect?
+    repaint(); // Jamz: Seems to have no affect?
   }
 
   public boolean hasMoveSelectionSetMoved(GUID keyToken, ZonePoint point) {
@@ -399,7 +397,7 @@ public class ZoneRenderer extends JComponent
     }
     Token token = zone.getToken(keyToken);
     set.setOffset(offset.x - token.getX(), offset.y - token.getY());
-    repaint(REPAINT_DEBOUNCE_INTERVAL); // Jamz: may cause flicker when using AI
+    repaint(); // Jamz: may cause flicker when using AI
   }
 
   public void toggleMoveSelectionSetWaypoint(GUID keyToken, ZonePoint location) {
@@ -408,7 +406,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
     set.toggleWaypoint(location);
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public ZonePoint getLastWaypoint(GUID keyToken) {
@@ -424,7 +422,7 @@ public class ZoneRenderer extends JComponent
     if (set == null) {
       return;
     }
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public void commitMoveSelectionSet(GUID keyTokenId) {
@@ -619,7 +617,7 @@ public class ZoneRenderer extends JComponent
 
     setViewOffset(x, y);
 
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public void centerOn(CellPoint point) {
@@ -682,13 +680,13 @@ public class ZoneRenderer extends JComponent
     renderedLightMap = null;
     renderedAuraMap = null;
     zoneView.flush();
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public void flushFog() {
     flushFog = true;
     visibleScreenArea = null;
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public Zone getZone() {
@@ -2720,7 +2718,7 @@ public class ZoneRenderer extends JComponent
     if (!keepSelectedTokenSet) selectedTokenSet.clear();
     else keepSelectedTokenSet = false; // Always reset it back, temp boolean only
 
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   /**
@@ -3622,7 +3620,7 @@ public class ZoneRenderer extends JComponent
     // flushFog = true; // could call flushFog() but also clears visibleScreenArea and I don't know
     // if we want
     // that...
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public boolean selectToken(GUID tokenGUID) {
@@ -3634,7 +3632,7 @@ public class ZoneRenderer extends JComponent
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
     // flushFog = true;
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
     return true;
   }
 
@@ -3647,7 +3645,7 @@ public class ZoneRenderer extends JComponent
     }
     addToSelectionHistory(selectedTokenSet);
 
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
   }
@@ -3669,7 +3667,7 @@ public class ZoneRenderer extends JComponent
     selectedTokenSet.clear();
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public void undoSelectToken() {
@@ -3702,7 +3700,7 @@ public class ZoneRenderer extends JComponent
     // disable the undo button.
     MapTool.getFrame().resetTokenPanels();
     HTMLFrameFactory.selectedListChanged();
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   private void addToSelectionHistory(Set<GUID> selectionSet) {
@@ -3873,7 +3871,7 @@ public class ZoneRenderer extends JComponent
 
   public void adjustGridSize(int delta) {
     zone.getGrid().setSize(Math.max(0, zone.getGrid().getSize() + delta));
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   public void moveGridBy(int dx, int dy) {
@@ -3890,7 +3888,7 @@ public class ZoneRenderer extends JComponent
       gridOffsetX = gridOffsetX - (int) zone.getGrid().getCellWidth();
     }
     zone.getGrid().setOffset(gridOffsetX, gridOffsetY);
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   /**
@@ -3929,7 +3927,7 @@ public class ZoneRenderer extends JComponent
   /** This makes sure that any image updates get refreshed. This could be a little smarter. */
   @Override
   public boolean imageUpdate(Image img, int infoflags, int x, int y, int w, int h) {
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
     return super.imageUpdate(img, infoflags, x, y, w, h);
   }
 
@@ -4436,7 +4434,7 @@ public class ZoneRenderer extends JComponent
     // Copy them to the clipboard so that we can quickly copy them onto the map
     AppActions.copyTokens(tokens);
     requestFocusInWindow();
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   /**
@@ -4524,7 +4522,7 @@ public class ZoneRenderer extends JComponent
         flushFog = true;
       }
       MapTool.getFrame().updateTokenTree();
-      repaint(REPAINT_DEBOUNCE_INTERVAL);
+      repaint();
     }
   }
 
@@ -4546,7 +4544,7 @@ public class ZoneRenderer extends JComponent
 
   public void setHighlightCommonMacros(List<Token> affectedTokens) {
     highlightCommonMacros = affectedTokens;
-    repaint(REPAINT_DEBOUNCE_INTERVAL);
+    repaint();
   }
 
   // End token common macro identification


### PR DESCRIPTION
This PR would modify the several locations in ZoneRenderer that currently call repaint().  Often these get called in very rapid succession, which tends toward a cascade of event dispatches and conquest switches that can make the program unresponsive.

The PR adds a class, DebounceExecutor, that debounces or throttles serial calls to a initiate a task by scheduling the task to run at most once, after a specified cool-down or aggregation interval.  Calls made to initiate that task during the interval are ignored.

With the change here, ZoneRenderer waits 33ms (the duration of one frame at 30fps) from the time repaint() is first required until it is executed.  During that time, any other changes to the backbuffer can accumulate.  All changes are then painted to the screen at once, opening the performance bottleneck caused by having each part of the rendering code call repaint() as that part becomes ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/610)
<!-- Reviewable:end -->
