### PR TITLE
Fix execFunction failing for functions when defer = 1

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ExecFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExecFunction.java
@@ -202,12 +202,14 @@ public class ExecFunction extends AbstractFunction {
    * @param execArgs the arguments to the function
    */
   private static void runExecFunction(String functionName, List<Object> execArgs) {
+    MapToolVariableResolver resolver = new MapToolVariableResolver(null);
+    Parser parser = MapToolLineParser.createParser(resolver, false).getParser();
+    Function function = parser.getFunction(functionName);
+    MapTool.getParser().enterTrustedContext(functionName, "execFunction");
     try {
-      MapToolVariableResolver resolver = new MapToolVariableResolver(null);
-      Parser parser = MapToolLineParser.createParser(resolver, false).getParser();
-      Function function = parser.getFunction(functionName);
       function.evaluate(parser, functionName, execArgs);
     } catch (ParserException ignored) {
     }
+    MapTool.getParser().exitContext();
   }
 }


### PR DESCRIPTION
- Fix execFunction failing for functions requiring a trusted macro when defer is set to 1.
- Create a proper parser context for execFunction
- Close #1149

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1150)
<!-- Reviewable:end -->
