### PR TITLE
Fix incorrect tooltip for Show Chat Notification Background

### DIFF
--- a/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
@@ -3646,13 +3646,13 @@ Disabled: &lt;b&gt;[ ]&lt;/b&gt; acts like &lt;b&gt;[h: ]&lt;/b&gt;&amp;nbsp;</a
                                    </at>
                                    <at name="width">176</at>
                                    <at name="name"/>
-                                   <at name="text">Show Chat Notification Background</at>
+                                   <at name="text">Typing Notification Background</at>
                                    <at name="fill">
                                     <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                      <at name="name">fill</at>
                                     </object>
                                    </at>
-                                   <at name="toolTipText">Color of the text for typing notifications</at>
+                                   <at name="toolTipText">If enabled, shows a background frame underneath the typing notification.</at>
                                    <at name="height">14</at>
                                   </object>
                                  </at>
@@ -3705,7 +3705,7 @@ Disabled: &lt;b&gt;[ ]&lt;/b&gt; acts like &lt;b&gt;[h: ]&lt;/b&gt;&amp;nbsp;</a
                                      </at>
                                     </object>
                                    </at>
-                                   <at name="actionCommand">Show Chat Notification Background	</at>
+                                   <at name="actionCommand">Typing Notification Background</at>
                                    <at name="name">chatNotificationShowBackground</at>
                                    <at name="width">31</at>
                                    <at name="text">	</at>


### PR DESCRIPTION
- Change tooltip to "If enabled, the background flashes if a message is received when MapTool doesn't have the focus."
- Close #800

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/808)
<!-- Reviewable:end -->
