### PR TITLE
Badly formed anchor link resulted in null object returned

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/TooltipView.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TooltipView.java
@@ -19,6 +19,7 @@ import javax.swing.text.*;
 import javax.swing.text.html.*;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
+import net.rptools.maptool.language.I18N;
 
 public class TooltipView extends InlineView {
 
@@ -36,11 +37,19 @@ public class TooltipView extends InlineView {
 
   @Override
   public String getToolTipText(float x, float y, Shape allocation) {
-    AttributeSet att;
+    AttributeSet attSet;
 
-    att = (AttributeSet) getElement().getAttributes().getAttribute(HTML.Tag.A);
-    if (att != null) {
-      String href = att.getAttribute(HTML.Attribute.HREF).toString();
+    attSet = (AttributeSet) getElement().getAttributes().getAttribute(HTML.Tag.A);
+    if (attSet != null) {
+      Object attribute = attSet.getAttribute(HTML.Attribute.HREF);
+      String href;
+
+      if (attribute != null) {
+        href = attribute.toString();
+      } else {
+        href = I18N.getString("macroLink.error.tooltip.bad.href");
+      }
+
       if (href.startsWith("macro:")) {
         boolean isInsideChat = mlToolTips;
         boolean allowToolTipToShow = !AppPreferences.getSuppressToolTipsForMacroLinks();
@@ -54,8 +63,8 @@ public class TooltipView extends InlineView {
       }
     }
 
-    att = (AttributeSet) getElement().getAttributes().getAttribute(HTML.Tag.SPAN);
-    if (att != null) return (String) att.getAttribute(HTML.Attribute.TITLE);
+    attSet = (AttributeSet) getElement().getAttributes().getAttribute(HTML.Tag.SPAN);
+    if (attSet != null) return (String) attSet.getAttribute(HTML.Attribute.TITLE);
 
     return null;
   }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -987,6 +987,7 @@ macro.function.varsFromstrProp.wrongArgs           = varsFromStrProp called with
 
 # Macro Link
 macroLink.error.running = Error running macro link.
+macroLink.error.tooltip.bad.href = Invalid or missing HREF
 
 macromanager.alias.indexNotFound = (error: "{0}" is not found)
 # {0} is the command, {1} is the exception


### PR DESCRIPTION
Null captured and error message returned instead.  Will stop the NPE but won't fix bad macro code.  Issue #1015.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1063)
<!-- Reviewable:end -->
