### PR TITLE
Add tooltips for Startup tab

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
@@ -335,7 +335,8 @@ public class PreferencesDialog extends JDialog {
     dataDirTextField = panel.getTextField("dataDirTextField");
 
     jvmAssertionsCheckbox = panel.getCheckBox("jvmAssertionsCheckbox");
-    jvmAssertionsCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.enableAssertions.tooltip"));
+    jvmAssertionsCheckbox.setToolTipText(
+        I18N.getText("prefs.jvm.advanced.enableAssertions.tooltip"));
     jvmDirect3dCheckbox = panel.getCheckBox("jvmDirect3dCheckbox");
     jvmDirect3dCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.direct3d.tooltip"));
     jvmOpenGLCheckbox = panel.getCheckBox("jvmOpenGLCheckbox");

--- a/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
@@ -54,6 +54,7 @@ import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MediaPlayerAdapter;
 import net.rptools.maptool.client.walker.WalkerMetric;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.Token;
@@ -326,16 +327,24 @@ public class PreferencesDialog extends JDialog {
     fileSyncPathButton = (JButton) panel.getButton("fileSyncPathButton");
 
     jvmXmxTextField = panel.getTextField("jvmXmxTextField");
+    jvmXmxTextField.setToolTipText(I18N.getText("prefs.jvm.xmx.tooltip"));
     jvmXmsTextField = panel.getTextField("jvmXmsTextField");
+    jvmXmsTextField.setToolTipText(I18N.getText("prefs.jvm.xms.tooltip"));
     jvmXssTextField = panel.getTextField("jvmXssTextField");
+    jvmXssTextField.setToolTipText(I18N.getText("prefs.jvm.xss.tooltip"));
     dataDirTextField = panel.getTextField("dataDirTextField");
 
     jvmAssertionsCheckbox = panel.getCheckBox("jvmAssertionsCheckbox");
+    jvmAssertionsCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.enableAssertions.tooltip"));
     jvmDirect3dCheckbox = panel.getCheckBox("jvmDirect3dCheckbox");
+    jvmDirect3dCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.direct3d.tooltip"));
     jvmOpenGLCheckbox = panel.getCheckBox("jvmOpenGLCheckbox");
+    jvmOpenGLCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.opengl.tooltip"));
     jvmInitAwtCheckbox = panel.getCheckBox("jvmInitAwtCheckbox");
+    jvmInitAwtCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.initAWTbeforeJFX.tooltip"));
 
     jvmLanguageOverideComboBox = panel.getComboBox("jvmLanguageOverideComboBox");
+    jvmLanguageOverideComboBox.setToolTipText(I18N.getText("prefs.language.override.tooltip"));
 
     DefaultComboBoxModel<String> languageModel = new DefaultComboBoxModel<String>();
     for (Entry<String, String> language : UserJvmPrefs.getLanguages())

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1206,6 +1206,17 @@ panel.Selected.tooltip.revertToPrevious       = Revert to previous selection
 panel.Selected.tooltip.selectAll              = Select all tokens on the map
 panel.Tables                                  = Tables
 
+prefs.language.override.tooltip = Select a language for the MapTool interface.
+
+prefs.jvm.advanced.enableAssertions.tooltip = Enables Java language assertions in the MapTool code.
+prefs.jvm.advanced.direct3d.tooltip         = Disable the use of Direct3D pipeline for problem video cards/drivers.
+prefs.jvm.advanced.opengl.tooltip           = Enable the OpenGL pipeline.
+prefs.jvm.advanced.initAWTbeforeJFX.tooltip = Initialize AWT before JavaFx. This is for issues specific to the MacOS.
+
+prefs.jvm.xmx.tooltip     = <html>Set the maximum memory (heap size) that MapTool is allowed to use. Input a number followed by either a single letter <b>M</b> or <b>G</b>.<br>Examples: 4G is 4 Gigabytes, 4096M is 4096 Megabytes and is the same as 4G.</html>
+prefs.jvm.xms.tooltip     = <html>Set the initial and minimum memory setting for MapTool. Must be less than or equal to max heap size.<br>Input a number followed by either a single letter <b>M</b> or <b>G</b>.</html>
+prefs.jvm.xss.tooltip     = <html>Set the stack size for MapTool program threads.  Values between 4M and 12M are recommended.<br>Values too large will cause problems.</html>
+
 roll.description         = Roll and broadcast the result to all connected players.
 roll.general.unknown     = <html>Unknown roll: "{0}".  Use #<b>d</b>#<b>+</b>#.
 # {0} is the players name, {1} is the roll


### PR DESCRIPTION
Add/replace tooltips on Preferences Startup tab with i18n strings.   More changes are needed in the XML form for the prefs dialog to get rid of the hard-coded strings and to give all the labels names so they can also get localized tooltips.  Issue #333

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/928)
<!-- Reviewable:end -->
