### PR TITLE
Fix player error message when GM duplicates names

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenGMNameFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenGMNameFunction.java
@@ -16,7 +16,6 @@ package net.rptools.maptool.client.functions;
 
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.util.FunctionUtil;
@@ -27,7 +26,7 @@ import net.rptools.parser.function.AbstractFunction;
 public class TokenGMNameFunction extends AbstractFunction {
 
   private TokenGMNameFunction() {
-    super(0, 2, "getGMName", "setGMName");
+    super(0, 3, "getGMName", "setGMName");
   }
 
   /** Singleton instance of GMName. */
@@ -38,8 +37,24 @@ public class TokenGMNameFunction extends AbstractFunction {
    *
    * @return the instance.
    */
-  public static final TokenGMNameFunction getInstance() {
+  public static TokenGMNameFunction getInstance() {
     return instance;
+  }
+
+  @Override
+  public Object childEvaluate(Parser parser, String functionName, List<Object> args)
+      throws ParserException {
+
+    if (functionName.equals("getGMName")) {
+      FunctionUtil.checkNumberParam("getGMName", args, 0, 2);
+      Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 0, 1);
+      return getGMName(token);
+    } else {
+      FunctionUtil.checkNumberParam("setGMName", args, 1, 3);
+      String gmName = args.get(0).toString();
+      Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 1, 2);
+      return setGMName(token, gmName);
+    }
   }
 
   /**
@@ -57,77 +72,18 @@ public class TokenGMNameFunction extends AbstractFunction {
   }
 
   /**
-   * Sets the GMName of the token.
+   * Sets the GMName of the token, and update server.
    *
    * @param token the token to set the GMName of.
-   * @param name The name to set the GMName to.
+   * @param gmName The name to set the GMName to.
    * @throws ParserException if the user does not have the permission.
+   * @return the new GMName of the token.
    */
-  public static void setGMName(Token token, String name) throws ParserException {
+  public static String setGMName(Token token, String gmName) throws ParserException {
     if (!MapTool.getParser().isMacroTrusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", "setGMName"));
     }
-    token.setGMName(name);
-  }
-
-  @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> args)
-      throws ParserException {
-
-    if (functionName.equals("getGMName")) {
-      return getGMName(parser, args);
-    } else {
-      return setGMName(parser, args);
-    }
-  }
-
-  /**
-   * Gets the GM name of the token
-   *
-   * @param parser The parser that called the Object.
-   * @param args The arguments passed.
-   * @return the name of the token.
-   * @throws ParserException when an error occurs.
-   */
-  private Object getGMName(Parser parser, List<Object> args) throws ParserException {
-    Token token;
-
-    if (args.size() == 1) {
-      token = FindTokenFunctions.findToken(args.get(0).toString(), null);
-      if (token == null) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.general.unknownToken", "getGMName", args.get(0).toString()));
-      }
-    } else if (args.size() == 0) {
-      MapToolVariableResolver res = (MapToolVariableResolver) parser.getVariableResolver();
-      token = res.getTokenInContext();
-      if (token == null) {
-        throw new ParserException(
-            I18N.getText("macro.function.general.noImpersonated", "getGMName"));
-      }
-    } else {
-      throw new ParserException(
-          I18N.getText("macro.function.general.tooManyParam", "getGMName", 1, args.size()));
-    }
-    return getGMName(token);
-  }
-
-  /**
-   * Sets the GM name of the token.
-   *
-   * @param parser The parser that called the Object.
-   * @param args The arguments passed.
-   * @return the new name of the token.
-   * @throws ParserException when an error occurs.
-   */
-  private Object setGMName(Parser parser, List<Object> args) throws ParserException {
-    FunctionUtil.checkNumberParam("setGMName", args, 1, 3);
-    String gmName = args.get(0).toString();
-    Token token = FunctionUtil.getTokenFromParam(parser, "setGMName", args, 1, 2);
-
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.setGMName, gmName);
-
     return gmName;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenNameFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenNameFunction.java
@@ -57,7 +57,7 @@ public class TokenNameFunction extends AbstractFunction {
         throw new ParserException(
             I18N.getText("macro.function.tokenName.emptyTokenNameForbidden", "setName"));
       }
-      MapTool.serverCommand().updateTokenProperty(token, Token.Update.setName, name);
+      setName(token, name);
     }
     return token.getName();
   }
@@ -73,12 +73,13 @@ public class TokenNameFunction extends AbstractFunction {
   }
 
   /**
-   * Sets the name of the token.
+   * Validates the name, sets the name of the token, and updates the server.
    *
    * @param token The token to set the name of.
    * @param name the name of the token.
    */
   public static void setName(Token token, String name) {
-    token.setName(name);
+    token.validateName(name);
+    MapTool.serverCommand().updateTokenProperty(token, Token.Update.setName, name);
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -974,7 +974,16 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   /**
-   * Set the name of this token to the provided string. There is a potential exposure of information
+   * Set the name of this token to the provided string.
+   *
+   * @param name the new name of the token
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Validate a token name by testing for duplicates. There is a potential exposure of information
    * to the player in this method: through repeated attempts to name a token they own to another
    * name, they could determine which token names the GM is already using. Fortunately, the
    * showError() call makes this extremely unlikely due to the interactive nature of a failure.
@@ -982,22 +991,19 @@ public class Token extends BaseModel implements Cloneable {
    * @param name the new name of the token
    * @throws IllegalArgumentException thrown if a token has the same name
    */
-  public void setName(String name) throws IllegalArgumentException {
-    // Let's see if there is another Token with that name (only if Player is not GM)
+  public void validateName(String name) {
     if (!MapTool.getPlayer().isGM() && !MapTool.getParser().isMacroTrusted()) {
-      Zone curZone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+      Zone curZone = getZoneRenderer().getZone();
       List<Token> tokensList = curZone.getTokens();
 
-      for (int i = 0; i < tokensList.size(); i++) {
-        String curTokenName = tokensList.get(i).getName();
-        if (curTokenName.equalsIgnoreCase(name)) {
+      for (Token token : tokensList) {
+        String curTokenName = token.getName();
+        if (curTokenName.equalsIgnoreCase(name) && !(token.equals(this))) {
           MapTool.showError(I18N.getText("Token.error.unableToRename", name));
           throw new IllegalArgumentException("Player dropped token with duplicate name");
         }
       }
     }
-    this.name = name;
-    fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.name, name));
   }
 
   public MD5Key getImageAssetId() {


### PR DESCRIPTION
- Remove the error message received by players when the GM uses a duplicate name with setName()
- Fix token.name and token.gm_name not updating the names of clients
- Close #993

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/994)
<!-- Reviewable:end -->
