### PR TITLE
macOS mouse wheel issue

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client;
 
+import com.jidesoft.docking.DockableFrame;
 import java.awt.Dimension;
 import java.awt.Event;
 import java.awt.Graphics2D;
@@ -45,7 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -56,14 +56,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 import javax.swing.text.BadLocationException;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jdesktop.swingworker.SwingWorker;
-
-import com.jidesoft.docking.DockableFrame;
-
 import net.rptools.lib.FileUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.image.ImageUtil;
@@ -126,6 +118,10 @@ import net.rptools.maptool.util.PersistenceUtil.PersistedCampaign;
 import net.rptools.maptool.util.PersistenceUtil.PersistedMap;
 import net.rptools.maptool.util.SysInfo;
 import net.rptools.maptool.util.UPnPUtil;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdesktop.swingworker.SwingWorker;
 
 /**
  * This class acts as a container for a wide variety of {@link Action}s that are used throughout the
@@ -1418,7 +1414,8 @@ public class AppActions {
           // XXX Perhaps ask the user if the copied map should have its GEA and/or TEA cleared? An
           // imported map would ask...
           String zoneName =
-              JOptionPane.showInputDialog(MapTool.getFrame(), "New map name:", "Copy of " + zone.getName());
+              JOptionPane.showInputDialog(
+                  MapTool.getFrame(), "New map name:", "Copy of " + zone.getName());
           if (zoneName != null) {
             Zone zoneCopy = new Zone(zone);
             zoneCopy.setName(zoneName);
@@ -1886,7 +1883,7 @@ public class AppActions {
           };
           String title = I18N.getText("msg.title.messageDialogConfirm");
           int val =
-              JOptionPane.showOptionDialog(		// XXX Use MapTool.confirm()?
+              JOptionPane.showOptionDialog( // XXX Use MapTool.confirm()?
                   MapTool.getFrame(),
                   msg,
                   title,

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.client;
 
-import com.jidesoft.docking.DockableFrame;
 import java.awt.Dimension;
 import java.awt.Event;
 import java.awt.Graphics2D;
@@ -46,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -56,6 +56,14 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 import javax.swing.text.BadLocationException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdesktop.swingworker.SwingWorker;
+
+import com.jidesoft.docking.DockableFrame;
+
 import net.rptools.lib.FileUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.image.ImageUtil;
@@ -118,10 +126,6 @@ import net.rptools.maptool.util.PersistenceUtil.PersistedCampaign;
 import net.rptools.maptool.util.PersistenceUtil.PersistedMap;
 import net.rptools.maptool.util.SysInfo;
 import net.rptools.maptool.util.UPnPUtil;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jdesktop.swingworker.SwingWorker;
 
 /**
  * This class acts as a container for a wide variety of {@link Action}s that are used throughout the
@@ -1414,7 +1418,7 @@ public class AppActions {
           // XXX Perhaps ask the user if the copied map should have its GEA and/or TEA cleared? An
           // imported map would ask...
           String zoneName =
-              JOptionPane.showInputDialog("New map name:", "Copy of " + zone.getName());
+              JOptionPane.showInputDialog(MapTool.getFrame(), "New map name:", "Copy of " + zone.getName());
           if (zoneName != null) {
             Zone zoneCopy = new Zone(zone);
             zoneCopy.setName(zoneName);
@@ -1882,7 +1886,7 @@ public class AppActions {
           };
           String title = I18N.getText("msg.title.messageDialogConfirm");
           int val =
-              JOptionPane.showOptionDialog(
+              JOptionPane.showOptionDialog(		// XXX Use MapTool.confirm()?
                   MapTool.getFrame(),
                   msg,
                   title,

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -14,21 +14,35 @@
  */
 package net.rptools.maptool.client;
 
