### PR TITLE
Fix previously exposed areas not shown after starting server

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -920,9 +920,8 @@ public class AppActions {
         if (originalToken.getY() < topLeft.getY() || originalToken.getX() < topLeft.getX()) {
           topLeft = originalToken;
         }
-        Token newToken = new Token(originalToken);
-        newToken.setId(
-            originalToken.getId()); // keep same ids. Will be changed on paste if need be.
+        Token newToken =
+            new Token(originalToken, true); // keep same ids. Changed on paste if need be.
         tokenCopySet.add(newToken);
       }
       /*
@@ -1026,10 +1025,7 @@ public class AppActions {
     List<String> failedPaste = new ArrayList<String>(tokenList.size());
 
     for (Token origToken : tokenList) {
-      Token token = new Token(origToken);
-      if (keepIdsOnPaste) {
-        token.setId(origToken.getId()); // keep ids if first paste since cut
-      }
+      Token token = new Token(origToken, keepIdsOnPaste); // keep id if first paste since cut
 
       // need this here to get around times when a token is copied and pasted into the
       // same zone, such as a framework "template"
@@ -2079,10 +2075,7 @@ public class AppActions {
                      * You need to modify either Campaign(Campaign) or Zone(Zone) to get any data you need to persist from the pre-server campaign to the post server start up campaign.
                      */
                     MapTool.startServer(
-                        dialog.getUsernameTextField().getText(),
-                        config,
-                        policy,
-                        new Campaign(campaign));
+                        dialog.getUsernameTextField().getText(), config, policy, campaign, true);
 
                     // Connect to server
                     String playerType = dialog.getRoleCombo().getSelectedItem().toString();

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -996,8 +996,18 @@ public class MapTool {
     return assetTransferManager;
   }
 
+  /**
+   * Start the server from a campaign file and various settings.
+   *
+   * @param id the id of the server for announcement
+   * @param config the server configuration
+   * @param campaign the campaign
+   * @param copyCampaign should the campaign be a copy of the one provided
+   * @throws IOException if new MapToolServer fails
+   */
   public static void startServer(
-      String id, ServerConfig config, ServerPolicy policy, Campaign campaign) throws IOException {
+      String id, ServerConfig config, ServerPolicy policy, Campaign campaign, boolean copyCampaign)
+      throws IOException {
     if (server != null) {
       Thread.dumpStack();
       showError("msg.error.alreadyRunningServer");
@@ -1009,9 +1019,13 @@ public class MapTool {
     // TODO: the client and server campaign MUST be different objects.
     // Figure out a better init method
     server = new MapToolServer(config, policy);
-    server.setCampaign(campaign);
 
     serverPolicy = server.getPolicy();
+    if (copyCampaign) {
+      server.setCampaign(new Campaign(campaign)); // copy of FoW depends on server policies
+    } else {
+      server.setCampaign(campaign);
+    }
 
     if (announcer != null) {
       announcer.stop();
@@ -1117,7 +1131,7 @@ public class MapTool {
 
   public static void startPersonalServer(Campaign campaign) throws IOException {
     ServerConfig config = ServerConfig.createPersonalServerConfig();
-    MapTool.startServer(null, config, new ServerPolicy(), campaign);
+    MapTool.startServer(null, config, new ServerPolicy(), campaign, false);
 
     String username = System.getProperty("user.name", "Player");
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -245,6 +245,24 @@ public class Token extends BaseModel implements Cloneable {
 
   private HeroLabData heroLabData;
 
+  /**
+   * Constructor from another token, with the option to keep the token id
+   *
+   * @param token the token to copy
+   * @param keepId should the Id be kept
+   */
+  public Token(Token token, boolean keepId) {
+    this(token);
+    if (keepId) {
+      this.setId(token.getId());
+    }
+  }
+
+  /**
+   * Constructor from another token. The token id is not kept.
+   *
+   * @param token the token to copy
+   */
   public Token(Token token) {
     this(token.name, token.getImageAssetId());
     currentImageAsset = token.currentImageAsset;

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -351,9 +350,8 @@ public class Zone extends BaseModel {
       Collections.copy(gmDrawables, zone.gmDrawables);
     }
     if (zone.labels != null && !zone.labels.isEmpty()) {
-      Iterator<GUID> i = zone.labels.keySet().iterator();
-      while (i.hasNext()) {
-        this.putLabel(new Label(zone.labels.get(i.next())));
+      for (GUID guid : zone.labels.keySet()) {
+        this.putLabel(new Label(zone.labels.get(guid)));
       }
     }
     exposedAreaMeta = new HashMap<GUID, ExposedAreaMetaData>(zone.exposedAreaMeta.size() * 4 / 3);
@@ -364,11 +362,9 @@ public class Zone extends BaseModel {
     initiativeList.setZone(null);
 
     if (zone.tokenMap != null && !zone.tokenMap.isEmpty()) {
-      Iterator<GUID> i = zone.tokenMap.keySet().iterator();
-      while (i.hasNext()) {
-        Token old = zone.tokenMap.get(i.next());
-        Token token = new Token(old);
-        if (keepIds) token.setId(old.getId()); // keep the old token ids
+      for (GUID oldGUID : zone.tokenMap.keySet()) {
+        Token old = zone.tokenMap.get(oldGUID);
+        Token token = new Token(old, keepIds); // keep old ids at server start
         if (old.getExposedAreaGUID() != null) {
           GUID guid = new GUID();
           token.setExposedAreaGUID(guid);
@@ -746,6 +742,13 @@ public class Zone extends BaseModel {
     fireModelChangeEvent(new ModelChangeEvent(this, Event.FOG_CHANGED));
   }
 
+  /**
+   * Expose a FoW area. Add the exposed area to the metadata of the token. If tok is set to null or
+   * the settings disable individual FoW, instead add it to the general exposedArea.
+   *
+   * @param area the area to expose
+   * @param tok the token to expose for, or null
+   */
   public void exposeArea(Area area, Token tok) {
     if (area == null || area.isEmpty()) {
       return;


### PR DESCRIPTION
- Fix exposed areas not being shown when starting server with Individualized Views
- Bug was caused by MapTool.getServerPolicy().isUseIndividualFOW() not returning correct value at server start
- Close #887

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/894)
<!-- Reviewable:end -->
