### PR TITLE
Fix stream / clip issues

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -185,7 +185,6 @@ public class MapTool {
   private static AssetTransferManager assetTransferManager;
   private static ServiceAnnouncer announcer;
   private static AutoSaveManager autoSaveManager;
-  private static SoundManager soundManager;
   private static TaskBarFlasher taskbarFlasher;
   private static EventDispatcher eventDispatcher;
   private static MapToolLineParser parser = new MapToolLineParser();
@@ -531,10 +530,6 @@ public class MapTool {
     }
   }
 
-  public static SoundManager getSoundManager() {
-    return soundManager;
-  }
-
   /**
    * Play the sound registered to an eventId.
    *
@@ -545,7 +540,7 @@ public class MapTool {
       if (AppPreferences.getPlaySystemSoundsOnlyWhenNotFocused() && isInFocus()) {
         return;
       }
-      soundManager.playSoundEvent(eventId);
+      SoundManager.playSoundEvent(eventId);
     }
   }
 
@@ -689,11 +684,10 @@ public class MapTool {
     eventDispatcher = new EventDispatcher();
     registerEvents();
 
-    soundManager = new SoundManager();
     try {
-      soundManager.configure(SOUND_PROPERTIES);
-      soundManager.registerSoundEvent(
-          SND_INVALID_OPERATION, soundManager.getRegisteredSound("Dink"));
+      SoundManager.configure(SOUND_PROPERTIES);
+      SoundManager.registerSoundEvent(
+          SND_INVALID_OPERATION, SoundManager.getRegisteredSound("Dink"));
     } catch (IOException ioe) {
       MapTool.showError("While initializing (configuring sound)", ioe);
     }

--- a/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.client.functions;
 
 import java.net.*;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
@@ -24,6 +25,7 @@ import javafx.application.Platform;
 import javafx.scene.media.Media;
 import javafx.scene.media.MediaPlayer;
 import javafx.util.Duration;
+import net.rptools.lib.sound.SoundManager;
 import net.rptools.maptool.language.I18N;
 import net.rptools.parser.ParserException;
 import net.sf.json.JSONArray;
@@ -45,12 +47,31 @@ public class MediaPlayerAdapter {
   private final String strUri;
   private final Media media;
   private final MediaPlayer player;
-  private Double volume; // stored because player volume also depends on global volume
 
-  private MediaPlayerAdapter(String strUri, Media media) {
+  private int cycleCount; // store to remember last cycleCount used. Never 0.
+  private double volume; // store because player volume also depends on global volume
+  private Duration start;
+  private Duration stop; // can be null to not set stop time for player, needed to avoid bug
+
+  /**
+   * Set the values of the adapter, create the MediaPlayer, and set the properties of the
+   * MediaPlayer
+   *
+   * @param strUri the String url of the stream
+   * @param media the media to play
+   * @param cycleCount the number of cycles (null: 1)
+   * @param volume the volume level of the stream (0-1, null: 1)
+   * @param start the start time in seconds (null: 0)
+   * @param stop the stop time in seconds (null/negative: max length)
+   */
+  private MediaPlayerAdapter(
+      String strUri, Media media, Integer cycleCount, Double volume, Double start, Double stop) {
+    this.player = new MediaPlayer(media);
+
     this.strUri = strUri;
     this.media = media;
-    this.player = new MediaPlayer(media);
+    editStream(cycleCount, volume, start, stop, true);
+
     this.player.setOnEndOfMedia(
         new Runnable() {
           @Override
@@ -61,7 +82,64 @@ public class MediaPlayerAdapter {
               player.stop(); // otherwise, status stuck on "PLAYING" at end
           }
         });
-  };
+  }
+
+  /**
+   * Edit the adapter values, and update the player. Should be accessed from JavaFX app thread. If a
+   * parameter is null and useDefault is false, no change to that value. If null and useDefault is
+   * true, change to the defaults.
+   *
+   * @param cycleCount how many times should the stream play (-1: infinite, default: 1)
+   * @param volume the volume level of the stream (0-1, default: 1)
+   * @param start the start time in seconds (default: 0)
+   * @param stop the stop time in seconds (-1: file duration, default: -1)
+   * @param useDefault if true, use default when receiving a null argument
+   */
+  private void editStream(
+      Integer cycleCount, Double volume, Double start, Double stop, boolean useDefault) {
+    // don't change adapter cycleCount if 0, but stop play.
+    if (cycleCount != null && cycleCount != 0) {
+      this.cycleCount = cycleCount;
+    } else if (useDefault) {
+      this.cycleCount = 1;
+    }
+    if (volume != null) {
+      this.volume = volume;
+    } else if (useDefault) {
+      this.volume = 1.0;
+    }
+    if (start != null) {
+      this.start = Duration.seconds(start);
+    } else if (useDefault) {
+      this.start = Duration.seconds(0.0);
+    }
+    if (stop != null) {
+      this.stop = stop >= 0 ? Duration.seconds(stop) : player.getMedia().getDuration();
+    } else if (useDefault) {
+      this.stop = null;
+    }
+    updatePlayer(cycleCount != null && cycleCount == 0);
+  }
+
+  /**
+   * Update the MediaPlayer with the values in the adapter
+   *
+   * @param stopPlay should the player be stopped
+   */
+  private void updatePlayer(boolean stopPlay) {
+    int newCycle =
+        this.cycleCount >= 0 ? this.cycleCount + player.getCurrentCount() : this.cycleCount;
+
+    this.player.setCycleCount(newCycle);
+    this.player.setVolume(this.volume * globalVolume);
+    this.player.setStartTime(this.start);
+    if (this.stop != null) this.player.setStopTime(this.stop);
+
+    this.player.setMute(globalMute);
+    if (stopPlay) {
+      this.player.stop();
+    }
+  }
   /**
    * Start a given stream from its url string. If already streaming the file, dispose of the
    * previous stream.
@@ -71,17 +149,27 @@ public class MediaPlayerAdapter {
    * @param volume the volume level of the stream (0-1)
    * @param start the start time in ms
    * @param stop the stop time in ms, -1: file duration
+   * @param preloadOnly should the stream be only preloaded and not played
    * @return false if the file doesn't exist, true otherwise
    * @throws ParserException if issue with file
    */
   public static boolean playStream(
-      String strUri, int cycleCount, double volume, double start, double stop)
+      String strUri,
+      Integer cycleCount,
+      Double volume,
+      Double start,
+      Double stop,
+      boolean preloadOnly)
       throws ParserException {
     final Media media;
     try {
-      if (!SoundFunctions.uriExists(strUri))
-        return false; // leave without error message if uri ok but no file
-      media = new Media(strUri);
+      if (mapStreams.containsKey(strUri)) {
+        media = mapStreams.get(strUri).media;
+      } else {
+        if (!SoundFunctions.uriExists(strUri))
+          return false; // leave without error message if uri ok but no file
+        media = new Media(strUri);
+      }
     } catch (Exception e) {
       throw new ParserException(
           I18N.getText(
@@ -98,25 +186,18 @@ public class MediaPlayerAdapter {
           public void run() {
             MediaPlayerAdapter adapter = mapStreams.get(strUri);
             boolean old = adapter != null;
-            if (!old) {
-              adapter = new MediaPlayerAdapter(strUri, media);
+            if (old) {
+              adapter.editStream(cycleCount, volume, start, stop, false);
+            } else {
+              adapter = new MediaPlayerAdapter(strUri, media, cycleCount, volume, start, stop);
               mapStreams.put(strUri, adapter);
             }
-            adapter.volume = volume;
             MediaPlayer player = adapter.player;
 
-            int newCycle = cycleCount >= 0 ? cycleCount + player.getCurrentCount() : cycleCount;
-            Duration durStart = new Duration(start);
-            Duration durStop = stop >= 0 ? new Duration(stop) : player.getMedia().getDuration();
-
-            player.setCycleCount(newCycle);
-            player.setVolume(volume * globalVolume);
-            player.setStartTime(durStart);
-            player.setStopTime(durStop);
-
-            player.setMute(globalMute);
-            player.seek(durStart); // start playing from the start
-            if (cycleCount != 0) {
+            // cycleCount of zero doesn't change adapter, but instead doesn't activate play
+            boolean play = (cycleCount == null || cycleCount != 0) && !preloadOnly;
+            if (play) {
+              player.seek(player.getStartTime()); // start playing from the start
               if (old) player.play();
               else player.setAutoPlay(true);
             } else player.stop();
@@ -130,7 +211,7 @@ public class MediaPlayerAdapter {
    *
    * @param strUri the String url of the stream
    * @param remove should the stream be disposed
-   * @param fadeout time in ms to fadeout (0: no fadeout)
+   * @param fadeout time in seconds to fadeout (0: no fadeout)
    */
   public static void stopStream(String strUri, boolean remove, double fadeout) {
     Platform.runLater(
@@ -164,14 +245,14 @@ public class MediaPlayerAdapter {
    * Stop the stream. Should be ran from JavaFX app thread.
    *
    * @param remove should the stream be disposed and map updated
-   * @param fadeout time in ms to fadeout (0: no fadeout)
+   * @param fadeout time in seconds to fadeout (0: no fadeout)
    */
   private void stopStream(boolean remove, double fadeout) {
     if (fadeout <= 0) stopStream(remove);
     else {
       Timeline timeline =
           new Timeline(
-              new KeyFrame(Duration.millis(fadeout), new KeyValue(player.volumeProperty(), 0)));
+              new KeyFrame(Duration.seconds(fadeout), new KeyValue(player.volumeProperty(), 0)));
       timeline.setOnFinished(
           (event -> {
             stopStream(remove); // stop the stream at the end
@@ -198,41 +279,13 @@ public class MediaPlayerAdapter {
             if (strUri.equals("*")) {
               for (HashMap.Entry mapElement : mapStreams.entrySet())
                 ((MediaPlayerAdapter) mapElement.getValue())
-                    .editStream(cycleCount, volume, start, stop);
+                    .editStream(cycleCount, volume, start, stop, false);
             } else {
               MediaPlayerAdapter adapter = mapStreams.get(strUri);
-              if (adapter != null) adapter.editStream(cycleCount, volume, start, stop);
+              if (adapter != null) adapter.editStream(cycleCount, volume, start, stop, false);
             }
           }
         });
-  }
-
-  /**
-   * Edit the stream. Should be accessed from JavaFX app thread. If a parameter is null, no change
-   * to that value.
-   *
-   * @param cycleCount how many times should the stream play. -1: infinite
-   * @param volume the volume level of the stream (0-1)
-   * @param start the start time in ms
-   * @param stop the stop time in ms, -1: file duration
-   */
-  private void editStream(Integer cycleCount, Double volume, Double start, Double stop) {
-    if (cycleCount != null) {
-      if (cycleCount == 0) player.stop();
-      else {
-        int newCycle = cycleCount >= 0 ? cycleCount + player.getCurrentCount() : cycleCount;
-        player.setCycleCount(newCycle);
-      }
-    }
-    if (volume != null) {
-      this.volume = volume;
-      player.setVolume(volume * globalVolume);
-    }
-    if (start != null) player.setStartTime(new Duration(start));
-    if (stop != null) {
-      Duration durStop = stop >= 0 ? new Duration(stop) : Duration.INDEFINITE;
-      player.setStopTime(durStop);
-    }
   }
 
   /**
@@ -280,15 +333,21 @@ public class MediaPlayerAdapter {
       else objStop = durStop.toSeconds();
 
       JSONObject info = new JSONObject();
+
+      List<String> listNicks = SoundFunctions.getNicks(strUri);
+      if (listNicks.size() > 0) {
+        info.put("nicknames", String.join(",", listNicks));
+      }
       info.put("uri", strUri);
-      info.put("cycleCount", player.getCycleCount());
       info.put("volume", volume);
-      info.put("startTime", player.getStartTime().toSeconds());
+      info.put("cycleCount", cycleCount);
+      info.put("startTime", start.toSeconds());
       info.put("stopTime", objStop);
       info.put("currentTime", player.getCurrentTime().toSeconds());
       info.put("totalTime", objTotal);
       info.put("bufferTime", player.getBufferProgressTime().toSeconds());
       info.put("currentCount", player.getCurrentCount());
+      info.put("endCount", player.getCycleCount());
       info.put("status", player.getStatus().toString());
       info.put("type", "stream");
       return info;
@@ -340,8 +399,14 @@ public class MediaPlayerAdapter {
         new Runnable() {
           @Override
           public void run() {
-            for (HashMap.Entry mapElement : mapStreams.entrySet())
+            // mute / unmute all streams
+            for (HashMap.Entry mapElement : mapStreams.entrySet()) {
               ((MediaPlayerAdapter) mapElement.getValue()).updateMute();
+            }
+            // if muting, stop all audio clips
+            if (mute) {
+              SoundManager.stopClip("*", false);
+            }
           }
         });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
@@ -37,6 +37,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Element;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.StyleSheet;
+import net.rptools.lib.sound.SoundManager;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
@@ -130,9 +131,7 @@ public class MessagePanel extends JPanel {
     add(scrollPane);
     clearMessages();
 
-    MapTool.getSoundManager()
-        .registerSoundEvent(
-            SND_MESSAGE_RECEIVED, MapTool.getSoundManager().getRegisteredSound("Clink"));
+    SoundManager.registerSoundEvent(SND_MESSAGE_RECEIVED, SoundManager.getRegisteredSound("Clink"));
   }
 
   public void refreshRenderer() {


### PR DESCRIPTION
- Change so that playClip / playStream have their default parameter values be those used during the previous play of the clip/stream, or the values changed by editStream
- Add parameter "preload" to defineAudioSource. If set to "stream", preload the sound as stream; if set to "clip", preload the sound as clip.
- Add parameters to defineAudioSource: cycleCount, volume, start and stop. These parameters will be used as default until they are replaced by using playStream/playClip
- Add list of nicknames to getSoundProperties
- Internal change: start and stop are now defined in seconds everywhere
- Fix issues discussed in #810 and #822

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/826)
<!-- Reviewable:end -->
