### PR TITLE
Add parameter "players" and "delim" to execLink

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientCommand.java
+++ b/src/main/java/net/rptools/maptool/client/ClientCommand.java
@@ -38,6 +38,7 @@ public class ClientCommand {
     playerConnected,
     playerDisconnected,
     message,
+    execLink,
     undoDraw,
     showPointer,
     hidePointer,

--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import net.rptools.clientserver.hessian.AbstractMethodHandler;
 import net.rptools.lib.MD5Key;
+import net.rptools.maptool.client.functions.MacroLinkFunction;
 import net.rptools.maptool.client.ui.MapToolFrame;
 import net.rptools.maptool.client.ui.tokenpanel.InitiativePanel;
 import net.rptools.maptool.client.ui.zone.FogUtil;
@@ -369,6 +370,10 @@ public class ClientMethodHandler extends AbstractMethodHandler {
               case message:
                 TextMessage message = (TextMessage) parameters[0];
                 MapTool.addServerMessage(message);
+                return;
+
+              case execLink:
+                MacroLinkFunction.receiveExecLink((String) parameters[0], (String) parameters[1]);
                 return;
 
               case showPointer:

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -193,6 +193,11 @@ public class ServerCommandClientImpl implements ServerCommand {
     makeServerCall(COMMAND.message, message);
   }
 
+  @Override
+  public void execLink(String link, String target) {
+    makeServerCall(COMMAND.execLink, link, target);
+  }
+
   public void showPointer(String player, Pointer pointer) {
     makeServerCall(COMMAND.showPointer, player, pointer);
   }

--- a/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
@@ -17,13 +17,9 @@ package net.rptools.maptool.client.functions;
 import java.awt.Color;
 import java.awt.EventQueue;
 import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.rptools.lib.MD5Key;
@@ -40,10 +36,12 @@ import net.rptools.maptool.model.Player;
 import net.rptools.maptool.model.TextMessage;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.StringUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.logging.log4j.LogManager;
@@ -145,14 +143,28 @@ public class MacroLinkFunction extends AbstractFunction {
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
       }
+      FunctionUtil.checkNumberParam(functionName, args, 1, 4);
 
-      boolean defer = false;
-      if (args.size() > 1) {
-        if (args.get(1) instanceof BigDecimal) {
-          defer = BigDecimal.ZERO.equals(args.get(1)) ? false : true;
-        }
+      String link = args.get(0).toString();
+      boolean defer =
+          args.size() > 1 ? FunctionUtil.paramAsBoolean(functionName, args, 1, true) : false;
+      String strTargets = args.size() > 2 ? args.get(2).toString().trim() : "self";
+      String delim = args.size() > 3 ? args.get(3).toString() : ",";
+
+      JSONArray jsonTargets;
+      if ("json".equals(delim) || strTargets.charAt(0) == '[')
+        jsonTargets = JSONArray.fromObject(strTargets);
+      else {
+        jsonTargets = new JSONArray();
+        for (String t : strTargets.split(delim)) jsonTargets.add(t.trim());
       }
-      execLink((String) args.get(0), defer);
+      if (jsonTargets.isEmpty()) return ""; // dont send to empty lists
+
+      @SuppressWarnings("unchecked")
+      Collection<String> targets =
+          JSONArray.toCollection(jsonTargets, List.class); // Returns an ArrayList<String>
+
+      sendExecLink(link, defer, targets);
       return "";
     }
 
@@ -168,16 +180,70 @@ public class MacroLinkFunction extends AbstractFunction {
     return sb.toString();
   }
 
-  private void execLink(final String link, boolean defer) {
+  /**
+   * Send the execLink to targets, either immediately or with a delay
+   *
+   * @param link the macroLinkText
+   * @param defer should the execLink be delayed
+   * @param targets the list of targets
+   */
+  private static void sendExecLink(final String link, boolean defer, Collection<String> targets) {
     if (defer) {
       EventQueue.invokeLater(
           new Runnable() {
             public void run() {
-              runMacroLink(link);
+              sendExecLink(link, targets);
             }
           });
     } else {
-      this.runMacroLink(link);
+      sendExecLink(link, targets);
+    }
+  }
+
+  /**
+   * Send the execLink. If target is local, run locally instead.
+   *
+   * @param link the macroLinkText
+   * @param targets the list of targets
+   */
+  private static void sendExecLink(final String link, Collection<String> targets) {
+    boolean isGM = MapTool.getPlayer().isGM();
+
+    for (String target : targets) {
+      switch (target.toLowerCase()) {
+        case "gm-self":
+          MapTool.serverCommand().execLink(link, "gm");
+          if (isGM) break; // // FALLTHRU if not a GM
+        case "self":
+          runMacroLink(link);
+          break;
+        case "none":
+          break;
+        default:
+          MapTool.serverCommand().execLink(link, target);
+      }
+    }
+  }
+
+  /**
+   * Receive an execLink, and run it if the player is a target.
+   *
+   * @param link the macroLinkText
+   * @param target the target. Can also be "gm" or "all".
+   */
+  public static void receiveExecLink(final String link, String target) {
+    String playerName = MapTool.getPlayer().getName();
+    boolean isGM = MapTool.getPlayer().isGM();
+    switch (target.toLowerCase()) {
+      case "gm":
+        if (isGM) runMacroLink(link);
+        break;
+      case "all":
+        runMacroLink(link);
+        break;
+      default:
+        if (target.equals(playerName)) runMacroLink(link);
+        break;
     }
   }
 
@@ -240,7 +306,7 @@ public class MacroLinkFunction extends AbstractFunction {
    * @return a property list representation of the arguments.
    * @throws ParserException if the argument encoding is incorrect.
    */
-  public String argsToStrPropList(String args) throws ParserException {
+  public static String argsToStrPropList(String args) throws ParserException {
     String vals[] = args.split("&");
     StringBuilder propList = new StringBuilder();
 
@@ -368,7 +434,7 @@ public class MacroLinkFunction extends AbstractFunction {
    *
    * @param link the link to the macro.
    */
-  public void runMacroLink(String link) {
+  public static void runMacroLink(String link) {
     runMacroLink(link, false);
   }
 
@@ -383,7 +449,7 @@ public class MacroLinkFunction extends AbstractFunction {
    *     macro.args.
    */
   @SuppressWarnings("unchecked")
-  public void runMacroLink(String link, boolean setVars) {
+  public static void runMacroLink(String link, boolean setVars) {
     if (link == null || link.length() == 0) {
       return;
     }
@@ -475,7 +541,8 @@ public class MacroLinkFunction extends AbstractFunction {
     }
   }
 
-  private void doOutput(Token token, OutputTo outputTo, String line, Set<String> playerList) {
+  private static void doOutput(
+      Token token, OutputTo outputTo, String line, Set<String> playerList) {
     /*
      * First we check our player list to make sure we are not sending things out multiple times or the wrong way. This looks a little ugly, but all it is doing is searching for the strings "say",
      * "gm", or "gmself", and if it contains no other strings changes it to a more appropriate for such as /togm, /self, etc. If it contains other names then gm, self etc will be replaced with
@@ -573,7 +640,7 @@ public class MacroLinkFunction extends AbstractFunction {
     }
   }
 
-  private void doWhisper(String message, Token token, String playerName) {
+  private static void doWhisper(String message, Token token, String playerName) {
     ObservableList<Player> playerList = MapTool.getPlayerList();
     List<String> players = new ArrayList<String>();
     for (int count = 0; count < playerList.size(); count++) {
@@ -612,7 +679,7 @@ public class MacroLinkFunction extends AbstractFunction {
             null));
   }
 
-  private String getSelf() {
+  private static String getSelf() {
     return MapTool.getPlayer().getName();
   }
 
@@ -688,7 +755,7 @@ public class MacroLinkFunction extends AbstractFunction {
     return false;
   }
 
-  private void doSay(String msg, Token token, boolean trusted, String macroName) {
+  private static void doSay(String msg, Token token, boolean trusted, String macroName) {
     StringBuilder sb = new StringBuilder();
 
     String identity = token == null ? MapTool.getPlayer().getName() : token.getName();

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -55,6 +55,7 @@ public interface ServerCommand {
     clearAllDrawings,
     setZoneGridSize,
     message,
+    execLink,
     undoDraw,
     showPointer,
     movePointer,
@@ -153,6 +154,8 @@ public interface ServerCommand {
   public void setZoneGridSize(GUID zoneGUID, int xOffset, int yOffset, int size, int color);
 
   public void message(TextMessage message);
+
+  public void execLink(String link, String target);
 
   public void showPointer(String player, Pointer pointer);
 

--- a/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -16,10 +16,7 @@ package net.rptools.maptool.server;
 
 import java.awt.geom.Area;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import net.rptools.clientserver.hessian.AbstractMethodHandler;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.ClientCommand;
@@ -117,6 +114,9 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
           break;
         case message:
           message((TextMessage) context.get(0));
+          break;
+        case execLink:
+          execLink((String) context.get(0), (String) context.get(1));
           break;
         case putAsset:
           putAsset((Asset) context.get(0));
@@ -506,6 +506,11 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
 
   public void message(TextMessage message) {
     forwardToClients();
+  }
+
+  @Override
+  public void execLink(String link, String target) {
+    forwardToAllClients();
   }
 
   public void putAsset(Asset asset) {


### PR DESCRIPTION
- Add new parameter "players" to execLink. All players specified will have the macro run for them. Default: self.
- The parameter "players" can be a string, a list, or json array. Use new delim parameter for list or array (defaults to ",").
- execLink also accepts "gm", "gm-self", "self", "all", and "none".
- Close #716

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/721)
<!-- Reviewable:end -->
