### PR TITLE
Add propertyType option for getTokens(), improve getTokens()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
@@ -15,11 +15,7 @@
 package net.rptools.maptool.client.functions;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
@@ -47,113 +43,111 @@ public class FindTokenFunctions extends AbstractFunction {
     STATE,
     OWNED,
     VISIBLE,
+    PROPERTYTYPE, // 1.5.5
     LAYER // FJE 1.3b77
   }
   // @formatter:on
 
   private static final FindTokenFunctions instance = new FindTokenFunctions();
 
-  /** Filter for all tokens. */
+  /** Filter for all non image / non lib tokens. */
   private class AllFilter implements Zone.Filter {
+    private final boolean match;
+
+    private AllFilter(boolean match) {
+      this.match = match;
+    }
+
     public boolean matchToken(Token t) {
-      // Filter out the utility lib: and image: tokens
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      return true;
+      // Match=true: filter out utility lib: and image: tokens
+      return match == !t.isImgOrLib();
     }
   }
 
   /** Filter for NPC tokens. */
   private class NPCFilter implements Zone.Filter {
+    private final boolean match; // true: NPC, false: Non-NPC
+
+    private NPCFilter(boolean match) {
+      this.match = match;
+    }
+
     public boolean matchToken(Token t) {
-      // Filter out the utility lib: and image: tokens
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      return t.getType() == Token.Type.NPC;
+      boolean isNPC = t.getType() == Token.Type.NPC && !t.isImgOrLib();
+      return match == isNPC;
     }
   }
 
   /** Filter for PC tokens. */
   private class PCFilter implements Zone.Filter {
+    private final boolean match; // true: PC, false: Non-PC
+
+    private PCFilter(boolean match) {
+      this.match = match;
+    }
+
     public boolean matchToken(Token t) {
       // Filter out the utility lib: and image: tokens
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      return t.getType() == Token.Type.PC;
+      boolean isPC = t.getType() == Token.Type.PC && !t.isImgOrLib();
+      return match == isPC;
     }
   }
 
   /** Filter for player exposed tokens. */
   private class ExposedFilter implements Zone.Filter {
     private final Zone zone;
+    private final boolean match;
 
-    public ExposedFilter(Zone zone) {
+    public ExposedFilter(Zone zone, boolean match) {
       this.zone = zone;
+      this.match = match;
     }
 
     public boolean matchToken(Token t) {
-      // Filter out the utility lib: and image: tokens
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      return zone.isTokenVisible(t);
+      boolean isExposed = zone.isTokenVisible(t) && !t.isImgOrLib();
+      return match == isExposed;
     }
   }
 
   /** Filter for finding tokens by set state. */
   private class StateFilter implements Zone.Filter {
     private final String stateName;
+    private final boolean match;
 
-    public StateFilter(String stateName) {
+    public StateFilter(String stateName, boolean match) {
       this.stateName = stateName;
+      this.match = match;
     }
 
     public boolean matchToken(Token t) {
       Object val = t.getState(stateName);
+      boolean hasState = true;
       // Filter out the utility lib: and image: tokens
-      if (val == null) {
-        return false;
+      if (val == null || t.isImgOrLib()) {
+        hasState = false;
+      } else if (val instanceof Boolean) {
+        hasState = (Boolean) val;
+      } else if (val instanceof BigDecimal) {
+        hasState = !val.equals(BigDecimal.ZERO);
       }
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      if (val instanceof Boolean) {
-        return ((Boolean) val).booleanValue();
-      }
-      if (val instanceof BigDecimal) {
-        if (val.equals(BigDecimal.ZERO)) {
-          return false;
-        } else {
-          return true;
-        }
-      }
-      return true;
+      return match == hasState;
     }
   }
 
   /** Filter for finding tokens by owner. */
   private class OwnedFilter implements Zone.Filter {
     private final String name;
+    private final boolean match;
 
-    public OwnedFilter(String name) {
+    public OwnedFilter(String name, boolean match) {
       this.name = name;
+      this.match = match;
     }
 
     public boolean matchToken(Token t) {
       // Filter out the utility lib: and image: tokens
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      return t.isOwner(name);
+      boolean isOwner = t.isOwner(name) && !t.isImgOrLib();
+      return match == isOwner;
     }
   }
 
@@ -174,11 +168,21 @@ public class FindTokenFunctions extends AbstractFunction {
 
     public boolean matchToken(Token t) {
       // Filter out the utility lib: and image: tokens
-      if (t.getName().toLowerCase().startsWith("image:")
-          || t.getName().toLowerCase().startsWith("lib:")) {
-        return false;
-      }
-      return layers.contains(t.getLayer());
+      return layers.contains(t.getLayer()) && !t.isImgOrLib();
+    }
+  }
+
+  private class PropertyTypeFilter implements Zone.Filter {
+    private final JSONArray types;
+
+    public PropertyTypeFilter(JSONArray types) {
+      this.types = types;
+    }
+
+    public boolean matchToken(Token t) {
+      // Don't filter out lib and image
+      boolean isType = types.contains(t.getPropertyType());
+      return isType;
     }
   }
 
@@ -302,7 +306,7 @@ public class FindTokenFunctions extends AbstractFunction {
    * @param nameOnly whether to return only token names (<code>false</code> = token GUIDs)
    * @param delim either <code>json</code> or a string delimiter between output entries
    * @param jsonString incoming JSON data structure to filter results
-   * @return
+   * @return list of filtered tokens
    * @throws ParserException
    */
   private Object getTokenList(Parser parser, boolean nameOnly, String delim, String jsonString)
@@ -335,23 +339,22 @@ public class FindTokenFunctions extends AbstractFunction {
     JSONObject range = null;
     JSONObject area = null;
 
-    // Now loop through conditions that are true and only retain tokens returned.
+    Boolean match;
+    // Now loop through conditions and filter out tokens that don't match conditions
     for (Object key : jobj.keySet()) {
       String searchType = key.toString();
-      if ("setStates".equalsIgnoreCase(searchType)) {
-        // setStates and layers work the same until you get to the filtering part...
-        JSONArray ary;
+      if ("setStates".equalsIgnoreCase(searchType) || "unsetStates".equalsIgnoreCase(searchType)) {
+        JSONArray states;
         Object o = jobj.get(searchType);
-        if (o instanceof JSONArray) {
-          ary = (JSONArray) o;
-        } else {
-          ary = new JSONArray();
-          ary.add(o.toString());
+        if (o instanceof JSONArray) states = (JSONArray) o;
+        else {
+          states = new JSONArray();
+          states.add(o.toString());
         }
-        // Looking for tokens with all of these states set
-        for (Object item : ary) {
-          List<Token> lst = getTokenList(parser, FindType.STATE, item.toString());
-          tokenList.retainAll(lst);
+        match = "setStates".equalsIgnoreCase(searchType);
+        // Looking for tokens that either match or don't match the states
+        for (Object item : states) {
+          tokenList = getTokenList(parser, FindType.STATE, item.toString(), match, tokenList);
         }
       } else if ("range".equalsIgnoreCase(searchType)) {
         // We will do this as one of the last steps as it's one of the most expensive so we want to
@@ -363,73 +366,32 @@ public class FindTokenFunctions extends AbstractFunction {
         area = jobj.getJSONObject(searchType);
         // } else if ("unsetStates".equalsIgnoreCase(searchType)) {
         // // ignore
-      } else {
-        if (booleanCheck(jobj, searchType)) {
-          List<Token> lst = null;
-          if ("npc".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.NPC, "");
-          } else if ("pc".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.PC, "");
-          } else if ("selected".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.SELECTED, "");
-          } else if ("visible".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.VISIBLE, "");
-          } else if ("owned".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.OWNED, MapTool.getPlayer().getName());
-          } else if ("current".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.CURRENT, "");
-          } else if ("impersonated".equalsIgnoreCase(searchType)) {
-            lst = getTokenList(parser, FindType.IMPERSONATED, "");
-          }
-          if (lst != null) tokenList.retainAll(lst);
+      } else if ("propertyType".equalsIgnoreCase(searchType)) {
+        JSONArray types;
+        Object o = jobj.get(searchType);
+        if (o instanceof JSONArray) types = (JSONArray) o;
+        else {
+          types = new JSONArray();
+          types.add(o.toString());
         }
-      }
-    }
-
-    // After looping through all the true conditions it's time to loop through
-    // the false conditions and remove any tokens that match from our list.
-    // This is a little more painful as first we get the tokens that match
-    // the criteria, remove those from a list of all tokens, and use that
-    // resultant list to tell the tokenList which to retain.
-    // FJE Huh? Why not just remove ones that match from 'tokenList'???
-    List<Token> inverseList = new ArrayList<Token>();
-    for (Object key : jobj.keySet()) {
-      String searchType = key.toString();
-      if ("unsetStates".equalsIgnoreCase(searchType)) {
-        JSONArray states = (JSONArray) jobj.get(searchType);
-        for (Object st : states) {
-          inverseList.clear();
-          inverseList.addAll(allTokens);
-          inverseList.removeAll(getTokenList(parser, FindType.STATE, st.toString()));
-          tokenList.retainAll(inverseList);
-        }
-        // } else if ("setStates".equalsIgnoreCase(searchType)) {
-        // // ignore
-        // } else if ("range".equalsIgnoreCase(searchType)) {
-        // // ignore
-        // } else if ("area".equalsIgnoreCase(searchType)) {
-        // // ignore
+        tokenList = getTokensFiltered(new PropertyTypeFilter(types), tokenList);
       } else {
-        if (!booleanCheck(jobj, searchType)) {
-          inverseList.clear();
-          inverseList.addAll(allTokens);
-          if ("npc".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(getTokenList(parser, FindType.NPC, ""));
-          } else if ("pc".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(getTokenList(parser, FindType.PC, ""));
-          } else if ("selected".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(getTokenList(parser, FindType.SELECTED, ""));
-          } else if ("visible".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(getTokenList(parser, FindType.VISIBLE, ""));
-          } else if ("owned".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(
-                getTokenList(parser, FindType.OWNED, MapTool.getPlayer().getName()));
-          } else if ("current".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(getTokenList(parser, FindType.CURRENT, ""));
-          } else if ("impersonated".equalsIgnoreCase(searchType)) {
-            inverseList.removeAll(getTokenList(parser, FindType.IMPERSONATED, ""));
-          }
-          if (inverseList != null) tokenList.retainAll(inverseList);
+        match = booleanCheck(jobj, searchType);
+        if ("npc".equalsIgnoreCase(searchType)) {
+          tokenList = getTokenList(parser, FindType.NPC, "", match, tokenList);
+        } else if ("pc".equalsIgnoreCase(searchType)) {
+          tokenList = getTokenList(parser, FindType.PC, "", match, tokenList);
+        } else if ("selected".equalsIgnoreCase(searchType)) {
+          tokenList = getTokenList(parser, FindType.SELECTED, "", match, tokenList);
+        } else if ("visible".equalsIgnoreCase(searchType)) {
+          tokenList = getTokenList(parser, FindType.VISIBLE, "", match, tokenList);
+        } else if ("owned".equalsIgnoreCase(searchType)) {
+          tokenList =
+              getTokenList(parser, FindType.OWNED, MapTool.getPlayer().getName(), match, tokenList);
+        } else if ("current".equalsIgnoreCase(searchType)) {
+          tokenList = getTokenList(parser, FindType.CURRENT, "", match, tokenList);
+        } else if ("impersonated".equalsIgnoreCase(searchType)) {
+          tokenList = getTokenList(parser, FindType.IMPERSONATED, "", match, tokenList);
         }
       }
     }
@@ -574,52 +536,68 @@ public class FindTokenFunctions extends AbstractFunction {
     }
   }
 
-  private List<Token> getTokenList(Parser parser, FindType findType, String findArgs)
+  /**
+   * Take a list of tokens and return a new sublist where each token satisfies the specified
+   * condition
+   *
+   * @param parser The parser, to get variables in context
+   * @param findType the type of search to do
+   * @param findArgs additional argument for the search
+   * @param match should the property match? true: only include matches, false: exclude matches
+   * @param originalList the list of tokens to search from
+   * @return tokenList satisfying the requirement
+   */
+  private List<Token> getTokenList(
+      Parser parser, FindType findType, String findArgs, boolean match, List<Token> originalList)
       throws ParserException {
     List<Token> tokenList = new LinkedList<Token>();
+    if (originalList.size() == 0) return tokenList;
+
     ZoneRenderer zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
     Zone zone = zoneRenderer.getZone();
     switch (findType) {
       case ALL:
-        tokenList = zone.getTokensFiltered(new AllFilter());
+        tokenList = getTokensFiltered(new AllFilter(match), originalList);
         break;
       case NPC:
-        tokenList = zone.getTokensFiltered(new NPCFilter());
+        tokenList = getTokensFiltered(new NPCFilter(match), originalList);
         break;
       case PC:
-        tokenList = zone.getTokensFiltered(new PCFilter());
+        tokenList = getTokensFiltered(new PCFilter(match), originalList);
         break;
       case SELECTED:
-        tokenList = zoneRenderer.getSelectedTokensList();
+        tokenList = getTokensFiltered(zoneRenderer.getSelectedTokensList(), originalList, match);
         break;
       case CURRENT:
         Token token = ((MapToolVariableResolver) parser.getVariableResolver()).getTokenInContext();
         if (token != null) {
-          tokenList.add(token);
-        }
+          tokenList = getTokensFiltered(Collections.singletonList(token), originalList, match);
+        } else if (!match) tokenList = originalList;
         break;
       case IMPERSONATED:
         Token t;
         GUID guid = MapTool.getFrame().getCommandPanel().getIdentityGUID();
         if (guid != null) t = MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(guid);
         else t = zone.resolveToken(MapTool.getFrame().getCommandPanel().getIdentity());
-        if (t != null) tokenList.add(t);
+        if (t != null) {
+          tokenList = getTokensFiltered(Collections.singletonList(t), originalList, match);
+        } else if (!match) tokenList = originalList;
         break;
       case EXPOSED:
-        tokenList = zone.getTokensFiltered(new ExposedFilter(zone));
+        tokenList = getTokensFiltered(new ExposedFilter(zone, match), originalList);
         break;
       case STATE:
-        tokenList = zone.getTokensFiltered(new StateFilter(findArgs));
+        tokenList = getTokensFiltered(new StateFilter(findArgs, match), originalList);
         break;
       case OWNED:
-        tokenList = zone.getTokensFiltered(new OwnedFilter(findArgs));
+        tokenList = getTokensFiltered(new OwnedFilter(findArgs, match), originalList);
         break;
       case VISIBLE:
-        for (GUID id : zoneRenderer.getVisibleTokenSet()) {
-          tokenList.add(zone.getToken(id));
-        }
+        tokenList = getTokensFiltered(zoneRenderer.getVisibleTokens(), originalList, match);
+        break;
       case LAYER:
         // Layer check already performed and unneeded here
+        tokenList = originalList;
         break;
       default:
         // Should never get here, but if we do then another enum type was added and we didn't
@@ -628,6 +606,24 @@ public class FindTokenFunctions extends AbstractFunction {
             I18N.getText(
                 "macro.function.findTokenFunctions.unknownEnum", "getTokens", findType.toString()));
     }
+    return tokenList;
+  }
+
+  private static List<Token> getTokensFiltered(Zone.Filter filter, List<Token> originalList) {
+    List<Token> tokenList = new ArrayList<Token>(originalList.size());
+
+    for (Token token : originalList) {
+      if (filter.matchToken(token)) tokenList.add(token);
+    }
+    return tokenList;
+  }
+
+  private static List<Token> getTokensFiltered(
+      List<Token> editList, List<Token> originalList, boolean match) {
+    List<Token> tokenList = new ArrayList<Token>(originalList);
+
+    if (match) tokenList.retainAll(editList); // keep tokens in both lists
+    else tokenList.removeAll(editList); // remove edit list from original list
     return tokenList;
   }
 
@@ -646,7 +642,8 @@ public class FindTokenFunctions extends AbstractFunction {
       Parser parser, FindType findType, boolean nameOnly, String delim, String findArgs)
       throws ParserException {
     ArrayList<String> values = new ArrayList<String>();
-    List<Token> tokens = getTokenList(parser, findType, findArgs);
+    Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+    List<Token> tokens = getTokenList(parser, findType, findArgs, true, zone.getAllTokens());
 
     if (tokens != null && !tokens.isEmpty()) {
       for (Token token : tokens) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -4526,6 +4526,14 @@ public class ZoneRenderer extends JComponent
     return visibleTokenSet;
   }
 
+  public List<Token> getVisibleTokens() {
+    List<Token> tokenList = new ArrayList<Token>(visibleTokenSet.size());
+    for (GUID id : visibleTokenSet) {
+      tokenList.add(zone.getToken(id));
+    }
+    return tokenList;
+  }
+
   /*
    * (non-Javadoc)
    *

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1952,6 +1952,12 @@ public class Token extends BaseModel implements Cloneable {
     }
   }
 
+  /** @return is token an image/lib token */
+  public boolean isImgOrLib() {
+    return (getName().toLowerCase().startsWith("image:")
+        || getName().toLowerCase().startsWith("lib:"));
+  }
+
   public HeroLabData getHeroLabData() {
     return heroLabData;
   }


### PR DESCRIPTION
- Add new option "propertyType" to conditions in getTokens()
- Value can be a single type as string, or an array of types
- Simplify getTokens() code by removing the second loop. Now include/exclude is a filter property ("match")
- Improve performance of getTokens() by trimming the list continuously instead of constantly filtering the list of all tokens
- Close #676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/677)
<!-- Reviewable:end -->
