### PR TITLE
Adds ISO Formatted time with UTC offset

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -16,6 +16,8 @@ package net.rptools.maptool.client.functions;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -165,6 +167,7 @@ public class getInfoFunction extends AbstractFunction {
     cinfo.put("isFullScreen", MapTool.getFrame().isFullScreen() ? BigDecimal.ONE : BigDecimal.ZERO);
     cinfo.put("timeInMs", System.currentTimeMillis());
     cinfo.put("timeDate", getTimeDate());
+    cinfo.put("isoTimeDate", getIsoTimeDate());
     if (MapTool.getParser().isMacroTrusted()) {
       Map<String, Object> libInfo = new HashMap<String, Object>();
       for (ZoneRenderer zr : MapTool.getFrame().getZoneRenderers()) {
@@ -194,6 +197,10 @@ public class getInfoFunction extends AbstractFunction {
     Calendar cal = Calendar.getInstance();
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     return sdf.format(cal.getTime());
+  }
+
+  private String getIsoTimeDate() {
+    return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now());
   }
 
   /**


### PR DESCRIPTION
Current timeDate fields in Client Info does not include any timezone information which is needed for some API calls.

New field `isoTimeDate` was added which now includes UTC offset following ISO 8601 standards.
such as `2019-11-09T10:15:30.3444-06:00`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/877)
<!-- Reviewable:end -->