-import com.jayway.jsonpath.JsonPath;
-import java.io.*;
-import java.net.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Properties;
-import java.util.jar.*;
-import javax.swing.*;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import javax.swing.JCheckBox;
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import javax.swing.ProgressMonitor;
+import javax.swing.ProgressMonitorInputStream;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.jayway.jsonpath.JsonPath;
+
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class AppUpdate {
   private static final Logger log = LogManager.getLogger(AppUpdate.class);
@@ -197,7 +211,7 @@ public class AppUpdate {
     Object[] msgContent = {msg1, msg2, blankLine, dontAskCheckbox};
     Object[] options = {"Yes", "No", "Skip this Version"};
     int result =
-        JOptionPane.showOptionDialog(
+        JOptionPane.showOptionDialog(		// XXX Use MapTool.confirm() or similar?
             MapTool.getFrame(),
             msgContent,
             title,
@@ -233,7 +247,8 @@ public class AppUpdate {
 
     Runnable updatethread =
         new Runnable() {
-          public void run() {
+          @Override
+		public void run() {
             try (InputStream stream = assetDownloadURL.openStream()) {
               ProgressMonitorInputStream pmis =
                   new ProgressMonitorInputStream(MapTool.getFrame(), "Downloading...\n", stream);

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client;
 
+import com.jayway.jsonpath.JsonPath;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,7 +24,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -31,18 +31,14 @@ import javax.swing.ProgressMonitor;
 import javax.swing.ProgressMonitorInputStream;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import com.jayway.jsonpath.JsonPath;
-
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AppUpdate {
   private static final Logger log = LogManager.getLogger(AppUpdate.class);
@@ -211,7 +207,7 @@ public class AppUpdate {
     Object[] msgContent = {msg1, msg2, blankLine, dontAskCheckbox};
     Object[] options = {"Yes", "No", "Skip this Version"};
     int result =
-        JOptionPane.showOptionDialog(		// XXX Use MapTool.confirm() or similar?
+        JOptionPane.showOptionDialog( // XXX Use MapTool.confirm() or similar?
             MapTool.getFrame(),
             msgContent,
             title,
@@ -248,7 +244,7 @@ public class AppUpdate {
     Runnable updatethread =
         new Runnable() {
           @Override
-		public void run() {
+          public void run() {
             try (InputStream stream = assetDownloadURL.openStream()) {
               ProgressMonitorInputStream pmis =
                   new ProgressMonitorInputStream(MapTool.getFrame(), "Downloading...\n", stream);

--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -14,21 +14,15 @@
  */
 package net.rptools.maptool.client;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.swing.JOptionPane;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JOptionPane;
 import net.rptools.maptool.client.functions.CurrentInitiativeFunction;
 import net.rptools.maptool.client.functions.InitiativeRoundFunction;
 import net.rptools.maptool.client.functions.TokenBarFunction;
@@ -49,6 +43,8 @@ import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.MapVariableResolver;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableModifiers;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class MapToolVariableResolver extends MapVariableResolver {
 
@@ -258,9 +254,11 @@ public class MapToolVariableResolver extends MapVariableResolver {
         DialogTitle = I18N.getText("lineParser.dialogTitle", tokenInContext.getName());
       }
       result =
-          JOptionPane.showInputDialog(	// XXX Why not use method from client.MapTool?
+          JOptionPane.showInputDialog( // XXX Why not use method from client.MapTool?
               MapTool.getFrame(),
-              I18N.getText("lineParser.dialogValueFor") + " " + name, // XXX Why not a parameterized msg?
+              I18N.getText("lineParser.dialogValueFor")
+                  + " "
+                  + name, // XXX Why not a parameterized msg?
               DialogTitle,
               JOptionPane.QUESTION_MESSAGE,
               null,
@@ -464,7 +462,7 @@ public class MapToolVariableResolver extends MapVariableResolver {
     }
 
     @Override
-	public void run() {
+    public void run() {
       MapTool.serverCommand().putToken(zoneId, token);
     }
 

--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -14,16 +14,32 @@
  */
 package net.rptools.maptool.client;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JOptionPane;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-import javax.swing.JOptionPane;
-import net.rptools.maptool.client.functions.*;
+
+import net.rptools.maptool.client.functions.CurrentInitiativeFunction;
+import net.rptools.maptool.client.functions.InitiativeRoundFunction;
+import net.rptools.maptool.client.functions.TokenBarFunction;
+import net.rptools.maptool.client.functions.TokenGMNameFunction;
+import net.rptools.maptool.client.functions.TokenHaloFunction;
+import net.rptools.maptool.client.functions.TokenInitFunction;
+import net.rptools.maptool.client.functions.TokenInitHoldFunction;
+import net.rptools.maptool.client.functions.TokenLabelFunction;
+import net.rptools.maptool.client.functions.TokenNameFunction;
+import net.rptools.maptool.client.functions.TokenStateFunction;
+import net.rptools.maptool.client.functions.TokenVisibleFunction;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
@@ -33,8 +49,6 @@ import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.MapVariableResolver;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableModifiers;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class MapToolVariableResolver extends MapVariableResolver {
 
@@ -244,9 +258,9 @@ public class MapToolVariableResolver extends MapVariableResolver {
         DialogTitle = I18N.getText("lineParser.dialogTitle", tokenInContext.getName());
       }
       result =
-          JOptionPane.showInputDialog(
+          JOptionPane.showInputDialog(	// XXX Why not use method from client.MapTool?
               MapTool.getFrame(),
-              I18N.getText("lineParser.dialogValueFor") + " " + name,
+              I18N.getText("lineParser.dialogValueFor") + " " + name, // XXX Why not a parameterized msg?
               DialogTitle,
               JOptionPane.QUESTION_MESSAGE,
               null,
@@ -449,7 +463,8 @@ public class MapToolVariableResolver extends MapVariableResolver {
       this.token = token;
     }
 
-    public void run() {
+    @Override
+	public void run() {
       MapTool.serverCommand().putToken(zoneId, token);
     }
 

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -14,16 +14,24 @@
  */
 package net.rptools.maptool.client.swing;
 
-import com.jidesoft.dialog.JideOptionPane;
-import io.sentry.Sentry;
-import io.sentry.event.UserBuilder;
 import java.awt.AWTEvent;
 import java.awt.EventQueue;
+import java.awt.event.MouseWheelEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Collections;
+
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.jidesoft.dialog.JideOptionPane;
+
+import io.sentry.Sentry;
+import io.sentry.event.UserBuilder;
+import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.functions.getInfoFunction;
@@ -31,8 +39,6 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Player;
 import net.rptools.maptool.util.SysInfo;
 import net.rptools.parser.ParserException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class MapToolEventQueue extends EventQueue {
   private static final Logger log = LogManager.getLogger(MapToolEventQueue.class);
@@ -45,7 +51,14 @@ public class MapToolEventQueue extends EventQueue {
   @Override
   protected void dispatchEvent(AWTEvent event) {
     try {
-      super.dispatchEvent(event);
+      if (event instanceof MouseWheelEvent
+          && AppUtil.MAC_OS_X
+          && ((MouseWheelEvent) event).isShiftDown()) {
+        // System.out.println("Ignoring: " + event.paramString());
+        // ignore this event
+      } else {
+        super.dispatchEvent(event);
+      }
     } catch (StackOverflowError soe) {
       log.error(soe, soe);
       optionPane.setTitle(I18N.getString("MapToolEventQueue.stackOverflow.title")); // $NON-NLS-1$

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -22,9 +22,7 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.AffineTransform;
 import java.util.Set;
-
 import javax.swing.SwingUtilities;
-
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.AppUtil;
@@ -88,7 +86,7 @@ public abstract class DefaultTool extends Tool
   ////
   // Mouse
   @Override
-public void mousePressed(MouseEvent e) {
+  public void mousePressed(MouseEvent e) {
     // Potential map dragging
     if (SwingUtilities.isRightMouseButton(e)) {
       dragStartX = e.getX();
@@ -97,7 +95,7 @@ public void mousePressed(MouseEvent e) {
   }
 
   @Override
-public void mouseReleased(MouseEvent e) {
+  public void mouseReleased(MouseEvent e) {
     if (isDraggingMap && isRightMouseButton(e)) {
       renderer.maybeForcePlayersView();
     }
@@ -111,7 +109,7 @@ public void mouseReleased(MouseEvent e) {
    * @see java.awt.event.MouseListener#mouseClicked(java.awt.event.MouseEvent)
    */
   @Override
-public void mouseClicked(MouseEvent e) {}
+  public void mouseClicked(MouseEvent e) {}
 
   /*
    * (non-Javadoc)
@@ -119,7 +117,7 @@ public void mouseClicked(MouseEvent e) {}
    * @see java.awt.event.MouseListener#mouseEntered(java.awt.event.MouseEvent)
    */
   @Override
-public void mouseEntered(MouseEvent e) {}
+  public void mouseEntered(MouseEvent e) {}
 
   /*
    * (non-Javadoc)
@@ -127,7 +125,7 @@ public void mouseEntered(MouseEvent e) {}
    * @see java.awt.event.MouseListener#mouseExited(java.awt.event.MouseEvent)
    */
   @Override
-public void mouseExited(MouseEvent e) {}
+  public void mouseExited(MouseEvent e) {}
 
   ////
   // MouseMotion
@@ -137,7 +135,7 @@ public void mouseExited(MouseEvent e) {}
    * @see java.awt.event.MouseMotionListener#mouseMoved(java.awt.event.MouseEvent)
    */
   @Override
-public void mouseMoved(MouseEvent e) {
+  public void mouseMoved(MouseEvent e) {
     if (renderer == null) {
       return;
     }
@@ -154,7 +152,7 @@ public void mouseMoved(MouseEvent e) {
   }
 
   @Override
-public void mouseDragged(MouseEvent e) {
+  public void mouseDragged(MouseEvent e) {
     int mX = e.getX();
     int mY = e.getY();
     CellPoint cellUnderMouse = renderer.getCellAt(new ScreenPoint(mX, mY));
@@ -191,11 +189,9 @@ public void mouseDragged(MouseEvent e) {
 
   ////
   // Mouse Wheel
-  /**
-   * 
-   */
-@Override
-public void mouseWheelMoved(MouseWheelEvent e) {
+  /** */
+  @Override
+  public void mouseWheelMoved(MouseWheelEvent e) {
     // Fix for High Resolution Mouse Wheels
     if (e.getWheelRotation() == 0) {
       return;
@@ -286,7 +282,7 @@ public void mouseWheelMoved(MouseWheelEvent e) {
     // ZOOM
     if (!AppState.isZoomLocked()) {
       boolean direction = e.getWheelRotation() < 0;
-      direction = isKeyDown('z') ? direction : !direction;	// XXX Why check for this?
+      direction = isKeyDown('z') ? direction : !direction; // XXX Why check for this?
       if (direction) {
         renderer.zoomOut(e.getX(), e.getY());
       } else {

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -48,6 +49,7 @@ import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
+
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppActions;
@@ -124,7 +126,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
               Zone.Layer.TOKEN, Zone.Layer.GM, Zone.Layer.OBJECT, Zone.Layer.BACKGROUND
             },
             new LayerSelectionListener() {
-              public void layerSelected(Layer layer) {
+              @Override
+			public void layerSelected(Layer layer) {
                 if (renderer != null) {
                   renderer.setActiveLayer(layer);
                   MapTool.getFrame().setLastSelectedLayer(layer);
@@ -863,7 +866,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_R, AppActions.menuShortcut),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             if (renderer.getSelectedTokenSet().isEmpty()) {
               return;
             }
@@ -880,7 +884,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_D, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             if (!isDraggingToken) {
               return;
             }
@@ -891,7 +896,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD5, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             if (!isDraggingToken) {
               return;
             }
@@ -904,56 +910,64 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, -1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, -1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 1, false);
           }
         });
@@ -961,126 +975,144 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, -1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, -1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_T, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             cycleSelectedToken(1);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.SHIFT_DOWN_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             cycleSelectedToken(-1);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, false);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, true);
           }
         });
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.SHIFT_MASK),
         new AbstractAction() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, true);
           }
         });
@@ -1174,7 +1206,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
    *
    * @see net.rptools.maptool.client.ZoneOverlay#paintOverlay(net.rptools.maptool .client.ZoneRenderer, java.awt.Graphics2D)
    */
-  public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
+  @Override
+public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
     if (selectionBoundBox != null) {
       if (renderer.isAutoResizeStamp()) {
         Stroke stroke = g.getStroke();
@@ -1324,8 +1357,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
   public void resizeStamp() {
     if (tokenUnderMouse == null) {
       // Cancel action, didn't start/end the selection over the stamp
-      JOptionPane.showMessageDialog(
-          null,
+      JOptionPane.showMessageDialog(	// XXX Why isn't client.MapTool.showError() being used?
+    	  MapTool.getFrame(),
           I18N.getText("dialog.stampTool.error.noSelection"),
           I18N.getText("msg.title.messageDialogError"),
           JOptionPane.ERROR_MESSAGE);
@@ -1333,8 +1366,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     }
     if (selectionBoundBox.width <= 1 || selectionBoundBox.height <= 1) {
       // Cancel action, didn't select enough pixels
-      JOptionPane.showMessageDialog(
-          null,
+      JOptionPane.showMessageDialog(	// XXX Why isn't client.MapTool.showError() being used?
+    	  MapTool.getFrame(),
           I18N.getText("dialog.stampTool.error.badSelection"),
           I18N.getText("msg.title.messageDialogError"),
           JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -49,7 +48,6 @@ import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppActions;
@@ -127,7 +125,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
             },
             new LayerSelectionListener() {
               @Override
-			public void layerSelected(Layer layer) {
+              public void layerSelected(Layer layer) {
                 if (renderer != null) {
                   renderer.setActiveLayer(layer);
                   MapTool.getFrame().setLastSelectedLayer(layer);
@@ -867,7 +865,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_R, AppActions.menuShortcut),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             if (renderer.getSelectedTokenSet().isEmpty()) {
               return;
             }
@@ -885,7 +883,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_D, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             if (!isDraggingToken) {
               return;
             }
@@ -897,7 +895,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD5, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             if (!isDraggingToken) {
               return;
             }
@@ -911,7 +909,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, false);
           }
         });
@@ -919,7 +917,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, false);
           }
         });
@@ -927,7 +925,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, false);
           }
         });
@@ -935,7 +933,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, false);
           }
         });
@@ -943,7 +941,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, -1, false);
           }
         });
@@ -951,7 +949,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, -1, false);
           }
         });
@@ -959,7 +957,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 1, false);
           }
         });
@@ -967,7 +965,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 1, false);
           }
         });
@@ -976,7 +974,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, true);
           }
         });
@@ -984,7 +982,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, true);
           }
         });
@@ -992,7 +990,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, true);
           }
         });
@@ -1000,7 +998,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, true);
           }
         });
@@ -1008,7 +1006,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, -1, true);
           }
         });
@@ -1016,7 +1014,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, -1, true);
           }
         });
@@ -1024,7 +1022,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 1, true);
           }
         });
@@ -1032,7 +1030,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 1, true);
           }
         });
@@ -1040,7 +1038,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_T, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             cycleSelectedToken(1);
           }
         });
@@ -1048,7 +1046,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.SHIFT_DOWN_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             cycleSelectedToken(-1);
           }
         });
@@ -1056,7 +1054,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, false);
           }
         });
@@ -1064,7 +1062,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, false);
           }
         });
@@ -1072,7 +1070,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, false);
           }
         });
@@ -1080,7 +1078,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, false);
           }
         });
@@ -1088,7 +1086,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, true);
           }
         });
@@ -1096,7 +1094,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, true);
           }
         });
@@ -1104,7 +1102,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, true);
           }
         });
@@ -1112,7 +1110,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.SHIFT_MASK),
         new AbstractAction() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, true);
           }
         });
@@ -1207,7 +1205,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
    * @see net.rptools.maptool.client.ZoneOverlay#paintOverlay(net.rptools.maptool .client.ZoneRenderer, java.awt.Graphics2D)
    */
   @Override
