### PR TITLE
Fix broken loggers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,14 +150,16 @@ repositories {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    // For Sentry bug reporting
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.13.0'	// Bridges v1 to v2 for other code in other libs
+    // Jamz: Do NOT update log4j libs without testing with uberjar build, 2.13.0 currently does not work
+    // See open issue: https://issues.apache.org/jira/browse/LOG4J2-673
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.12.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.12.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.12.1'	// Bridges v1 to v2 for other code in other libs
 
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
 
+    // For Sentry bug reporting
     implementation group: 'io.sentry', name: 'sentry', version: '1.7.29'
     implementation group: 'io.sentry', name: 'sentry-log4j2', version: '1.7.29'
 


### PR DESCRIPTION
Fixes issue #1127 

This could possibly be fixed using a shade + transformer plugin but for now, reverted libs back to 2.12.1 and added a warning for future devs.

Open issue should explain core issue here: https://issues.apache.org/jira/browse/LOG4J2-673

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1128)
<!-- Reviewable:end -->
