### PR TITLE
Fix execFunction failing when using quote marks

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -386,7 +386,10 @@ public class ClientMethodHandler extends AbstractMethodHandler {
 
               case execFunction:
                 ExecFunction.receiveExecFunction(
-                    (String) parameters[0], (String) parameters[1], (String) parameters[2]);
+                    (String) parameters[0],
+                    (String) parameters[1],
+                    (String) parameters[2],
+                    (List<Object>) parameters[3]);
                 return;
 
               case execLink:

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1487,8 +1487,7 @@ public class MapToolLineParser {
         b.append(expression);
         log.debug(b.toString());
       }
-      Result res =
-          createParser(resolver, tokenInContext == null ? false : true).evaluate(expression);
+      Result res = createParser(resolver, tokenInContext != null).evaluate(expression);
       rolled.addAll(res.getRolled());
       newRolls.addAll(res.getRolled());
 
@@ -1943,7 +1942,8 @@ public class MapToolLineParser {
     return retval;
   }
 
-  private ExpressionParser createParser(VariableResolver resolver, boolean hasTokenInContext) {
+  public static ExpressionParser createParser(
+      VariableResolver resolver, boolean hasTokenInContext) {
     ExpressionParser parser = new ExpressionParser(resolver);
     parser.getParser().addFunctions(mapToolParserFunctions);
     return parser;

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -208,11 +208,12 @@ public class ServerCommandClientImpl implements ServerCommand {
   }
 
   @Override
-  public void execFunction(String functionText, String target, String source) {
-    ExecFunction.receiveExecFunction(functionText, target, source); // receive locally right away
+  public void execFunction(String target, String source, String functionName, List<Object> args) {
+    // Execute locally right away
+    ExecFunction.receiveExecFunction(target, source, functionName, args);
 
     if (ExecFunction.isMessageGlobal(target, source)) {
-      makeServerCall(COMMAND.execFunction, functionText, target, source);
+      makeServerCall(COMMAND.execFunction, target, source, functionName, args);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/ExecFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExecFunction.java
@@ -18,6 +18,8 @@ import java.awt.*;
 import java.util.*;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolLineParser;
+import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
@@ -61,8 +63,7 @@ public class ExecFunction extends AbstractFunction {
     }
 
     JSONArray jsonArgs = FunctionUtil.paramAsJsonArray(functionName, args, 1);
-    @SuppressWarnings("unchecked")
-    ArrayList execArgs = new ArrayList(jsonArgs);
+    ArrayList<Object> execArgs = new ArrayList<Object>(jsonArgs);
 
     boolean defer =
         args.size() > 2 ? FunctionUtil.paramAsBoolean(functionName, args, 2, true) : false;
@@ -113,30 +114,31 @@ public class ExecFunction extends AbstractFunction {
   /**
    * Send the execFunction. If target is local, run locally instead.
    *
-   * @param execName the name of the function.
+   * @param functionName the name of the function.
    * @param execArgs the list of arguments to the function.
    * @param targets the list of targets.
    */
   private static void sendExecFunction(
-      final String execName, List<Object> execArgs, Collection<String> targets) {
-    String functionText = getExecFunctionText(execName, execArgs);
+      String functionName, List<Object> execArgs, Collection<String> targets) {
     String source = MapTool.getPlayer().getName();
 
     for (String target : targets) {
-      MapTool.serverCommand().execFunction(functionText, target, source);
+      MapTool.serverCommand().execFunction(target, source, functionName, execArgs);
     }
   }
 
   /**
    * Receive the execFunction, and execute it if need be.
    *
-   * @param functionText the text of the function call.
    * @param target the target player.
    * @param source the name of the player who sent the link.
+   * @param functionName the name of the function.
+   * @param execArgs the arguments of the function.
    */
-  public static void receiveExecFunction(final String functionText, String target, String source) {
+  public static void receiveExecFunction(
+      String target, String source, String functionName, List<Object> execArgs) {
     if (isMessageForMe(target, source)) {
-      runExecFunction(functionText);
+      runExecFunction(functionName, execArgs);
     }
   }
 
@@ -174,6 +176,13 @@ public class ExecFunction extends AbstractFunction {
     }
   }
 
+  /**
+   * Return true if the message is for other clients, false otherwise.
+   *
+   * @param target the target of the message
+   * @param source the source of the message
+   * @return true if the message if for other clients, false otherwise
+   */
   public static boolean isMessageGlobal(String target, String source) {
     if (target.equals(source)) return false;
     if (target.equalsIgnoreCase("none")) return false;
@@ -182,37 +191,17 @@ public class ExecFunction extends AbstractFunction {
   }
 
   /**
-   * Get a String corresponding to the function call from the function name and list of arguments.
-   * The text is then intended to be run through runMacroBlock. This is a workaround as it is not
-   * currently possible to run a macro directly as doing so would require a reference to the parser,
-   * which is not available to us.
+   * Run the execFunction locally.
    *
-   * @param execName the name of the function.
-   * @param execArgs a list of arguments to the function.
-   * @return the string of the function call.
+   * @param functionName the name of the function
+   * @param execArgs the arguments to the function
    */
-  private static String getExecFunctionText(final String execName, List<Object> execArgs) {
-    StringBuilder functionText = new StringBuilder("[h:" + execName + "(");
-
-    for (int i = 0; i < execArgs.size(); i++) {
-      if (execArgs.get(i) instanceof String) {
-        functionText.append('"').append(execArgs.get(i)).append('"');
-      } else {
-        functionText.append(execArgs.get(i).toString());
-      }
-
-      if (i < (execArgs.size() - 1)) {
-        functionText.append(",");
-      } else {
-        functionText.append(")]");
-      }
-    }
-    return functionText.toString();
-  }
-
-  private static void runExecFunction(final String functionText) {
+  private static void runExecFunction(String functionName, List<Object> execArgs) {
     try {
-      MapTool.getParser().runMacroBlock(null, functionText, "execFunction", "remote", true);
+      MapToolVariableResolver resolver = new MapToolVariableResolver(null);
+      Parser parser = MapToolLineParser.createParser(resolver, false).getParser();
+      Function function = parser.getFunction(functionName);
+      function.evaluate(parser, functionName, execArgs);
     } catch (ParserException ignored) {
     }
   }

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -160,7 +160,7 @@ public interface ServerCommand {
 
   public void message(TextMessage message);
 
-  public void execFunction(String functionText, String target, String source);
+  public void execFunction(String target, String source, String functionName, List<Object> args);
 
   public void execLink(String link, String target, String source);
 

--- a/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -126,7 +126,11 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
           message((TextMessage) context.get(0));
           break;
         case execFunction:
-          execFunction((String) context.get(0), (String) context.get(1), (String) context.get(2));
+          execFunction(
+              (String) context.get(0),
+              (String) context.get(1),
+              (String) context.get(2),
+              (List<Object>) context.get(3));
           break;
         case execLink:
           execLink((String) context.get(0), (String) context.get(1), (String) context.get(2));
@@ -552,7 +556,7 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
   }
 
   @Override
-  public void execFunction(String functionText, String target, String source) {
+  public void execFunction(String target, String source, String functionName, List<Object> args) {
     forwardToClients();
   }
 


### PR DESCRIPTION
- Fix execFunction not working correctly when one of the function parameters contains a quote mark
- Close #1024

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1025)
<!-- Reviewable:end -->
