### PR TITLE
Fix getStreamProperties wrongly returning "PLAYING" , change ms to secs

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
@@ -52,6 +52,16 @@ public class MediaPlayerAdapter {
     this.strUri = strUri;
     this.media = media;
     this.player = new MediaPlayer(media);
+    this.player.setOnEndOfMedia(
+        new Runnable() {
+          @Override
+          public void run() {
+            int curCount = player.getCurrentCount();
+            int cycCount = player.getCycleCount();
+            if (cycCount != MediaPlayer.INDEFINITE && curCount >= cycCount)
+              player.stop(); // otherwise, status stuck on "PLAYING" at end
+          }
+        });
   };
   /**
    * Start a given stream from its url string. If already streaming the file, dispose of the

--- a/src/main/java/net/rptools/maptool/client/functions/SoundFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/SoundFunctions.java
@@ -50,8 +50,8 @@ public class SoundFunctions extends AbstractFunction {
       String strUri = args.get(0).toString();
       int cycleCount = psize > 1 ? FunctionUtil.paramAsInteger(functionName, args, 1, true) : 1;
       double volume = psize > 2 ? FunctionUtil.paramAsDouble(functionName, args, 2, true) : 1;
-      double start = psize > 3 ? FunctionUtil.paramAsDouble(functionName, args, 3, true) : 0;
-      double stop = psize > 4 ? FunctionUtil.paramAsDouble(functionName, args, 4, true) : -1;
+      double start = psize > 3 ? FunctionUtil.paramAsDouble(functionName, args, 3, true) * 1000 : 0;
+      double stop = psize > 4 ? FunctionUtil.paramAsDouble(functionName, args, 4, true) * 1000 : -1;
 
       return MediaPlayerAdapter.playStream(strUri, cycleCount, volume, start, stop)
           ? BigDecimal.ONE
@@ -70,9 +70,9 @@ public class SoundFunctions extends AbstractFunction {
       if (psize > 2 && !args.get(2).equals(""))
         volume = FunctionUtil.paramAsDouble(functionName, args, 2, true);
       if (psize > 3 && !args.get(3).equals(""))
-        start = FunctionUtil.paramAsDouble(functionName, args, 3, true);
+        start = FunctionUtil.paramAsDouble(functionName, args, 3, true) * 1000;
       if (psize > 4 && !args.get(4).equals(""))
-        stop = FunctionUtil.paramAsDouble(functionName, args, 4, true);
+        stop = FunctionUtil.paramAsDouble(functionName, args, 4, true) * 1000;
 
       MediaPlayerAdapter.editStream(strUri, cycleCount, volume, start, stop);
       return "";


### PR DESCRIPTION
- Fix getStreamProperties to return status "STOPPED" after song finished playing
- Change parameters startTime and stopTime to take seconds instead of ms
- Suggestion from @Phergus in #667

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/671)
<!-- Reviewable:end -->
