### PR TITLE
Fix auto-expose fog on token movement

### DIFF
--- a/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
@@ -9542,13 +9542,13 @@ Disabled (default): show tooltips for macroLinks</at>
                                    </at>
                                    <at name="width">464</at>
                                    <at name="name"/>
-                                   <at name="text">Auto-expose fog on token movement (GM Only)</at>
+                                   <at name="text">Auto-expose fog on token movement (personal server)</at>
                                    <at name="fill">
                                     <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                      <at name="name">fill</at>
                                     </object>
                                    </at>
-                                   <at name="toolTipText">If enabled, the fog of war is automatically exposed as a token moves on maps with a grid.  Gridless maps cannot auto-expose fog.</at>
+                                   <at name="toolTipText">If enabled, the fog of war is automatically exposed as a token moves on maps with a grid.  Gridless maps cannot auto-expose fog.  When running a server, this setting is ignored in favor of the settings in the 'Start Server' dialog.</at>
                                    <at name="height">14</at>
                                   </object>
                                  </at>


### PR DESCRIPTION
- Fix auto-expose fog on token movement so that tokens expose the fog on personal servers if moved or if their facing is changed
- Change text of setting to be clearer
- Close #962

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/965)
<!-- Reviewable:end -->
