### PR TITLE
More Terrain Modifier choices

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/ToolHelper.java
+++ b/src/main/java/net/rptools/maptool/client/tool/ToolHelper.java
@@ -23,7 +23,8 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.text.NumberFormat;
 import java.util.Set;
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.SwingUtilities;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ScreenPoint;
@@ -63,7 +64,8 @@ public class ToolHelper {
                   .hideFrame(MapToolFrame.MTFrame.SELECTION.name());
             }
           }
-          Set<GUID> selectedTokenSet = renderer.getSelectedTokenSet();
+
+          Set<GUID> selectedTokenSet = Set.copyOf(renderer.getSelectedTokenSet());
 
           for (GUID tokenGUID : selectedTokenSet) {
             Token token = renderer.getZone().getToken(tokenGUID);
@@ -94,12 +96,24 @@ public class ToolHelper {
       double[] coords = new double[2];
       int segType = path.currentSegment(coords);
       if (segType != PathIterator.SEG_CLOSE) {
-        if (north == null) north = coords;
-        if (west == null) west = coords;
-        if (east == null) east = coords;
-        if (coords[1] < north[1]) north = coords;
-        if (coords[0] < west[0]) west = coords;
-        if (coords[0] > east[0]) east = coords;
+        if (north == null) {
+          north = coords;
+        }
+        if (west == null) {
+          west = coords;
+        }
+        if (east == null) {
+          east = coords;
+        }
+        if (coords[1] < north[1]) {
+          north = coords;
+        }
+        if (coords[0] < west[0]) {
+          west = coords;
+        }
+        if (coords[0] > east[0]) {
+          east = coords;
+        }
       }
       path.next();
     }
@@ -141,7 +155,9 @@ public class ToolHelper {
 
   public static void drawBoxedMeasurement(
       ZoneRenderer renderer, Graphics2D g, ScreenPoint startPoint, ScreenPoint endPoint) {
-    if (!MapTool.getFrame().isPaintDrawingMeasurement()) return;
+    if (!MapTool.getFrame().isPaintDrawingMeasurement()) {
+      return;
+    }
 
     // Calculations
     int left = (int) Math.min(startPoint.x, endPoint.x);
@@ -191,7 +207,9 @@ public class ToolHelper {
 
   public static void drawMeasurement(
       ZoneRenderer renderer, Graphics2D g, ScreenPoint startPoint, ScreenPoint endPoint) {
-    if (!MapTool.getFrame().isPaintDrawingMeasurement()) return;
+    if (!MapTool.getFrame().isPaintDrawingMeasurement()) {
+      return;
+    }
 
     boolean dirLeft = startPoint.x > endPoint.x;
     boolean dirUp = startPoint.y < endPoint.y;
@@ -216,7 +234,9 @@ public class ToolHelper {
    * @param y The y location of the measurement
    */
   public static void drawMeasurement(Graphics2D g, double distance, int x, int y) {
-    if (!MapTool.getFrame().isPaintDrawingMeasurement()) return;
+    if (!MapTool.getFrame().isPaintDrawingMeasurement()) {
+      return;
+    }
     String radius = NumberFormat.getInstance().format(distance);
     GraphicsUtil.drawBoxedString(g, radius, x, y);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/RenderPathWorker.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/RenderPathWorker.java
@@ -14,9 +14,11 @@
  */
 package net.rptools.maptool.client.ui.zone;
 
+import java.util.Set;
 import javax.swing.SwingWorker;
 import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.model.CellPoint;
+import net.rptools.maptool.model.Token.TerrainModifierOperation;
 
 public class RenderPathWorker extends SwingWorker<Void, Void> {
   // private static final Logger log = LogManager.getLogger(RenderPathWorker.class);
@@ -24,19 +26,25 @@ public class RenderPathWorker extends SwingWorker<Void, Void> {
   ZoneRenderer zoneRenderer;
   ZoneWalker walker;
   CellPoint startPoint, endPoint;
-  private boolean restrictMovement = false;
+  private final boolean restrictMovement;
+  private final Set<TerrainModifierOperation> terrainModifiersIgnored;
 
   public RenderPathWorker(
-      ZoneWalker walker, CellPoint endPoint, boolean restrictMovement, ZoneRenderer zoneRenderer) {
+      ZoneWalker walker,
+      CellPoint endPoint,
+      boolean restrictMovement,
+      Set<TerrainModifierOperation> terrainModifiersIgnored,
+      ZoneRenderer zoneRenderer) {
     this.walker = walker;
     this.endPoint = endPoint;
     this.restrictMovement = restrictMovement;
     this.zoneRenderer = zoneRenderer;
+    this.terrainModifiersIgnored = terrainModifiersIgnored;
   }
 
   @Override
   protected Void doInBackground() throws Exception {
-    walker.replaceLastWaypoint(endPoint, restrictMovement);
+    walker.replaceLastWaypoint(endPoint, restrictMovement, terrainModifiersIgnored);
     return null;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -126,9 +126,11 @@ import net.rptools.maptool.model.Path;
 import net.rptools.maptool.model.Player;
 import net.rptools.maptool.model.TextMessage;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.Token.TokenShape;
 import net.rptools.maptool.model.TokenFootprint;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.Zone.Layer;
 import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawableNoise;
@@ -146,6 +148,7 @@ import org.apache.logging.log4j.Logger;
 /** */
 public class ZoneRenderer extends JComponent
     implements DropTargetListener, Comparable<ZoneRenderer> {
+
   private static final long serialVersionUID = 3832897780066104884L;
   private static final Logger log = LogManager.getLogger(ZoneRenderer.class);
 
@@ -327,7 +330,9 @@ public class ZoneRenderer extends JComponent
 
     // Jamz: even though the layer was being activated the dialog list was not updating...
     Tool currentTool = MapTool.getFrame().getToolbox().getSelectedTool();
-    if (currentTool instanceof StampTool) ((StampTool) currentTool).updateLayerSelectionView();
+    if (currentTool instanceof StampTool) {
+      ((StampTool) currentTool).updateLayerSelectionView();
+    }
 
     selectToken(token.getId());
     requestFocusInWindow();
@@ -489,8 +494,12 @@ public class ZoneRenderer extends JComponent
 
     boolean stg = false;
     if (set.getWalker() != null) {
-      if (set.getWalker().getDistance() >= 0) stg = true;
-    } else stg = true;
+      if (set.getWalker().getDistance() >= 0) {
+        stg = true;
+      }
+    } else {
+      stg = true;
+    }
 
     // Lee: check only matters for snap-to-grid
     if (stg) {
@@ -503,9 +512,11 @@ public class ZoneRenderer extends JComponent
       // Lee: the 1st of evils. changing it to handle proper computation
       // for a key token's snapped state
       AbstractPoint originPoint, tokenCell;
-      if (keyToken.isSnapToGrid())
+      if (keyToken.isSnapToGrid()) {
         originPoint = zone.getGrid().convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
-      else originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
+      } else {
+        originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
+      }
 
       Path<? extends AbstractPoint> path =
           set.getWalker() != null ? set.getWalker().getPath() : set.gridlessPath;
@@ -522,18 +533,24 @@ public class ZoneRenderer extends JComponent
         Token token = zone.getToken(tokenGUID);
         // If the token has been deleted, the GUID will still be in the
         // set but getToken() will return null.
-        if (token == null) continue;
+        if (token == null) {
+          continue;
+        }
 
         // Lee: get offsets based on key token's snapped state
-        if (token.isSnapToGrid())
+        if (token.isSnapToGrid()) {
           tokenCell = zone.getGrid().convert(new ZonePoint(token.getX(), token.getY()));
-        else tokenCell = new ZonePoint(token.getX(), token.getY());
+        } else {
+          tokenCell = new ZonePoint(token.getX(), token.getY());
+        }
 
         int cellOffX, cellOffY;
         if (token.isSnapToGrid() == keyToken.isSnapToGrid()) {
           cellOffX = originPoint.x - tokenCell.x;
           cellOffY = originPoint.y - tokenCell.y;
-        } else cellOffX = cellOffY = 0; // not used unless both are of same SnapToGrid
+        } else {
+          cellOffX = cellOffY = 0; // not used unless both are of same SnapToGrid
+        }
 
         if (token.isSnapToGrid()
             && (!AppPreferences.getTokensSnapWhileDragging() || !keyToken.isSnapToGrid())) {
@@ -575,7 +592,9 @@ public class ZoneRenderer extends JComponent
           filteredTokens.add(tokenGUID);
         }
 
-        if (token.hasVBL()) vblTokenMoved = true;
+        if (token.hasVBL()) {
+          vblTokenMoved = true;
+        }
 
         // renderPath((Graphics2D) this.getGraphics(), path, token.getFootprint(zone.getGrid()));
       }
@@ -619,14 +638,20 @@ public class ZoneRenderer extends JComponent
       if (moveTimer.isEnabled()) {
         String results = moveTimer.toString();
         MapTool.getProfilingNoteFrame().addText(results);
-        if (log.isDebugEnabled()) log.debug(results);
+        if (log.isDebugEnabled()) {
+          log.debug(results);
+        }
         moveTimer.clear();
       }
     } else {
-      for (GUID tokenGUID : selectionSet) denyMovement(zone.getToken(tokenGUID));
+      for (GUID tokenGUID : selectionSet) {
+        denyMovement(zone.getToken(tokenGUID));
+      }
     }
 
-    if (vblTokenMoved) zone.tokenTopologyChanged();
+    if (vblTokenMoved) {
+      zone.tokenTopologyChanged();
+    }
   }
 
   /**
@@ -859,7 +884,9 @@ public class ZoneRenderer extends JComponent
 
   @Override
   public void paintComponent(Graphics g) {
-    if (timer == null) timer = new CodeTimer("ZoneRenderer.renderZone");
+    if (timer == null) {
+      timer = new CodeTimer("ZoneRenderer.renderZone");
+    }
     timer.setEnabled(AppState.isCollectProfilingData() || log.isDebugEnabled());
     timer.clear();
     timer.setThreshold(10);
@@ -883,7 +910,9 @@ public class ZoneRenderer extends JComponent
     if (timer.isEnabled()) {
       String results = timer.toString();
       MapTool.getProfilingNoteFrame().addText(results);
-      if (log.isDebugEnabled()) log.debug(results);
+      if (log.isDebugEnabled()) {
+        log.debug(results);
+      }
       timer.clear();
     }
   }
@@ -981,8 +1010,11 @@ public class ZoneRenderer extends JComponent
           drawnBounds.width + (penSize * 2),
           drawnBounds.height + (penSize * 2));
 
-      if (extents == null) extents = drawnBounds;
-      else extents.add(drawnBounds);
+      if (extents == null) {
+        extents = drawnBounds;
+      } else {
+        extents.add(drawnBounds);
+      }
     }
     // now, add the stamps/tokens
     // tokens and stamps are the same thing, just treated differently
@@ -1043,13 +1075,19 @@ public class ZoneRenderer extends JComponent
           }
         }
         // TODO: Handle auras here?
-        if (extents == null) extents = drawnBounds;
-        else extents.add(drawnBounds);
+        if (extents == null) {
+          extents = drawnBounds;
+        } else {
+          extents.add(drawnBounds);
+        }
       }
     }
     if (zone.hasFog()) {
-      if (extents == null) extents = fogExtents();
-      else extents.add(fogExtents());
+      if (extents == null) {
+        extents = fogExtents();
+      } else {
+        extents.add(fogExtents());
+      }
     }
     // TODO: What are token templates?
     // renderTokenTemplates(g2d, view);
@@ -1152,7 +1190,9 @@ public class ZoneRenderer extends JComponent
       timer.stop("ZoneRenderer-getVisibleArea");
 
       timer.start("createTransformedArea");
-      if (a != null && !a.isEmpty()) visibleScreenArea = a.createTransformedArea(af);
+      if (a != null && !a.isEmpty()) {
+        visibleScreenArea = a.createTransformedArea(af);
+      }
       timer.stop("createTransformedArea");
     }
 
@@ -1162,9 +1202,9 @@ public class ZoneRenderer extends JComponent
       // renderMoveSelectionSet() requires exposedFogArea to be properly set
       exposedFogArea = new Area(zone.getExposedArea());
       if (exposedFogArea != null && zone.hasFog()) {
-        if (visibleScreenArea != null && !visibleScreenArea.isEmpty())
+        if (visibleScreenArea != null && !visibleScreenArea.isEmpty()) {
           exposedFogArea.intersect(visibleScreenArea);
-        else {
+        } else {
           try {
             // Try to calculate the inverse transform and apply it.
             viewArea.transform(af.createInverse());
@@ -1319,7 +1359,9 @@ public class ZoneRenderer extends JComponent
     renderLabels(g2d, view);
 
     // (This method has it's own 'timer' calls)
-    if (zone.hasFog()) renderFog(g2d, view);
+    if (zone.hasFog()) {
+      renderFog(g2d, view);
+    }
 
     if (Zone.Layer.TOKEN.isEnabled()) {
       // Jamz: If there is fog or vision we may need to re-render vision-blocking type tokens
@@ -1377,7 +1419,9 @@ public class ZoneRenderer extends JComponent
         timer.start(msg);
       }
       overlay.paintOverlay(this, g2d);
-      if (timer.isEnabled()) timer.stop(msg);
+      if (timer.isEnabled()) {
+        timer.stop(msg);
+      }
     }
     timer.stop("overlays");
 
@@ -1643,14 +1687,18 @@ public class ZoneRenderer extends JComponent
    */
   private void renderVisionOverlay(Graphics2D g, PlayerView view) {
     Area currentTokenVisionArea = getVisibleArea(tokenUnderMouse);
-    if (currentTokenVisionArea == null) return;
+    if (currentTokenVisionArea == null) {
+      return;
+    }
     Area combined = new Area(currentTokenVisionArea);
     ExposedAreaMetaData meta = zone.getExposedAreaMetaData(tokenUnderMouse.getExposedAreaGUID());
 
     Area tmpArea = new Area(meta.getExposedAreaHistory());
     tmpArea.add(zone.getExposedArea());
     if (zone.hasFog()) {
-      if (tmpArea.isEmpty()) return;
+      if (tmpArea.isEmpty()) {
+        return;
+      }
       combined.intersect(tmpArea);
     }
     boolean isOwner = AppUtil.playerOwns(tokenUnderMouse);
@@ -2144,13 +2192,19 @@ public class ZoneRenderer extends JComponent
         Token token = zone.getToken(tokenGUID);
 
         // Perhaps deleted?
-        if (token == null) continue;
+        if (token == null) {
+          continue;
+        }
 
         // Don't bother if it's not visible
-        if (!token.isVisible() && !view.isGMView()) continue;
+        if (!token.isVisible() && !view.isGMView()) {
+          continue;
+        }
 
         // ... or if it's visible only to the owner and that's not us!
-        if (token.isVisibleOnlyToOwner() && !AppUtil.playerOwns(token)) continue;
+        if (token.isVisibleOnlyToOwner() && !AppUtil.playerOwns(token)) {
+          continue;
+        }
 
         // ... or there are no lights/visibleScreen and you are not the owner or gm and there is fow
         // or vision
@@ -2164,7 +2218,9 @@ public class ZoneRenderer extends JComponent
 
         // ... or if it doesn't have an image to display. (Hm, should still show *something*?)
         Asset asset = AssetManager.getAsset(token.getImageAssetId());
-        if (asset == null) continue;
+        if (asset == null) {
+          continue;
+        }
 
         // OPTIMIZE: combine this with the code in renderTokens()
         Rectangle footprintBounds = token.getBounds(zone);
@@ -2418,7 +2474,9 @@ public class ZoneRenderer extends JComponent
   @SuppressWarnings("unchecked")
   public void renderPath(
       Graphics2D g, Path<? extends AbstractPoint> path, TokenFootprint footprint) {
-    if (path == null) return;
+    if (path == null) {
+      return;
+    }
 
     Object oldRendering = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -2658,7 +2716,9 @@ public class ZoneRenderer extends JComponent
   private Shape shape2;
 
   public void setShape(Shape shape) {
-    if (shape == null) return;
+    if (shape == null) {
+      return;
+    }
 
     AffineTransform at = new AffineTransform();
     at.translate(getViewOffsetX(), getViewOffsetY());
@@ -2668,7 +2728,9 @@ public class ZoneRenderer extends JComponent
   }
 
   public void setShape2(Shape shape) {
-    if (shape == null) return;
+    if (shape == null) {
+      return;
+    }
 
     AffineTransform at = new AffineTransform();
     at.translate(getViewOffsetX(), getViewOffsetY());
@@ -2748,7 +2810,9 @@ public class ZoneRenderer extends JComponent
   }
 
   public void addDistanceText(Graphics2D g, ZonePoint point, float size, double distance) {
-    if (distance == 0) return;
+    if (distance == 0) {
+      return;
+    }
 
     Grid grid = zone.getGrid();
     double cwidth = grid.getCellWidth() * getScale();
@@ -2833,8 +2897,11 @@ public class ZoneRenderer extends JComponent
   public void setActiveLayer(Zone.Layer layer) {
     activeLayer = layer;
 
-    if (!keepSelectedTokenSet) selectedTokenSet.clear();
-    else keepSelectedTokenSet = false; // Always reset it back, temp boolean only
+    if (!keepSelectedTokenSet) {
+      selectedTokenSet.clear();
+    } else {
+      keepSelectedTokenSet = false; // Always reset it back, temp boolean only
+    }
 
     repaintDebouncer.dispatch();
   }
@@ -2955,7 +3022,9 @@ public class ZoneRenderer extends JComponent
     for (Token token : tokenList) {
       if ((figuresOnly && token.getShape() != Token.TokenShape.FIGURE)
           && figuresOnly
-          && !token.isAlwaysVisible()) continue;
+          && !token.isAlwaysVisible()) {
+        continue;
+      }
       timer.start("tokenlist-1");
       try {
         if (token.isStamp() && isTokenMoving(token)) {
@@ -3077,7 +3146,9 @@ public class ZoneRenderer extends JComponent
             if (tokenStackSet == null) {
               tokenStackSet = new HashSet<Token>();
               // Sometimes got NPE here
-              if (tokenStackMap == null) tokenStackMap = new HashMap<Token, Set<Token>>();
+              if (tokenStackMap == null) {
+                tokenStackMap = new HashMap<Token, Set<Token>>();
+              }
               tokenStackMap.put(token, tokenStackSet);
               tokenStackSet.add(token);
             }
@@ -3293,7 +3364,9 @@ public class ZoneRenderer extends JComponent
         }
       } else if (!isGMView && zoneView.isUsingVision() && token.isAlwaysVisible()) {
         // Lets skip tokens on the Hidden layer
-        if (token.isGMStamp()) continue;
+        if (token.isGMStamp()) {
+          continue;
+        }
         // Jamz: Always Visible tokens will get rendered again here to place on top of FoW
         Area cb = zone.getGrid().getTokenCellArea(tokenBounds);
         if (GraphicsUtil.intersects(visibleScreenArea, cb)) {
@@ -3333,29 +3406,38 @@ public class ZoneRenderer extends JComponent
           case FIGURE:
             if (token.getHasImageTable()
                 && token.hasFacing()
-                && AppPreferences.getForceFacingArrow() == false) break;
+                && AppPreferences.getForceFacingArrow() == false) {
+              break;
+            }
             Shape arrow = getFigureFacingArrow(token.getFacing(), footprintBounds.width / 2);
 
-            if (!zone.getGrid().isIsometric())
+            if (!zone.getGrid().isIsometric()) {
               arrow = getCircleFacingArrow(token.getFacing(), footprintBounds.width / 2);
+            }
 
             double fx = location.x + location.scaledWidth / 2;
             double fy = location.y + location.scaledHeight / 2;
 
             clippedG.translate(fx, fy);
-            if (token.getFacing() < 0) clippedG.setColor(Color.yellow);
-            else clippedG.setColor(TRANSLUCENT_YELLOW);
+            if (token.getFacing() < 0) {
+              clippedG.setColor(Color.yellow);
+            } else {
+              clippedG.setColor(TRANSLUCENT_YELLOW);
+            }
             clippedG.fill(arrow);
             clippedG.setColor(Color.darkGray);
             clippedG.draw(arrow);
             clippedG.translate(-fx, -fy);
             break;
           case TOP_DOWN:
-            if (AppPreferences.getForceFacingArrow() == false) break;
+            if (AppPreferences.getForceFacingArrow() == false) {
+              break;
+            }
           case CIRCLE:
             arrow = getCircleFacingArrow(token.getFacing(), footprintBounds.width / 2);
-            if (zone.getGrid().isIsometric())
+            if (zone.getGrid().isIsometric()) {
               arrow = getFigureFacingArrow(token.getFacing(), footprintBounds.width / 2);
+            }
 
             double cx = location.x + location.scaledWidth / 2;
             double cy = location.y + location.scaledHeight / 2;
@@ -3465,7 +3547,9 @@ public class ZoneRenderer extends JComponent
       timer.start("tokenlist-11");
       // Keep track of which tokens have been drawn so we can perform post-processing on them later
       // (such as selection borders and names/labels)
-      if (getActiveLayer().equals(token.getLayer())) tokenPostProcessing.add(token);
+      if (getActiveLayer().equals(token.getLayer())) {
+        tokenPostProcessing.add(token);
+      }
       timer.stop("tokenlist-11");
 
       // DEBUGGING
@@ -3480,7 +3564,9 @@ public class ZoneRenderer extends JComponent
     // Selection and labels
     for (Token token : tokenPostProcessing) {
       TokenLocation location = tokenLocationCache.get(token);
-      if (location == null) continue;
+      if (location == null) {
+        continue;
+      }
       Area bounds = location.bounds;
 
       // TODO: This isn't entirely accurate as it doesn't account for the actual text
@@ -3511,7 +3597,9 @@ public class ZoneRenderer extends JComponent
                   RectangleExposeTool // XXX Change to use marker interface such as ExposeTool?
               || tool instanceof OvalExposeTool
               || tool instanceof FreehandExposeTool
-              || tool instanceof PolygonExposeTool) selectedBorder = AppConstants.FOW_TOOLS_BORDER;
+              || tool instanceof PolygonExposeTool) {
+            selectedBorder = AppConstants.FOW_TOOLS_BORDER;
+          }
         }
         if (token.hasFacing()
             && (token.getShape() == Token.TokenShape.TOP_DOWN || token.isStamp())) {
@@ -3668,7 +3756,9 @@ public class ZoneRenderer extends JComponent
     }
     timer.stop("tokenlist-13");
 
-    if (figuresOnly) tempVisTokens.addAll(visibleTokenSet);
+    if (figuresOnly) {
+      tempVisTokens.addAll(visibleTokenSet);
+    }
 
     visibleTokenSet = Collections.unmodifiableSet(tempVisTokens);
   }
@@ -4064,11 +4154,13 @@ public class ZoneRenderer extends JComponent
   }
 
   private interface ItemRenderer {
+
     public void render(Graphics2D g);
   }
 
   /** Represents a delayed label render */
   private class LabelRenderer implements ItemRenderer {
+
     private final String text;
     private int x;
     private final int y;
@@ -4147,6 +4239,7 @@ public class ZoneRenderer extends JComponent
 
   /** Represents a movement set */
   public class SelectionSet {
+
     private final Logger log = LogManager.getLogger(ZoneRenderer.SelectionSet.class);
 
     private final HashSet<GUID> selectionSet = new HashSet<GUID>();
@@ -4240,9 +4333,17 @@ public class ZoneRenderer extends JComponent
           renderPathTask.cancel(true);
         }
 
+        boolean restictMovement = AppPreferences.isUsingAstarPathfinding();
+        Set<TerrainModifierOperation> terrainModifiersIgnored = token.getTerrainModifiersIgnored();
+
+        // Skip AI Pathfinding if not on the token layer...
+        if (!ZoneRenderer.this.getActiveLayer().equals(Layer.TOKEN)) {
+          restictMovement = false;
+        }
+
         renderPathTask =
             new RenderPathWorker(
-                walker, point, AppPreferences.isUsingAstarPathfinding(), ZoneRenderer.this);
+                walker, point, restictMovement, terrainModifiersIgnored, ZoneRenderer.this);
         renderPathThreadPool.execute(renderPathTask);
       } else {
         if (gridlessPath.getCellPath().size() > 1) {
@@ -4306,6 +4407,7 @@ public class ZoneRenderer extends JComponent
   }
 
   private class TokenLocation {
+
     public Area bounds;
     public Token token;
     public Rectangle boundsCache;
@@ -4374,6 +4476,7 @@ public class ZoneRenderer extends JComponent
   }
 
   private static class LabelLocation {
+
     public Rectangle bounds;
     public Label label;
 
@@ -4612,7 +4715,9 @@ public class ZoneRenderer extends JComponent
             .convertToZone(this);
     TransferableHelper th = (TransferableHelper) getTransferHandler();
     List<Token> tokens = th.getTokens();
-    if (tokens != null && !tokens.isEmpty()) addTokens(tokens, zp, th.getConfigureTokens(), false);
+    if (tokens != null && !tokens.isEmpty()) {
+      addTokens(tokens, zp, th.getConfigureTokens(), false);
+    }
   }
 
   public Set<GUID> getVisibleTokenSet() {
@@ -4636,6 +4741,7 @@ public class ZoneRenderer extends JComponent
 
   /** ZONE MODEL CHANGE LISTENER */
   private class ZoneModelChangeListener implements ModelChangeListener {
+
     /**
      * ALL events trigger updateTokenTree and a repaint. Reacts specifically to events
      * TOPOLOGY_CHANGED, TOKEN_CHANGED, TOKEN_REMOVED, and TOKEN_ADDED.

--- a/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
@@ -18,9 +18,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
+import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.Zone;
 
 public abstract class AbstractZoneWalker implements ZoneWalker {
@@ -28,6 +30,7 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
       Collections.synchronizedList(new ArrayList<PartialPath>());
   protected final Zone zone;
   protected boolean restrictMovement = false;
+  protected Set<TerrainModifierOperation> terrainModifiersIgnored;
   protected RenderPathWorker renderPathWorker;
 
   public AbstractZoneWalker(Zone zone) {
@@ -46,13 +49,11 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   }
 
   public void setWaypoints(CellPoint... points) {
-    // System.out.println("AbstractZoneWalker setWaypoints called");
     partialPaths.clear();
     addWaypoints(points);
   }
 
   public void addWaypoints(CellPoint... points) {
-    // System.out.println("AbstractZoneWalker addWaypoints called");
     CellPoint previous =
         partialPaths.size() > 0 ? partialPaths.get(partialPaths.size() - 1).end : null;
     for (CellPoint current : points) {
@@ -64,13 +65,17 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   }
 
   public CellPoint replaceLastWaypoint(CellPoint point) {
-    return replaceLastWaypoint(point, false);
+    return replaceLastWaypoint(point, false, Collections.singleton(TerrainModifierOperation.NONE));
   }
 
   @Override
-  public CellPoint replaceLastWaypoint(CellPoint point, boolean restrictMovement) {
-    // System.out.println("AbstractZoneWalker replaceLastWaypoint2 called");
+  public CellPoint replaceLastWaypoint(
+      CellPoint point,
+      boolean restrictMovement,
+      Set<TerrainModifierOperation> terrainModifiersIgnored) {
+
     this.restrictMovement = restrictMovement;
+    this.terrainModifiersIgnored = terrainModifiersIgnored;
 
     if (partialPaths.isEmpty()) return null;
     PartialPath oldPartial = partialPaths.remove(partialPaths.size() - 1);
@@ -86,14 +91,10 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
 
   public Path<CellPoint> getPath(RenderPathWorker renderPathWorker) {
     this.renderPathWorker = renderPathWorker;
-    // System.out.println("########## AbstractZoneWalker.getPath(RenderPathWorker renderPathWorker)
-    // renderPathWorker null? " + (renderPathWorker == null));
     return getPath();
   }
 
   public Path<CellPoint> getPath() {
-    // System.out.println("########## AbstractZoneWalker.getPath() renderPathWorker null? " +
-    // (renderPathWorker == null));
     Path<CellPoint> path = new Path<CellPoint>();
 
     PartialPath last = null;

--- a/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
@@ -15,10 +15,12 @@
 package net.rptools.maptool.client.walker;
 
 import java.util.Collection;
+import java.util.Set;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.client.walker.astar.AStarCellPoint;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
+import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.TokenFootprint;
 
 public interface ZoneWalker {
@@ -28,7 +30,10 @@ public interface ZoneWalker {
 
   public CellPoint replaceLastWaypoint(CellPoint point);
 
-  public CellPoint replaceLastWaypoint(CellPoint point, boolean restrictMovement);
+  public CellPoint replaceLastWaypoint(
+      CellPoint point,
+      boolean restrictMovement,
+      Set<TerrainModifierOperation> terrainModifiersIgnored);
 
   public boolean isWaypoint(CellPoint point);
 

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 import net.rptools.maptool.model.CellPoint;
+import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.Zone;
 
 public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoint> {
@@ -30,6 +31,7 @@ public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoi
   double h;
   double f;
   double terrainModifier;
+  TerrainModifierOperation terrainModifierOperation;
 
   // Store if it's valid to move from Point2D to this cell.
   HashMap<Point2D, Boolean> validMoves = new HashMap<Point2D, Boolean>();
@@ -46,9 +48,10 @@ public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoi
     super(p.x, p.y, p.distanceTraveled);
   }
 
-  public AStarCellPoint(CellPoint p, double mod) {
+  public AStarCellPoint(CellPoint p, double mod, TerrainModifierOperation operation) {
     super(p.x, p.y);
     terrainModifier = mod;
+    terrainModifierOperation = operation;
   }
 
   public double fCost() {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -27,6 +27,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -63,6 +64,7 @@ import org.apache.logging.log4j.Logger;
 
 // Lee: made tokens cloneable
 public class Token extends BaseModel implements Cloneable {
+
   private static final Logger log = LogManager.getLogger(Token.class);
 
   private GUID id = new GUID();
@@ -145,6 +147,8 @@ public class Token extends BaseModel implements Cloneable {
     setIsAlwaysVisible,
     setTokenOpacity,
     setTerrainModifier,
+    setTerrainModifierOperation,
+    setTerrainModifiersIgnored,
     setVBL,
     setImageAsset,
     setPortraitImage,
@@ -233,8 +237,20 @@ public class Token extends BaseModel implements Cloneable {
   // Jamz: allow token alpha channel modification
   private float tokenOpacity = 1.0f;
 
+  /** Terrain Modifier Operations */
+  public enum TerrainModifierOperation {
+    NONE, // Default, no terrain modifications to pathfinding cost
+    MULTIPLY, // All tokens with this type are added together and multiplied against the Cell cost
+    ADD, // All tokens with this type are added together and added to the cell cost
+    BLOCK, // Movement through tokens with this type are blocked just as if they had VBL
+    FREE // Any cell with a token of this type in it has ALL movement costs removed
+  }
+
   // Jamz: modifies A* cost of other tokens
-  private double terrainModifier = 1;
+  private double terrainModifier = 0.0d;
+  private TerrainModifierOperation terrainModifierOperation = TerrainModifierOperation.NONE;
+  private Set<TerrainModifierOperation> terrainModifiersIgnored =
+      new HashSet<>(Arrays.asList(TerrainModifierOperation.NONE));
 
   private boolean isFlippedX;
   private boolean isFlippedY;
@@ -372,9 +388,13 @@ public class Token extends BaseModel implements Cloneable {
     hasImageTable = token.hasImageTable;
     imageTableName = token.imageTableName;
 
-    if (isoWidth == 0) isoWidth = width;
+    if (isoWidth == 0) {
+      isoWidth = width;
+    }
 
-    if (isoHeight == 0) isoHeight = height;
+    if (isoHeight == 0) {
+      isoHeight = height;
+    }
 
     ownerType = token.ownerType;
     if (token.ownerList != null) {
@@ -418,6 +438,11 @@ public class Token extends BaseModel implements Cloneable {
     heroLabData = token.heroLabData;
     tokenOpacity = token.tokenOpacity;
     terrainModifier = token.terrainModifier;
+    terrainModifierOperation = token.terrainModifierOperation;
+
+    if (token.terrainModifiersIgnored != null) {
+      terrainModifiersIgnored = new HashSet<>(token.terrainModifiersIgnored);
+    }
   }
 
   public Token() {
@@ -481,8 +506,9 @@ public class Token extends BaseModel implements Cloneable {
 
     // Try and silently catch any errors if there is an issue with sightType...
     try {
-      if (!MapTool.getCampaign().getCampaignProperties().getSightTypeMap().containsKey(sightType))
+      if (!MapTool.getCampaign().getCampaignProperties().getSightTypeMap().containsKey(sightType)) {
         sightType = MapTool.getCampaign().getCampaignProperties().getDefaultSightType();
+      }
     } catch (Exception e) {
       sightType = MapTool.getCampaign().getCampaignProperties().getDefaultSightType();
       e.printStackTrace();
@@ -497,8 +523,11 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public void setHasImageTable(boolean hasImageTable) {
-    if (hasImageTable) this.hasImageTable = true;
-    else this.hasImageTable = null;
+    if (hasImageTable) {
+      this.hasImageTable = true;
+    } else {
+      this.hasImageTable = null;
+    }
   }
 
   public void setImageTableName(String imageTableName) {
@@ -506,23 +535,35 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public void setWidth(int width) {
-    if (isFlippedIso()) isoWidth = width;
-    else this.width = width;
+    if (isFlippedIso()) {
+      isoWidth = width;
+    } else {
+      this.width = width;
+    }
   }
 
   public void setHeight(int height) {
-    if (isFlippedIso()) isoHeight = height;
-    else this.height = height;
+    if (isFlippedIso()) {
+      isoHeight = height;
+    } else {
+      this.height = height;
+    }
   }
 
   public int getWidth() {
-    if (isFlippedIso() && isoWidth != 0) return isoWidth;
-    else return width;
+    if (isFlippedIso() && isoWidth != 0) {
+      return isoWidth;
+    } else {
+      return width;
+    }
   }
 
   public int getHeight() {
-    if (isFlippedIso() && isoHeight != 0) return isoHeight;
-    else return height;
+    if (isFlippedIso() && isoHeight != 0) {
+      return isoHeight;
+    } else {
+      return height;
+    }
   }
 
   public boolean isMarker() {
@@ -591,7 +632,9 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public float getTokenOpacity() {
-    if (tokenOpacity <= 0.0f) tokenOpacity = 1.0f;
+    if (tokenOpacity <= 0.0f) {
+      tokenOpacity = 1.0f;
+    }
 
     return tokenOpacity;
   }
@@ -605,6 +648,7 @@ public class Token extends BaseModel implements Cloneable {
   public float setTokenOpacity(String alpha) {
     return setTokenOpacity(Float.parseFloat(alpha));
   }
+
   /**
    * Set the token opacity from a float trimmed to [0.05f, 1.0f]
    *
@@ -612,8 +656,12 @@ public class Token extends BaseModel implements Cloneable {
    * @return the float of the opacity trimmed.
    */
   public float setTokenOpacity(float alpha) {
-    if (alpha > 1.0f) alpha = 1.0f;
-    if (alpha <= 0.0f) alpha = 0.05f;
+    if (alpha > 1.0f) {
+      alpha = 1.0f;
+    }
+    if (alpha <= 0.0f) {
+      alpha = 0.05f;
+    }
 
     tokenOpacity = alpha;
 
@@ -621,16 +669,52 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public double getTerrainModifier() {
-    if (terrainModifier == 0) terrainModifier = 1.0f;
-
     return terrainModifier;
   }
 
   public double setTerrainModifier(double modifier) {
-    if (modifier != 0) terrainModifier = modifier;
-    else terrainModifier = 1.0f;
-
+    terrainModifier = modifier;
     return terrainModifier;
+  }
+
+  public TerrainModifierOperation getTerrainModifierOperation() {
+    // This should only happen on existing campaigns. For those tokens,
+    // the default was a multiplier of 1.0f so we will set those to 0 and operation NONE
+    if (terrainModifierOperation == null) {
+      if (terrainModifier != 1) {
+        terrainModifierOperation = TerrainModifierOperation.MULTIPLY;
+      } else {
+        terrainModifier = 0.0d;
+        terrainModifierOperation = TerrainModifierOperation.NONE;
+      }
+    }
+
+    return terrainModifierOperation;
+  }
+
+  public void setTerrainModifierOperation(TerrainModifierOperation terrainModifierOperation) {
+    this.terrainModifierOperation = terrainModifierOperation;
+  }
+
+  public Set<TerrainModifierOperation> getTerrainModifiersIgnored() {
+    if (terrainModifiersIgnored == null) {
+      terrainModifiersIgnored = new HashSet<>();
+    }
+
+    if (terrainModifiersIgnored.isEmpty()) {
+      terrainModifiersIgnored.add(TerrainModifierOperation.NONE);
+    }
+
+    return terrainModifiersIgnored;
+  }
+
+  public void setTerrainModifiersIgnored(Set<TerrainModifierOperation> terrainModifiersIgnored) {
+    this.terrainModifiersIgnored = terrainModifiersIgnored;
+
+    if (this.terrainModifiersIgnored.contains(TerrainModifierOperation.NONE)) {
+      terrainModifiersIgnored.clear();
+      this.terrainModifiersIgnored.add(TerrainModifierOperation.NONE);
+    }
   }
 
   public boolean isObjectStamp() {
@@ -740,15 +824,23 @@ public class Token extends BaseModel implements Cloneable {
    * @return angle in degrees
    */
   public Integer getFacingInDegrees() {
-    if (facing == null) return 0;
-    else return -(facing + 90);
+    if (facing == null) {
+      return 0;
+    } else {
+      return -(facing + 90);
+    }
   }
 
   public Integer getFacingInRealDegrees() {
-    if (facing == null) return 270;
+    if (facing == null) {
+      return 270;
+    }
 
-    if (facing >= 0) return facing;
-    else return facing + 360;
+    if (facing >= 0) {
+      return facing;
+    } else {
+      return facing + 360;
+    }
   }
 
   public boolean getHasSight() {
@@ -756,7 +848,9 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public boolean getHasImageTable() {
-    if (hasImageTable != null) return hasImageTable;
+    if (hasImageTable != null) {
+      return hasImageTable;
+    }
     return false;
   }
 
@@ -768,8 +862,9 @@ public class Token extends BaseModel implements Cloneable {
     if (lightSourceList == null) {
       lightSourceList = new ArrayList<AttachedLightSource>();
     }
-    if (!lightSourceList.contains(source))
+    if (!lightSourceList.contains(source)) {
       lightSourceList.add(new AttachedLightSource(source, direction));
+    }
   }
 
   public void removeLightSourceType(LightSource.Type lightType) {
@@ -777,7 +872,9 @@ public class Token extends BaseModel implements Cloneable {
       for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
         AttachedLightSource als = i.next();
         LightSource lightSource = MapTool.getCampaign().getLightSource(als.getLightSourceId());
-        if (lightSource != null && lightSource.getType() == lightType) i.remove();
+        if (lightSource != null && lightSource.getType() == lightType) {
+          i.remove();
+        }
       }
     }
   }
@@ -790,7 +887,9 @@ public class Token extends BaseModel implements Cloneable {
         if (lightSource != null) {
           List<Light> lights = lightSource.getLightList();
           for (Light light : lights) {
-            if (light != null && light.isGM()) i.remove();
+            if (light != null && light.isGM()) {
+              i.remove();
+            }
           }
         }
       }
@@ -805,7 +904,9 @@ public class Token extends BaseModel implements Cloneable {
         if (lightSource != null) {
           List<Light> lights = lightSource.getLightList();
           for (Light light : lights) {
-            if (light.isOwnerOnly()) i.remove();
+            if (light.isOwnerOnly()) {
+              i.remove();
+            }
           }
         }
       }
@@ -820,7 +921,9 @@ public class Token extends BaseModel implements Cloneable {
         if (lightSource != null) {
           List<Light> lights = lightSource.getLightList();
           for (Light light : lights) {
-            if (light.isOwnerOnly()) return true;
+            if (light.isOwnerOnly()) {
+              return true;
+            }
           }
         }
       }
@@ -836,7 +939,9 @@ public class Token extends BaseModel implements Cloneable {
         if (lightSource != null) {
           List<Light> lights = lightSource.getLightList();
           for (Light light : lights) {
-            if (light.isGM()) return true;
+            if (light.isGM()) {
+              return true;
+            }
           }
         }
       }
@@ -849,7 +954,9 @@ public class Token extends BaseModel implements Cloneable {
       for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
         AttachedLightSource als = i.next();
         LightSource lightSource = MapTool.getCampaign().getLightSource(als.getLightSourceId());
-        if (lightSource != null && lightSource.getType() == lightType) return true;
+        if (lightSource != null && lightSource.getType() == lightType) {
+          return true;
+        }
       }
     }
     return false;
@@ -1037,8 +1144,11 @@ public class Token extends BaseModel implements Cloneable {
     assetSet.add(charsheetImage);
     assetSet.add(portraitImage);
 
-    if (heroLabData != null)
-      if (heroLabData.getAllAssetIDs() != null) assetSet.addAll(heroLabData.getAllAssetIDs());
+    if (heroLabData != null) {
+      if (heroLabData.getAllAssetIDs() != null) {
+        assetSet.addAll(heroLabData.getAllAssetIDs());
+      }
+    }
 
     assetSet.remove(null); // Clean up from any null values from above
     return assetSet;
@@ -1108,7 +1218,9 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public ZonePoint getOriginPoint() {
-    if (tokenOrigin == null) tokenOrigin = new ZonePoint(getX(), getY());
+    if (tokenOrigin == null) {
+      tokenOrigin = new ZonePoint(getX(), getY());
+    }
 
     return tokenOrigin;
   }
@@ -1206,16 +1318,23 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public void setAlwaysVisibleTolerance(int tolerance) {
-    if (tolerance < 1) tolerance = 1;
+    if (tolerance < 1) {
+      tolerance = 1;
+    }
 
-    if (tolerance > 9) tolerance = 9;
+    if (tolerance > 9) {
+      tolerance = 9;
+    }
 
     alwaysVisibleTolerance = tolerance;
   }
 
   public int getAlwaysVisibleTolerance() {
-    if (alwaysVisibleTolerance <= 0) return 2;
-    else return alwaysVisibleTolerance;
+    if (alwaysVisibleTolerance <= 0) {
+      return 2;
+    } else {
+      return alwaysVisibleTolerance;
+    }
   }
 
   public void setAlphaSensitivity(int tolerance) {
@@ -1233,7 +1352,9 @@ public class Token extends BaseModel implements Cloneable {
    */
   public void setVBL(Area vbl) {
     this.vbl = vbl;
-    if (vbl == null) vblAlphaSensitivity = -1;
+    if (vbl == null) {
+      vblAlphaSensitivity = -1;
+    }
   }
 
   /** Return the vbl area of the token */
@@ -1249,9 +1370,9 @@ public class Token extends BaseModel implements Cloneable {
    * This method returns the vbl stored on the token with AffineTransformations applied for scale,
    * position, rotation, &amp; flipping.
    *
+   * @return
    * @author Jamz
    * @since 1.4.1.5
-   * @return
    */
   public Area getTransformedVBL(Area areaToTransform) {
     Rectangle footprintBounds = getBounds(MapTool.getFrame().getCurrentZoneRenderer().getZone());
@@ -1297,18 +1418,20 @@ public class Token extends BaseModel implements Cloneable {
               ((double) imgSize.width) / getWidth(), ((double) imgSize.height) / getHeight()));
 
       // Apply the rotation transformation...
-      if (getShape() == Token.TokenShape.TOP_DOWN)
+      if (getShape() == Token.TokenShape.TOP_DOWN) {
         atArea.concatenate(
             AffineTransform.getRotateInstance(Math.toRadians(getFacingInDegrees()), rx, ry));
+      }
     } else {
       // Find the center x,y coords of the rectangle
       rx = ((getWidth() / 2) - (getAnchor().getX() / scaleX)) * scaleX;
       ry = ((getHeight() / 2) - (getAnchor().getY() / scaleY)) * scaleY;
 
       // Apply the rotation transformation...
-      if (getShape() == Token.TokenShape.TOP_DOWN)
+      if (getShape() == Token.TokenShape.TOP_DOWN) {
         atArea.concatenate(
             AffineTransform.getRotateInstance(Math.toRadians(getFacingInDegrees()), rx, ry));
+      }
 
       // Apply the scale transformation
       atArea.concatenate(AffineTransform.getScaleInstance(scaleX, scaleY));
@@ -1452,7 +1575,9 @@ public class Token extends BaseModel implements Cloneable {
    * @return The original value of the state, if any.
    */
   public Object setState(String aState, Object aValue) {
-    if (aValue == null) return state.remove(aState);
+    if (aValue == null) {
+      return state.remove(aState);
+    }
     return state.put(aState, aValue);
   }
 
@@ -1580,8 +1705,9 @@ public class Token extends BaseModel implements Cloneable {
       macroPropertiesMap.put(prop.getIndex(), prop);
     }
     macroMap = null;
-    if (log.isDebugEnabled())
+    if (log.isDebugEnabled()) {
       log.debug("Token.loadOldMacros() set up " + macroPropertiesMap.size() + " new macros.");
+    }
   }
 
   public int getMacroNextIndex() {
@@ -1591,7 +1717,9 @@ public class Token extends BaseModel implements Cloneable {
     Set<Integer> indexSet = macroPropertiesMap.keySet();
     int maxIndex = 0;
     for (int index : indexSet) {
-      if (index > maxIndex) maxIndex = index;
+      if (index > maxIndex) {
+        maxIndex = index;
+      }
     }
     return maxIndex + 1;
   }
@@ -1731,7 +1859,9 @@ public class Token extends BaseModel implements Cloneable {
   public Set<String> getStatePropertyNames(Object value) {
     Map<String, Object> matches = new HashMap(state);
     for (Map.Entry<String, Object> entry : state.entrySet()) {
-      if (!value.equals(entry.getValue())) matches.remove(entry.getKey());
+      if (!value.equals(entry.getValue())) {
+        matches.remove(entry.getKey());
+      }
     }
     return matches.keySet();
   }
@@ -1763,13 +1893,18 @@ public class Token extends BaseModel implements Cloneable {
   }
 
   public boolean isFlippedIso() {
-    if (isFlippedIso != null) return isFlippedIso;
+    if (isFlippedIso != null) {
+      return isFlippedIso;
+    }
     return false;
   }
 
   public void setFlippedIso(boolean isFlippedIso) {
-    if (isFlippedIso) this.isFlippedIso = true;
-    else this.isFlippedIso = null;
+    if (isFlippedIso) {
+      this.isFlippedIso = true;
+    } else {
+      this.isFlippedIso = null;
+    }
   }
 
   public Color getVisionOverlayColor() {
@@ -1842,13 +1977,17 @@ public class Token extends BaseModel implements Cloneable {
     // Put all of the serializable state into the map
     for (String key : getStatePropertyNames()) {
       Object value = getState(key);
-      if (value instanceof Serializable) td.put(key, value);
+      if (value instanceof Serializable) {
+        td.put(key, value);
+      }
     }
     td.putAll(state);
 
     // Create the image from the asset and add it to the map
     Image image = ImageManager.getImageAndWait(imageAssetMap.get(null));
-    if (image != null) td.setToken(new ImageIcon(image)); // Image icon makes it serializable.
+    if (image != null) {
+      td.setToken(new ImageIcon(image)); // Image icon makes it serializable.
+    }
     return td;
   }
 
@@ -1885,9 +2024,13 @@ public class Token extends BaseModel implements Cloneable {
 
     // Get the image and portrait for the token
     Asset asset = createAssetFromIcon(td.getToken());
-    if (asset != null) imageAssetMap.put(null, asset.getId());
+    if (asset != null) {
+      imageAssetMap.put(null, asset.getId());
+    }
     asset = createAssetFromIcon((ImageIcon) td.get(TokenTransferData.PORTRAIT));
-    if (asset != null) portraitImage = asset.getId();
+    if (asset != null) {
+      portraitImage = asset.getId();
+    }
 
     // Get the macros
     @SuppressWarnings("unchecked")
@@ -1907,13 +2050,17 @@ public class Token extends BaseModel implements Cloneable {
 
     // Get all of the non maptool specific state
     for (String key : td.keySet()) {
-      if (key.startsWith(TokenTransferData.MAPTOOL)) continue;
+      if (key.startsWith(TokenTransferData.MAPTOOL)) {
+        continue;
+      }
       setProperty(key, td.get(key));
     } // endfor
   }
 
   private Asset createAssetFromIcon(ImageIcon icon) {
-    if (icon == null) return null;
+    if (icon == null) {
+      return null;
+    }
 
     // Make sure there is a buffered image for it
     Image image = icon.getImage();
@@ -1927,7 +2074,9 @@ public class Token extends BaseModel implements Cloneable {
     Asset asset = null;
     try {
       asset = new Asset(name, ImageUtil.imageToBytes((BufferedImage) image));
-      if (!AssetManager.hasAsset(asset)) AssetManager.putAsset(asset);
+      if (!AssetManager.hasAsset(asset)) {
+        AssetManager.putAsset(asset);
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -1944,7 +2093,9 @@ public class Token extends BaseModel implements Cloneable {
    */
   private static int getInt(Map<String, Object> map, String propName, int defaultValue) {
     Integer integer = (Integer) map.get(propName);
-    if (integer == null) return defaultValue;
+    if (integer == null) {
+      return defaultValue;
+    }
     return integer.intValue();
   }
 
@@ -1959,7 +2110,9 @@ public class Token extends BaseModel implements Cloneable {
   private static boolean getBoolean(
       Map<String, Object> map, String propName, boolean defaultValue) {
     Boolean bool = (Boolean) map.get(propName);
-    if (bool == null) return defaultValue;
+    if (bool == null) {
+      return defaultValue;
+    }
     return bool.booleanValue();
   }
 
@@ -1972,9 +2125,13 @@ public class Token extends BaseModel implements Cloneable {
   public List<InitiativeList.TokenInitiative> getInitiatives() {
     Zone zone = getZoneRenderer().getZone();
     List<Integer> list = zone.getInitiativeList().indexOf(this);
-    if (list.isEmpty()) return Collections.EMPTY_LIST;
+    if (list.isEmpty()) {
+      return Collections.EMPTY_LIST;
+    }
     List<InitiativeList.TokenInitiative> ret = new ArrayList<>(list.size());
-    for (Integer index : list) ret.add(zone.getInitiativeList().getTokenInitiative(index));
+    for (Integer index : list) {
+      ret.add(zone.getInitiativeList().getTokenInitiative(index));
+    }
     return ret;
   }
 
@@ -1986,7 +2143,9 @@ public class Token extends BaseModel implements Cloneable {
   public InitiativeList.TokenInitiative getInitiative() {
     Zone zone = getZoneRenderer().getZone();
     List<Integer> list = zone.getInitiativeList().indexOf(this);
-    if (list.isEmpty()) return null;
+    if (list.isEmpty()) {
+      return null;
+    }
     return zone.getInitiativeList().getTokenInitiative(list.get(0));
   }
 
@@ -2177,7 +2336,9 @@ public class Token extends BaseModel implements Cloneable {
         zone.sortZOrder(); // update new ZOrder
         break;
       case setFacing:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         setFacing((Integer) parameters[0]);
         break;
       case clearAllOwners:
@@ -2209,15 +2370,21 @@ public class Token extends BaseModel implements Cloneable {
         setGMNotes(parameters[0].toString());
         break;
       case setX:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         setX((int) parameters[0]);
         break;
       case setY:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         setY((int) parameters[0]);
         break;
       case setXY:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         setX((int) parameters[0]);
         setY((int) parameters[1]);
         break;
@@ -2248,6 +2415,12 @@ public class Token extends BaseModel implements Cloneable {
       case setTerrainModifier:
         setTerrainModifier((double) parameters[0]);
         break;
+      case setTerrainModifierOperation:
+        setTerrainModifierOperation((TerrainModifierOperation) parameters[0]);
+        break;
+      case setTerrainModifiersIgnored:
+        setTerrainModifiersIgnored((Set<TerrainModifierOperation>) parameters[0]);
+        break;
       case setVBL:
         setVBL((Area) parameters[0]);
         if (!hasVBL()) { // if VBL removed
@@ -2264,11 +2437,15 @@ public class Token extends BaseModel implements Cloneable {
         setCharsheetImage((MD5Key) parameters[0]);
         break;
       case clearLightSources:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         clearLightSources();
         break;
       case removeLightSource:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         removeLightSource((LightSource) parameters[0]);
         break;
       case addLightSource:
@@ -2276,15 +2453,21 @@ public class Token extends BaseModel implements Cloneable {
         addLightSource((LightSource) parameters[0], (Direction) parameters[1]);
         break;
       case setHasSight:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         setHasSight((boolean) parameters[0]);
         break;
       case setSightType:
-        if (hasLightSources()) lightChanged = true;
+        if (hasLightSources()) {
+          lightChanged = true;
+        }
         setSightType((String) parameters[0]);
         break;
     }
-    if (lightChanged) getZoneRenderer().flushLight(); // flush lights if it changed
+    if (lightChanged) {
+      getZoneRenderer().flushLight(); // flush lights if it changed
+    }
     zone.tokenChanged(this); // fire Event.TOKEN_CHANGED, which updates topology if token has VBL
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -40,6 +40,7 @@ import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.client.ui.zone.ZoneView;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.InitiativeList.TokenInitiative;
+import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
@@ -59,6 +60,7 @@ import org.apache.logging.log4j.Logger;
  * initialized for maximum compatibility.
  */
 public class Zone extends BaseModel {
+
   private static final Logger log = LogManager.getLogger(Zone.class);
 
   /** The vision type (OFF, DAY, NIGHT). */
@@ -372,7 +374,9 @@ public class Zone extends BaseModel {
     exposedAreaMeta = new HashMap<GUID, ExposedAreaMetaData>(zone.exposedAreaMeta.size() * 4 / 3);
 
     // Copy the tokens, save a map between old and new for the initiative list.
-    if (zone.initiativeList == null) zone.initiativeList = new InitiativeList(zone);
+    if (zone.initiativeList == null) {
+      zone.initiativeList = new InitiativeList(zone);
+    }
     Object[][] saveInitiative = new Object[zone.initiativeList.getSize()][2];
     initiativeList.setZone(null);
 
@@ -385,7 +389,9 @@ public class Zone extends BaseModel {
           token.setExposedAreaGUID(guid);
           // Update the TEA on the new map, since we have the Token object available...
           ExposedAreaMetaData eamd = zone.getExposedAreaMetaData(old.getExposedAreaGUID());
-          if (eamd != null) exposeArea(eamd.getExposedAreaHistory(), token);
+          if (eamd != null) {
+            exposeArea(eamd.getExposedAreaHistory(), token);
+          }
         }
         putToken(token);
         List<Integer> list = zone.initiativeList.indexOf(old);
@@ -587,7 +593,9 @@ public class Zone extends BaseModel {
       if (toks != null && !toks.isEmpty()) {
         for (Token tok : toks) {
           ExposedAreaMetaData meta = exposedAreaMeta.get(tok.getExposedAreaGUID());
-          if (meta != null) combined.add(meta.getExposedAreaHistory());
+          if (meta != null) {
+            combined.add(meta.getExposedAreaHistory());
+          }
         }
       }
       return combined.contains(point.x, point.y);
@@ -807,9 +815,11 @@ public class Zone extends BaseModel {
         meta.addToExposedAreaHistory(area);
         ZoneRenderer zr = MapTool.getFrame().getZoneRenderer(this.getId());
         if (zr != null) // Could be null if the AutoSaveManager is saving the campaign by copying
-          // Zones, but not
-          // ZoneRenderers
+        // Zones, but not
+        // ZoneRenderers
+        {
           zr.getZoneView().flush();
+        }
         putToken(tok);
         fireModelChangeEvent(new ModelChangeEvent(this, Event.FOG_CHANGED));
         return; // FJE Added so that TEA isn't added to the GEA, below.
@@ -851,7 +861,9 @@ public class Zone extends BaseModel {
 
       for (GUID guid : selectedToks) {
         Token tok = getToken(guid);
-        if (tok == null) continue;
+        if (tok == null) {
+          continue;
+        }
         if ((isAllowed || tok.isOwner(playerId)) && tok.getHasSight()) {
           GUID tea = tok.getExposedAreaGUID();
           meta = exposedAreaMeta.get(tea);
@@ -864,7 +876,9 @@ public class Zone extends BaseModel {
       }
       // If 'meta' is not null, it means at least one token's TEA was modified so we need to flush
       // the ZoneView
-      if (meta != null) zoneView.flush();
+      if (meta != null) {
+        zoneView.flush();
+      }
     } else {
       // Not using IF so add the EA to the GEA instead of a TEA.
       exposedArea.add(area);
@@ -894,7 +908,9 @@ public class Zone extends BaseModel {
           continue;
         }
         ExposedAreaMetaData meta = exposedAreaMeta.get(tok.getExposedAreaGUID());
-        if (meta == null) meta = new ExposedAreaMetaData();
+        if (meta == null) {
+          meta = new ExposedAreaMetaData();
+        }
         meta.clearExposedAreaHistory();
         meta.addToExposedAreaHistory(area);
         exposedAreaMeta.put(tok.getExposedAreaGUID(), meta);
@@ -931,7 +947,9 @@ public class Zone extends BaseModel {
           continue;
         }
         ExposedAreaMetaData meta = exposedAreaMeta.get(tok.getExposedAreaGUID());
-        if (meta == null) meta = new ExposedAreaMetaData();
+        if (meta == null) {
+          meta = new ExposedAreaMetaData();
+        }
         meta.removeExposedAreaHistory(area);
         exposedAreaMeta.put(tok.getExposedAreaGUID(), meta);
         MapTool.getFrame().getZoneRenderer(this.getId()).getZoneView().flush(tok);
@@ -977,7 +995,9 @@ public class Zone extends BaseModel {
       // continue;
       // }
       ExposedAreaMetaData meta = exposedAreaMeta.get(tok.getExposedAreaGUID());
-      if (meta != null) combined.add(meta.getExposedAreaHistory());
+      if (meta != null) {
+        combined.add(meta.getExposedAreaHistory());
+      }
     }
     return combined;
   }
@@ -1189,6 +1209,7 @@ public class Zone extends BaseModel {
   ///////////////////////////////////////////////////////////////////////////
   // tokens
   ///////////////////////////////////////////////////////////////////////////
+
   /**
    * Adds the specified Token to this zone, accounting for updating the ordered list of tokens as
    * well as firing the appropriate <code>ModelChangeEvent</code> (either <code>Event.TOKEN_ADDED
@@ -1215,8 +1236,7 @@ public class Zone extends BaseModel {
 
   /**
    * Same as {@link #putToken(Token)} but optimizes map updates by accepting a list of Tokens. Note
-   * that this method fires a single <code>ModelChangeEvent</code> using <code>
-   * Event.TOKEN_ADDED
+   * that this method fires a single <code>ModelChangeEvent</code> using <code> Event.TOKEN_ADDED
    * </code> and passes the list of added tokens as a parameter. Ditto for <code>Event.TOKEN_CHANGED
    * </code>.
    *
@@ -1244,10 +1264,12 @@ public class Zone extends BaseModel {
     tokenOrderedList.addAll(tokens);
     tokenOrderedList.sort(TOKEN_Z_ORDER_COMPARATOR);
 
-    if (!addedTokens.isEmpty())
+    if (!addedTokens.isEmpty()) {
       fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_ADDED, addedTokens));
-    if (!changedTokens.isEmpty())
+    }
+    if (!changedTokens.isEmpty()) {
       fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_CHANGED, changedTokens));
+    }
   }
 
   public void removeToken(GUID id) {
@@ -1287,7 +1309,9 @@ public class Zone extends BaseModel {
   public Token resolveToken(String identifier) {
     Token token = getTokenByName(identifier);
 
-    if (token == null) token = getTokenByGMName(identifier);
+    if (token == null) {
+      token = getTokenByGMName(identifier);
+    }
 
     if (token == null) {
       try {
@@ -1333,11 +1357,15 @@ public class Zone extends BaseModel {
 
   private DrawnElement findDrawnElement(List<DrawnElement> list, GUID id) {
     for (DrawnElement de : list) {
-      if (de.getDrawable().getId() == id) return de;
+      if (de.getDrawable().getId() == id) {
+        return de;
+      }
       if (de.getDrawable() instanceof DrawablesGroup) {
         DrawnElement result =
             findDrawnElement(((DrawablesGroup) de.getDrawable()).getDrawableList(), id);
-        if (result != null) return result;
+        if (result != null) {
+          return result;
+        }
       }
     }
     return null;
@@ -1413,8 +1441,11 @@ public class Zone extends BaseModel {
         new Filter() {
           @Override
           public boolean matchToken(Token t) {
-            if (getAlwaysVisible) return !t.isStamp();
-            else return !t.isStamp() && !t.isAlwaysVisible();
+            if (getAlwaysVisible) {
+              return !t.isStamp();
+            } else {
+              return !t.isStamp() && !t.isAlwaysVisible();
+            }
           }
         });
   }
@@ -1428,8 +1459,11 @@ public class Zone extends BaseModel {
         new Filter() {
           @Override
           public boolean matchToken(Token t) {
-            if (getAlwaysVisible) return t.isGMStamp();
-            else return t.isGMStamp() && !t.isAlwaysVisible();
+            if (getAlwaysVisible) {
+              return t.isGMStamp();
+            } else {
+              return t.isGMStamp() && !t.isAlwaysVisible();
+            }
           }
         });
   }
@@ -1443,8 +1477,11 @@ public class Zone extends BaseModel {
         new Filter() {
           @Override
           public boolean matchToken(Token t) {
-            if (getAlwaysVisible) return t.isObjectStamp();
-            else return t.isObjectStamp() && !t.isAlwaysVisible();
+            if (getAlwaysVisible) {
+              return t.isObjectStamp();
+            } else {
+              return t.isObjectStamp() && !t.isAlwaysVisible();
+            }
           }
         });
   }
@@ -1458,8 +1495,11 @@ public class Zone extends BaseModel {
         new Filter() {
           @Override
           public boolean matchToken(Token t) {
-            if (getAlwaysVisible) return t.isBackgroundStamp();
-            else return t.isBackgroundStamp() && !t.isAlwaysVisible();
+            if (getAlwaysVisible) {
+              return t.isBackgroundStamp();
+            } else {
+              return t.isBackgroundStamp() && !t.isAlwaysVisible();
+            }
           }
         });
   }
@@ -1509,7 +1549,7 @@ public class Zone extends BaseModel {
         new Filter() {
           @Override
           public boolean matchToken(Token t) {
-            return t.getTerrainModifier() != 1.0f;
+            return !t.getTerrainModifierOperation().equals(TerrainModifierOperation.NONE);
           }
         });
   }
@@ -1519,10 +1559,10 @@ public class Zone extends BaseModel {
    * New buttons were added to select what type of tokens, by ownership, should be shown and driven
    * by the TokenSelection enum.
    *
-   * @author updated by Jamz
-   * @since updated 1.4.1.0
    * @param p the player
    * @return the list of tokens
+   * @author updated by Jamz
+   * @since updated 1.4.1.0
    */
   public List<Token> getOwnedTokensWithSight(Player p) {
     return getTokensFiltered(
@@ -1533,7 +1573,9 @@ public class Zone extends BaseModel {
             // AppUtil.playerOwns(t));
             // return t.getType() == Token.Type.PC && t.getHasSight() && AppUtil.playerOwns(t);
 
-            if (tokenSelection == null) tokenSelection = TokenSelection.ALL;
+            if (tokenSelection == null) {
+              tokenSelection = TokenSelection.ALL;
+            }
             // System.out.println("TokenSelection: " + tokenSelection);
             switch (tokenSelection) {
               case ALL: // Show FoW for ANY Token I own
@@ -1645,6 +1687,7 @@ public class Zone extends BaseModel {
 
   /** Interface for matchToken. */
   public static interface Filter {
+
     public boolean matchToken(Token t);
   }
 
@@ -1653,6 +1696,7 @@ public class Zone extends BaseModel {
 
   /** The class used to compare the Zorder of two tokens. */
   public static class TokenZOrderComparator implements Comparator<Token> {
+
     @Override
     public int compare(Token o1, Token o2) {
       int lval = o1.getZOrder();
@@ -1686,9 +1730,15 @@ public class Zone extends BaseModel {
          */
         int v1 = getFigureZOrder(o1);
         int v2 = getFigureZOrder(o2);
-        if ((v1 - v2) != 0) return v1 - v2;
-        if (!o1.isToken() && o2.isToken()) return -1;
-        if (!o2.isToken() && o1.isToken()) return +1;
+        if ((v1 - v2) != 0) {
+          return v1 - v2;
+        }
+        if (!o1.isToken() && o2.isToken()) {
+          return -1;
+        }
+        if (!o2.isToken() && o1.isToken()) {
+          return +1;
+        }
         if (o1.getHeight() != o2.getHeight()) {
           // Larger tokens at the same position, go behind
           return o2.getHeight() - o1.getHeight();

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
@@ -24,7 +24,8 @@
     </at>
     <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
    </super>
-   <at name="id">D:\Development\git\JamzTheMan\MapTool\src\main\resources\net\rptools\maptool\client\ui\forms\tokenPropertiesDialog.xml</at>
+   <at name="id">C:\Users\Jamz\Development\git\JamzTheMan\MapTool\src\main\resources\net\rptools\maptool\client\ui\forms\tokenPropertiesDialog.xml</at>
+   <at name="path">resources\net\rptools\maptool\client\ui\forms\tokenPropertiesDialog.xml</at>
    <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
    <at name="colspecs">FILL:8DLU:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:8DLU:NONE</at>
    <at name="components">
@@ -168,7 +169,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.249615762</at>
+                     <at name="id">embedded.1082445014</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -221,7 +222,7 @@
                               <at name="scrollableTracksViewportHeight">true</at>
                               <at name="scrollableTracksViewportWidth">true</at>
                               <at name="name">@notes</at>
-                              <at name="width">1265</at>
+                              <at name="width">911</at>
                               <at name="wrapStyleWord">true</at>
                               <at name="scollBars">
                                <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
@@ -250,7 +251,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="height">352</at>
+                              <at name="height">205</at>
                              </object>
                             </at>
                            </object>
@@ -302,7 +303,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="width">1267</at>
+                              <at name="width">913</at>
                               <at name="name"/>
                               <at name="text">Notes</at>
                               <at name="fill">
@@ -335,7 +336,7 @@
                            </at>
                            <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                           </super>
-                          <at name="id">embedded.346556291</at>
+                          <at name="id">embedded.1411549683</at>
                           <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0)</at>
                           <at name="colspecs">FILL:DEFAULT:GROW(1.0)</at>
                           <at name="components">
@@ -384,7 +385,7 @@
                                      </at>
                                     </object>
                                    </at>
-                                   <at name="width">1262</at>
+                                   <at name="width">908</at>
                                    <at name="name"/>
                                    <at name="text">GM Notes</at>
                                    <at name="fill">
@@ -448,7 +449,7 @@
                                    <at name="scrollableTracksViewportHeight">true</at>
                                    <at name="scrollableTracksViewportWidth">true</at>
                                    <at name="name">@GMNotes</at>
-                                   <at name="width">1260</at>
+                                   <at name="width">906</at>
                                    <at name="wrapStyleWord">true</at>
                                    <at name="scollBars">
                                     <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
@@ -477,7 +478,7 @@
                                      </at>
                                     </object>
                                    </at>
-                                   <at name="height">352</at>
+                                   <at name="height">204</at>
                                   </object>
                                  </at>
                                 </object>
@@ -697,7 +698,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.826917676</at>
+                     <at name="id">embedded.1248512955</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -747,7 +748,7 @@
                                </object>
                               </at>
                               <at name="name">propertiesTable</at>
-                              <at name="width">1267</at>
+                              <at name="width">913</at>
                               <at name="text">propertiesTable</at>
                               <at name="fill">
                                <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
@@ -880,7 +881,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.661565767</at>
+                     <at name="id">embedded.469436388</at>
                      <at name="rowspecs">CENTER:5DLU:NONE,CENTER:DEFAULT:NONE,FILL:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:6DLU:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:6DLU:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,BOTTOM:DEFAULT:GROW(1.0),TOP:DEFAULT:NONE,CENTER:5DLU:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -1478,7 +1479,7 @@
                            </at>
                            <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                           </super>
-                          <at name="id">embedded.935772340</at>
+                          <at name="id">embedded.75412152</at>
                           <at name="rowspecs">FILL:DEFAULT:GROW(1.0)</at>
                           <at name="colspecs">FILL:DEFAULT:GROW(1.0)</at>
                           <at name="components">
@@ -1528,14 +1529,14 @@
                                     </object>
                                    </at>
                                    <at name="name">vblPreview</at>
-                                   <at name="width">1103</at>
+                                   <at name="width">749</at>
                                    <at name="text">VBL Preview</at>
                                    <at name="fill">
                                     <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                      <at name="name">fill</at>
                                     </object>
                                    </at>
-                                   <at name="height">759</at>
+                                   <at name="height">464</at>
                                   </object>
                                  </at>
                                 </object>
@@ -2093,7 +2094,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.944647398</at>
+                     <at name="id">embedded.923727352</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -2115,7 +2116,7 @@
                            </at>
                            <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                           </super>
-                          <at name="id">embedded.1480603197</at>
+                          <at name="id">embedded.1625401712</at>
                           <at name="rowspecs">CENTER:DEFAULT:NONE</at>
                           <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                           <at name="components">
@@ -2309,7 +2310,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.1897521988</at>
+                     <at name="id">embedded.1691340922</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -2359,7 +2360,7 @@
                                </object>
                               </at>
                               <at name="name">speechTable</at>
-                              <at name="width">1265</at>
+                              <at name="width">911</at>
                               <at name="scollBars">
                                <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
                                 <at name="name">scollBars</at>
@@ -2412,7 +2413,7 @@
                            </at>
                            <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                           </super>
-                          <at name="id">embedded.925888093</at>
+                          <at name="id">embedded.1742689551</at>
                           <at name="rowspecs">CENTER:DEFAULT:NONE</at>
                           <at name="colspecs">FILL:DEFAULT:NONE</at>
                           <at name="components">
@@ -2679,7 +2680,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.623007568</at>
+                     <at name="id">embedded.1558788581</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -2730,7 +2731,7 @@
                               </at>
                               <at name="actionCommand">All Players</at>
                               <at name="name">@ownedByAll</at>
-                              <at name="width">1267</at>
+                              <at name="width">913</at>
                               <at name="text">All Players</at>
                               <at name="height">16</at>
                              </object>
@@ -2785,14 +2786,14 @@
                                </object>
                               </at>
                               <at name="name">ownershipList</at>
-                              <at name="width">1267</at>
+                              <at name="width">913</at>
                               <at name="text">ownerShipLabel</at>
                               <at name="fill">
                                <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                 <at name="name">fill</at>
                                </object>
                               </at>
-                              <at name="height">755</at>
+                              <at name="height">460</at>
                              </object>
                             </at>
                            </object>
@@ -2924,7 +2925,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.1745084612</at>
+                     <at name="id">embedded.2105835867</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:GROW(1.0)</at>
                      <at name="components">
@@ -2946,9 +2947,9 @@
                            </at>
                            <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                           </super>
-                          <at name="id">embedded.1353468643</at>
-                          <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
-                          <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:60DLU:NONE,LEFT:5DLU:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:5DLU:NONE,FILL:MAX(16DLU;DEFAULT):NONE,FILL:DEFAULT:NONE</at>
+                          <at name="id">embedded.524762276</at>
+                          <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,TOP:PREF:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
+                          <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:60DLU:NONE,LEFT:5DLU:NONE,FILL:DEFAULT:NONE,FILL:5DLU:NONE,CENTER:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                           <at name="components">
                            <object classname="java.util.LinkedList">
                             <item >
@@ -3314,7 +3315,7 @@
                                <super classname="com.jeta.forms.store.memento.ComponentMemento">
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">16</at>
+                                  <at name="column">15</at>
                                   <at name="row">2</at>
                                   <at name="colspan">1</at>
                                   <at name="rowspan">1</at>
@@ -3368,7 +3369,7 @@
                                <super classname="com.jeta.forms.store.memento.ComponentMemento">
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">16</at>
+                                  <at name="column">15</at>
                                   <at name="row">4</at>
                                   <at name="colspan">1</at>
                                   <at name="rowspan">1</at>
@@ -3595,7 +3596,7 @@
                                <super classname="com.jeta.forms.store.memento.ComponentMemento">
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">16</at>
+                                  <at name="column">15</at>
                                   <at name="row">6</at>
                                   <at name="colspan">1</at>
                                   <at name="rowspan">1</at>
@@ -3636,6 +3637,396 @@
                                    <at name="name">@visibleOnlyToOwner</at>
                                    <at name="width">15</at>
                                    <at name="height">15</at>
+                                  </object>
+                                 </at>
+                                </object>
+                               </at>
+                              </object>
+                             </at>
+                            </item>
+                            <item >
+                             <at name="value">
+                              <object classname="com.jeta.forms.store.memento.BeanMemento">
+                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
+                                <at name="cellconstraints">
+                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                                  <at name="column">11</at>
+                                  <at name="row">6</at>
+                                  <at name="colspan">3</at>
+                                  <at name="rowspan">1</at>
+                                  <at name="halign">default</at>
+                                  <at name="valign">default</at>
+                                  <at name="insets" object="insets">0,0,0,0</at>
+                                 </object>
+                                </at>
+                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+                               </super>
+                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+                               <at name="beanproperties">
+                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+                                 <at name="properties">
+                                  <object classname="com.jeta.forms.store.support.PropertyMap">
+                                   <at name="border">
+                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                      <at name="name">border</at>
+                                     </super>
+                                     <at name="borders">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                           <at name="name">border</at>
+                                          </super>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="name">visibleOnlyToOwnerLabel</at>
+                                   <at name="width">169</at>
+                                   <at name="text">Visible to Owners Only:</at>
+                                   <at name="fill">
+                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                     <at name="name">fill</at>
+                                    </object>
+                                   </at>
+                                   <at name="height">14</at>
+                                  </object>
+                                 </at>
+                                </object>
+                               </at>
+                              </object>
+                             </at>
+                            </item>
+                            <item >
+                             <at name="value">
+                              <object classname="com.jeta.forms.store.memento.BeanMemento">
+                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
+                                <at name="cellconstraints">
+                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                                  <at name="column">11</at>
+                                  <at name="row">4</at>
+                                  <at name="colspan">3</at>
+                                  <at name="rowspan">1</at>
+                                  <at name="halign">default</at>
+                                  <at name="valign">default</at>
+                                  <at name="insets" object="insets">0,0,0,0</at>
+                                 </object>
+                                </at>
+                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+                               </super>
+                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+                               <at name="beanproperties">
+                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+                                 <at name="properties">
+                                  <object classname="com.jeta.forms.store.support.PropertyMap">
+                                   <at name="border">
+                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                      <at name="name">border</at>
+                                     </super>
+                                     <at name="borders">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                           <at name="name">border</at>
+                                          </super>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="name">visibleLabel</at>
+                                   <at name="width">169</at>
+                                   <at name="text">Visible to players:</at>
+                                   <at name="fill">
+                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                     <at name="name">fill</at>
+                                    </object>
+                                   </at>
+                                   <at name="height">14</at>
+                                  </object>
+                                 </at>
+                                </object>
+                               </at>
+                              </object>
+                             </at>
+                            </item>
+                            <item >
+                             <at name="value">
+                              <object classname="com.jeta.forms.store.memento.BeanMemento">
+                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
+                                <at name="cellconstraints">
+                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                                  <at name="column">11</at>
+                                  <at name="row">2</at>
+                                  <at name="colspan">3</at>
+                                  <at name="rowspan">1</at>
+                                  <at name="halign">default</at>
+                                  <at name="valign">default</at>
+                                  <at name="insets" object="insets">0,0,0,0</at>
+                                 </object>
+                                </at>
+                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+                               </super>
+                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+                               <at name="beanproperties">
+                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+                                 <at name="properties">
+                                  <object classname="com.jeta.forms.store.support.PropertyMap">
+                                   <at name="border">
+                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                      <at name="name">border</at>
+                                     </super>
+                                     <at name="borders">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                           <at name="name">border</at>
+                                          </super>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="width">169</at>
+                                   <at name="name"/>
+                                   <at name="text">Snap To Grid:</at>
+                                   <at name="fill">
+                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                     <at name="name">fill</at>
+                                    </object>
+                                   </at>
+                                   <at name="height">14</at>
+                                  </object>
+                                 </at>
+                                </object>
+                               </at>
+                              </object>
+                             </at>
+                            </item>
+                            <item >
+                             <at name="value">
+                              <object classname="com.jeta.forms.store.memento.BeanMemento">
+                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
+                                <at name="cellconstraints">
+                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                                  <at name="column">11</at>
+                                  <at name="row">8</at>
+                                  <at name="colspan">1</at>
+                                  <at name="rowspan">1</at>
+                                  <at name="halign">default</at>
+                                  <at name="valign">default</at>
+                                  <at name="insets" object="insets">0,0,0,0</at>
+                                 </object>
+                                </at>
+                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+                               </super>
+                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+                               <at name="beanproperties">
+                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+                                 <at name="properties">
+                                  <object classname="com.jeta.forms.store.support.PropertyMap">
+                                   <at name="border">
+                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                      <at name="name">border</at>
+                                     </super>
+                                     <at name="borders">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                           <at name="name">border</at>
+                                          </super>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="name">terrainModifierLabel</at>
+                                   <at name="width">86</at>
+                                   <at name="text">Terrain Modifier:</at>
+                                   <at name="fill">
+                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                                     <at name="name">fill</at>
+                                    </object>
+                                   </at>
+                                   <at name="toolTipText">Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 = 1).</at>
+                                   <at name="height">14</at>
+                                  </object>
+                                 </at>
+                                </object>
+                               </at>
+                              </object>
+                             </at>
+                            </item>
+                            <item >
+                             <at name="value">
+                              <object classname="com.jeta.forms.store.memento.BeanMemento">
+                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
+                                <at name="cellconstraints">
+                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                                  <at name="column">15</at>
+                                  <at name="row">8</at>
+                                  <at name="colspan">1</at>
+                                  <at name="rowspan">1</at>
+                                  <at name="halign">default</at>
+                                  <at name="valign">default</at>
+                                  <at name="insets" object="insets">0,0,0,0</at>
+                                 </object>
+                                </at>
+                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+                               </super>
+                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+                               <at name="beanclass">javax.swing.JTextField</at>
+                               <at name="beanproperties">
+                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+                                 <at name="classname">javax.swing.JTextField</at>
+                                 <at name="properties">
+                                  <object classname="com.jeta.forms.store.support.PropertyMap">
+                                   <at name="border">
+                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                      <at name="name">border</at>
+                                     </super>
+                                     <at name="borders">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                           <at name="name">border</at>
+                                          </super>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="columns">4</at>
+                                   <at name="name">terrainModifier</at>
+                                   <at name="width">39</at>
+                                   <at name="toolTipText">Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 = 1).</at>
+                                   <at name="height">20</at>
+                                  </object>
+                                 </at>
+                                </object>
+                               </at>
+                              </object>
+                             </at>
+                            </item>
+                            <item >
+                             <at name="value">
+                              <object classname="com.jeta.forms.store.memento.BeanMemento">
+                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
+                                <at name="cellconstraints">
+                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                                  <at name="column">13</at>
+                                  <at name="row">8</at>
+                                  <at name="colspan">1</at>
+                                  <at name="rowspan">1</at>
+                                  <at name="halign">default</at>
+                                  <at name="valign">default</at>
+                                  <at name="insets" object="insets">0,0,0,0</at>
+                                 </object>
+                                </at>
+                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+                               </super>
+                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+                               <at name="beanclass">javax.swing.JComboBox</at>
+                               <at name="beanproperties">
+                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+                                 <at name="classname">javax.swing.JComboBox</at>
+                                 <at name="properties">
+                                  <object classname="com.jeta.forms.store.support.PropertyMap">
+                                   <at name="border">
+                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                      <at name="name">border</at>
+                                     </super>
+                                     <at name="borders">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                           <at name="name">border</at>
+                                          </super>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="selectedItem">
+                                    <object classname="com.jeta.forms.store.properties.ListItemProperty">
+                                     <at name="name">listitem</at>
+                                     <at name="label">MULTIPLY</at>
+                                     <at name="icon">
+                                      <object classname="com.jeta.forms.store.properties.IconProperty">
+                                       <at name="embedded">false</at>
+                                       <at name="width">0</at>
+                                       <at name="height">0</at>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="name">terrainModifierOperation</at>
+                                   <at name="width">71</at>
+                                   <at name="items">
+                                    <object classname="com.jeta.forms.store.properties.ItemsProperty">
+                                     <at name="name">items</at>
+                                     <at name="items">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.ListItemProperty">
+                                          <at name="name">listitem</at>
+                                          <at name="label">MULTIPLY</at>
+                                          <at name="icon">
+                                           <object classname="com.jeta.forms.store.properties.IconProperty">
+                                            <at name="embedded">false</at>
+                                            <at name="width">0</at>
+                                            <at name="height">0</at>
+                                           </object>
+                                          </at>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="toolTipText">Set whether the cell cost should be added or multiplied. Use negative numbers to subtract and decimal values to divide costs.</at>
+                                   <at name="height">18</at>
+                                   <at name="itemCount">1</at>
                                   </object>
                                  </at>
                                 </object>
@@ -3823,186 +4214,6 @@
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                                   <at name="column">11</at>
-                                  <at name="row">6</at>
-                                  <at name="colspan">4</at>
-                                  <at name="rowspan">1</at>
-                                  <at name="halign">default</at>
-                                  <at name="valign">default</at>
-                                  <at name="insets" object="insets">0,0,0,0</at>
-                                 </object>
-                                </at>
-                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-                               </super>
-                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
-                               <at name="beanproperties">
-                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
-                                 <at name="properties">
-                                  <object classname="com.jeta.forms.store.support.PropertyMap">
-                                   <at name="border">
-                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                      <at name="name">border</at>
-                                     </super>
-                                     <at name="borders">
-                                      <object classname="java.util.LinkedList">
-                                       <item >
-                                        <at name="value">
-                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                           <at name="name">border</at>
-                                          </super>
-                                         </object>
-                                        </at>
-                                       </item>
-                                      </object>
-                                     </at>
-                                    </object>
-                                   </at>
-                                   <at name="name">visibleOnlyToOwnerLabel</at>
-                                   <at name="width">126</at>
-                                   <at name="text">Visible to Owners Only:</at>
-                                   <at name="fill">
-                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                     <at name="name">fill</at>
-                                    </object>
-                                   </at>
-                                   <at name="height">14</at>
-                                  </object>
-                                 </at>
-                                </object>
-                               </at>
-                              </object>
-                             </at>
-                            </item>
-                            <item >
-                             <at name="value">
-                              <object classname="com.jeta.forms.store.memento.BeanMemento">
-                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
-                                <at name="cellconstraints">
-                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">11</at>
-                                  <at name="row">4</at>
-                                  <at name="colspan">4</at>
-                                  <at name="rowspan">1</at>
-                                  <at name="halign">default</at>
-                                  <at name="valign">default</at>
-                                  <at name="insets" object="insets">0,0,0,0</at>
-                                 </object>
-                                </at>
-                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-                               </super>
-                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
-                               <at name="beanproperties">
-                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
-                                 <at name="properties">
-                                  <object classname="com.jeta.forms.store.support.PropertyMap">
-                                   <at name="border">
-                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                      <at name="name">border</at>
-                                     </super>
-                                     <at name="borders">
-                                      <object classname="java.util.LinkedList">
-                                       <item >
-                                        <at name="value">
-                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                           <at name="name">border</at>
-                                          </super>
-                                         </object>
-                                        </at>
-                                       </item>
-                                      </object>
-                                     </at>
-                                    </object>
-                                   </at>
-                                   <at name="name">visibleLabel</at>
-                                   <at name="width">126</at>
-                                   <at name="text">Visible to players:</at>
-                                   <at name="fill">
-                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                     <at name="name">fill</at>
-                                    </object>
-                                   </at>
-                                   <at name="height">14</at>
-                                  </object>
-                                 </at>
-                                </object>
-                               </at>
-                              </object>
-                             </at>
-                            </item>
-                            <item >
-                             <at name="value">
-                              <object classname="com.jeta.forms.store.memento.BeanMemento">
-                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
-                                <at name="cellconstraints">
-                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">11</at>
-                                  <at name="row">2</at>
-                                  <at name="colspan">4</at>
-                                  <at name="rowspan">1</at>
-                                  <at name="halign">default</at>
-                                  <at name="valign">default</at>
-                                  <at name="insets" object="insets">0,0,0,0</at>
-                                 </object>
-                                </at>
-                                <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-                               </super>
-                               <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-                               <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
-                               <at name="beanproperties">
-                                <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-                                 <at name="classname">com.jeta.forms.components.label.JETALabel</at>
-                                 <at name="properties">
-                                  <object classname="com.jeta.forms.store.support.PropertyMap">
-                                   <at name="border">
-                                    <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                                     <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                      <at name="name">border</at>
-                                     </super>
-                                     <at name="borders">
-                                      <object classname="java.util.LinkedList">
-                                       <item >
-                                        <at name="value">
-                                         <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                                          <super classname="com.jeta.forms.store.properties.BorderProperty">
-                                           <at name="name">border</at>
-                                          </super>
-                                         </object>
-                                        </at>
-                                       </item>
-                                      </object>
-                                     </at>
-                                    </object>
-                                   </at>
-                                   <at name="width">126</at>
-                                   <at name="name"/>
-                                   <at name="text">Snap To Grid:</at>
-                                   <at name="fill">
-                                    <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                                     <at name="name">fill</at>
-                                    </object>
-                                   </at>
-                                   <at name="height">14</at>
-                                  </object>
-                                 </at>
-                                </object>
-                               </at>
-                              </object>
-                             </at>
-                            </item>
-                            <item >
-                             <at name="value">
-                              <object classname="com.jeta.forms.store.memento.BeanMemento">
-                               <super classname="com.jeta.forms.store.memento.ComponentMemento">
-                                <at name="cellconstraints">
-                                 <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">11</at>
                                   <at name="row">10</at>
                                   <at name="colspan">1</at>
                                   <at name="rowspan">1</at>
@@ -4065,9 +4276,9 @@
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                                   <at name="column">13</at>
                                   <at name="row">10</at>
-                                  <at name="colspan">2</at>
+                                  <at name="colspan">1</at>
                                   <at name="rowspan">1</at>
-                                  <at name="halign">center</at>
+                                  <at name="halign">default</at>
                                   <at name="valign">default</at>
                                   <at name="insets" object="insets">0,0,0,0</at>
                                  </object>
@@ -4102,7 +4313,7 @@
                                     </object>
                                    </at>
                                    <at name="name">tokenOpacityValueLabel</at>
-                                   <at name="width">29</at>
+                                   <at name="width">71</at>
                                    <at name="text">100%</at>
                                    <at name="fill">
                                     <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
@@ -4123,10 +4334,10 @@
                                <super classname="com.jeta.forms.store.memento.ComponentMemento">
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                                  <at name="column">16</at>
+                                  <at name="column">15</at>
                                   <at name="row">10</at>
                                   <at name="colspan">1</at>
-                                  <at name="rowspan">4</at>
+                                  <at name="rowspan">5</at>
                                   <at name="halign">default</at>
                                   <at name="valign">default</at>
                                   <at name="insets" object="insets">0,0,0,0</at>
@@ -4171,7 +4382,7 @@
                                    <at name="minorTickSpacing">5</at>
                                    <at name="minimum">5</at>
                                    <at name="value">100</at>
-                                   <at name="height">68</at>
+                                   <at name="height">84</at>
                                   </object>
                                  </at>
                                 </object>
@@ -4186,11 +4397,11 @@
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                                   <at name="column">11</at>
-                                  <at name="row">8</at>
+                                  <at name="row">16</at>
                                   <at name="colspan">1</at>
                                   <at name="rowspan">1</at>
                                   <at name="halign">default</at>
-                                  <at name="valign">default</at>
+                                  <at name="valign">top</at>
                                   <at name="insets" object="insets">0,0,0,0</at>
                                  </object>
                                 </at>
@@ -4223,15 +4434,15 @@
                                      </at>
                                     </object>
                                    </at>
-                                   <at name="name">movementModifierLabel</at>
+                                   <at name="name">ignoreTerrainModifierLabel</at>
                                    <at name="width">86</at>
-                                   <at name="text">Terrain Modifier:</at>
+                                   <at name="text">Ignore Terrain:</at>
                                    <at name="fill">
                                     <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                      <at name="name">fill</at>
                                     </object>
                                    </at>
-                                   <at name="toolTipText">Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 = 1).</at>
+                                   <at name="toolTipText">Select any terrain modifier types you want this token to ignore.</at>
                                    <at name="height">14</at>
                                   </object>
                                  </at>
@@ -4247,8 +4458,8 @@
                                 <at name="cellconstraints">
                                  <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                                   <at name="column">13</at>
-                                  <at name="row">8</at>
-                                  <at name="colspan">4</at>
+                                  <at name="row">16</at>
+                                  <at name="colspan">3</at>
                                   <at name="rowspan">1</at>
                                   <at name="halign">default</at>
                                   <at name="valign">default</at>
@@ -4258,10 +4469,10 @@
                                 <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
                                </super>
                                <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-                               <at name="beanclass">javax.swing.JTextField</at>
+                               <at name="beanclass">javax.swing.JList</at>
                                <at name="beanproperties">
                                 <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-                                 <at name="classname">javax.swing.JTextField</at>
+                                 <at name="classname">javax.swing.JList</at>
                                  <at name="properties">
                                   <object classname="com.jeta.forms.store.support.PropertyMap">
                                    <at name="border">
@@ -4284,10 +4495,96 @@
                                      </at>
                                     </object>
                                    </at>
-                                   <at name="name">terrainModifier</at>
-                                   <at name="width">69</at>
-                                   <at name="toolTipText">Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 = 1).</at>
-                                   <at name="height">20</at>
+                                   <at name="visibleRowCount">0</at>
+                                   <at name="scrollableTracksViewportHeight">true</at>
+                                   <at name="scrollableTracksViewportWidth">true</at>
+                                   <at name="firstVisibleIndex">0</at>
+                                   <at name="name">terrainModifiersIgnored</at>
+                                   <at name="width">120</at>
+                                   <at name="lastVisibleIndex">2</at>
+                                   <at name="items">
+                                    <object classname="com.jeta.forms.store.properties.ItemsProperty">
+                                     <at name="name">items</at>
+                                     <at name="items">
+                                      <object classname="java.util.LinkedList">
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.ListItemProperty">
+                                          <at name="name">listitem</at>
+                                          <at name="label">NONE</at>
+                                          <at name="icon">
+                                           <object classname="com.jeta.forms.store.properties.IconProperty">
+                                            <at name="embedded">false</at>
+                                            <at name="width">0</at>
+                                            <at name="height">0</at>
+                                           </object>
+                                          </at>
+                                         </object>
+                                        </at>
+                                       </item>
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.ListItemProperty">
+                                          <at name="name">listitem</at>
+                                          <at name="label">ADD</at>
+                                          <at name="icon">
+                                           <object classname="com.jeta.forms.store.properties.IconProperty">
+                                            <at name="embedded">false</at>
+                                            <at name="width">0</at>
+                                            <at name="height">0</at>
+                                           </object>
+                                          </at>
+                                         </object>
+                                        </at>
+                                       </item>
+                                       <item >
+                                        <at name="value">
+                                         <object classname="com.jeta.forms.store.properties.ListItemProperty">
+                                          <at name="name">listitem</at>
+                                          <at name="label">MULTIPLY</at>
+                                          <at name="icon">
+                                           <object classname="com.jeta.forms.store.properties.IconProperty">
+                                            <at name="embedded">false</at>
+                                            <at name="width">0</at>
+                                            <at name="height">0</at>
+                                           </object>
+                                          </at>
+                                         </object>
+                                        </at>
+                                       </item>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="scollBars">
+                                    <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
+                                     <at name="name">scollBars</at>
+                                     <at name="verticalpolicy">20</at>
+                                     <at name="horizontalpolicy">30</at>
+                                     <at name="border">
+                                      <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                                       <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                        <at name="name">border</at>
+                                       </super>
+                                       <at name="borders">
+                                        <object classname="java.util.LinkedList">
+                                         <item >
+                                          <at name="value">
+                                           <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                                            <super classname="com.jeta.forms.store.properties.BorderProperty">
+                                             <at name="name">border</at>
+                                            </super>
+                                           </object>
+                                          </at>
+                                         </item>
+                                        </object>
+                                       </at>
+                                      </object>
+                                     </at>
+                                    </object>
+                                   </at>
+                                   <at name="toolTipText">Select any terrain modifier types this token should ignore.</at>
+                                   <at name="height">78</at>
                                   </object>
                                  </at>
                                 </object>
@@ -4352,45 +4649,57 @@
                           <at name="cellpainters">
                            <object classname="com.jeta.forms.store.support.Matrix">
                             <at name="rows">
-                             <object classname="[Ljava.lang.Object;" size="13">
+                             <object classname="[Ljava.lang.Object;" size="17">
                               <at name="item" index="0">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="1">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="2">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="3">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="4">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="5">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="6">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="7">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="8">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="9">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="10">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="11">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                               <at name="item" index="12">
-                               <object classname="[Ljava.lang.Object;" size="17"/>
+                               <object classname="[Ljava.lang.Object;" size="16"/>
+                              </at>
+                              <at name="item" index="13">
+                               <object classname="[Ljava.lang.Object;" size="16"/>
+                              </at>
+                              <at name="item" index="14">
+                               <object classname="[Ljava.lang.Object;" size="16"/>
+                              </at>
+                              <at name="item" index="15">
+                               <object classname="[Ljava.lang.Object;" size="16"/>
+                              </at>
+                              <at name="item" index="16">
+                               <object classname="[Ljava.lang.Object;" size="16"/>
                               </at>
                              </object>
                             </at>
@@ -4449,7 +4758,7 @@
                            </at>
                            <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                           </super>
-                          <at name="id">embedded.916728161</at>
+                          <at name="id">embedded.1616166872</at>
                           <at name="rowspecs">CENTER:DEFAULT:NONE</at>
                           <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                           <at name="components">
@@ -4471,7 +4780,7 @@
                                 </at>
                                 <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                </super>
-                               <at name="id">embedded.747272560</at>
+                               <at name="id">embedded.581388833</at>
                                <at name="rowspecs">CENTER:DEFAULT:NONE</at>
                                <at name="colspecs">FILL:DEFAULT:NONE</at>
                                <at name="components">
@@ -4656,7 +4965,7 @@
                                 </at>
                                 <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                </super>
-                               <at name="id">embedded.1982352072</at>
+                               <at name="id">embedded.1055635686</at>
                                <at name="rowspecs">CENTER:DEFAULT:NONE</at>
                                <at name="colspecs">FILL:DEFAULT:NONE</at>
                                <at name="components">
@@ -4841,7 +5150,7 @@
                                 </at>
                                 <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                </super>
-                               <at name="id">embedded.1129807522</at>
+                               <at name="id">embedded.243850797</at>
                                <at name="rowspecs">CENTER:DEFAULT:NONE</at>
                                <at name="colspecs">FILL:DEFAULT:NONE</at>
                                <at name="components">
@@ -5214,7 +5523,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.363925074</at>
+                     <at name="id">embedded.1989401629</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:3DLU:NONE,CENTER:DEFAULT:NONE,CENTER:3DLU:NONE,BOTTOM:DEFAULT:NONE,CENTER:5DLU:NONE,FILL:DEFAULT:GROW(1.0),CENTER:5DLU:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,LEFT:DEFAULT:NONE,FILL:5DLU:NONE,LEFT:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,CENTER:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -5358,7 +5667,7 @@
                                         </at>
                                         <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                        </super>
-                                       <at name="id">embedded.2042583876</at>
+                                       <at name="id">embedded.1407942221</at>
                                        <at name="rowspecs">CENTER:DEFAULT:GROW(1.0)</at>
                                        <at name="colspecs">FILL:DEFAULT:GROW(1.0)</at>
                                        <at name="components">
@@ -5411,7 +5720,7 @@
                                                 <at name="scrollableTracksViewportHeight">true</at>
                                                 <at name="scrollableTracksViewportWidth">true</at>
                                                 <at name="name">HTMLstatblockTextArea</at>
-                                                <at name="width">1230</at>
+                                                <at name="width">876</at>
                                                 <at name="scollBars">
                                                  <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
                                                   <at name="name">scollBars</at>
@@ -5439,7 +5748,7 @@
                                                   </at>
                                                  </object>
                                                 </at>
-                                                <at name="height">645</at>
+                                                <at name="height">350</at>
                                                </object>
                                               </at>
                                              </object>
@@ -5559,7 +5868,7 @@
                                         </at>
                                         <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                        </super>
-                                       <at name="id">embedded.587221962</at>
+                                       <at name="id">embedded.1798632782</at>
                                        <at name="rowspecs">FILL:DEFAULT:GROW(1.0),CENTER:3DLU:NONE,CENTER:DEFAULT:NONE,CENTER:3DLU:NONE</at>
                                        <at name="colspecs">FILL:5DLU:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:5DLU:NONE,FILL:DEFAULT:NONE,FILL:5DLU:NONE</at>
                                        <at name="components">
@@ -5669,7 +5978,7 @@
                                                  </object>
                                                 </at>
                                                 <at name="name">xmlStatblockSearchTextField</at>
-                                                <at name="width">1093</at>
+                                                <at name="width">739</at>
                                                 <at name="toolTipText">Enter raw text, a regular expression or an xPath expresstion to search the statblock for.</at>
                                                 <at name="height">20</at>
                                                </object>
@@ -5781,8 +6090,8 @@
                                                  </object>
                                                 </at>
                                                 <at name="name">xmlStatblockRTextScrollPane</at>
-                                                <at name="width">1220</at>
-                                                <at name="height">615</at>
+                                                <at name="width">866</at>
+                                                <at name="height">320</at>
                                                </object>
                                               </at>
                                              </object>
@@ -5911,7 +6220,7 @@
                                         </at>
                                         <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                        </super>
-                                       <at name="id">embedded.1449568333</at>
+                                       <at name="id">embedded.2111910794</at>
                                        <at name="rowspecs">FILL:DEFAULT:GROW(1.0),CENTER:3DLU:NONE,CENTER:DEFAULT:NONE,CENTER:3DLU:NONE</at>
                                        <at name="colspecs">FILL:5DLU:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:5DLU:NONE,FILL:DEFAULT:NONE,FILL:5DLU:NONE</at>
                                        <at name="components">
@@ -6078,7 +6387,7 @@
                                                  </object>
                                                 </at>
                                                 <at name="name">textStatblockSearchTextField</at>
-                                                <at name="width">1093</at>
+                                                <at name="width">739</at>
                                                 <at name="toolTipText">Enter raw text, a regular expression or an xPath expresstion to search the statblock for.</at>
                                                 <at name="height">20</at>
                                                </object>
@@ -6133,8 +6442,8 @@
                                                  </object>
                                                 </at>
                                                 <at name="name">textStatblockRTextScrollPane</at>
-                                                <at name="width">1220</at>
-                                                <at name="height">615</at>
+                                                <at name="width">866</at>
+                                                <at name="height">320</at>
                                                </object>
                                               </at>
                                              </object>
@@ -6263,7 +6572,7 @@
                                         </at>
                                         <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                                        </super>
-                                       <at name="id">embedded.585551172</at>
+                                       <at name="id">embedded.588356027</at>
                                        <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                                        <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                                        <at name="components">
@@ -6371,7 +6680,7 @@
                                                 <at name="scrollableTracksViewportHeight">true</at>
                                                 <at name="scrollableTracksViewportWidth">true</at>
                                                 <at name="name">heroLabImagesList</at>
-                                                <at name="width">1044</at>
+                                                <at name="width">690</at>
                                                 <at name="items">
                                                  <object classname="com.jeta.forms.store.properties.ItemsProperty">
                                                   <at name="name">items</at>
@@ -6404,7 +6713,7 @@
                                                   </at>
                                                  </object>
                                                 </at>
-                                                <at name="height">617</at>
+                                                <at name="height">322</at>
                                                </object>
                                               </at>
                                              </object>
@@ -6636,10 +6945,10 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="width">1267</at>
+                              <at name="width">913</at>
                               <at name="tabCount">4</at>
                               <at name="toolTipText">View the statblocks from Hero Lab</at>
-                              <at name="height">727</at>
+                              <at name="height">432</at>
                              </object>
                             </at>
                            </object>
@@ -6752,7 +7061,7 @@
                                </object>
                               </at>
                               <at name="name">summaryText</at>
-                              <at name="width">1120</at>
+                              <at name="width">766</at>
                               <at name="text">summaryText</at>
                               <at name="fill">
                                <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
@@ -7063,7 +7372,7 @@
                               <at name="name">refreshDataButton</at>
                               <at name="width">48</at>
                               <at name="toolTipText">&lt;html&gt;Refresh data from Hero Lab&lt;br/&gt;
-&lt;b&gt;&lt;i&gt;No changes detected.&lt;/i&gt;&lt;/b&gt;&lt;/html&gt;</at>
+                               &lt;b&gt;&lt;i&gt;No changes detected.&lt;/i&gt;&lt;/b&gt;&lt;/html&gt;</at>
                               <at name="height">42</at>
                              </object>
                             </at>
@@ -7089,7 +7398,7 @@
                            </at>
                           </object>
                          </at>
-                         <at name="name"></at>
+                         <at name="name"/>
                          <at name="fill">
                           <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                            <at name="name">fill</at>
@@ -7184,9 +7493,9 @@
               </at>
              </object>
             </at>
-            <at name="width">1330</at>
+            <at name="width">976</at>
             <at name="tabCount">8</at>
-            <at name="height">899</at>
+            <at name="height">604</at>
            </object>
           </at>
          </object>
@@ -7211,7 +7520,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.455705468</at>
+        <at name="id">embedded.1768415394</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:8DLU:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -7427,7 +7736,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.535243425</at>
+        <at name="id">embedded.1430032151</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">


### PR DESCRIPTION
 * NEW TerrainModifierOperation added to TerrainModifier, the following options are now available:
   * NONE - Default, no terrain modifications to pathfinding cost
   * MULTIPLY - All tokens with this type are added together and multiplied against the Cell cost
   * ADD - All tokens with this type are added together and added to the cell cost
   * BLOCK - Movement through tokens with this type are blocked just as if they had VBL
   * FREE - Any cell with a token of this type in it has ALL movement costs removed
 * The new default value is 0 with an Operation of NONE
 * ADD does NOT use Cell units. e.g. if your Map's distances per cell is 5, and you wanted to add 10 feet per cell, enter 10 for the terrain modifier.
 * NEW Ignore Terrain option
   * Can specify one or more of the above TerrainModifierOperation's. Those selected operations will not be applied for this token.

*Note*: Terrain Modifier Tokens still require the token to not be free-size, for best results use snap-to-grid tokens as calculations are on a cell by cell case.

*2nd Note*: The changes look at least twice as big as it really is. There is a lot of code cleanup along with spotless putting back the {}'s all over the place per Craig's google style request...

Fixes #459, Potentially closes #728 

Signed-off-by: JamzTheMan <JamzTheMan@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1068)
<!-- Reviewable:end -->
