### PR TITLE
Added titleCase() macro function

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -62,7 +62,8 @@ public class StringFunctions extends AbstractFunction {
         "encode",
         "decode",
         "startsWith",
-        "endsWith");
+        "endsWith",
+        "titleCase");
   }
 
   public static StringFunctions getInstance() {
@@ -387,8 +388,39 @@ public class StringFunctions extends AbstractFunction {
           ? BigDecimal.ONE
           : BigDecimal.ZERO;
     }
+    if (functionName.equals("titleCase")) {
+      if (parameters.size() < 1) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.general.notEnoughParam", functionName, 1, parameters.size()));
+      }
+      return titleCase(parameters.get(0).toString());
+    }
     // should never happen
     throw new ParserException(functionName + "(): Unknown function.");
+  }
+
+  /**
+   * This method returns a version of the passed in string where all the first letters of words are
+   * uppercase.
+   *
+   * @param str The string converted to title case.
+   *
+   * @return The string converted to title case.
+   */
+  private String titleCase(String str) {
+    Pattern pattern = Pattern.compile("(\\p{IsAlphabetic}+)");
+    Matcher matcher = pattern.matcher(str);
+
+    StringBuffer result = new StringBuffer();
+    while (matcher.find()) {
+      String word = matcher.group();
+      matcher.appendReplacement(result, Character.toTitleCase(word.charAt(0)) + word.substring(1));
+    }
+
+    matcher.appendTail(result);
+
+    return result.toString();
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -405,7 +405,6 @@ public class StringFunctions extends AbstractFunction {
    * uppercase.
    *
    * @param str The string converted to title case.
-   *
    * @return The string converted to title case.
    */
   private String titleCase(String str) {


### PR DESCRIPTION
Added new macro function titleCase() which will convert the first letter of each word into title case based on locale. 
e.g. "Fists of Fury" becomes "Fists Of Fury"
Digits are considered word boundarys so
"johnny3fingers" becomes "Johnny3Fingers"

Fixes #829

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/830)
<!-- Reviewable:end -->
