### PR TITLE
Fix getAssetProperties returning Width twice

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -139,7 +139,7 @@ public class Asset {
     }
     properties.put("status", status);
     properties.put("width", img.getWidth(null));
-    properties.put("height", img.getWidth(null));
+    properties.put("height", img.getHeight(null));
     return properties;
   }
 


### PR DESCRIPTION
- Fix issue found by @Phergus in #950

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/955)
<!-- Reviewable:end -->
