### PR TITLE
Closes #848 - Add File Sync Directory to getInfo("client") macro

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -160,6 +160,7 @@ public class getInfoFunction extends AbstractFunction {
     cinfo.put("portrait size", AppPreferences.getPortraitSize());
     cinfo.put("show portrait", AppPreferences.getShowPortrait());
     cinfo.put("show stat sheet", AppPreferences.getShowStatSheet());
+    cinfo.put("file sync directory", AppPreferences.getFileSyncPath());
     cinfo.put("version", MapTool.getVersion());
     cinfo.put("isFullScreen", MapTool.getFrame().isFullScreen() ? BigDecimal.ONE : BigDecimal.ZERO);
     cinfo.put("timeInMs", System.currentTimeMillis());


### PR DESCRIPTION
Add missing "file sync directory" to client info.develop.

Documentation/Wiki should be updated to reflect changes. *Side note: file sync directory preference technically can be ANY directory on the users system. It's used internally for HeroLab portfolio linking and but can be used for other uses such as streaming audio or exportData macro's*

Signed-off-by: JamzTheMan <JamzTheMan@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/849)
<!-- Reviewable:end -->
