### PR TITLE
Fix setTokenImage to update native width and height

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -45,7 +45,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Area;
-import java.awt.image.BufferedImage;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -673,11 +672,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     // IMAGE
     if (!token.getImageAssetId().equals(getTokenIconPanel().getImageId())) {
-      BufferedImage image = ImageManager.getImageAndWait(getTokenIconPanel().getImageId());
       MapToolUtil.uploadAsset(AssetManager.getAsset(getTokenIconPanel().getImageId()));
       token.setImageAsset(null, getTokenIconPanel().getImageId()); // Default image for now
-      token.setWidth(image.getWidth(null));
-      token.setHeight(image.getHeight(null));
     }
     // PORTRAIT
     if (getPortraitPanel().getImageId() != null) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1008,8 +1008,18 @@ public class Token extends BaseModel implements Cloneable {
     return assetId;
   }
 
+  /**
+   * Store the token image, and set the native Width and Height.
+   *
+   * @param name the name of the image.
+   * @param assetId the asset MD5Key.
+   */
   public void setImageAsset(String name, MD5Key assetId) {
     imageAssetMap.put(name, assetId);
+
+    BufferedImage image = ImageManager.getImageAndWait(assetId);
+    setWidth(image.getWidth(null));
+    setHeight(image.getHeight(null));
   }
 
   public void setImageAsset(String name) {


### PR DESCRIPTION
- Change so that setting the token's image asset always updates the token's native width and height.
- Close #952

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/953)
<!-- Reviewable:end -->