-public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
+  public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
     if (selectionBoundBox != null) {
       if (renderer.isAutoResizeStamp()) {
         Stroke stroke = g.getStroke();
@@ -1357,8 +1355,8 @@ public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
   public void resizeStamp() {
     if (tokenUnderMouse == null) {
       // Cancel action, didn't start/end the selection over the stamp
-      JOptionPane.showMessageDialog(	// XXX Why isn't client.MapTool.showError() being used?
-    	  MapTool.getFrame(),
+      JOptionPane.showMessageDialog( // XXX Why isn't client.MapTool.showError() being used?
+          MapTool.getFrame(),
           I18N.getText("dialog.stampTool.error.noSelection"),
           I18N.getText("msg.title.messageDialogError"),
           JOptionPane.ERROR_MESSAGE);
@@ -1366,8 +1364,8 @@ public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
     }
     if (selectionBoundBox.width <= 1 || selectionBoundBox.height <= 1) {
       // Cancel action, didn't select enough pixels
-      JOptionPane.showMessageDialog(	// XXX Why isn't client.MapTool.showError() being used?
-    	  MapTool.getFrame(),
+      JOptionPane.showMessageDialog( // XXX Why isn't client.MapTool.showError() being used?
+          MapTool.getFrame(),
           I18N.getText("dialog.stampTool.error.badSelection"),
           I18N.getText("msg.title.messageDialogError"),
           JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
@@ -14,8 +14,6 @@
  */
 package net.rptools.maptool.client.ui;
 
-import com.jeta.forms.components.panel.FormPanel;
-import com.jeta.forms.gui.form.GridView;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
@@ -26,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashSet;
+
 import javax.swing.Action;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
@@ -45,19 +44,7 @@ import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
-import net.rptools.lib.swing.SwingUtil;
-import net.rptools.lib.swing.preference.WindowPreferences;
-import net.rptools.maptool.client.AppActions;
-import net.rptools.maptool.client.AppConstants;
-import net.rptools.maptool.client.AppPreferences;
-import net.rptools.maptool.client.AppUtil;
-import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.MapToolUtil;
-import net.rptools.maptool.client.ui.macrobuttons.buttons.MacroButton;
-import net.rptools.maptool.client.ui.syntax.MapToolScriptAutoComplete;
-import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.MacroButtonProperties;
-import net.rptools.maptool.model.Token;
+
 import org.fife.rsta.ui.CollapsibleSectionPanel;
 import org.fife.rsta.ui.GoToDialog;
 import org.fife.rsta.ui.search.FindDialog;
@@ -80,6 +67,23 @@ import org.fife.ui.rtextarea.RTextScrollPane;
 import org.fife.ui.rtextarea.SearchContext;
 import org.fife.ui.rtextarea.SearchEngine;
 import org.fife.ui.rtextarea.SearchResult;
+
+import com.jeta.forms.components.panel.FormPanel;
+import com.jeta.forms.gui.form.GridView;
+
+import net.rptools.lib.swing.SwingUtil;
+import net.rptools.lib.swing.preference.WindowPreferences;
+import net.rptools.maptool.client.AppActions;
+import net.rptools.maptool.client.AppConstants;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppUtil;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolUtil;
+import net.rptools.maptool.client.ui.macrobuttons.buttons.MacroButton;
+import net.rptools.maptool.client.ui.syntax.MapToolScriptAutoComplete;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.MacroButtonProperties;
+import net.rptools.maptool.model.Token;
 
 public class MacroButtonDialog extends JDialog implements SearchListener {
 
@@ -179,7 +183,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
         break;
       case REPLACE_ALL:
         result = SearchEngine.replaceAll(macroEditorRSyntaxTextArea, context);
-        JOptionPane.showMessageDialog(null, result.getCount() + " occurrences replaced.");
+        JOptionPane.showMessageDialog(MapTool.getFrame(), result.getCount() + " occurrences replaced."); // XXX Use MapTool.showMessage()?
         break;
     }
 
@@ -244,7 +248,8 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("runButton");
     button.addActionListener(
         new ActionListener() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             save(false);
 
             if (properties.getApplyToTokens() || properties.getCommonMacro()) {
@@ -263,7 +268,8 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("applyButton");
     button.addActionListener(
         new ActionListener() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             save(false);
           }
         });
@@ -273,7 +279,8 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("okButton");
     button.addActionListener(
         new ActionListener() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             save(true);
           }
         });
@@ -285,7 +292,8 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("cancelButton");
     button.addActionListener(
         new ActionListener() {
-          public void actionPerformed(ActionEvent e) {
+          @Override
+		public void actionPerformed(ActionEvent e) {
             cancel();
           }
         });
@@ -439,15 +447,18 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
         .getDocument()
         .addDocumentListener(
             new DocumentListener() {
-              public void changedUpdate(DocumentEvent e) {
+              @Override
+			public void changedUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
 
-              public void removeUpdate(DocumentEvent e) {
+              @Override
+			public void removeUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
 
-              public void insertUpdate(DocumentEvent e) {
+              @Override
+			public void insertUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
             });

--- a/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
@@ -14,6 +14,8 @@
  */
 package net.rptools.maptool.client.ui;
 
+import com.jeta.forms.components.panel.FormPanel;
+import com.jeta.forms.gui.form.GridView;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
@@ -24,7 +26,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashSet;
-
 import javax.swing.Action;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
@@ -44,7 +45,19 @@ import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
-
+import net.rptools.lib.swing.SwingUtil;
+import net.rptools.lib.swing.preference.WindowPreferences;
+import net.rptools.maptool.client.AppActions;
+import net.rptools.maptool.client.AppConstants;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppUtil;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolUtil;
+import net.rptools.maptool.client.ui.macrobuttons.buttons.MacroButton;
+import net.rptools.maptool.client.ui.syntax.MapToolScriptAutoComplete;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.MacroButtonProperties;
+import net.rptools.maptool.model.Token;
 import org.fife.rsta.ui.CollapsibleSectionPanel;
 import org.fife.rsta.ui.GoToDialog;
 import org.fife.rsta.ui.search.FindDialog;
@@ -67,23 +80,6 @@ import org.fife.ui.rtextarea.RTextScrollPane;
 import org.fife.ui.rtextarea.SearchContext;
 import org.fife.ui.rtextarea.SearchEngine;
 import org.fife.ui.rtextarea.SearchResult;
-
-import com.jeta.forms.components.panel.FormPanel;
-import com.jeta.forms.gui.form.GridView;
-
-import net.rptools.lib.swing.SwingUtil;
-import net.rptools.lib.swing.preference.WindowPreferences;
-import net.rptools.maptool.client.AppActions;
-import net.rptools.maptool.client.AppConstants;
-import net.rptools.maptool.client.AppPreferences;
-import net.rptools.maptool.client.AppUtil;
-import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.MapToolUtil;
-import net.rptools.maptool.client.ui.macrobuttons.buttons.MacroButton;
-import net.rptools.maptool.client.ui.syntax.MapToolScriptAutoComplete;
-import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.MacroButtonProperties;
-import net.rptools.maptool.model.Token;
 
 public class MacroButtonDialog extends JDialog implements SearchListener {
 
@@ -183,7 +179,9 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
         break;
       case REPLACE_ALL:
         result = SearchEngine.replaceAll(macroEditorRSyntaxTextArea, context);
-        JOptionPane.showMessageDialog(MapTool.getFrame(), result.getCount() + " occurrences replaced."); // XXX Use MapTool.showMessage()?
+        JOptionPane.showMessageDialog(
+            MapTool.getFrame(),
+            result.getCount() + " occurrences replaced."); // XXX Use MapTool.showMessage()?
         break;
     }
 
@@ -249,7 +247,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     button.addActionListener(
         new ActionListener() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             save(false);
 
             if (properties.getApplyToTokens() || properties.getCommonMacro()) {
@@ -269,7 +267,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     button.addActionListener(
         new ActionListener() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             save(false);
           }
         });
@@ -280,7 +278,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     button.addActionListener(
         new ActionListener() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             save(true);
           }
         });
@@ -293,7 +291,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     button.addActionListener(
         new ActionListener() {
           @Override
-		public void actionPerformed(ActionEvent e) {
+          public void actionPerformed(ActionEvent e) {
             cancel();
           }
         });
@@ -448,17 +446,17 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
         .addDocumentListener(
             new DocumentListener() {
               @Override
-			public void changedUpdate(DocumentEvent e) {
+              public void changedUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
 
               @Override
-			public void removeUpdate(DocumentEvent e) {
+              public void removeUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
 
               @Override
-			public void insertUpdate(DocumentEvent e) {
+              public void insertUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
             });

--- a/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
@@ -14,6 +14,8 @@
  */
 package net.rptools.maptool.client.ui;
 
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -27,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JCheckBox;
@@ -45,10 +46,6 @@ import javax.swing.KeyStroke;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
-
-import com.jgoodies.forms.layout.CellConstraints;
-import com.jgoodies.forms.layout.FormLayout;
-
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
@@ -232,7 +229,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       Token sourceToken = zone.getToken(tokID);
       ExposedAreaMetaData sourceMeta =
@@ -265,7 +262,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       ZoneRenderer renderer = getRenderer();
       Zone zone = renderer.getZone();
 
@@ -304,7 +301,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       Area area = zone.getExposedArea();
       for (GUID tok : selectedTokenSet) {
@@ -328,7 +325,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       if (MapTool.getServerPolicy().isUseIndividualFOW()) {
         Zone zone = getRenderer().getZone();
         for (GUID tok : selectedTokenSet) {
@@ -353,7 +350,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       FogUtil.exposeVisibleArea(getRenderer(), selectedTokenSet, true);
       getRenderer().repaint();
     }
@@ -367,7 +364,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       FogUtil.exposePCArea(getRenderer());
     }
   }
@@ -381,7 +378,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       FogUtil.exposeLastPath(getRenderer(), selectedTokenSet);
       getRenderer().repaint();
     }
@@ -578,7 +575,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	@SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
     public void actionPerformed(ActionEvent e) {
       for (GUID guid : tokenSet) {
         Token token = zone.getToken(guid);
@@ -637,7 +634,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = renderer.getZone();
       for (GUID guid : tokenSet) {
         Token token = zone.getToken(guid);
@@ -674,7 +671,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Color color = showColorChooserDialog();
       if (color != null) {
         Zone zone = renderer.getZone();
@@ -749,7 +746,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       String name = (String) getValue(NAME);
       JSlider slider = new JSlider(0, 100);
       JPanel labelPanel = new JPanel(new FormLayout("pref", "pref 2px:grow pref"));
@@ -761,7 +758,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       hide.addChangeListener(
           new ChangeListener() {
             @Override
-			public void stateChanged(ChangeEvent e) {
+            public void stateChanged(ChangeEvent e) {
               JSlider js = (JSlider) ((JCheckBox) e.getSource()).getClientProperty("JSlider");
               js.setEnabled(!((JCheckBox) e.getSource()).isSelected());
             }
@@ -788,7 +785,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       JPanel barPanel = new JPanel(new FormLayout("right:pref 2px pref", "pref"));
       barPanel.add(labelPanel, new CellConstraints(1, 1));
       barPanel.add(slider, new CellConstraints(3, 1));
-      if (JOptionPane.showOptionDialog(		// XXX Why not use MapTool.confirm()?
+      if (JOptionPane.showOptionDialog( // XXX Why not use MapTool.confirm()?
               MapTool.getFrame(),
               barPanel,
               "Set " + name + " Value",
@@ -845,7 +842,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
      * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
      */
     @Override
-	public void actionPerformed(ActionEvent aE) {
+    public void actionPerformed(ActionEvent aE) {
       ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
       for (GUID tokenGUID : selectedTokenSet) {
 
@@ -875,7 +872,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       InitiativeList init = MapTool.getFrame().getInitiativePanel().getList();
       String input = null;
@@ -914,7 +911,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     private static final long serialVersionUID = -2995489619896660807L;
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
 
       for (GUID tokenGUID : selectedTokenSet) {
@@ -932,7 +929,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     private static final long serialVersionUID = -6767778461889310579L;
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
 
       for (GUID tokenGUID : selectedTokenSet) {
@@ -953,7 +950,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       for (GUID tokenGUID : selectedTokenSet) {
         Token token = getRenderer().getZone().getToken(tokenGUID);
         if (token == null) {
@@ -985,7 +982,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       for (GUID tokenGUID : selectedTokenSet) {
         Token token = zone.getToken(tokenGUID);
@@ -1035,7 +1032,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       Set<Token> guidSet = new HashSet<Token>();
       for (GUID tokenID : selectedTokenSet) {
         guidSet.add(getRenderer().getZone().getToken(tokenID));
@@ -1054,7 +1051,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     }
 
     @Override
-	public void actionPerformed(ActionEvent e) {
+    public void actionPerformed(ActionEvent e) {
       String identity = getTokenUnderMouse().getName();
       String command = "/im " + identity + ":" + speech;
       JTextComponent commandArea = MapTool.getFrame().getCommandPanel().getCommandTextArea();

--- a/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
@@ -14,8 +14,6 @@
  */
 package net.rptools.maptool.client.ui;
 
-import com.jgoodies.forms.layout.CellConstraints;
-import com.jgoodies.forms.layout.FormLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -29,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JCheckBox;
@@ -46,6 +45,10 @@ import javax.swing.KeyStroke;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
+
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
+
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
@@ -228,7 +231,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction(tokensView, this, true);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       Token sourceToken = zone.getToken(tokID);
       ExposedAreaMetaData sourceMeta =
@@ -260,7 +264,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.fow.party", this, true);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       ZoneRenderer renderer = getRenderer();
       Zone zone = renderer.getZone();
 
@@ -298,7 +303,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.fow.global", this, true);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       Area area = zone.getExposedArea();
       for (GUID tok : selectedTokenSet) {
@@ -321,7 +327,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.fow.clearselected", this, true);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       if (MapTool.getServerPolicy().isUseIndividualFOW()) {
         Zone zone = getRenderer().getZone();
         for (GUID tok : selectedTokenSet) {
@@ -345,7 +352,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.expose.visible", this, true);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       FogUtil.exposeVisibleArea(getRenderer(), selectedTokenSet, true);
       getRenderer().repaint();
     }
@@ -358,7 +366,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.expose.currentonly", this, true);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       FogUtil.exposePCArea(getRenderer());
     }
   }
@@ -371,7 +380,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       setEnabled(getTokenUnderMouse().getLastPath() != null);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       FogUtil.exposeLastPath(getRenderer(), selectedTokenSet);
       getRenderer().repaint();
     }
@@ -567,7 +577,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       addActionListener(this);
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public void actionPerformed(ActionEvent e) {
       for (GUID guid : tokenSet) {
         Token token = zone.getToken(guid);
@@ -625,7 +636,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(Action.NAME, name);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = renderer.getZone();
       for (GUID guid : tokenSet) {
         Token token = zone.getToken(guid);
@@ -661,7 +673,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(Action.NAME, name);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Color color = showColorChooserDialog();
       if (color != null) {
         Zone zone = renderer.getZone();
@@ -735,7 +748,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(NAME, bar);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       String name = (String) getValue(NAME);
       JSlider slider = new JSlider(0, 100);
       JPanel labelPanel = new JPanel(new FormLayout("pref", "pref 2px:grow pref"));
@@ -746,7 +760,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       hide.putClientProperty("JSlider", slider);
       hide.addChangeListener(
           new ChangeListener() {
-            public void stateChanged(ChangeEvent e) {
+            @Override
+			public void stateChanged(ChangeEvent e) {
               JSlider js = (JSlider) ((JCheckBox) e.getSource()).getClientProperty("JSlider");
               js.setEnabled(!((JCheckBox) e.getSource()).isSelected());
             }
@@ -773,7 +788,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       JPanel barPanel = new JPanel(new FormLayout("right:pref 2px pref", "pref"));
       barPanel.add(labelPanel, new CellConstraints(1, 1));
       barPanel.add(slider, new CellConstraints(3, 1));
-      if (JOptionPane.showOptionDialog(
+      if (JOptionPane.showOptionDialog(		// XXX Why not use MapTool.confirm()?
               MapTool.getFrame(),
               barPanel,
               "Set " + name + " Value",
@@ -829,7 +844,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
      *
      * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
      */
-    public void actionPerformed(ActionEvent aE) {
+    @Override
+	public void actionPerformed(ActionEvent aE) {
       ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
       for (GUID tokenGUID : selectedTokenSet) {
 
@@ -858,7 +874,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction(aName, this);
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       InitiativeList init = MapTool.getFrame().getInitiativePanel().getList();
       String input = null;
@@ -896,7 +913,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
   private class AllOwnershipAction extends AbstractAction {
     private static final long serialVersionUID = -2995489619896660807L;
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
 
       for (GUID tokenGUID : selectedTokenSet) {
@@ -913,7 +931,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
   private class RemoveAllOwnershipAction extends AbstractAction {
     private static final long serialVersionUID = -6767778461889310579L;
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
 
       for (GUID tokenGUID : selectedTokenSet) {
@@ -933,7 +952,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(Action.NAME, "Show Path");
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       for (GUID tokenGUID : selectedTokenSet) {
         Token token = getRenderer().getZone().getToken(tokenGUID);
         if (token == null) {
@@ -964,7 +984,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       }
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       for (GUID tokenGUID : selectedTokenSet) {
         Token token = zone.getToken(tokenGUID);
@@ -1013,7 +1034,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       this.macro = macro;
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       Set<Token> guidSet = new HashSet<Token>();
       for (GUID tokenID : selectedTokenSet) {
         guidSet.add(getRenderer().getZone().getToken(tokenID));
@@ -1031,7 +1053,8 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       this.speech = speech;
     }
 
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       String identity = getTokenUnderMouse().getName();
       String command = "/im " + identity + ":" + speech;
       JTextComponent commandArea = MapTool.getFrame().getCommandPanel().getCommandTextArea();

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
@@ -28,9 +28,11 @@ import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
+
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.ui.Scale;
@@ -43,7 +45,7 @@ public class AdjustGridPanel extends JComponent
   private static enum Direction {
     Increase,
     Decrease
-  };
+  }
 
   public static final String PROPERTY_GRID_OFFSET_X = "gridOffsetX";
   public static final String PROPERTY_GRID_OFFSET_Y = "gridOffsetY";
@@ -83,7 +85,8 @@ public class AdjustGridPanel extends JComponent
         .put(
             "zoomOut",
             new AbstractAction() {
-              public void actionPerformed(ActionEvent e) {
+              @Override
+			public void actionPerformed(ActionEvent e) {
                 zoomOut();
               }
             });
@@ -93,7 +96,8 @@ public class AdjustGridPanel extends JComponent
         .put(
             "zoomIn",
             new AbstractAction() {
-              public void actionPerformed(ActionEvent e) {
+              @Override
+			public void actionPerformed(ActionEvent e) {
                 zoomIn();
               }
             });
@@ -104,7 +108,8 @@ public class AdjustGridPanel extends JComponent
         .put(
             "zoomReset",
             new AbstractAction() {
-              public void actionPerformed(ActionEvent e) {
+              @Override
+			public void actionPerformed(ActionEvent e) {
                 zoomReset();
               }
             });
@@ -299,13 +304,17 @@ public class AdjustGridPanel extends JComponent
 
   ////
   // MOUSE LISTENER
-  public void mouseClicked(MouseEvent e) {}
+  @Override
+public void mouseClicked(MouseEvent e) {}
 
-  public void mouseEntered(MouseEvent e) {}
+  @Override
+public void mouseEntered(MouseEvent e) {}
 
-  public void mouseExited(MouseEvent e) {}
+  @Override
+public void mouseExited(MouseEvent e) {}
 
-  public void mousePressed(MouseEvent e) {
+  @Override
+public void mousePressed(MouseEvent e) {
 
     mouseX = e.getX();
     mouseY = e.getY();
@@ -322,11 +331,13 @@ public class AdjustGridPanel extends JComponent
     dragOffsetY = y % gridSize;
   }
 
-  public void mouseReleased(MouseEvent e) {}
+  @Override
+public void mouseReleased(MouseEvent e) {}
 
   ////
   // MOUSE MOTION LISTENER
-  public void mouseDragged(MouseEvent e) {
+  @Override
+public void mouseDragged(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
 
@@ -365,7 +376,8 @@ public class AdjustGridPanel extends JComponent
     }
   }
 
-  public void mouseMoved(MouseEvent e) {
+  @Override
+public void mouseMoved(MouseEvent e) {
 
     Dimension imgSize = getScaledImageSize();
     Point imgPos = getScaledImagePosition();
@@ -386,25 +398,21 @@ public class AdjustGridPanel extends JComponent
 
   ////
   // MOUSE WHEEL LISTENER
-  public void mouseWheelMoved(MouseWheelEvent e) {
-
+  @Override
+public void mouseWheelMoved(MouseWheelEvent e) {
     if (SwingUtil.isControlDown(e)) {
-
       double oldScale = scale.getScale();
-      if (e.getWheelRotation() > 0) {
-        scale.zoomOut(e.getX(), e.getY());
-      } else {
+      if (e.getWheelRotation() < 0) {
         scale.zoomIn(e.getX(), e.getY());
+      } else {
+        scale.zoomOut(e.getX(), e.getY());
       }
       propertyChangeSupport.firePropertyChange(PROPERTY_ZOOM, oldScale, scale.getScale());
     } else {
-
-      if (e.getWheelRotation() > 0) {
-
-        adjustGridSize(Direction.Increase);
-      } else {
-
+      if (e.getWheelRotation() < 0) {
         adjustGridSize(Direction.Decrease);
+      } else {
+        adjustGridSize(Direction.Increase);
       }
     }
     repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
@@ -28,11 +28,9 @@ import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
-
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.ui.Scale;
@@ -86,7 +84,7 @@ public class AdjustGridPanel extends JComponent
             "zoomOut",
             new AbstractAction() {
               @Override
-			public void actionPerformed(ActionEvent e) {
+              public void actionPerformed(ActionEvent e) {
                 zoomOut();
               }
             });
@@ -97,7 +95,7 @@ public class AdjustGridPanel extends JComponent
             "zoomIn",
             new AbstractAction() {
               @Override
-			public void actionPerformed(ActionEvent e) {
+              public void actionPerformed(ActionEvent e) {
                 zoomIn();
               }
             });
@@ -109,7 +107,7 @@ public class AdjustGridPanel extends JComponent
             "zoomReset",
             new AbstractAction() {
               @Override
-			public void actionPerformed(ActionEvent e) {
+              public void actionPerformed(ActionEvent e) {
                 zoomReset();
               }
             });
@@ -305,16 +303,16 @@ public class AdjustGridPanel extends JComponent
   ////
   // MOUSE LISTENER
   @Override
-public void mouseClicked(MouseEvent e) {}
+  public void mouseClicked(MouseEvent e) {}
 
   @Override
-public void mouseEntered(MouseEvent e) {}
+  public void mouseEntered(MouseEvent e) {}
 
   @Override
-public void mouseExited(MouseEvent e) {}
+  public void mouseExited(MouseEvent e) {}
 
   @Override
-public void mousePressed(MouseEvent e) {
+  public void mousePressed(MouseEvent e) {
 
     mouseX = e.getX();
     mouseY = e.getY();
@@ -332,12 +330,12 @@ public void mousePressed(MouseEvent e) {
   }
 
   @Override
-public void mouseReleased(MouseEvent e) {}
+  public void mouseReleased(MouseEvent e) {}
 
   ////
   // MOUSE MOTION LISTENER
   @Override
-public void mouseDragged(MouseEvent e) {
+  public void mouseDragged(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
 
@@ -377,7 +375,7 @@ public void mouseDragged(MouseEvent e) {
   }
 
   @Override
-public void mouseMoved(MouseEvent e) {
+  public void mouseMoved(MouseEvent e) {
 
     Dimension imgSize = getScaledImageSize();
     Point imgPos = getScaledImagePosition();
@@ -399,7 +397,7 @@ public void mouseMoved(MouseEvent e) {
   ////
   // MOUSE WHEEL LISTENER
   @Override
-public void mouseWheelMoved(MouseWheelEvent e) {
+  public void mouseWheelMoved(MouseWheelEvent e) {
     if (SwingUtil.isControlDown(e)) {
       double oldScale = scale.getScale();
       if (e.getWheelRotation() < 0) {

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
@@ -28,11 +28,9 @@ import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
-
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
-
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.ui.Scale;
 
@@ -82,7 +80,7 @@ public class AdvancedAdjustGridPanel extends JComponent
             "zoomOut",
             new AbstractAction() {
               @Override
-			public void actionPerformed(ActionEvent e) {
+              public void actionPerformed(ActionEvent e) {
                 zoomOut();
               }
             });
@@ -93,7 +91,7 @@ public class AdvancedAdjustGridPanel extends JComponent
             "zoomIn",
             new AbstractAction() {
               @Override
-			public void actionPerformed(ActionEvent e) {
+              public void actionPerformed(ActionEvent e) {
                 zoomIn();
               }
             });
@@ -105,7 +103,7 @@ public class AdvancedAdjustGridPanel extends JComponent
             "zoomReset",
             new AbstractAction() {
               @Override
-			public void actionPerformed(ActionEvent e) {
+              public void actionPerformed(ActionEvent e) {
                 zoomReset();
               }
             });
@@ -360,16 +358,16 @@ public class AdvancedAdjustGridPanel extends JComponent
   ////
   // MOUSE LISTENER
   @Override
-public void mouseClicked(MouseEvent e) {}
+  public void mouseClicked(MouseEvent e) {}
 
   @Override
-public void mouseEntered(MouseEvent e) {}
+  public void mouseEntered(MouseEvent e) {}
 
   @Override
-public void mouseExited(MouseEvent e) {}
+  public void mouseExited(MouseEvent e) {}
 
   @Override
-public void mousePressed(MouseEvent e) {
+  public void mousePressed(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
       float imgRatio = getScaledImageRatio();
@@ -409,7 +407,7 @@ public void mousePressed(MouseEvent e) {
   }
 
   @Override
-public void mouseReleased(MouseEvent e) {
+  public void mouseReleased(MouseEvent e) {
     draggingHandle = null;
 
     repaint();
@@ -418,7 +416,7 @@ public void mouseReleased(MouseEvent e) {
   ////
   // MOUSE MOTION LISTENER
   @Override
-public void mouseDragged(MouseEvent e) {
+  public void mouseDragged(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
       updateHandles(e);
@@ -436,7 +434,7 @@ public void mouseDragged(MouseEvent e) {
   }
 
   @Override
-public void mouseMoved(MouseEvent e) {
+  public void mouseMoved(MouseEvent e) {
 
     Dimension imgSize = getScaledImageSize();
     Point imgPos = getScaledImagePosition();
@@ -458,7 +456,7 @@ public void mouseMoved(MouseEvent e) {
   ////
   // MOUSE WHEEL LISTENER
   @Override
-public void mouseWheelMoved(MouseWheelEvent e) {
+  public void mouseWheelMoved(MouseWheelEvent e) {
     if (e.getWheelRotation() < 0) {
       scale.zoomIn(e.getX(), e.getY());
     } else {

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
@@ -28,9 +28,11 @@ import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
+
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
+
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.ui.Scale;
 
@@ -79,7 +81,8 @@ public class AdvancedAdjustGridPanel extends JComponent
         .put(
             "zoomOut",
             new AbstractAction() {
-              public void actionPerformed(ActionEvent e) {
+              @Override
+			public void actionPerformed(ActionEvent e) {
                 zoomOut();
               }
             });
@@ -89,7 +92,8 @@ public class AdvancedAdjustGridPanel extends JComponent
         .put(
             "zoomIn",
             new AbstractAction() {
-              public void actionPerformed(ActionEvent e) {
+              @Override
+			public void actionPerformed(ActionEvent e) {
                 zoomIn();
               }
             });
@@ -100,7 +104,8 @@ public class AdvancedAdjustGridPanel extends JComponent
         .put(
             "zoomReset",
             new AbstractAction() {
-              public void actionPerformed(ActionEvent e) {
+              @Override
+			public void actionPerformed(ActionEvent e) {
                 zoomReset();
               }
             });
@@ -354,13 +359,17 @@ public class AdvancedAdjustGridPanel extends JComponent
 
   ////
   // MOUSE LISTENER
-  public void mouseClicked(MouseEvent e) {}
+  @Override
+public void mouseClicked(MouseEvent e) {}
 
-  public void mouseEntered(MouseEvent e) {}
+  @Override
+public void mouseEntered(MouseEvent e) {}
 
-  public void mouseExited(MouseEvent e) {}
+  @Override
+public void mouseExited(MouseEvent e) {}
 
-  public void mousePressed(MouseEvent e) {
+  @Override
+public void mousePressed(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
       float imgRatio = getScaledImageRatio();
@@ -399,7 +408,8 @@ public class AdvancedAdjustGridPanel extends JComponent
     }
   }
 
-  public void mouseReleased(MouseEvent e) {
+  @Override
+public void mouseReleased(MouseEvent e) {
     draggingHandle = null;
 
     repaint();
@@ -407,7 +417,8 @@ public class AdvancedAdjustGridPanel extends JComponent
 
   ////
   // MOUSE MOTION LISTENER
-  public void mouseDragged(MouseEvent e) {
+  @Override
+public void mouseDragged(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
       updateHandles(e);
@@ -424,7 +435,8 @@ public class AdvancedAdjustGridPanel extends JComponent
     repaint();
   }
 
-  public void mouseMoved(MouseEvent e) {
+  @Override
+public void mouseMoved(MouseEvent e) {
 
     Dimension imgSize = getScaledImageSize();
     Point imgPos = getScaledImagePosition();
@@ -445,14 +457,13 @@ public class AdvancedAdjustGridPanel extends JComponent
 
   ////
   // MOUSE WHEEL LISTENER
-  public void mouseWheelMoved(MouseWheelEvent e) {
-
-    if (e.getWheelRotation() > 0) {
-      scale.zoomOut(e.getX(), e.getY());
-    } else {
+  @Override
+public void mouseWheelMoved(MouseWheelEvent e) {
+    if (e.getWheelRotation() < 0) {
       scale.zoomIn(e.getX(), e.getY());
+    } else {
+      scale.zoomOut(e.getX(), e.getY());
     }
-
     repaint();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
@@ -24,6 +24,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.util.List;
+
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
@@ -43,6 +44,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.plaf.metal.MetalSliderUI;
+
 import net.rptools.lib.swing.ImagePanel;
 import net.rptools.lib.swing.ImagePanel.SelectionMode;
 import net.rptools.lib.swing.SelectionListener;
@@ -125,8 +127,9 @@ public class AssetPanel extends JComponent {
 
     imagePanel.addMouseWheelListener(
         new MouseWheelListener() {
-          public void mouseWheelMoved(MouseWheelEvent e) {
-            if (SwingUtil.isControlDown(e) || e.isMetaDown()) {
+          @Override
+		public void mouseWheelMoved(MouseWheelEvent e) {
+            if (SwingUtil.isControlDown(e) || e.isMetaDown()) {		// XXX Why either one?
               e.consume();
               int steps = e.getWheelRotation();
               imagePanel.setGridSize(imagePanel.getGridSize() + steps);
@@ -214,15 +217,18 @@ public class AssetPanel extends JComponent {
           .getDocument()
           .addDocumentListener(
               new DocumentListener() {
-                public void changedUpdate(DocumentEvent e) {
+                @Override
+				public void changedUpdate(DocumentEvent e) {
                   // no op
                 }
 
-                public void insertUpdate(DocumentEvent e) {
+                @Override
+				public void insertUpdate(DocumentEvent e) {
                   updateFilter();
                 }
 
-                public void removeUpdate(DocumentEvent e) {
+                @Override
+				public void removeUpdate(DocumentEvent e) {
                   updateFilter();
                 }
               });
@@ -242,7 +248,8 @@ public class AssetPanel extends JComponent {
           new JCheckBox(I18N.getText("panel.Asset.ImageModel.checkbox.searchSubDir1"), false);
       globalSearchField.addActionListener(
           new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
+            @Override
+			public void actionPerformed(ActionEvent ev) {
               updateFilter();
             }
           });
@@ -287,7 +294,8 @@ public class AssetPanel extends JComponent {
 
       thumbnailPreviewSlider.setUI(
           new MetalSliderUI() {
-            protected void scrollDueToClickInTrack(int direction) {
+            @Override
+			protected void scrollDueToClickInTrack(int direction) {
               int value = thumbnailPreviewSlider.getValue();
 
               if (thumbnailPreviewSlider.getOrientation() == JSlider.HORIZONTAL) {
@@ -327,7 +335,8 @@ public class AssetPanel extends JComponent {
           new Timer(
               500,
               new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
+                @Override
+				public void actionPerformed(ActionEvent e) {
                   ImageFileImagePanelModel model = (ImageFileImagePanelModel) imagePanel.getModel();
                   if (model == null) {
                     return;

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
@@ -24,7 +24,6 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.util.List;
-
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
@@ -44,7 +43,6 @@ import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.plaf.metal.MetalSliderUI;
-
 import net.rptools.lib.swing.ImagePanel;
 import net.rptools.lib.swing.ImagePanel.SelectionMode;
 import net.rptools.lib.swing.SelectionListener;
@@ -128,8 +126,8 @@ public class AssetPanel extends JComponent {
     imagePanel.addMouseWheelListener(
         new MouseWheelListener() {
           @Override
-		public void mouseWheelMoved(MouseWheelEvent e) {
-            if (SwingUtil.isControlDown(e) || e.isMetaDown()) {		// XXX Why either one?
+          public void mouseWheelMoved(MouseWheelEvent e) {
+            if (SwingUtil.isControlDown(e) || e.isMetaDown()) { // XXX Why either one?
               e.consume();
               int steps = e.getWheelRotation();
               imagePanel.setGridSize(imagePanel.getGridSize() + steps);
@@ -218,17 +216,17 @@ public class AssetPanel extends JComponent {
           .addDocumentListener(
               new DocumentListener() {
                 @Override
-				public void changedUpdate(DocumentEvent e) {
+                public void changedUpdate(DocumentEvent e) {
                   // no op
                 }
 
                 @Override
-				public void insertUpdate(DocumentEvent e) {
+                public void insertUpdate(DocumentEvent e) {
                   updateFilter();
                 }
 
                 @Override
-				public void removeUpdate(DocumentEvent e) {
+                public void removeUpdate(DocumentEvent e) {
                   updateFilter();
                 }
               });
@@ -249,7 +247,7 @@ public class AssetPanel extends JComponent {
       globalSearchField.addActionListener(
           new ActionListener() {
             @Override
-			public void actionPerformed(ActionEvent ev) {
+            public void actionPerformed(ActionEvent ev) {
               updateFilter();
             }
           });
@@ -295,7 +293,7 @@ public class AssetPanel extends JComponent {
       thumbnailPreviewSlider.setUI(
           new MetalSliderUI() {
             @Override
-			protected void scrollDueToClickInTrack(int direction) {
+            protected void scrollDueToClickInTrack(int direction) {
               int value = thumbnailPreviewSlider.getValue();
 
               if (thumbnailPreviewSlider.getOrientation() == JSlider.HORIZONTAL) {
@@ -336,7 +334,7 @@ public class AssetPanel extends JComponent {
               500,
               new ActionListener() {
                 @Override
-				public void actionPerformed(ActionEvent e) {
+                public void actionPerformed(ActionEvent e) {
                   ImageFileImagePanelModel model = (ImageFileImagePanelModel) imagePanel.getModel();
                   if (model == null) {
                     return;

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -14,6 +14,9 @@
  */
 package net.rptools.maptool.client.ui.campaignproperties;
 
+import com.jeta.forms.components.colors.JETAColorWell;
+import com.jeta.forms.components.panel.FormPanel;
+import com.jeta.forms.store.properties.ListItemProperty;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics2D;
@@ -33,7 +36,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
 import javax.swing.Icon;
@@ -54,11 +56,6 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.filechooser.FileFilter;
-
-import com.jeta.forms.components.colors.JETAColorWell;
-import com.jeta.forms.components.panel.FormPanel;
-import com.jeta.forms.store.properties.ListItemProperty;
-
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
@@ -267,7 +264,7 @@ public class TokenStatesController
 
   /** @see java.awt.event.ItemListener#itemStateChanged(java.awt.event.ItemEvent) */
   @Override
-public void itemStateChanged(ItemEvent e) {
+  public void itemStateChanged(ItemEvent e) {
     changedUpdate(null);
   }
 
@@ -277,7 +274,7 @@ public void itemStateChanged(ItemEvent e) {
    * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
    */
   @Override
-public void actionPerformed(ActionEvent e) {
+  public void actionPerformed(ActionEvent e) {
     String name = ((JComponent) e.getSource()).getName();
     JList<Object> list = formPanel.getList(STATES);
     DefaultListModel<Object> model = (DefaultListModel<Object>) list.getModel();
@@ -363,7 +360,7 @@ public void actionPerformed(ActionEvent e) {
   }
 
   @Override
-public void stateChanged(ChangeEvent e) {
+  public void stateChanged(ChangeEvent e) {
     String name = ((JComponent) e.getSource()).getName();
     JList<Object> list = formPanel.getList(STATES);
     DefaultListModel<Object> model = (DefaultListModel<Object>) list.getModel();
@@ -429,7 +426,7 @@ public void stateChanged(ChangeEvent e) {
    * @see javax.swing.event.DocumentListener#changedUpdate(javax.swing.event.DocumentEvent)
    */
   @Override
-public void changedUpdate(DocumentEvent e) {
+  public void changedUpdate(DocumentEvent e) {
     String text = formPanel.getText(IMAGE);
     boolean hasImage =
         !((ListItemProperty) formPanel.getSelectedItem(TYPE)).getLabel().contains("Image")
@@ -450,13 +447,13 @@ public void changedUpdate(DocumentEvent e) {
 
   /** @see javax.swing.event.DocumentListener#insertUpdate(javax.swing.event.DocumentEvent) */
   @Override
-public void insertUpdate(DocumentEvent e) {
+  public void insertUpdate(DocumentEvent e) {
     changedUpdate(e);
   }
 
   /** @see javax.swing.event.DocumentListener#removeUpdate(javax.swing.event.DocumentEvent) */
   @Override
-public void removeUpdate(DocumentEvent e) {
+  public void removeUpdate(DocumentEvent e) {
     changedUpdate(e);
   }
 
@@ -466,7 +463,7 @@ public void removeUpdate(DocumentEvent e) {
    * @see javax.swing.event.ListSelectionListener#valueChanged(javax.swing.event.ListSelectionEvent)
    */
   @Override
-public void valueChanged(ListSelectionEvent e) {
+  public void valueChanged(ListSelectionEvent e) {
     if (e.getValueIsAdjusting()) return;
     int selected = formPanel.getList(STATES).getSelectedIndex();
     formPanel.getButton(DELETE).setEnabled(selected >= 0);
@@ -578,17 +575,17 @@ public void valueChanged(ListSelectionEvent e) {
     Icon icon =
         new Icon() {
           @Override
-		public int getIconHeight() {
+          public int getIconHeight() {
             return ICON_SIZE + 2;
           }
 
           @Override
-		public int getIconWidth() {
+          public int getIconWidth() {
             return ICON_SIZE + 2;
           }
 
           @Override
-		public void paintIcon(Component c, java.awt.Graphics g, int x, int y) {
+          public void paintIcon(Component c, java.awt.Graphics g, int x, int y) {
             g.setColor(Color.BLACK);
             g.drawRect(x, y, ICON_SIZE + 2, ICON_SIZE + 2);
             g.translate(x + 1, y + 1);
@@ -776,7 +773,7 @@ public void valueChanged(ListSelectionEvent e) {
       spinner.commitEdit();
       width = ((Integer) spinner.getValue()).intValue();
     } catch (ParseException e) {
-      JOptionPane.showMessageDialog(		// XXX Use MapTool.showMessage()?
+      JOptionPane.showMessageDialog( // XXX Use MapTool.showMessage()?
           spinner,
           "There is an invalid "
               + displayName
@@ -819,7 +816,7 @@ public void valueChanged(ListSelectionEvent e) {
       message = "The file specified is a directory: ";
     }
     if (message != null) {
-      JOptionPane.showMessageDialog(	// XXX Use MapTool.showError()?
+      JOptionPane.showMessageDialog( // XXX Use MapTool.showError()?
           formPanel, message + file.getAbsolutePath(), "Error", JOptionPane.ERROR_MESSAGE);
       return null;
     }
@@ -827,7 +824,7 @@ public void valueChanged(ListSelectionEvent e) {
     try {
       asset = AssetManager.createAsset(file);
     } catch (IOException e) {
-      JOptionPane.showMessageDialog(	// XXX Use MapTool.showError()?
+      JOptionPane.showMessageDialog( // XXX Use MapTool.showError()?
           formPanel,
           "Error reading image file: " + file.getAbsolutePath(),
           "Error",

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -14,9 +14,6 @@
  */
 package net.rptools.maptool.client.ui.campaignproperties;
 
-import com.jeta.forms.components.colors.JETAColorWell;
-import com.jeta.forms.components.panel.FormPanel;
-import com.jeta.forms.store.properties.ListItemProperty;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics2D;
@@ -36,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
 import javax.swing.Icon;
@@ -56,6 +54,11 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.filechooser.FileFilter;
+
+import com.jeta.forms.components.colors.JETAColorWell;
+import com.jeta.forms.components.panel.FormPanel;
+import com.jeta.forms.store.properties.ListItemProperty;
+
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
@@ -263,7 +266,8 @@ public class TokenStatesController
   }
 
   /** @see java.awt.event.ItemListener#itemStateChanged(java.awt.event.ItemEvent) */
-  public void itemStateChanged(ItemEvent e) {
+  @Override
+public void itemStateChanged(ItemEvent e) {
     changedUpdate(null);
   }
 
@@ -272,7 +276,8 @@ public class TokenStatesController
    *
    * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
    */
-  public void actionPerformed(ActionEvent e) {
+  @Override
+public void actionPerformed(ActionEvent e) {
     String name = ((JComponent) e.getSource()).getName();
     JList<Object> list = formPanel.getList(STATES);
     DefaultListModel<Object> model = (DefaultListModel<Object>) list.getModel();
@@ -357,7 +362,8 @@ public class TokenStatesController
     } // endif
   }
 
-  public void stateChanged(ChangeEvent e) {
+  @Override
+public void stateChanged(ChangeEvent e) {
     String name = ((JComponent) e.getSource()).getName();
     JList<Object> list = formPanel.getList(STATES);
     DefaultListModel<Object> model = (DefaultListModel<Object>) list.getModel();
@@ -422,7 +428,8 @@ public class TokenStatesController
    *
    * @see javax.swing.event.DocumentListener#changedUpdate(javax.swing.event.DocumentEvent)
    */
-  public void changedUpdate(DocumentEvent e) {
+  @Override
+public void changedUpdate(DocumentEvent e) {
     String text = formPanel.getText(IMAGE);
     boolean hasImage =
         !((ListItemProperty) formPanel.getSelectedItem(TYPE)).getLabel().contains("Image")
@@ -442,12 +449,14 @@ public class TokenStatesController
   }
 
   /** @see javax.swing.event.DocumentListener#insertUpdate(javax.swing.event.DocumentEvent) */
-  public void insertUpdate(DocumentEvent e) {
+  @Override
+public void insertUpdate(DocumentEvent e) {
     changedUpdate(e);
   }
 
   /** @see javax.swing.event.DocumentListener#removeUpdate(javax.swing.event.DocumentEvent) */
-  public void removeUpdate(DocumentEvent e) {
+  @Override
+public void removeUpdate(DocumentEvent e) {
     changedUpdate(e);
   }
 
@@ -456,7 +465,8 @@ public class TokenStatesController
    *
    * @see javax.swing.event.ListSelectionListener#valueChanged(javax.swing.event.ListSelectionEvent)
    */
-  public void valueChanged(ListSelectionEvent e) {
+  @Override
+public void valueChanged(ListSelectionEvent e) {
     if (e.getValueIsAdjusting()) return;
     int selected = formPanel.getList(STATES).getSelectedIndex();
     formPanel.getButton(DELETE).setEnabled(selected >= 0);
@@ -567,15 +577,18 @@ public class TokenStatesController
      */
     Icon icon =
         new Icon() {
-          public int getIconHeight() {
+          @Override
+		public int getIconHeight() {
             return ICON_SIZE + 2;
           }
 
-          public int getIconWidth() {
+          @Override
+		public int getIconWidth() {
             return ICON_SIZE + 2;
           }
 
-          public void paintIcon(Component c, java.awt.Graphics g, int x, int y) {
+          @Override
+		public void paintIcon(Component c, java.awt.Graphics g, int x, int y) {
             g.setColor(Color.BLACK);
             g.drawRect(x, y, ICON_SIZE + 2, ICON_SIZE + 2);
             g.translate(x + 1, y + 1);
@@ -763,7 +776,7 @@ public class TokenStatesController
       spinner.commitEdit();
       width = ((Integer) spinner.getValue()).intValue();
     } catch (ParseException e) {
-      JOptionPane.showMessageDialog(
+      JOptionPane.showMessageDialog(		// XXX Use MapTool.showMessage()?
           spinner,
           "There is an invalid "
               + displayName
@@ -806,7 +819,7 @@ public class TokenStatesController
       message = "The file specified is a directory: ";
     }
     if (message != null) {
-      JOptionPane.showMessageDialog(
+      JOptionPane.showMessageDialog(	// XXX Use MapTool.showError()?
           formPanel, message + file.getAbsolutePath(), "Error", JOptionPane.ERROR_MESSAGE);
       return null;
     }
@@ -814,7 +827,7 @@ public class TokenStatesController
     try {
       asset = AssetManager.createAsset(file);
     } catch (IOException e) {
-      JOptionPane.showMessageDialog(
+      JOptionPane.showMessageDialog(	// XXX Use MapTool.showError()?
           formPanel,
           "Error reading image file: " + file.getAbsolutePath(),
           "Error",

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
@@ -28,10 +28,8 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
-
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppStyle;
@@ -59,7 +57,7 @@ public class TokenLayoutPanel extends JPanel {
     addMouseWheelListener(
         new MouseWheelListener() {
           @Override
-		public void mouseWheelMoved(MouseWheelEvent e) {
+          public void mouseWheelMoved(MouseWheelEvent e) {
             // Not for snap-to-scale
             if (!token.isSnapToScale()) {
               return;
@@ -77,7 +75,7 @@ public class TokenLayoutPanel extends JPanel {
             double scale = token.getSizeScale() + delta;
 
             // Range
-            scale = Math.max(.1, scale);	// XXX Why these arbitrary limits?  Document them?
+            scale = Math.max(.1, scale); // XXX Why these arbitrary limits?  Document them?
             scale = Math.min(3, scale);
             token.setSizeScale(scale);
             repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
@@ -28,8 +28,10 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
+
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
+
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppStyle;
@@ -56,12 +58,13 @@ public class TokenLayoutPanel extends JPanel {
   public TokenLayoutPanel() {
     addMouseWheelListener(
         new MouseWheelListener() {
-          public void mouseWheelMoved(MouseWheelEvent e) {
+          @Override
+		public void mouseWheelMoved(MouseWheelEvent e) {
             // Not for snap-to-scale
             if (!token.isSnapToScale()) {
               return;
             }
-            double delta = e.getWheelRotation() > 0 ? -.1 : .1;
+            double delta = e.getWheelRotation() < 0 ? .1 : +.1;
             if (SwingUtil.isShiftDown(e)) {
               // Nothing yet, as changing the facing isn't the right way to handle it --
               // the image itself really should be rotated. And it's probably better to
@@ -74,7 +77,7 @@ public class TokenLayoutPanel extends JPanel {
             double scale = token.getSizeScale() + delta;
 
             // Range
-            scale = Math.max(.1, scale);
+            scale = Math.max(.1, scale);	// XXX Why these arbitrary limits?  Document them?
             scale = Math.min(3, scale);
             token.setSizeScale(scale);
             repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
@@ -27,9 +27,7 @@ import java.awt.event.MouseWheelListener;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
-
 import javax.swing.JPanel;
-
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
@@ -47,9 +45,9 @@ public class TokenVblPanel extends JPanel {
 
   public TokenVblPanel() {
     addMouseWheelListener(
-        new MouseWheelListener() {		// XXX Why is this here?
+        new MouseWheelListener() { // XXX Why is this here?
           @Override
-		public void mouseWheelMoved(MouseWheelEvent e) {
+          public void mouseWheelMoved(MouseWheelEvent e) {
             // Not for snap-to-scale
             if (!token.isSnapToScale()) {
               return;
@@ -65,14 +63,14 @@ public class TokenVblPanel extends JPanel {
           }
         });
     addMouseListener(
-        new MouseAdapter() {		// XXX Why is this here?
+        new MouseAdapter() { // XXX Why is this here?
           String old;
 
           @Override
           public void mousePressed(MouseEvent e) {}
 
           @Override
-		public void mouseReleased(MouseEvent e) {}
+          public void mouseReleased(MouseEvent e) {}
 
           @Override
           public void mouseEntered(MouseEvent e) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
@@ -27,7 +27,9 @@ import java.awt.event.MouseWheelListener;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
+
 import javax.swing.JPanel;
+
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
@@ -45,8 +47,9 @@ public class TokenVblPanel extends JPanel {
 
   public TokenVblPanel() {
     addMouseWheelListener(
-        new MouseWheelListener() {
-          public void mouseWheelMoved(MouseWheelEvent e) {
+        new MouseWheelListener() {		// XXX Why is this here?
+          @Override
+		public void mouseWheelMoved(MouseWheelEvent e) {
             // Not for snap-to-scale
             if (!token.isSnapToScale()) {
               return;
@@ -62,13 +65,14 @@ public class TokenVblPanel extends JPanel {
           }
         });
     addMouseListener(
-        new MouseAdapter() {
+        new MouseAdapter() {		// XXX Why is this here?
           String old;
 
           @Override
           public void mousePressed(MouseEvent e) {}
 
-          public void mouseReleased(MouseEvent e) {}
+          @Override
+		public void mouseReleased(MouseEvent e) {}
 
           @Override
           public void mouseEntered(MouseEvent e) {

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -14,6 +14,12 @@
  */
 package net.rptools.maptool.client.ui.tokenpanel;
 
+import com.jeta.forms.components.line.HorizontalLineComponent;
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jidesoft.plaf.LookAndFeelFactory;
+import com.jidesoft.swing.JideButton;
+import com.jidesoft.swing.JideSplitButton;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.EventQueue;
@@ -27,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ActionMap;
@@ -46,14 +51,6 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-
-import com.jeta.forms.components.line.HorizontalLineComponent;
-import com.jgoodies.forms.layout.CellConstraints;
-import com.jgoodies.forms.layout.FormLayout;
-import com.jidesoft.plaf.LookAndFeelFactory;
-import com.jidesoft.swing.JideButton;
-import com.jidesoft.swing.JideSplitButton;
-
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
@@ -326,7 +323,7 @@ public class InitiativePanel extends JPanel
     EventQueue.invokeLater(
         new Runnable() {
           @Override
-		public void run() {
+          public void run() {
             model.setList(list);
             if (menuButton != null && menuButton.getAction() == NEXT_ACTION)
               menuButton.setButtonEnabled(
@@ -464,7 +461,7 @@ public class InitiativePanel extends JPanel
    * @see javax.swing.event.ListSelectionListener#valueChanged(javax.swing.event.ListSelectionEvent)
    */
   @Override
-public void valueChanged(ListSelectionEvent e) {
+  public void valueChanged(ListSelectionEvent e) {
     if (e != null && e.getValueIsAdjusting()) return;
     TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
     boolean enabled = (ti != null && hasOwnerPermission(ti.getToken())) ? true : false;
@@ -492,7 +489,7 @@ public void valueChanged(ListSelectionEvent e) {
 
   /** @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent) */
   @Override
-public void propertyChange(PropertyChangeEvent evt) {
+  public void propertyChange(PropertyChangeEvent evt) {
     if (evt.getPropertyName().equals(InitiativeList.ROUND_PROP)) {
       String text = list.getRound() < 0 ? "" : Integer.toString(list.getRound());
       round.setText(text);
@@ -528,7 +525,7 @@ public void propertyChange(PropertyChangeEvent evt) {
    *     net.rptools.maptool.model.ModelChangeListener#modelChanged(net.rptools.maptool.model.ModelChangeEvent)
    */
   @Override
-public void modelChanged(ModelChangeEvent event) {
+  public void modelChanged(ModelChangeEvent event) {
     if (event.getEvent().equals(Event.INITIATIVE_LIST_CHANGED)) {
       if ((Zone) event.getModel() == zone) {
         int oldSize = model.getSize();
@@ -550,7 +547,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action NEXT_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           list.nextInitiative();
         };
       };
@@ -559,7 +556,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action PREV_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           list.prevInitiative();
         };
       };
@@ -568,7 +565,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action REMOVE_TOKEN_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           int index = list.indexOf(ti);
@@ -580,7 +577,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action TOGGLE_HOLD_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           ti.setHolding(!ti.isHolding());
@@ -591,7 +588,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action MAKE_CURRENT_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           list.setCurrent(list.indexOf(ti));
@@ -602,7 +599,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action SHOW_TOKENS_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           showTokens = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -615,7 +612,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action SHOW_TOKEN_STATES_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           showTokenStates = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -628,7 +625,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action SHOW_INIT_STATE =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           showInitState = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -641,7 +638,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action INIT_STATE_SECOND_LINE =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           initStateSecondLine = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -654,7 +651,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action SORT_LIST_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           list.sort();
         };
       };
@@ -663,7 +660,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action SET_INIT_STATE_VALUE =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           Token token = ti.getToken();
@@ -684,7 +681,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action CLEAR_INIT_STATE_VALUE =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           ti.setState(null);
@@ -695,7 +692,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action REMOVE_ALL_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           clearTokens();
         };
       };
@@ -704,7 +701,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action ADD_ALL_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           list.insertTokens(list.getZone().getTokens());
         };
       };
@@ -713,7 +710,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action ADD_PCS_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           List<Token> tokens = new ArrayList<Token>();
           for (Token token : list.getZone().getTokens()) {
             if (token.getType() == Type.PC) tokens.add(token);
@@ -726,7 +723,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action TOGGLE_HIDE_NPC_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           list.setHideNPC(!list.isHideNPC());
           if (list.isHideNPC() != hideNPCMenuItem.isSelected())
             hideNPCMenuItem.setSelected(list.isHideNPC());
@@ -739,7 +736,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action TOGGLE_OWNER_PERMISSIONS_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           boolean op = !MapTool.getCampaign().isInitiativeOwnerPermissions();
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
           MapTool.getCampaign().setInitiativeOwnerPermissions(op);
@@ -753,7 +750,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action TOGGLE_MOVEMENT_LOCK_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           boolean op = !MapTool.getCampaign().isInitiativeMovementLock();
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
           MapTool.getCampaign().setInitiativeMovementLock(op);
@@ -765,7 +762,7 @@ public void modelChanged(ModelChangeEvent event) {
   public final Action RESET_COUNTER_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           if (!MapTool.getPlayer().isGM()) {
             return;
           }
@@ -801,7 +798,7 @@ public void modelChanged(ModelChangeEvent event) {
         SwingUtilities.invokeLater(
             new Runnable() {
               @Override
-			public void run() {
+              public void run() {
                 if (displayList.getSelectedValue() != null) {
                   // Show the selected token on the map.
                   Token token = ((TokenInitiative) displayList.getSelectedValue()).getToken();

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -14,12 +14,6 @@
  */
 package net.rptools.maptool.client.ui.tokenpanel;
 
-import com.jeta.forms.components.line.HorizontalLineComponent;
-import com.jgoodies.forms.layout.CellConstraints;
-import com.jgoodies.forms.layout.FormLayout;
-import com.jidesoft.plaf.LookAndFeelFactory;
-import com.jidesoft.swing.JideButton;
-import com.jidesoft.swing.JideSplitButton;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.EventQueue;
@@ -33,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ActionMap;
@@ -51,6 +46,14 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
+
+import com.jeta.forms.components.line.HorizontalLineComponent;
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
+import com.jidesoft.plaf.LookAndFeelFactory;
+import com.jidesoft.swing.JideButton;
+import com.jidesoft.swing.JideSplitButton;
+
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
@@ -322,7 +325,8 @@ public class InitiativePanel extends JPanel
     }
     EventQueue.invokeLater(
         new Runnable() {
-          public void run() {
+          @Override
+		public void run() {
             model.setList(list);
             if (menuButton != null && menuButton.getAction() == NEXT_ACTION)
               menuButton.setButtonEnabled(
@@ -459,7 +463,8 @@ public class InitiativePanel extends JPanel
   /**
    * @see javax.swing.event.ListSelectionListener#valueChanged(javax.swing.event.ListSelectionEvent)
    */
-  public void valueChanged(ListSelectionEvent e) {
+  @Override
+public void valueChanged(ListSelectionEvent e) {
     if (e != null && e.getValueIsAdjusting()) return;
     TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
     boolean enabled = (ti != null && hasOwnerPermission(ti.getToken())) ? true : false;
@@ -486,7 +491,8 @@ public class InitiativePanel extends JPanel
    *-------------------------------------------------------------------------------------------*/
 
   /** @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent) */
-  public void propertyChange(PropertyChangeEvent evt) {
+  @Override
+public void propertyChange(PropertyChangeEvent evt) {
     if (evt.getPropertyName().equals(InitiativeList.ROUND_PROP)) {
       String text = list.getRound() < 0 ? "" : Integer.toString(list.getRound());
       round.setText(text);
@@ -521,7 +527,8 @@ public class InitiativePanel extends JPanel
    * @see
    *     net.rptools.maptool.model.ModelChangeListener#modelChanged(net.rptools.maptool.model.ModelChangeEvent)
    */
-  public void modelChanged(ModelChangeEvent event) {
+  @Override
+public void modelChanged(ModelChangeEvent event) {
     if (event.getEvent().equals(Event.INITIATIVE_LIST_CHANGED)) {
       if ((Zone) event.getModel() == zone) {
         int oldSize = model.getSize();
@@ -542,7 +549,8 @@ public class InitiativePanel extends JPanel
   /** This action will advance initiative to the next token in the list. */
   public final Action NEXT_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           list.nextInitiative();
         };
       };
@@ -550,7 +558,8 @@ public class InitiativePanel extends JPanel
   /** This action will reverse initiative to the previous token in the list. */
   public final Action PREV_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           list.prevInitiative();
         };
       };
@@ -558,7 +567,8 @@ public class InitiativePanel extends JPanel
   /** This action will remove the selected token from the list. */
   public final Action REMOVE_TOKEN_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           int index = list.indexOf(ti);
@@ -569,7 +579,8 @@ public class InitiativePanel extends JPanel
   /** This action will turn the selected token's initiative on and off. */
   public final Action TOGGLE_HOLD_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           ti.setHolding(!ti.isHolding());
@@ -579,7 +590,8 @@ public class InitiativePanel extends JPanel
   /** This action will make the selected token the current token. */
   public final Action MAKE_CURRENT_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           list.setCurrent(list.indexOf(ti));
@@ -589,7 +601,8 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action SHOW_TOKENS_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           showTokens = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -601,7 +614,8 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action SHOW_TOKEN_STATES_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           showTokenStates = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -613,7 +627,8 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action SHOW_INIT_STATE =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           showInitState = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -625,7 +640,8 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action INIT_STATE_SECOND_LINE =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           initStateSecondLine = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
@@ -637,7 +653,8 @@ public class InitiativePanel extends JPanel
   /** This action sorts the tokens in the list. */
   public final Action SORT_LIST_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           list.sort();
         };
       };
@@ -645,7 +662,8 @@ public class InitiativePanel extends JPanel
   /** This action will set the initiative state of the currently selected token. */
   public final Action SET_INIT_STATE_VALUE =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           Token token = ti.getToken();
@@ -656,7 +674,7 @@ public class InitiativePanel extends JPanel
               && token.getGMName().trim().length() != 0)
             sName += " (" + token.getGMName().trim() + ")";
           String s = I18N.getText("initPanel.enterState", sName);
-          String input = JOptionPane.showInputDialog(s, ti.getState());
+          String input = JOptionPane.showInputDialog(MapTool.getFrame(), s, ti.getState());
           if (input == null) return;
           ti.setState(input.trim());
         };
@@ -665,7 +683,8 @@ public class InitiativePanel extends JPanel
   /** This action will clear the initiative state of the currently selected token. */
   public final Action CLEAR_INIT_STATE_VALUE =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
           ti.setState(null);
@@ -675,7 +694,8 @@ public class InitiativePanel extends JPanel
   /** This action will remove all tokens from the initiative panel. */
   public final Action REMOVE_ALL_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           clearTokens();
         };
       };
@@ -683,7 +703,8 @@ public class InitiativePanel extends JPanel
   /** This action will add all tokens in the zone to this initiative panel. */
   public final Action ADD_ALL_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           list.insertTokens(list.getZone().getTokens());
         };
       };
@@ -691,7 +712,8 @@ public class InitiativePanel extends JPanel
   /** This action will add all PC tokens in the zone to this initiative panel. */
   public final Action ADD_PCS_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           List<Token> tokens = new ArrayList<Token>();
           for (Token token : list.getZone().getTokens()) {
             if (token.getType() == Type.PC) tokens.add(token);
@@ -703,7 +725,8 @@ public class InitiativePanel extends JPanel
   /** This action will hide all initiative items with NPC tokens from players */
   public final Action TOGGLE_HIDE_NPC_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           list.setHideNPC(!list.isHideNPC());
           if (list.isHideNPC() != hideNPCMenuItem.isSelected())
             hideNPCMenuItem.setSelected(list.isHideNPC());
@@ -715,7 +738,8 @@ public class InitiativePanel extends JPanel
    */
   public final Action TOGGLE_OWNER_PERMISSIONS_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           boolean op = !MapTool.getCampaign().isInitiativeOwnerPermissions();
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
           MapTool.getCampaign().setInitiativeOwnerPermissions(op);
@@ -728,7 +752,8 @@ public class InitiativePanel extends JPanel
    */
   public final Action TOGGLE_MOVEMENT_LOCK_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           boolean op = !MapTool.getCampaign().isInitiativeMovementLock();
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
           MapTool.getCampaign().setInitiativeMovementLock(op);
@@ -739,7 +764,8 @@ public class InitiativePanel extends JPanel
   /** This action will reset the round counter for the initiative panel. */
   public final Action RESET_COUNTER_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           if (!MapTool.getPlayer().isGM()) {
             return;
           }
@@ -774,7 +800,8 @@ public class InitiativePanel extends JPanel
       if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
         SwingUtilities.invokeLater(
             new Runnable() {
-              public void run() {
+              @Override
+			public void run() {
                 if (displayList.getSelectedValue() != null) {
                   // Show the selected token on the map.
                   Token token = ((TokenInitiative) displayList.getSelectedValue()).getToken();

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
@@ -16,10 +16,12 @@ package net.rptools.maptool.client.ui.tokenpanel;
 
 import java.awt.event.ActionEvent;
 import java.util.Set;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
+
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.TokenPopupMenu;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
@@ -106,7 +108,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will turn the selected token's initiative on and off. */
   public final Action TOGGLE_HOLD_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setHolding(!ti.isHolding());
         };
       };
@@ -114,7 +117,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will make the token under the mouse the current token. */
   public final Action MAKE_CURRENT_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           list.setCurrent(list.indexOf(tokenInitiativeUnderMouse));
         };
@@ -123,7 +127,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will set the initiative state of the currently selected token. */
   public final Action SET_INIT_STATE_VALUE =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           String message = I18N.getText("initPanel.enterState");
           String defaultValue = "";
           if (selectedTokenInitiatives.size() == 1) {
@@ -136,7 +141,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
             message = String.format(I18N.getText("initPanel.enterState"), sName);
             defaultValue = ti.getState();
           } // endif
-          String input = JOptionPane.showInputDialog(message, defaultValue);
+          String input = JOptionPane.showInputDialog(MapTool.getFrame(), message, defaultValue);
           if (input == null) return;
           input = input.trim();
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setState(input.trim());
@@ -146,7 +151,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will set the initiative state of the currently selected token. */
   public final Action CLEAR_INIT_STATE_VALUE =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setState(null);
         };
       };
@@ -154,7 +160,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will remove the selected token from the list. */
   public final Action REMOVE_TOKEN_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           InitiativePanel ip = MapTool.getFrame().getInitiativePanel();
           for (TokenInitiative ti : selectedTokenInitiatives) {
@@ -169,7 +176,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will move a token up one space */
   public final Action MOVE_UP_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           int index = list.indexOf(tokenInitiativeUnderMouse);
           list.moveToken(index, index - 1);
@@ -179,7 +187,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will move a token up one space */
   public final Action MOVE_DOWN_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           int index = list.indexOf(tokenInitiativeUnderMouse);
           list.moveToken(index, index + 2);
@@ -189,7 +198,8 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will center the selected token on the map and select it. */
   public final Action CENTER_ACTION =
       new AbstractAction() {
-        public void actionPerformed(ActionEvent e) {
+        @Override
+		public void actionPerformed(ActionEvent e) {
           Token token = tokenInitiativeUnderMouse.getToken();
           getRenderer().centerOn(new ZonePoint(token.getX(), token.getY()));
           getRenderer().clearSelectedTokens();

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
@@ -16,12 +16,10 @@ package net.rptools.maptool.client.ui.tokenpanel;
 
 import java.awt.event.ActionEvent;
 import java.util.Set;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.TokenPopupMenu;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
@@ -109,7 +107,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action TOGGLE_HOLD_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setHolding(!ti.isHolding());
         };
       };
@@ -118,7 +116,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action MAKE_CURRENT_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           list.setCurrent(list.indexOf(tokenInitiativeUnderMouse));
         };
@@ -128,7 +126,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action SET_INIT_STATE_VALUE =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           String message = I18N.getText("initPanel.enterState");
           String defaultValue = "";
           if (selectedTokenInitiatives.size() == 1) {
@@ -152,7 +150,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action CLEAR_INIT_STATE_VALUE =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setState(null);
         };
       };
@@ -161,7 +159,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action REMOVE_TOKEN_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           InitiativePanel ip = MapTool.getFrame().getInitiativePanel();
           for (TokenInitiative ti : selectedTokenInitiatives) {
@@ -177,7 +175,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action MOVE_UP_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           int index = list.indexOf(tokenInitiativeUnderMouse);
           list.moveToken(index, index - 1);
@@ -188,7 +186,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action MOVE_DOWN_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           int index = list.indexOf(tokenInitiativeUnderMouse);
           list.moveToken(index, index + 2);
@@ -199,7 +197,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   public final Action CENTER_ACTION =
       new AbstractAction() {
         @Override
-		public void actionPerformed(ActionEvent e) {
+        public void actionPerformed(ActionEvent e) {
           Token token = tokenInitiativeUnderMouse.getToken();
           getRenderer().centerOn(new ZonePoint(token.getX(), token.getY()));
           getRenderer().clearSelectedTokens();


### PR DESCRIPTION
Fixes #413 

Filters all `MouseWheelEvent`s with the `Shift` modifier turned on when the platform is OSX.  This eliminates horizontal scrolling so that token facing isn't randomly changed by accidental left/right motion on the mouse.

This is a short-term fix.  A longer term fix is being worked on.  The issue has more, including a link to a full description of the problem and proposed solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1170)
<!-- Reviewable:end -->
