### PR TITLE
Fix incorrect Campaign name in title bar for clients

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2324,6 +2324,7 @@ public class AppActions {
               AppState.setCampaignFile(campaignFile);
               AppPreferences.setLoadDir(campaignFile.getParentFile());
               AppMenuBar.getMruManager().addMRUCampaign(campaignFile);
+              campaign.campaign.setName(AppState.getCampaignName()); // Update campaign name
 
               /*
                * Bypass the serialization when we are hosting the server.
@@ -2509,7 +2510,9 @@ public class AppActions {
       AppState.setCampaignFile(campaignFile);
       AppPreferences.setSaveDir(campaignFile.getParentFile());
       AppMenuBar.getMruManager().addMRUCampaign(AppState.getCampaignFile());
-      MapTool.getFrame().setTitleViaRenderer(MapTool.getFrame().getCurrentZoneRenderer());
+      if (MapTool.isHostingServer() || MapTool.isPersonalServer()) {
+        MapTool.serverCommand().setCampaignName(AppState.getCampaignName());
+      }
     }
   }
 
@@ -2531,7 +2534,9 @@ public class AppActions {
       AppState.setCampaignFile(campaignFile);
       AppPreferences.setSaveDir(campaignFile.getParentFile());
       AppMenuBar.getMruManager().addMRUCampaign(AppState.getCampaignFile());
-      MapTool.getFrame().setTitleViaRenderer(MapTool.getFrame().getCurrentZoneRenderer());
+      if (MapTool.isHostingServer() || MapTool.isPersonalServer()) {
+        MapTool.serverCommand().setCampaignName(AppState.getCampaignName());
+      }
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/AppState.java
+++ b/src/main/java/net/rptools/maptool/client/AppState.java
@@ -137,6 +137,22 @@ public class AppState {
     AppState.campaignFile = campaignFile;
   }
 
+  /**
+   * Returns the campaign name (without extension) from the campaign file. If no campaign file is
+   * defined, instead returns "Default".
+   *
+   * @return The string containing the campaign name
+   */
+  public static String getCampaignName() {
+    if (AppState.campaignFile == null) {
+      return "Default";
+    } else {
+      String s = AppState.campaignFile.getName();
+      // remove the file extension of the campaign file name
+      return s.substring(0, s.length() - AppConstants.CAMPAIGN_FILE_EXTENSION.length());
+    }
+  }
+
   public static void setShowMovementMeasurements(boolean show) {
     showMovementMeasurements = show;
   }

--- a/src/main/java/net/rptools/maptool/client/ClientCommand.java
+++ b/src/main/java/net/rptools/maptool/client/ClientCommand.java
@@ -74,6 +74,7 @@ public class ClientCommand {
     setBoard,
     updateExposedAreaMeta,
     clearExposedArea,
+    setCampaignName,
     restoreZoneView // Jamz: New command to restore player's view and let GM temporarily center and
     // scale a player's view
     // @formatter:on

--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -205,6 +205,11 @@ public class ClientMethodHandler extends AbstractMethodHandler {
                 MapTool.getFrame().hideGlassPane();
                 return;
 
+              case setCampaignName:
+                MapTool.getCampaign().setName((String) parameters[0]);
+                MapTool.getFrame().setTitle();
+                return;
+
               case putZone:
                 zone = (Zone) parameters[0];
                 MapTool.getCampaign().putZone(zone);

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -79,6 +79,12 @@ public class ServerCommandClientImpl implements ServerCommand {
     }
   }
 
+  public void setCampaignName(String name) {
+    MapTool.getCampaign().setName(name);
+    MapTool.getFrame().setTitle();
+    makeServerCall(COMMAND.setCampaignName, name);
+  }
+
   public void setVisionType(GUID zoneGUID, VisionType visionType) {
     makeServerCall(COMMAND.setVisionType, zoneGUID, visionType);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -98,7 +98,6 @@ import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.AppActions.ClientAction;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
-import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
@@ -1561,20 +1560,28 @@ public class MapToolFrame extends DefaultDockableHolder
     getZoomStatusBar().update();
   }
 
+  /**
+   * Set the MapTool title bar. The title includes the name of the app, the player name, the
+   * campaign name and the name of the specified zone.
+   *
+   * @param renderer the ZoneRenderer of the zone.
+   */
   public void setTitleViaRenderer(ZoneRenderer renderer) {
-    String campaignName = " - [Default]";
-    if (AppState.getCampaignFile() != null) {
-      String s = AppState.getCampaignFile().getName();
-      // remove the file extension of the campaign file name
-      s = s.substring(0, s.length() - AppConstants.CAMPAIGN_FILE_EXTENSION.length());
-      campaignName = " - [" + s + "]";
-    }
+    String campaignName = " - [" + MapTool.getCampaign().getName() + "]";
     setTitle(
         AppConstants.APP_NAME
             + " - "
             + MapTool.getPlayer()
             + campaignName
             + (renderer != null ? " - " + renderer.getZone().getName() : ""));
+  }
+
+  /**
+   * Set the MapTool title bar. The title includes the name of the app, the player name, the
+   * campaign name and the current zone name.
+   */
+  public void setTitle() {
+    setTitleViaRenderer(MapTool.getFrame().getCurrentZoneRenderer());
   }
 
   public Toolbox getToolbox() {

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -51,6 +51,7 @@ public class Campaign {
 
   private GUID id = new GUID();
   private Map<GUID, Zone> zones = Collections.synchronizedMap(new LinkedHashMap<GUID, Zone>());
+  private String name; // the name of the campaign, to be displayed in the MapToolFrame title bar
 
   @SuppressWarnings("unused")
   private static transient ExportDialog exportInfo =
@@ -108,6 +109,7 @@ public class Campaign {
   private Boolean hasUsedFogToolbar = null;
 
   public Campaign() {
+    name = "Default";
     macroButtonLastIndex = 0;
     gmMacroButtonLastIndex = 0;
     macroButtonProperties = new ArrayList<MacroButtonProperties>();
@@ -147,6 +149,7 @@ public class Campaign {
    * @param campaign The campaign to copy from.
    */
   public Campaign(Campaign campaign) {
+    name = campaign.getName();
     zones = Collections.synchronizedMap(new LinkedHashMap<GUID, Zone>());
 
     /*
@@ -166,6 +169,14 @@ public class Campaign {
 
   public GUID getId() {
     return id;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -41,6 +41,7 @@ public interface ServerCommand {
     // @formatter:off
     bootPlayer,
     setCampaign,
+    setCampaignName,
     getZone,
     putZone,
     removeZone,
@@ -119,6 +120,8 @@ public interface ServerCommand {
   public void restoreZoneView(GUID zoneGUID);
 
   public void setCampaign(Campaign campaign);
+
+  public void setCampaignName(String name);
 
   public void getZone(GUID zoneGUID);
 

--- a/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -166,6 +166,9 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
         case setCampaign:
           setCampaign((Campaign) context.get(0));
           break;
+        case setCampaignName:
+          setCampaignName((String) context.get(0));
+          break;
         case setZoneGridSize:
           setZoneGridSize(
               context.getGUID(0),
@@ -667,6 +670,11 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
 
   public void setCampaign(Campaign campaign) {
     server.setCampaign(campaign);
+    forwardToClients();
+  }
+
+  public void setCampaignName(String name) {
+    server.getCampaign().setName(name);
     forwardToClients();
   }
 


### PR DESCRIPTION
- Fix so clients see the proper campaign name instead of the name of the last campaign file they loaded
- Close #788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/827)
<!-- Reviewable:end -->
