### PR TITLE
Fix bug created by dragging token from library to map

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -908,7 +908,6 @@ public class AppActions {
     // lose what might already be in the clipboard.
     if (anythingCopied) {
       copyTokens(tokenList);
-      keepIdsOnPaste = false;
     } else {
       MapTool.playSound(MapTool.SND_INVALID_OPERATION);
     }
@@ -1002,6 +1001,7 @@ public class AppActions {
         token.setX(token.getX() - x);
         token.setY(token.getY() - y);
       }
+      keepIdsOnPaste = false; // if last operation is Copy, don't keep token ids.
     } else {
       MapTool.playSound(MapTool.SND_INVALID_OPERATION);
     }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -4462,6 +4462,7 @@ public class ZoneRenderer extends JComponent
     }
     // Copy them to the clipboard so that we can quickly copy them onto the map
     AppActions.copyTokens(tokens);
+    AppActions.updateActions();
     requestFocusInWindow();
     repaint();
   }


### PR DESCRIPTION
- Fix token having duplicated ids if a cut was followed by dragging token to map then a paste (induced by #625)
- Fix dragging token from library to map not ungraying the "Paste" option (fully completes #630)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/633)
<!-- Reviewable:end -->
