### PR TITLE
Remove two squares in roll results for dialog/frame

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
@@ -186,16 +186,19 @@ public class HTMLPane extends JEditorPane {
     }
     // We use ASCII control characters to mark off the rolls so that there's no limitation on what
     // (printable) characters the output can include
+    // Note: options gm, self, and whisper are currently ignored
+    // Tooltip rolls
     text =
         text.replaceAll(
-            "\036([^\036\037]*)\037([^\036]*)\036",
-            "<span class='roll' title='&#171; $1 &#187;'>$2</span>");
+            "\036(\001\002)?([^\036\037]*)\037([^\036]*)\036",
+            "<span class='roll' title='&#171; $2 &#187;'>$3</span>");
+    // Unformatted rolls
     text = text.replaceAll("\036\01u\02([^\036]*)\036", "&#171; $1 &#187;");
+    // Inline rolls
     text =
         text.replaceAll(
-            "\036([^\036]*)\036",
-            "&#171;<span class='roll' style='color:blue'>&nbsp;$1&nbsp;</span>&#187;");
-
+            "\036(\001\002)?([^\036]*)\036",
+            "&#171;<span class='roll' style='color:blue'>&nbsp;$2&nbsp;</span>&#187;");
     // Auto inline expansion
     text = text.replaceAll("(^|\\s)(https?://[\\w.%-/~?&+#=]+)", "$1<a href='$2'>$2</a>");
     super.setText(text);


### PR DESCRIPTION
- Remove the two squares showing up in front of tooltip and expended roll results for dialogs and frames
- Fix #989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/990)
<!-- Reviewable:end -->
