### PR TITLE
Add mapName parameter to TokenLocationFunctions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -39,8 +39,10 @@ import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
 import net.sf.json.JSONArray;
 
+/** Functions to move tokens, get a token's location, or calculate the distance from a token. */
 public class TokenLocationFunctions extends AbstractFunction {
 
+  /** Holds a token's x, y and z coordinates. */
   private static class TokenLocation {
     int x;
     int y;
@@ -69,7 +71,7 @@ public class TokenLocationFunctions extends AbstractFunction {
         "moveTokenFromMap");
   }
 
-  /** Gets an instance of TokenLocationFunctions. */
+  /** @return instance of TokenLocationFunctions. */
   public static TokenLocationFunctions getInstance() {
     return instance;
   }
@@ -77,40 +79,33 @@ public class TokenLocationFunctions extends AbstractFunction {
   @Override
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException {
-    if (!MapTool.getParser().isMacroTrusted()) {
-      throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
-    }
+    FunctionUtil.blockUntrustedMacro(functionName);
     MapToolVariableResolver res = (MapToolVariableResolver) parser.getVariableResolver();
 
-    if (functionName.equals("getTokenX")) {
-      return BigDecimal.valueOf(getTokenLocation(res, functionName, parameters).x);
-    }
-    if (functionName.equals("getTokenY")) {
-      return BigDecimal.valueOf(getTokenLocation(res, functionName, parameters).y);
+    if (functionName.equals("getTokenX") || functionName.equals("getTokenY")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
+      boolean useDistancePerCell =
+          parameters.size() > 0
+              ? FunctionUtil.paramAsBoolean(functionName, parameters, 0, false)
+              : true;
+      Token token = FunctionUtil.getTokenFromParam(res, functionName, parameters, 1, 2);
+      TokenLocation location = getTokenLocation(useDistancePerCell, token);
+      return BigDecimal.valueOf(functionName.equals("getTokenX") ? location.x : location.y);
     }
     if (functionName.equals("getTokenDrawOrder")) {
-      Token token = FunctionUtil.getTokenFromParam(res, functionName, parameters, 0, -1);
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
+      Token token = FunctionUtil.getTokenFromParam(res, functionName, parameters, 0, 1);
       return BigDecimal.valueOf(token.getZOrder());
     }
     if (functionName.equals("setTokenDrawOrder")) {
-      Token token = FunctionUtil.getTokenFromParam(res, functionName, parameters, 1, -1);
-      if (parameters.isEmpty()) {
-        throw new ParserException(
-            I18N.getText("macro.function.general.notEnoughParam", functionName, 1, 0));
-      }
-      if (!(parameters.get(0) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN",
-                functionName,
-                1,
-                parameters.get(0).toString()));
-      }
-      int newZOrder = ((BigDecimal) parameters.get(0)).intValue();
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
+      int newZOrder = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
+      Token token = FunctionUtil.getTokenFromParam(res, functionName, parameters, 1, 2);
       MapTool.serverCommand().updateTokenProperty(token, "setZOrder", newZOrder);
       return BigDecimal.valueOf(token.getZOrder());
     }
     if (functionName.equals("getDistance")) {
+      FunctionUtil.checkNumberParam("getDistance", parameters, 1, 4);
       return getDistance(res, parameters);
     }
     if (functionName.equals("getDistanceToXY")) {
@@ -118,15 +113,19 @@ public class TokenLocationFunctions extends AbstractFunction {
       return getDistanceToXY(res, parameters);
     }
     if (functionName.equals("goto")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       return gotoLoc(res, parameters);
     }
     if (functionName.equals("moveToken")) {
+      FunctionUtil.checkNumberParam("moveToken", parameters, 2, 4);
       return moveToken(res, parameters);
     }
     if (functionName.equals("moveTokenToMap")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 2, 5);
       return tokenMoveMap(true, parameters);
     }
     if (functionName.equals("moveTokenFromMap")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 2, 5);
       return tokenMoveMap(false, parameters);
     }
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
@@ -138,15 +137,11 @@ public class TokenLocationFunctions extends AbstractFunction {
    * @param fromCurrentMap true if it is begin moved from the named map to this one.
    * @param args The parameters for the function.
    * @return a message detailing the number of tokens moved.
-   * @throws ParserException
+   * @throws ParserException if the parameters are invalid, or the token is already on the map.
    */
   @SuppressWarnings("unchecked")
   private String tokenMoveMap(boolean fromCurrentMap, List<Object> args) throws ParserException {
     String functionName = fromCurrentMap ? "moveTokenToMap" : "moveTokenFromMap";
-    if (args.size() < 2) {
-      throw new ParserException(
-          I18N.getText("macro.function.general.notEnoughParam", functionName, 2, args.size()));
-    }
     Object tokenString = args.get(0);
     String map = (String) args.get(1);
 
@@ -185,37 +180,13 @@ public class TokenLocationFunctions extends AbstractFunction {
       throw new ParserException(
           I18N.getText("macro.function.moveTokenMap.alreadyThere", functionName));
     }
-    int x = 0;
-    int y = 0;
-    int z = zone.getLargestZOrder() + 1;
+    int x = args.size() > 2 ? FunctionUtil.paramAsInteger(functionName, args, 2, false) : 0;
+    int y = args.size() > 3 ? FunctionUtil.paramAsInteger(functionName, args, 3, false) : 0;
+    int z =
+        args.size() > 4
+            ? FunctionUtil.paramAsInteger(functionName, args, 4, false)
+            : zone.getLargestZOrder() + 1;
 
-    if (args.size() > 2) {
-      if (!(args.get(2) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", functionName, 2, args.get(2).toString()));
-      } else {
-        x = ((BigDecimal) args.get(2)).intValue();
-      }
-    }
-    if (args.size() > 3) {
-      if (!(args.get(3) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", functionName, 3, args.get(3).toString()));
-      } else {
-        y = ((BigDecimal) args.get(3)).intValue();
-      }
-    }
-    if (args.size() > 4) {
-      if (!(args.get(4) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", functionName, 4, args.get(4).toString()));
-      } else {
-        z = ((BigDecimal) args.get(4)).intValue();
-      }
-    }
     StringBuilder sb = new StringBuilder();
     for (String id : tokens) {
       Token token = fromZone.resolveToken(id);
@@ -232,7 +203,6 @@ public class TokenLocationFunctions extends AbstractFunction {
         token.setX(x);
         token.setY(y);
         token.setZOrder(z);
-        toZone.putToken(token);
         MapTool.serverCommand().putToken(toZone.getId(), token);
         MapTool.serverCommand().removeToken(fromZone.getId(), token.getId());
         sb.append(I18N.getText("macro.function.moveTokenMap.movedToken", token.getName(), map))
@@ -248,31 +218,14 @@ public class TokenLocationFunctions extends AbstractFunction {
   /**
    * Gets the location of the token on the map.
    *
-   * @param res The variable resolver.
-   * @param args The arguments.
+   * @param useDistancePerCell should the cell coordinates per returned?
+   * @param token the token to return the location of.
    * @return the location of the token.
-   * @throws ParserException if an error occurs.
    */
-  private TokenLocation getTokenLocation(
-      MapToolVariableResolver res, String functionName, List<Object> args) throws ParserException {
-    Token token = FunctionUtil.getTokenFromParam(res, functionName, args, 1, -1);
-    boolean useDistancePerCell = true;
-
-    if (args.size() > 0) {
-      if (!(args.get(0) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", functionName, 1, args.get(0).toString()));
-      }
-      BigDecimal val = (BigDecimal) args.get(0);
-      useDistancePerCell = val.equals(BigDecimal.ZERO) ? false : true;
-    }
-
+  private TokenLocation getTokenLocation(boolean useDistancePerCell, Token token) {
     TokenLocation loc = new TokenLocation();
-
     if (useDistancePerCell) {
-      Rectangle tokenBounds =
-          token.getBounds(MapTool.getFrame().getCurrentZoneRenderer().getZone());
+      Rectangle tokenBounds = token.getBounds(token.getZoneRenderer().getZone());
       loc.x = tokenBounds.x;
       loc.y = tokenBounds.y;
       loc.z = token.getZOrder();
@@ -487,29 +440,12 @@ public class TokenLocationFunctions extends AbstractFunction {
    */
   private BigDecimal getDistance(MapToolVariableResolver res, List<Object> args)
       throws ParserException {
-    if (args.size() < 1) {
-      throw new ParserException(
-          I18N.getText("macro.function.general.notEnoughParam", "getDistance", 1, args.size()));
-    }
-
     Token target = FunctionUtil.getTokenFromParam(res, "getDistance", args, 0, -1);
     Token source = FunctionUtil.getTokenFromParam(res, "getDistance", args, 2, -1);
 
-    boolean useDistancePerCell = true;
-    if (args.size() > 1) {
-      if (!(args.get(1) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", "getDistance", 2, args.get(1).toString()));
-      }
-      BigDecimal val = (BigDecimal) args.get(1);
-      useDistancePerCell = val.equals(BigDecimal.ZERO) ? false : true;
-    }
-
-    String metric = null;
-    if (args.size() > 3) {
-      metric = (String) args.get(3);
-    }
+    boolean useDistancePerCell =
+        args.size() > 1 ? FunctionUtil.paramAsBoolean("getDistance", args, 1, false) : true;
+    String metric = args.size() > 3 ? args.get(3).toString() : null;
 
     double dist = getDistance(source, target, useDistancePerCell, metric);
 
@@ -552,16 +488,16 @@ public class TokenLocationFunctions extends AbstractFunction {
   }
 
   /**
-   * Get a ZonePoint of the specified x,y location. If <code>units</code> is true, the incoming
-   * (x,y) is treated as a <code>ZonePoint</code>. If <code>units</code> is false, the incoming
-   * (x,y) is treated as a <code>CellPoint</code> and is converted to a ZonePoint by calling {@link
-   * Grid#convert(CellPoint)}.
+   * Get a ZonePoint of the specified x,y location for the current map. If <code>units</code> is
+   * true, the incoming (x,y) is treated as a <code>ZonePoint</code>. If <code>units</code> is
+   * false, the incoming (x,y) is treated as a <code>CellPoint</code> and is converted to a
+   * ZonePoint by calling {@link Grid#convert(CellPoint)}.
    *
    * @param x the x co-ordinate of the destination.
    * @param y the y co-ordinate of the destination.
    * @param units whether the (x,y) coordinate is a <code>ZonePoint</code> (true) or <code>CellPoint
    *     </code> (false)
-   * @return the ZonePoint of the coordinates
+   * @return the ZonePoint of the coordinates.
    */
   public static ZonePoint getZonePoint(int x, int y, boolean units) {
     ZonePoint zp;
@@ -583,13 +519,11 @@ public class TokenLocationFunctions extends AbstractFunction {
    */
   private static String moveToken(MapToolVariableResolver res, List<Object> args)
       throws ParserException {
-    FunctionUtil.checkNumberParam("moveToken", args, 2, 5);
-
     int x = FunctionUtil.paramAsInteger("moveToken", args, 0, false);
     int y = FunctionUtil.paramAsInteger("moveToken", args, 1, false);
     boolean useDistance =
         args.size() > 2 ? FunctionUtil.paramAsBoolean("moveToken", args, 2, false) : true;
-    Token token = FunctionUtil.getTokenFromParam(res, "moveToken", args, 3, 4);
+    Token token = FunctionUtil.getTokenFromParam(res, "moveToken", args, 3, -1);
 
     ZonePoint zp = getZonePoint(x, y, useDistance);
     MapTool.serverCommand().updateTokenProperty(token, "setXY", zp.x, zp.y);
@@ -605,35 +539,17 @@ public class TokenLocationFunctions extends AbstractFunction {
    * @throws ParserException if an error occurs.
    */
   private String gotoLoc(MapToolVariableResolver res, List<Object> args) throws ParserException {
-    Token token = null;
     int x;
     int y;
 
-    if (!MapTool.getParser().isMacroTrusted()) {
-      throw new ParserException(I18N.getText("macro.function.general.noPerm", "goto"));
-    }
-
     if (args.size() < 2) {
-      token = FunctionUtil.getTokenFromParam(res, "goto", args, 0, -1);
+      Token token = FunctionUtil.getTokenFromParam(res, "goto", args, 0, -1);
       x = token.getX();
       y = token.getY();
       MapTool.getFrame().getCurrentZoneRenderer().centerOn(new ZonePoint(x, y));
     } else {
-
-      if (!(args.get(0) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", "goto", 1, args.get(0).toString()));
-      }
-
-      if (!(args.get(1) instanceof BigDecimal)) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.argumentTypeN", "goto", 2, args.get(1).toString()));
-      }
-
-      x = ((BigDecimal) args.get(0)).intValue();
-      y = ((BigDecimal) args.get(1)).intValue();
+      x = FunctionUtil.paramAsInteger("goto", args, 0, false);
+      y = FunctionUtil.paramAsInteger("goto", args, 1, false);
       MapTool.getFrame().getCurrentZoneRenderer().centerOn(new CellPoint(x, y));
     }
 
@@ -641,7 +557,7 @@ public class TokenLocationFunctions extends AbstractFunction {
   }
 
   /**
-   * Gets the distance for each cell.
+   * Gets the distance for one cell on the current map.
    *
    * @return the distance for each cell.
    */
@@ -652,11 +568,11 @@ public class TokenLocationFunctions extends AbstractFunction {
   /**
    * Gets the cell point that the token is at.
    *
-   * @param token
-   * @return
+   * @param token the token.
+   * @return the CellPoint.
    */
   public CellPoint getTokenCell(Token token) {
-    Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+    Zone zone = token.getZoneRenderer().getZone();
     return zone.getGrid().convert(new ZonePoint(token.getX(), token.getY()));
   }
 }

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -375,4 +375,16 @@ public class FunctionUtil {
     } // endif
     return set;
   }
+
+  /**
+   * Throw an exception if the macro isn't trusted.
+   *
+   * @param functionName the name of the function.
+   * @throws ParserException if the macro isn't trusted.
+   */
+  public static void blockUntrustedMacro(String functionName) throws ParserException {
+    if (!MapTool.getParser().isMacroTrusted()) {
+      throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
+    }
+  }
 }


### PR DESCRIPTION
- Add parameter "mapName" to getTokenX, getTokenY, getTokenDrawOrder, and setTokenDrawOrder
- Add checks for the number of parameters for all functions in TokenLocationFunctions
- Close #938

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/940)
<!-- Reviewable:end -->
