### PR TITLE
Fix broken smileys

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/chat/SmileyChatTranslationRuleGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/chat/SmileyChatTranslationRuleGroup.java
@@ -89,8 +89,9 @@ public class SmileyChatTranslationRuleGroup extends ChatTranslationRuleGroup {
       String value = smileyProps.getProperty(key);
       /*
        * Make sure we're not in roll output. Wouldn't let me do this usinglookbehind :-/
+       * Prevent all characters surrounding smiley except space, tab, and newline
        */
-      key = "^((?:[^\036]|\036[^\036]*\036)*)" + key;
+      key = "^((?:[^\036]|\036[^\036]*\036)*)(?<![^\\s\t\n\r])" + key + "(?![^\\s\t\n\r])";
       value = "$1" + value;
       addRule(new RegularExpressionTranslationRule(key, value));
     }

--- a/src/main/resources/net/rptools/maptool/client/ui/chat/smileyMap.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/chat/smileyMap.xml
@@ -14,12 +14,12 @@
 -->
 <properties>
   <comment>Smilies</comment>
-  <entry key="\b([\:\=]\))\b">net/rptools/maptool/client/image/smiley/emsmile.png|:)</entry>
-  <entry key="\b([\:\=]\()\b">net/rptools/maptool/client/image/smiley/emfrown.png|:(</entry>
-  <entry key="\b([\:\=]\'\()\b">net/rptools/maptool/client/image/smiley/emcry.png|:'(</entry>
-  <entry key="\b([\:\=][sS])\b">net/rptools/maptool/client/image/smiley/emcurl.png|:s</entry>
-  <entry key="\b([\:\=][oO])\b">net/rptools/maptool/client/image/smiley/emgasp.png|:o</entry>
-  <entry key="\b([\:\=]D)\b">net/rptools/maptool/client/image/smiley/emgrin.png|:D</entry>
-  <entry key="\b(\;\))\b">net/rptools/maptool/client/image/smiley/emwink.png|;)</entry>
-  <entry key="\b([\:\=][pP])\b">net/rptools/maptool/client/image/smiley/emtongue.png|:P</entry>
+  <entry key="([\:\=]\))">net/rptools/maptool/client/image/smiley/emsmile.png|:)</entry>
+  <entry key="([\:\=]\()">net/rptools/maptool/client/image/smiley/emfrown.png|:(</entry>
+  <entry key="([\:\=]\'\()">net/rptools/maptool/client/image/smiley/emcry.png|:'(</entry>
+  <entry key="([\:\=][sS])">net/rptools/maptool/client/image/smiley/emcurl.png|:s</entry>
+  <entry key="([\:\=][oO])">net/rptools/maptool/client/image/smiley/emgasp.png|:o</entry>
+  <entry key="([\:\=]D)">net/rptools/maptool/client/image/smiley/emgrin.png|:D</entry>
+  <entry key="(\;\))">net/rptools/maptool/client/image/smiley/emwink.png|;)</entry>
+  <entry key="([\:\=][pP])">net/rptools/maptool/client/image/smiley/emtongue.png|:P</entry>
 </properties>


### PR DESCRIPTION
- Remove \b (word boundary) in regular expression as it doesn't work with non-word characters such as smileys
- Add negative lookbehind/ahead instead to prevent unwanted characters near smileys
- Only space, tab, and newline are allowed before/after smiley
- Close #529

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/798)
<!-- Reviewable:end -->
