### PR TITLE
Fix for #272 - content too large for memory bar

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
@@ -42,9 +42,9 @@ public class MemoryStatusBar extends JProgressBar {
     setStringPainted(true);
     
     // Adjust the minimum size to be big enought for the font used
-    // Add some padding cuz Macs.
+    // plus a bit extra padding.
     fm = getFontMetrics(getFont());
-    int w = 34 + fm.stringWidth("9.99MB/9.99MB");
+    int w = 26 + fm.stringWidth("9.99 MB/9.99 MB");
     int h = 4 + fm.getHeight();
     minSize = new Dimension(w,h);
     

--- a/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.swing;
 
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.MouseAdapter;
 import java.text.DecimalFormat;
 import javax.swing.JProgressBar;
@@ -24,11 +25,13 @@ import net.rptools.maptool.util.FileUtil;
 public class MemoryStatusBar extends JProgressBar {
   private static final long serialVersionUID = 1L;
 
-  private static final Dimension minSize = new Dimension(100, 10);
+  private static Dimension minSize;
   private static final DecimalFormat format = new DecimalFormat("#,##0.#");
   private static long largestMemoryUsed = -1;
   private static MemoryStatusBar msb = null;
 
+  private static FontMetrics fm = null;
+  
   public static MemoryStatusBar getInstance() {
     if (msb == null) msb = new MemoryStatusBar();
     return msb;
@@ -37,7 +40,14 @@ public class MemoryStatusBar extends JProgressBar {
   private MemoryStatusBar() {
     setMinimum(0);
     setStringPainted(true);
-
+    
+    // Adjust the minimum size to be big enought for the font used
+    // Add some padding cuz Macs.
+    fm = getFontMetrics(getFont());
+    int w = 34 + fm.stringWidth("9.99MB/9.99MB");
+    int h = 4 + fm.getHeight();
+    minSize = new Dimension(w,h);
+    
     new Thread() {
       @Override
       public void run() {

--- a/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
@@ -31,7 +31,7 @@ public class MemoryStatusBar extends JProgressBar {
   private static MemoryStatusBar msb = null;
 
   private static FontMetrics fm = null;
-  
+
   public static MemoryStatusBar getInstance() {
     if (msb == null) msb = new MemoryStatusBar();
     return msb;
@@ -40,14 +40,14 @@ public class MemoryStatusBar extends JProgressBar {
   private MemoryStatusBar() {
     setMinimum(0);
     setStringPainted(true);
-    
+
     // Adjust the minimum size to be big enought for the font used
     // plus a bit extra padding.
     fm = getFontMetrics(getFont());
     int w = 26 + fm.stringWidth("9.99 MB/9.99 MB");
     int h = 4 + fm.getHeight();
-    minSize = new Dimension(w,h);
-    
+    minSize = new Dimension(w, h);
+
     new Thread() {
       @Override
       public void run() {


### PR DESCRIPTION
Memory bar is now sized for the font in use and has a bit of extra padding for readability.  Will need to be tested on Mac/Linux platform to verify.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1011)
<!-- Reviewable:end -->
