### PR TITLE
Revert "Bump gson from 2.8.5 to 2.8.6"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.13.1'
 
     // Better JSON functions...
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'		// https://mvnrepository.com/artifact/com.google.code.gson/gson
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'		// https://mvnrepository.com/artifact/com.google.code.gson/gson
 
     // Declare the dependency for your favourite test framework you want to use in your tests.
     // TestNG is also supported by the Gradle Test task. Just change the


### PR DESCRIPTION
Reverts RPTools/maptool#840 - Can't handle modules yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/853)
<!-- Reviewable:end -->
