### PR TITLE
Fix getAssetProperties width/height if asset loading

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -37,7 +37,7 @@ public class Asset {
   private MD5Key id;
   private String name;
   private String extension;
-  private String type;
+  private String type = "image";
 
   @XStreamConverter(AssetImageConverter.class)
   private byte[] image;
@@ -125,12 +125,12 @@ public class Asset {
    */
   public JSONObject getProperties() {
     JSONObject properties = new JSONObject();
-    properties.put("type", "image");
+    properties.put("type", type);
     properties.put("subtype", extension);
     properties.put("id", id.toString());
     properties.put("name", name);
 
-    Image img = ImageManager.getImage(id);
+    Image img = ImageManager.getImageAndWait(id); // wait until loaded, so width/height are correct
     String status = "loaded";
     if (img == ImageManager.BROKEN_IMAGE) {
       status = "broken";


### PR DESCRIPTION
- Fix getAssetProperties to return the correct width and height when the asset is not loaded into the cache
- Close issue discussed in #949

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/960)
<!-- Reviewable:end -->
