### PR TITLE
Fix bug introduced by #707 with default metrics

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -326,7 +326,11 @@ public class TokenLocationFunctions extends AbstractFunction {
 
       distance = Double.MAX_VALUE;
       if (closedForm) {
-        if (wmetric == null && grid.useMetric()) wmetric = AppPreferences.getMovementMetric();
+        if (wmetric == null && grid.useMetric())
+          wmetric =
+              MapTool.isPersonalServer()
+                  ? AppPreferences.getMovementMetric()
+                  : MapTool.getServerPolicy().getMovementMetric();
         // explicitly find difference without walkers
         double curDist;
         for (CellPoint scell : sourceCells) {


### PR DESCRIPTION
- Fix bug where the default metric is the user's preferred one instead of the server's.
- Function affected: getDistance, getDistanceToXY, getTokens
- Fix issue mentioned in #684

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/717)
<!-- Reviewable:end -->
