### PR TITLE
Fix missing error msg when player duplicates token

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1147,11 +1147,9 @@ public class AppActions {
       MapTool.serverCommand().putToken(zone.getId(), token);
     }
     if (!failedPaste.isEmpty()) {
-      String mesg = "Failed to paste token(s) with duplicate name(s): " + failedPaste;
-      TextMessage msg = TextMessage.gm(null, mesg);
+      String mesg = I18N.getText("Token.error.unableToPaste", failedPaste);
+      TextMessage msg = TextMessage.gmMe(null, mesg);
       MapTool.addMessage(msg);
-      // msg.setChannel(Channel.ME);
-      // MapTool.addMessage(msg);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -106,6 +106,7 @@ import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.client.ui.token.NewTokenDialog;
 import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.client.walker.astar.AStarCellPoint;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.AbstractPoint;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetManager;
@@ -4551,17 +4552,14 @@ public class ZoneRenderer extends JComponent
     clearSelectedTokens();
     selectTokens(selectThese);
 
-    if (!isGM)
-      MapTool.addMessage(
-          TextMessage.gm(
-              null,
-              "Tokens dropped onto map '" + zone.getName() + "' by player " + MapTool.getPlayer()));
+    if (!isGM) {
+      String msg = I18N.getText("Token.dropped.byPlayer", zone.getName(), MapTool.getPlayer());
+      MapTool.addMessage(TextMessage.gm(null, msg));
+    }
     if (!failedPaste.isEmpty()) {
-      String mesg = "Failed to paste token(s) with duplicate name(s): " + failedPaste;
-      TextMessage msg = TextMessage.gm(null, mesg);
+      String mesg = I18N.getText("Token.error.unableToPaste", failedPaste);
+      TextMessage msg = TextMessage.gmMe(null, mesg);
       MapTool.addMessage(msg);
-      // msg.setChannel(Channel.ME);
-      // MapTool.addMessage(msg);
     }
     // Copy them to the clipboard so that we can quickly copy them onto the map
     AppActions.copyTokens(tokens);

--- a/src/main/java/net/rptools/maptool/model/TextMessage.java
+++ b/src/main/java/net/rptools/maptool/model/TextMessage.java
@@ -65,6 +65,13 @@ public class TextMessage {
         Channel.ME, null, MapTool.getPlayer().getName(), message, transformHistory);
   }
 
+  /**
+   * Creates a TextMessage address to the GMs and the current player.
+   *
+   * @param transformHistory the transform history of the message
+   * @param message the text of the message
+   * @return the message
+   */
   public static TextMessage gmMe(List<String> transformHistory, String message) {
     return new TextMessage(
         Channel.GMME, null, MapTool.getPlayer().getName(), message, transformHistory);

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -194,6 +194,8 @@ ServerDialog.msg.title                 = Start Server
 SquareGrid.error.pathhighlightingNotLoaded = Could not load path highlighting image.
 SquareGrid.error.squareGridNotLoaded       = Could not load square grid footprints.
 
+Token.dropped.byPlayer = Tokens dropped onto map "{0}" by player {1}
+Token.error.unableToPaste = Failed to paste token(s) with duplicate name(s): {0}
 Token.error.unableToRename = <html>Cannot rename token to "{0}" as there is already another token with this name on the map.<br>Only the GM can create multiple tokens with the same name!
 
 ToolbarPanel.manualFogActivated = Modifying the fog-of-war manually without a server running affects only the global exposed area (i.e. the entire map), even<br>if one or more tokens are selected.  If you want your changes to apply to individual tokens, start a MapTool server with<br><b>Individual Fog</b> enabled (you can leave the <b>Alias</b> field empty to make an anonymous server, if you wish).<br><br>This warning will not appear again for this campaign.


### PR DESCRIPTION
- Change error message to be addressed to both the GMs and the player instead of only the GMs
- Add localization for error message
- Close #998

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1004)
<!-- Reviewable:end -->
