### PR TITLE
Fix incorrect message of moveTokenFromMap

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -203,7 +203,12 @@ public class TokenLocationFunctions extends AbstractFunction {
         token.setZOrder(z);
         MapTool.serverCommand().putToken(toZone.getId(), token);
         MapTool.serverCommand().removeToken(fromZone.getId(), token.getId());
-        sb.append(I18N.getText("macro.function.moveTokenMap.movedToken", token.getName(), map))
+        sb.append(
+                I18N.getText(
+                    "macro.function.moveTokenMap.movedToken",
+                    token.getName(),
+                    toZone.getName(),
+                    fromZone.getName()))
             .append("<br>");
       }
     }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -941,7 +941,7 @@ macro.function.macroLink.unknown                   = Unknown
 # {0} is the function name
 macro.function.moveTokenMap.alreadyThere           = Can not use "{0}" to move tokens to a map that they are already on!
 # {0} is the token name/id, {1} is the map it's moved to.
-macro.function.moveTokenMap.movedToken             = Moved Token "{0}" to map "{1}".
+macro.function.moveTokenMap.movedToken             = Moved Token "{0}" to map "{1}" from map "{2}".
 # moveTokenToMap/moveTokenFromMap, {0} is the function name, {1} is the
 # map name or token id
 macro.function.moveTokenMap.unknownMap             = Can not find map "{1}" in function "{0}".

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
@@ -941,7 +941,7 @@ macro.function.macroLink.unknown                   = Inconnu
 # {0} is the function name
 macro.function.moveTokenMap.alreadyThere           = On ne peut utiliser {0} pour déplacer des Pions vers une carte où ils se trouvent déjà.
 # {0} is the token name/id, {1} is the map it's moved to.
-macro.function.moveTokenMap.movedToken             = Pion {0} déplacé vers {1}.
+macro.function.moveTokenMap.movedToken             = Pion {0} déplacé vers {1} depuis {2}.
 # moveTokenToMap/moveTokenFromMap, {0} is the function name, {1} is the
 # map name or token id
 macro.function.moveTokenMap.unknownMap             = Carte {1} introuvable dans la fonction {0}.


### PR DESCRIPTION
- Change message: Moved Token "Dragon" to map "Arid" from map "Grasslands".
- Close issue found by @Phergus in #938.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/954)
<!-- Reviewable:end -->
