### PR TITLE
Resolve #696 Implement dragTheshold in DefaultTool

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.tool;
 
+import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
@@ -43,6 +44,8 @@ public abstract class DefaultTool extends Tool
   private boolean isDraggingMap;
   private int dragStartX;
   private int dragStartY;
+  private int dragThreshold =
+      (int) Toolkit.getDefaultToolkit().getDesktopProperty("DnD.gestureMotionThreshold");
 
   protected int mouseX;
   protected int mouseY;
@@ -154,10 +157,13 @@ public abstract class DefaultTool extends Tool
     }
     // MAP MOVEMENT
     if (isRightMouseButton(e)) {
-      isDraggingMap = true;
 
       mapDX += mX - dragStartX;
       mapDY += mY - dragStartY;
+
+      if (mapDX * mapDX + mapDY * mapDY > dragThreshold * dragThreshold) {
+        isDraggingMap = true;
+      }
 
       dragStartX = mX;
       dragStartY = mY;


### PR DESCRIPTION
Resolve #696 

This PR makes a change to DefaultTool that causes it not to regard the beginning of a drag operation until the mouse has moved beyond the platform's drag theshold (*e.g.*, 4 pixels by default on Windows 10).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/697)
<!-- Reviewable:end -->
