### PR TITLE
Add token & mapname parameters to getTokenStates

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenStateFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenStateFunction.java
@@ -74,8 +74,14 @@ public class TokenStateFunction extends AbstractFunction {
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, args, 2, 3);
       return setState(token, stateName, value);
     } else if (functionName.equals("getTokenStates")) {
-      FunctionUtil.checkNumberParam(functionName, args, 0, 2);
-      return getTokenStates(parser, args);
+      FunctionUtil.checkNumberParam(functionName, args, 0, 4);
+      String delim = args.size() > 0 ? args.get(0).toString() : ",";
+      String group = args.size() > 1 ? args.get(1).toString() : "*";
+      Token token =
+          args.size() > 2
+              ? FunctionUtil.getTokenFromParam(resolver, functionName, args, 2, 3)
+              : null;
+      return getTokenStates(delim, group, token);
     } else {
       throw new ParserException(
           I18N.getText("macro.function.general.unknownFunction", functionName));
@@ -158,27 +164,30 @@ public class TokenStateFunction extends AbstractFunction {
   }
 
   /**
-   * Gets a list of the valid token states.
+   * Gets a list of the token states, either from the Campaign or from a token.
    *
-   * @param parser The parser.
-   * @param args The arguments.
+   * @param delim The delimiter to use to return the list.
+   * @param group The group to get the states of. If "*" returns states of all groups.
+   * @param token The token to get the states of. If null, get the Campaign states instead.
    * @return A string with the states.
    */
-  private String getTokenStates(Parser parser, List<Object> args) {
-    String delim = args.size() > 0 ? args.get(0).toString() : ",";
+  private String getTokenStates(String delim, String group, Token token) {
     Set<String> stateNames;
 
-    if (args.size() > 1) {
-      String group = (String) args.get(1);
+    if ("*".equals(group) && token != null) {
+      stateNames = token.getStatePropertyNames(); // return states of token
+    } else if ("*".equals(group)) {
+      stateNames = MapTool.getCampaign().getTokenStatesMap().keySet();
+    } else {
       Map<String, BooleanTokenOverlay> states = MapTool.getCampaign().getTokenStatesMap();
       stateNames = new HashSet<String>();
       for (BooleanTokenOverlay bto : states.values()) {
-        if (group.equals(bto.getGroup())) {
-          stateNames.add(bto.getName());
-        }
+        // return states of the group that matches
+        if (group.equals(bto.getGroup())) stateNames.add(bto.getName());
       }
-    } else {
-      stateNames = MapTool.getCampaign().getTokenStatesMap().keySet();
+      if (token != null) {
+        stateNames.retainAll(token.getStatePropertyNames()); // keep only states enabled on token
+      }
     }
 
     StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
- New token parameter: if specified, getTokenStates returns the list of all states of the specified group that are enabled on the token
- Set group to "*" to get all states of the token
- If no token parameter specified, the function returns the list of all campaign states
- Close #801

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/809)
<!-- Reviewable:end -->
