### PR TITLE
Fix bar functions returning wrong values if bar not defined

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -938,6 +938,8 @@ macro.function.tokenProperty.unknownLibToken       = Unknown Lib: token "{1}" in
 macro.function.tokenProperty.unknownPropType       = Unknown property type "{1}" in function "{0}".
 # TokenStateFunctions
 macro.function.tokenStateFunctions.unknownState    = Unknown state "{0}".
+# TokenBarFunction
+macro.function.tokenBarFunction.unknownBar         = Error with function "{0}": unknown bar "{1}".
 # String Property
 # {0} = value the user passed.
 macro.function.varsFromstrProp.wrongArgs           = varsFromStrProp called with 3 arguments, but second argument "{0}" was not one of NONE, SUFFIXED, or UNSUFFIXED.

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
@@ -626,6 +626,7 @@ macro.function.tokenProperty.unknownLibToken       = Lib: Pion {1} inconnu dans 
 macro.function.tokenProperty.unknownPropType       = Type de propri\u00E9t\u00E9 {1} inconnu dans la fonction {0}.
 # TokenStateFunctions {0} is the state name.
 macro.function.tokenStateFunctions.unknownState    = Etat {0} inconnu.
+macro.function.tokenBarFunction.unknownBar         = Erreur en \u00E9x\u00E9cutant {0}: barre {1} inconnue.
 # String Property
 #{0} = value the user passed.
 macro.function.varsFromstrProp.wrongArgs           = varsFromStrProp appel\u00E9 avec 3 arguments, mais le deuxi\u00E8me argument "{0}" n''\u00E9tait pas NONE, SUFFIXED, ou UNSUFFIXED.


### PR DESCRIPTION
- Change to throw exception if the name of the bar is not valid
- Change getBar to return an empty string instead of a null if the bar is defined but isn't visible
- Close #786

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/787)
<!-- Reviewable:end -->
