### PR TITLE
Adds missing variables init.current and init.hold

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
+++ b/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
@@ -44,7 +44,9 @@ public class MapToolScriptSyntax extends MapToolScriptTokenMaker {
     "token.name",
     "token.visible",
     "tokens.denyMove",
-    "tokens.moveCount"
+    "tokens.moveCount",
+    "init.current",
+    "init.round"
   };
 
   static String[] RESERVED_WORDS = {


### PR DESCRIPTION
This should fix #753 .
I didn't add them to the datatypes tag in MapToolScript.xml where they are also missing. Should I have done that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/981)
<!-- Reviewable:end -->
