### PR TITLE
Catch null assets and show error message

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/ImageChooserDialog.java
+++ b/src/main/java/net/rptools/maptool/client/swing/ImageChooserDialog.java
@@ -66,11 +66,17 @@ public class ImageChooserDialog extends JDialog {
               return;
             }
 
+            // Sometimes asset is coming back null causing an NPE. Could not reproduce but am
+            // putting in a check for it.  On Sentry:  MAPTOOL-11H
             Asset asset = imageChooser.getAsset((Integer) selected.get(0));
-            imageId = asset.getId();
+            if (asset != null) {
+              imageId = asset.getId();
 
-            // Put the asset into the asset manager since we have the asset handy here
-            AssetManager.putAsset(asset);
+              // Put the asset into the asset manager since we have the asset handy here
+              AssetManager.putAsset(asset);
+            } else {
+              MapTool.showError("msg.asset.error.invalidAsset");
+            }
           }
         });
   }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1193,6 +1193,8 @@ msg.warn.failedAutoSavingMessageHistory       = Could not autosave message histo
 msg.warning.macro.playerChangesNotAllowed     = The GM has not allowed players to change this macro.
 msg.warning.macro.willNotExport               = The macro "{0}" will not be exported.  Either it has been flagged by the GM as not player editable or you do not have ownership privileges over the source.</body></html>
 
+msg.asset.error.invalidAsset                  = An invalid asset has been selected. If you get this message please report it on the MapTool forums or Discord server.
+
 ooc.description = Out-Of-Character chat
 
 panel.Asset.ImageModel.checkbox.searchSubDir1 = Search subdirectories?


### PR DESCRIPTION
Catch null assets being returned and show user an error message.  Issue #1066

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1067)
<!-- Reviewable:end -->
