### PR TITLE
Fix prompt to "update" to old version when on pre-release

### DIFF
--- a/src/main/resources/github.properties
+++ b/src/main/resources/github.properties
@@ -1,2 +1,3 @@
 github.api.url=https://api.github.com/repos/RPTools/maptool/releases/latest?access_token=
+github.api.releases = https://api.github.com/repos/RPTools/maptool/releases?access_token=
 github.api.oauth.token=28276e82af1de2f79f0c38ceb17d2b23640784eb

--- a/src/main/resources/github.properties
+++ b/src/main/resources/github.properties
@@ -1,3 +1,2 @@
-github.api.url=https://api.github.com/repos/RPTools/maptool/releases/latest?access_token=
 github.api.releases = https://api.github.com/repos/RPTools/maptool/releases?access_token=
 github.api.oauth.token=28276e82af1de2f79f0c38ceb17d2b23640784eb


### PR DESCRIPTION
- Fix so that a release candidate / alpha / beta no longer gives prompt to "update" to an older release
- Change: users on a pre-release now get a prompt to update to the newest version, including pre-releases
- No change for those on stable releases
- Close #627

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/757)
<!-- Reviewable:end -->
