### PR TITLE
Fix exposePCOnlyArea keeps FoW when Individual Views Off

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
@@ -234,9 +234,9 @@ public class FogUtil {
    * net.rptools.maptool.server.ServerMethodHandler.exposePCArea(GUID), and the macro
    * exposePCOnlyArea().
    *
-   * @author updated Jamz
-   * @since updated 1.4.0.1
-   * @param renderer
+   * @author updated Jamz, Merudo
+   * @since updated 1.5.8
+   * @param renderer the ZoneRenderer
    */
   public static void exposePCArea(ZoneRenderer renderer) {
     Set<GUID> tokenSet = new HashSet<GUID>();
@@ -256,6 +256,7 @@ public class FogUtil {
       tokenSet.add(token.getId());
     }
 
+    renderer.getZone().clearGlobalExposedArea();
     renderer.getZone().clearExposedArea(tokenSet);
     // this was .clearExposedArea(), changed to expose current area only vs last path
     exposeVisibleArea(renderer, tokenSet, true);

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -713,7 +713,7 @@ public class Zone extends BaseModel {
     fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_CHANGED, token));
   }
 
-  // Clears FoW for ALL tokens, including NPC's
+  /** Clears FoW for ALL tokens, including NPC's */
   public void clearExposedArea() {
     exposedArea = new Area();
     // There used to be a foreach loop here that iterated over getTokens() and called .clear() --
@@ -722,7 +722,16 @@ public class Zone extends BaseModel {
     fireModelChangeEvent(new ModelChangeEvent(this, Event.FOG_CHANGED));
   }
 
-  // clear only exposed area for tokenSet, eg only PC's
+  /** Clear the exposedArea common to all tokens */
+  public void clearGlobalExposedArea() {
+    exposedArea.reset();
+  }
+
+  /**
+   * Clear only exposed area for tokenSet, eg only PC's
+   *
+   * @param tokenSet the set of token GUID to reset
+   */
   public void clearExposedArea(Set<GUID> tokenSet) {
     // Jamz: Clear FoW for set tokens only, for use by
     // ExposeVisibleAreaOnlyAction Menu action and exposePCOnlyArea() macro


### PR DESCRIPTION
- Fix exposePCOnlyArea not restoring FoW when individual views are off and the server is started
- exposePCOnlyArea now resets the global exposed area "exposedArea"
- Close #792

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/917)
<!-- Reviewable:end -->
