### PR TITLE
Change wrong nb of parameters error messages to display function name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     implementation 'net.rptools.decktool:decktool:1.0.b1'
 
     implementation 'net.rptools.maptool.resource:maptool.resource:1.0.b18'
-    implementation 'net.rptools.parser:parser:1.4.0.+'
+    implementation 'com.github.RPTools:parser:master-SNAPSHOT'
 
     implementation 'jide-common:jide-common:3.2.3'
     implementation 'jide-components:jide-components:3.2.3'

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -1181,8 +1181,9 @@ public class InputFunction extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof String))

--- a/src/main/java/net/rptools/maptool/client/functions/ReturnFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ReturnFunction.java
@@ -57,8 +57,10 @@ public class ReturnFunction extends AbstractFunction implements DefinesSpecialVa
     } else return new BigDecimal(value.intValue());
   }
 
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  @Override
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     Object param = parameters.get(0);
     if (!(param instanceof BigDecimal)) {

--- a/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
@@ -638,8 +638,9 @@ public class StrListFunctions extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
     // The work is done in checkVaryingParameters() instead.
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/StrPropFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StrPropFunctions.java
@@ -675,8 +675,9 @@ public class StrPropFunctions extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
     // The work is done in checkVaryingParameters() instead.
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
@@ -78,7 +78,9 @@ public class UserDefinedMacroFunctions implements Function, AdditionalFunctionDe
 
   private UserDefinedMacroFunctions() {}
 
-  public void checkParameters(List<Object> parameters) throws ParameterException {
+  @Override
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
     // Do nothing as we do not know what we will need.
   }
 
@@ -188,13 +190,13 @@ public class UserDefinedMacroFunctions implements Function, AdditionalFunctionDe
   }
 
   public Object executeOldFunction(Parser parser, List<Object> parameters) throws ParserException {
-    FunctionRedefinition functionRedef = redefinedFunctions.get(currentFunction.peek());
+    String functionName = currentFunction.peek();
+    FunctionRedefinition functionRedef = redefinedFunctions.get(functionName);
     if (functionRedef == null) {
-      throw new ParserException(
-          "Old definition for function " + currentFunction.peek() + "does not exist");
+      throw new ParserException("Old definition for function " + functionName + " does not exist");
     }
     Function function = functionRedef.function;
-    function.checkParameters(parameters);
+    function.checkParameters(functionName, parameters);
     return function.evaluate(parser, functionRedef.functionName, parameters);
   }
 


### PR DESCRIPTION
- Change wrong number of parameters error messages to always display name of function
- Needs https://github.com/RPTools/parser/pull/3 to work
- Close #629
- Example: for `[input()]`

Old error message:

> Invalid number of parameters 0, expected exactly 1 parameter(s)

New error message:

> Function 'input' requires exactly 1 parameters; 0 were provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/641)
<!-- Reviewable:end -->
