### PR TITLE
Change setName IA Exception to ParserException

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenNameFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenNameFunction.java
@@ -78,7 +78,7 @@ public class TokenNameFunction extends AbstractFunction {
    * @param token The token to set the name of.
    * @param name the name of the token.
    */
-  public static void setName(Token token, String name) {
+  public static void setName(Token token, String name) throws ParserException {
     token.validateName(name);
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.setName, name);
   }

--- a/src/main/java/net/rptools/maptool/client/script_deprecated/api/proxy/TokenProxy.java
+++ b/src/main/java/net/rptools/maptool/client/script_deprecated/api/proxy/TokenProxy.java
@@ -64,8 +64,8 @@ public class TokenProxy {
     return TokenNameFunction.getInstance().getName(token);
   }
 
-  public void setName(Object value) {
-    TokenNameFunction.getInstance().setName(token, value.toString());
+  public void setName(Object value) throws ParserException {
+    TokenNameFunction.setName(token, value.toString());
   }
 
   // GM Name

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -989,9 +989,9 @@ public class Token extends BaseModel implements Cloneable {
    * showError() call makes this extremely unlikely due to the interactive nature of a failure.
    *
    * @param name the new name of the token
-   * @throws IllegalArgumentException thrown if a token has the same name
+   * @throws ParserException thrown if a token has the same name
    */
-  public void validateName(String name) {
+  public void validateName(String name) throws ParserException {
     if (!MapTool.getPlayer().isGM() && !MapTool.getParser().isMacroTrusted()) {
       Zone curZone = getZoneRenderer().getZone();
       List<Token> tokensList = curZone.getTokens();
@@ -1000,7 +1000,7 @@ public class Token extends BaseModel implements Cloneable {
         String curTokenName = token.getName();
         if (curTokenName.equalsIgnoreCase(name) && !(token.equals(this))) {
           MapTool.showError(I18N.getText("Token.error.unableToRename", name));
-          throw new IllegalArgumentException("Player dropped token with duplicate name");
+          throw new ParserException(I18N.getText("Token.error.unableToRename", name));
         }
       }
     }


### PR DESCRIPTION
- Change duplicated token name exception from IllegalArgumentException to ParserException, which is handled more gracefully
- Fix issue raised in #993

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/995)
<!-- Reviewable:end -->
