### PR TITLE
Add function json.get.path to return element from nested json

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/JSONMacroFunctions.java
@@ -1152,6 +1152,8 @@ public class JSONMacroFunctions extends AbstractFunction {
         jObj = (JSONObject) obj;
         if (jObj.has(strPath)) {
           obj = jObj.get(strPath);
+        } else if (i == paths.size() - 1) {
+          return ""; // Returns "" if no value in the deepest json
         } else {
           String atPath = i > 0 ? " at " + paths.subList(0, i).toString() : "";
           throw new ParserException(

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -886,6 +886,9 @@ macro.function.json.onlyArray                      = Got {0} but "{1}" only acce
 macro.function.json.onlyJSON                       = Got {0} but "{1}" only accepts JSON Arrays or Objects.
 macro.function.json.onlyObject                     = Got {0} but "{1}" only accepts JSON Objects.
 macro.function.json.setNoMatchingValue             = No matching value for key in "{0}".
+macro.function.json.pathInvalidIndex               = Invalid index "{1}"{2} for array (size of {3}) in function "{0}".
+macro.function.json.pathInvalidObject              = Invalid path "{1}"{2} in function "{0}". Object is not a JSON Array or a JSON Object.
+macro.function.json.pathInvalidValue               = Invalid value for key "{1}"{2} in function "{0}".
 macro.function.json.unknownType                    = Unknown JSON type "{0}" in function "{1}".
 macro.function.macroLink.arguments                 = Arguments
 # Informational messages for Macro functions.


### PR DESCRIPTION
- First half of #612
- json.get.path returns appropriate error messages if path is invalid
- json.get.path can take two forms:

1. json.get.path(json, path)

where json is a json object or array, and path is a json array where each element specify a subpath (ex: ["Equipment", 1, "Name"])

2. json.get.path(json, subpath1, subpath2, ...)

for example, json.get.path(json, "Equipment", 1, "Name")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/651)
<!-- Reviewable:end -->
