### PR TITLE
Fix copy/pasted tokens sharing macro edits

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
@@ -142,7 +142,6 @@ public class TokenCopyDeleteFunctions extends AbstractFunction {
             }
           }
           setTokenValues(t, newVals, zone, res);
-          zone.putToken(t);
 
           MapTool.serverCommand().putToken(zone.getId(), t);
           newTokens.add(t.getId().toString());

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -221,8 +221,16 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     save();
   }
 
-  // constructor for creating a new copy of an existing token button, auto-saves
-  public MacroButtonProperties(Token token, int index, MacroButtonProperties properties) {
+  /**
+   * Constructor for creating a new copy of an existing token button, can auto-saves
+   *
+   * @param token the token for which to create the copy
+   * @param index the index of the next macro
+   * @param properties the MacroButtonProperties of the copied button
+   * @param autoSave should the macro be autosaved or not?
+   */
+  public MacroButtonProperties(
+      Token token, int index, MacroButtonProperties properties, boolean autoSave) {
     this(index);
     setSaveLocation("Token");
     setTokenId(token);
@@ -249,7 +257,20 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setCompareCommand(properties.getCompareCommand());
     String tt = properties.getToolTip();
     setToolTip(tt);
-    save();
+    if (autoSave) {
+      save();
+    }
+  }
+
+  /**
+   * Constructor for creating a new copy of an existing token button, auto-saves
+   *
+   * @param token the token for which to create the copy
+   * @param index the index of the next macro
+   * @param properties the MacroButtonProperties of the copied button
+   */
+  public MacroButtonProperties(Token token, int index, MacroButtonProperties properties) {
+    this(token, index, properties, true);
   }
 
   // constructor for creating common macro buttons on selection panel

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -342,8 +342,12 @@ public class Token extends BaseModel implements Cloneable {
       getPropertyMap().clear();
       getPropertyMap().putAll(token.propertyMapCI);
     }
-    if (token.macroPropertiesMap != null) {
-      macroPropertiesMap = new HashMap<Integer, Object>(token.macroPropertiesMap);
+    if (token.macroPropertiesMap != null) { // Deep copy of the macros
+      macroPropertiesMap = new HashMap<Integer, Object>(token.macroPropertiesMap.size());
+      token.macroPropertiesMap.forEach(
+          (key, value) ->
+              macroPropertiesMap.put(
+                  key, new MacroButtonProperties(this, key, (MacroButtonProperties) value, false)));
     }
     // convert old-style macros
     if (token.macroMap != null) {


### PR DESCRIPTION
- Fix editing a token's macros also affecting its copies
- Change: copy/paste a token now give the pasted token new macro UUIDs
- Close #907

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/911)
<!-- Reviewable:end -->
