### PR TITLE
Fixes AI Terrain Modifier distance calculations

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapPropertiesDialog.java
@@ -32,7 +32,21 @@ import java.awt.image.ImageObserver;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JSplitPane;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.filechooser.FileFilter;
 import net.rptools.lib.swing.PaintChooser;
 import net.rptools.lib.swing.SelectionListener;
@@ -121,6 +135,7 @@ public class MapPropertiesDialog extends JDialog {
     initPixelsPerCellTextField();
     initDefaultVisionTextField();
     initVisionTypeCombo();
+    initAStarRoundingOptionsComboBox();
 
     initIsometricRadio();
     initHexHoriRadio();
@@ -207,6 +222,10 @@ public class MapPropertiesDialog extends JDialog {
     return formPanel.getComboBox("visionType");
   }
 
+  public JComboBox getAStarRoundingOptionsComboBox() {
+    return formPanel.getComboBox("aStarRoundingOptionsComboBox");
+  }
+
   public void setZone(Zone zone) {
     this.zone = zone;
     copyZoneToUI();
@@ -223,6 +242,7 @@ public class MapPropertiesDialog extends JDialog {
     getSquareRadio().setSelected(zone.getGrid() instanceof SquareGrid);
     getNoGridRadio().setSelected(zone.getGrid() instanceof GridlessGrid);
     getVisionTypeCombo().setSelectedItem(zone.getVisionType());
+    getAStarRoundingOptionsComboBox().setSelectedItem(zone.getAStarRounding());
 
     gridOffsetX = zone.getGrid().getOffsetX();
     gridOffsetY = zone.getGrid().getOffsetY();
@@ -242,6 +262,8 @@ public class MapPropertiesDialog extends JDialog {
             getDefaultVisionTextField().getText(), zone.getTokenVisionDistance()));
 
     zone.setVisionType((Zone.VisionType) getVisionTypeCombo().getSelectedItem());
+    zone.setAStarRounding(
+        (Zone.AStarRoundingOptions) getAStarRoundingOptionsComboBox().getSelectedItem());
 
     zone.setFogPaint(fogPaint);
     zone.setBackgroundPaint(backgroundPaint);
@@ -444,6 +466,11 @@ public class MapPropertiesDialog extends JDialog {
     }
     model.setSelectedItem(AppPreferences.getDefaultVisionType());
     getVisionTypeCombo().setModel(model);
+  }
+
+  private void initAStarRoundingOptionsComboBox() {
+    getAStarRoundingOptionsComboBox()
+        .setModel(new DefaultComboBoxModel<>(Zone.AStarRoundingOptions.values()));
   }
 
   public String getZoneName() {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -2265,7 +2265,7 @@ public class ZoneRenderer extends JComponent
         }
 
         // Show current Blocked Movement directions for A*
-        if (walker != null && showAstarDebugging) {
+        if (walker != null && (log.isDebugEnabled() || showAstarDebugging)) {
           Collection<AStarCellPoint> checkPoints = walker.getCheckedPoints();
           // Color currentColor = g.getColor();
           for (AStarCellPoint acp : checkPoints) {
@@ -2533,7 +2533,8 @@ public class ZoneRenderer extends JComponent
           ZonePoint zp = grid.convert(p);
           zp.x += grid.getCellWidth() / cellAdj + cellOffset.width;
           zp.y += grid.getCellHeight() / cellAdj + cellOffset.height;
-          addDistanceText(g, zp, 1.0f, p.getDistanceTraveled(zone));
+          addDistanceText(
+              g, zp, 1.0f, p.getDistanceTraveled(zone), p.getDistanceTraveledWithoutTerrain());
         }
       }
       int w = 0;
@@ -2809,7 +2810,8 @@ public class ZoneRenderer extends JComponent
         this);
   }
 
-  public void addDistanceText(Graphics2D g, ZonePoint point, float size, double distance) {
+  public void addDistanceText(
+      Graphics2D g, ZonePoint point, float size, double distance, double distanceWithoutTerrain) {
     if (distance == 0) {
       return;
     }
@@ -2821,7 +2823,6 @@ public class ZoneRenderer extends JComponent
     double iwidth = cwidth * size;
     double iheight = cheight * size;
 
-    String distanceText = NumberFormat.getInstance().format(distance);
     ScreenPoint sp = ScreenPoint.fromZonePoint(this, point);
 
     int cellX = (int) (sp.x - iwidth / 2);
@@ -2831,6 +2832,12 @@ public class ZoneRenderer extends JComponent
     double fontScale = (double) grid.getSize() / 50; // Font size of 12 at grid size 50 is default
     int fontSize = (int) (getScale() * 12 * fontScale);
     int textOffset = (int) (getScale() * 7 * fontScale); // 7 pixels at 100% zoom & grid size of 50
+
+    String distanceText = NumberFormat.getInstance().format(distance);
+    if (log.isDebugEnabled() || showAstarDebugging) {
+      distanceText += " (" + NumberFormat.getInstance().format(distanceWithoutTerrain) + ")";
+      fontSize = (int) (fontSize * 0.75);
+    }
 
     Font font = new Font(Font.DIALOG, Font.BOLD, fontSize);
     Font originalFont = g.getFont();
@@ -4306,8 +4313,7 @@ public class ZoneRenderer extends JComponent
 
         if (renderPathTask != null) {
           while (!renderPathTask.isDone()) {
-            log.debug("Waiting on Path Rendering... ");
-
+            log.trace("Waiting on Path Rendering... ");
             try {
               Thread.sleep(10);
             } catch (InterruptedException e) {

--- a/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
@@ -26,6 +26,7 @@ import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.Zone;
 
 public abstract class AbstractZoneWalker implements ZoneWalker {
+
   protected List<PartialPath> partialPaths =
       Collections.synchronizedList(new ArrayList<PartialPath>());
   protected final Zone zone;
@@ -43,8 +44,11 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
 
   public CellPoint getLastPoint() {
     synchronized (partialPaths) {
-      if (partialPaths.isEmpty()) return null;
-      else return partialPaths.get(partialPaths.size() - 1).end;
+      if (partialPaths.isEmpty()) {
+        return null;
+      } else {
+        return partialPaths.get(partialPaths.size() - 1).end;
+      }
     }
   }
 
@@ -77,7 +81,9 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
     this.restrictMovement = restrictMovement;
     this.terrainModifiersIgnored = terrainModifiersIgnored;
 
-    if (partialPaths.isEmpty()) return null;
+    if (partialPaths.isEmpty()) {
+      return null;
+    }
     PartialPath oldPartial = partialPaths.remove(partialPaths.size() - 1);
 
     // short circuit exit if the point hasn't changed.
@@ -122,15 +128,21 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   }
 
   public boolean isWaypoint(CellPoint point) {
-    if (point == null) return false;
+    if (point == null) {
+      return false;
+    }
 
     PartialPath last = null;
     for (PartialPath partial : partialPaths) {
-      if (partial.start.equals(point)) return true;
+      if (partial.start.equals(point)) {
+        return true;
+      }
 
       last = partial;
     }
-    if (last != null && last.end != null && last.end.equals(point)) return true;
+    if (last != null && last.end != null && last.end.equals(point)) {
+      return true;
+    }
 
     return false;
   }
@@ -140,7 +152,9 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
    *     net.rptools.maptool.client.walker.ZoneWalker#removeWaypoint(net.rptools.maptool.model.CellPoint)
    */
   public boolean removeWaypoint(CellPoint aPoint) {
-    if (aPoint == null || partialPaths == null || partialPaths.isEmpty()) return false;
+    if (aPoint == null || partialPaths == null || partialPaths.isEmpty()) {
+      return false;
+    }
 
     // Find the partial path with the given end point
     ListIterator<PartialPath> i = partialPaths.listIterator();
@@ -149,7 +163,9 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
       if (path.end.equals(aPoint)) {
         // If this is the last partial path then done, otherwise
         // combine this path and the next and replace them with a combined path
-        if (!i.hasNext()) return false;
+        if (!i.hasNext()) {
+          return false;
+        }
         i.remove();
         PartialPath path2 = i.next();
         i.set(new PartialPath(path.start, path2.end, calculatePath(path.start, path2.end)));
@@ -164,7 +180,9 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
    *     net.rptools.maptool.client.walker.ZoneWalker#toggleWaypoint(net.rptools.maptool.model.CellPoint)
    */
   public boolean toggleWaypoint(CellPoint aPoint) {
-    if (removeWaypoint(aPoint)) return true;
+    if (removeWaypoint(aPoint)) {
+      return true;
+    }
     addWaypoints(aPoint);
     return true;
   }
@@ -183,6 +201,7 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   protected abstract List<CellPoint> calculatePath(CellPoint start, CellPoint end);
 
   protected static class PartialPath {
+
     final CellPoint start;
     final CellPoint end;
     final List<CellPoint> path;
@@ -193,7 +212,11 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
       this.path = path;
 
       // Get the distance traveled from the last partial path, eg from last waypoint...
-      if (!path.isEmpty()) this.end.distanceTraveled = path.get(path.size() - 1).distanceTraveled;
+      if (!path.isEmpty()) {
+        this.end.distanceTraveled = path.get(path.size() - 1).distanceTraveled;
+        this.end.distanceTraveledWithoutTerrain =
+            path.get(path.size() - 1).distanceTraveledWithoutTerrain;
+      }
     }
 
     /** @see java.lang.Object#toString() */

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
@@ -45,7 +45,7 @@ public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoi
   }
 
   public AStarCellPoint(CellPoint p) {
-    super(p.x, p.y, p.distanceTraveled);
+    super(p.x, p.y, p.distanceTraveled, p.distanceTraveledWithoutTerrain);
   }
 
   public AStarCellPoint(CellPoint p, double mod, TerrainModifierOperation operation) {

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -219,39 +219,38 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
       closedSet.add(currentNode);
       currentNode = null;
 
-      // We now calculate paths off the main UI thread but only one at a time. If the token moves we
-      // cancel the thread
-      // and restart so we're only calculating the most recent path request. Clearing the list
-      // effectively finishes
-      // this thread gracefully.
+      /*
+        We now calculate paths off the main UI thread but only one at a time.
+        If the token moves, we cancel the thread and restart so we're only calculating the most
+        recent path request. Clearing the list effectively finishes this thread gracefully.
+      */
       if (Thread.interrupted()) {
         // log.info("Thread interrupted!");
         openList.clear();
       }
     }
 
-    List<CellPoint> ret = new LinkedList<>();
+    List<CellPoint> returnedCellPointList = new LinkedList<>();
     while (currentNode != null) {
-      ret.add(currentNode);
+      returnedCellPointList.add(currentNode);
       currentNode = currentNode.parent;
     }
 
-    // Jamz We don't need to "calculate" distance after the fact as it's already stored as the G
-    // cost...
-    if (!ret.isEmpty()) {
-      distance = ret.get(0).getDistanceTraveled(zone);
-    } else { // if pathfinding interrupted because of timeout
+    // We don't need to "calculate" distance after the fact as it's already stored as the G cost...
+    if (!returnedCellPointList.isEmpty()) {
+      distance = returnedCellPointList.get(0).getDistanceTraveled(zone);
+    } else { // if path finding was interrupted because of timeout
       distance = 0;
       AStarCellPoint goalCell = new AStarCellPoint(goal); // we allow reaching of target location
       AStarCellPoint startCell = new AStarCellPoint(start);
 
       goalCell.parent = startCell;
 
-      ret.add(goalCell);
-      ret.add(startCell);
+      returnedCellPointList.add(goalCell);
+      returnedCellPointList.add(startCell);
     }
 
-    Collections.reverse(ret);
+    Collections.reverse(returnedCellPointList);
     timeOut = (System.currentTimeMillis() - timeOut);
     if (timeOut > 500) {
       log.debug("Time to calculate A* path warning: " + timeOut + "ms");
@@ -262,7 +261,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     // if (testCount > 0)
     // log.info("avgTestTime: " + Math.floor(avgTestTime / testCount)/1000 + " micro");
 
-    return ret;
+    return returnedCellPointList;
   }
 
   void pushNode(List<AStarCellPoint> list, AStarCellPoint node) {
@@ -315,7 +314,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
         for (CellPoint cellPoint : occupiedCells) {
           AStarCellPoint occupiedNode = new AStarCellPoint(cellPoint);
 
-          // VBL Check FIXME: Add to closed set?
+          // VBL Check
           if (vblBlocksMovement(occupiedNode, neighbor)) {
             closedSet.add(occupiedNode);
             blockNode = true;
@@ -368,15 +367,28 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
       double diagonalMultiplier = getDiagonalMultiplier(neighborArray);
 
       if (terrainIsFree) {
-        neighbor.distanceTraveled = node.distanceTraveled;
         neighbor.g = node.g;
+        neighbor.distanceTraveled = node.distanceTraveled;
       } else {
-        neighbor.distanceTraveled =
-            node.distanceTraveled
-                + (terrainMultiplier * diagonalMultiplier)
-                + (terrainAdder / cell_cost);
+        neighbor.distanceTraveledWithoutTerrain =
+            node.distanceTraveledWithoutTerrain + diagonalMultiplier;
 
-        neighbor.g = node.g + (cell_cost * terrainMultiplier * diagonalMultiplier) + terrainAdder;
+        // basic check to see if we are on the odd or even step of 1-2-1 movement
+        if ((int) neighbor.distanceTraveledWithoutTerrain
+            != neighbor.distanceTraveledWithoutTerrain) {
+
+          neighbor.g = node.g + terrainAdder + (cell_cost * terrainMultiplier);
+
+          neighbor.distanceTraveled =
+              node.distanceTraveled + terrainAdder + (cell_cost * terrainMultiplier);
+        } else {
+          neighbor.g = node.g + terrainAdder + (cell_cost * terrainMultiplier * diagonalMultiplier);
+
+          neighbor.distanceTraveled =
+              node.distanceTraveled
+                  + terrainAdder
+                  + (cell_cost * terrainMultiplier * Math.ceil(diagonalMultiplier));
+        }
       }
 
       neighbors.add(neighbor);

--- a/src/main/java/net/rptools/maptool/model/CellPoint.java
+++ b/src/main/java/net/rptools/maptool/model/CellPoint.java
@@ -27,16 +27,20 @@ import net.rptools.maptool.client.ui.zone.ZoneRenderer;
  * @author trevor
  */
 public class CellPoint extends AbstractPoint {
+
   public double g; // Only populated by AStarWalker classes to be used upstream
   public double distanceTraveled; // Only populated by AStarWalker classes to be used upstream
+  public double
+      distanceTraveledWithoutTerrain; // Only populated by AStarWalker classes to be used upstream
 
   public CellPoint(int x, int y) {
     super(x, y);
   }
 
-  public CellPoint(int x, int y, double distanceTraveled) {
+  public CellPoint(int x, int y, double distanceTraveled, double distanceTraveledWithoutTerrain) {
     super(x, y);
     this.distanceTraveled = distanceTraveled;
+    this.distanceTraveledWithoutTerrain = distanceTraveledWithoutTerrain;
   }
 
   @Override
@@ -83,7 +87,28 @@ public class CellPoint extends AbstractPoint {
 
   // Return distance in grid units for current map
   public double getDistanceTraveled(Zone zone) {
-    return Math.floor(distanceTraveled) * zone.getUnitsPerCell();
+    switch (zone.getAStarRounding()) {
+      case CELL_UNIT:
+        return roundToCellCost(distanceTraveled, zone.getUnitsPerCell());
+      case INTEGER:
+        return (int) distanceTraveled;
+      case NONE:
+      default:
+        return distanceTraveled;
+    }
+  }
+
+  public double getDistanceTraveledWithoutTerrain() {
+    return distanceTraveledWithoutTerrain;
+  }
+
+  private double roundToCellCost(double num, double unitsPerCell) {
+    if (num == 0) {
+      return 0;
+    } else {
+      double result = Math.floor((num + unitsPerCell / 2) / unitsPerCell) * unitsPerCell;
+      return Math.max(result, unitsPerCell);
+    }
   }
 
   public double gCost() {
@@ -93,5 +118,6 @@ public class CellPoint extends AbstractPoint {
   public void replaceG(CellPoint previousCell) {
     g = previousCell.g;
     distanceTraveled = previousCell.distanceTraveled;
+    distanceTraveledWithoutTerrain = previousCell.distanceTraveledWithoutTerrain;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -126,6 +126,13 @@ public class Zone extends BaseModel {
     GM
   }
 
+  /** Control how A* Pathfinding distances is rounded off due to terrain costs */
+  public enum AStarRoundingOptions {
+    NONE,
+    CELL_UNIT,
+    INTEGER
+  }
+
   public static final int DEFAULT_TOKEN_VISION_DISTANCE = 250; // In units
   public static final int DEFAULT_PIXELS_CELL = 50;
   public static final int DEFAULT_UNITS_PER_CELL = 5;
@@ -150,6 +157,7 @@ public class Zone extends BaseModel {
   private int tokenVisionDistance = DEFAULT_TOKEN_VISION_DISTANCE;
 
   private double unitsPerCell = DEFAULT_UNITS_PER_CELL;
+  private AStarRoundingOptions aStarRounding = AStarRoundingOptions.NONE;
 
   private List<DrawnElement> drawables = new LinkedList<DrawnElement>();
   private List<DrawnElement> gmDrawables = new LinkedList<DrawnElement>();
@@ -1017,6 +1025,18 @@ public class Zone extends BaseModel {
 
   public void setUnitsPerCell(double unitsPerCell) {
     this.unitsPerCell = unitsPerCell;
+  }
+
+  public AStarRoundingOptions getAStarRounding() {
+    if (aStarRounding == null) {
+      aStarRounding = AStarRoundingOptions.NONE;
+    }
+
+    return aStarRounding;
+  }
+
+  public void setAStarRounding(AStarRoundingOptions aStarRounding) {
+    this.aStarRounding = aStarRounding;
   }
 
   public int getLargestZOrder() {

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/mapPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/mapPropertiesDialog.xml
@@ -24,7 +24,7 @@
     </at>
     <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
    </super>
-   <at name="id">C:\Users\Asus\IdeaProjects\maptool\src\main\resources\net\rptools\maptool\client\ui\forms\mapPropertiesDialog.xml</at>
+   <at name="id">C:\Users\Jamz\Development\git\JamzTheMan\MapTool\src\main\resources\net\rptools\maptool\client\ui\forms\mapPropertiesDialog.xml</at>
    <at name="path">resources\net\rptools\maptool\client\ui\forms\mapPropertiesDialog.xml</at>
    <at name="rowspecs">CENTER:DEFAULT:NONE,FILL:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
    <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
@@ -47,8 +47,8 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.710398274</at>
-        <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
+        <at name="id">embedded.1353365589</at>
+        <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,LEFT:PREF:NONE,LEFT:MIN(100DLU;PREF):NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,LEFT:PREF:GROW(1.0)</at>
         <at name="components">
          <object classname="java.util.LinkedList">
@@ -96,7 +96,7 @@
                    </at>
                   </object>
                  </at>
-                 <at name="width">82</at>
+                 <at name="width">83</at>
                  <at name="name"/>
                  <at name="text">Name:</at>
                  <at name="fill">
@@ -158,7 +158,7 @@
                  </at>
                  <at name="columns">30</at>
                  <at name="name">name</at>
-                 <at name="width">710</at>
+                 <at name="width">677</at>
                  <at name="height">20</at>
                 </object>
                </at>
@@ -211,7 +211,7 @@
                    </at>
                   </object>
                  </at>
-                 <at name="width">82</at>
+                 <at name="width">83</at>
                  <at name="name"/>
                  <at name="text">Cell Type:</at>
                  <at name="fill">
@@ -271,8 +271,8 @@
                    </at>
                   </object>
                  </at>
-                 <at name="width">82</at>
-                 <at name="name"/>
+                 <at name="name"></at>
+                 <at name="width">83</at>
                  <at name="text">Distance per cell:</at>
                  <at name="fill">
                   <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
@@ -295,7 +295,7 @@
                <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                 <at name="column">3</at>
                 <at name="row">5</at>
-                <at name="colspan">1</at>
+                <at name="colspan">4</at>
                 <at name="rowspan">1</at>
                 <at name="halign">default</at>
                 <at name="valign">default</at>
@@ -333,7 +333,7 @@
                  </at>
                  <at name="columns">5</at>
                  <at name="name">distance</at>
-                 <at name="width">47</at>
+                 <at name="width">116</at>
                  <at name="height">20</at>
                 </object>
                </at>
@@ -349,7 +349,7 @@
               <at name="cellconstraints">
                <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                 <at name="column">1</at>
-                <at name="row">7</at>
+                <at name="row">13</at>
                 <at name="colspan">1</at>
                 <at name="rowspan">1</at>
                 <at name="halign">default</at>
@@ -386,238 +386,8 @@
                    </at>
                   </object>
                  </at>
-                 <at name="width">82</at>
+                 <at name="width">83</at>
                  <at name="name"/>
-                 <at name="text">Pixels per Cell:	</at>
-                 <at name="fill">
-                  <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                   <at name="name">fill</at>
-                  </object>
-                 </at>
-                 <at name="height">14</at>
-                </object>
-               </at>
-              </object>
-             </at>
-            </object>
-           </at>
-          </item>
-          <item >
-           <at name="value">
-            <object classname="com.jeta.forms.store.memento.BeanMemento">
-             <super classname="com.jeta.forms.store.memento.ComponentMemento">
-              <at name="cellconstraints">
-               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                <at name="column">3</at>
-                <at name="row">7</at>
-                <at name="colspan">1</at>
-                <at name="rowspan">1</at>
-                <at name="halign">default</at>
-                <at name="valign">default</at>
-                <at name="insets" object="insets">0,0,0,0</at>
-               </object>
-              </at>
-              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-             </super>
-             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-             <at name="beanclass">javax.swing.JTextField</at>
-             <at name="beanproperties">
-              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-               <at name="classname">javax.swing.JTextField</at>
-               <at name="properties">
-                <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="border">
-                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                   <at name="borders">
-                    <object classname="java.util.LinkedList">
-                     <item >
-                      <at name="value">
-                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                        <super classname="com.jeta.forms.store.properties.BorderProperty">
-                         <at name="name">border</at>
-                        </super>
-                       </object>
-                      </at>
-                     </item>
-                    </object>
-                   </at>
-                  </object>
-                 </at>
-                 <at name="columns">5</at>
-                 <at name="name">pixelsPerCell</at>
-                 <at name="width">47</at>
-                 <at name="height">20</at>
-                </object>
-               </at>
-              </object>
-             </at>
-            </object>
-           </at>
-          </item>
-          <item >
-           <at name="value">
-            <object classname="com.jeta.forms.store.memento.BeanMemento">
-             <super classname="com.jeta.forms.store.memento.ComponentMemento">
-              <at name="cellconstraints">
-               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                <at name="column">1</at>
-                <at name="row">9</at>
-                <at name="colspan">1</at>
-                <at name="rowspan">1</at>
-                <at name="halign">default</at>
-                <at name="valign">default</at>
-                <at name="insets" object="insets">0,0,0,0</at>
-               </object>
-              </at>
-              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-             </super>
-             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-             <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
-             <at name="beanproperties">
-              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-               <at name="classname">com.jeta.forms.components.label.JETALabel</at>
-               <at name="properties">
-                <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="border">
-                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                   <at name="borders">
-                    <object classname="java.util.LinkedList">
-                     <item >
-                      <at name="value">
-                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                        <super classname="com.jeta.forms.store.properties.BorderProperty">
-                         <at name="name">border</at>
-                        </super>
-                       </object>
-                      </at>
-                     </item>
-                    </object>
-                   </at>
-                  </object>
-                 </at>
-                 <at name="width">82</at>
-                 <at name="name"/>
-                 <at name="text">Vision Distance:</at>
-                 <at name="fill">
-                  <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-                   <at name="name">fill</at>
-                  </object>
-                 </at>
-                 <at name="height">14</at>
-                </object>
-               </at>
-              </object>
-             </at>
-            </object>
-           </at>
-          </item>
-          <item >
-           <at name="value">
-            <object classname="com.jeta.forms.store.memento.BeanMemento">
-             <super classname="com.jeta.forms.store.memento.ComponentMemento">
-              <at name="cellconstraints">
-               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                <at name="column">3</at>
-                <at name="row">9</at>
-                <at name="colspan">1</at>
-                <at name="rowspan">1</at>
-                <at name="halign">default</at>
-                <at name="valign">default</at>
-                <at name="insets" object="insets">0,0,0,0</at>
-               </object>
-              </at>
-              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-             </super>
-             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-             <at name="beanclass">javax.swing.JTextField</at>
-             <at name="beanproperties">
-              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-               <at name="classname">javax.swing.JTextField</at>
-               <at name="properties">
-                <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="border">
-                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                   <at name="borders">
-                    <object classname="java.util.LinkedList">
-                     <item >
-                      <at name="value">
-                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                        <super classname="com.jeta.forms.store.properties.BorderProperty">
-                         <at name="name">border</at>
-                        </super>
-                       </object>
-                      </at>
-                     </item>
-                    </object>
-                   </at>
-                  </object>
-                 </at>
-                 <at name="columns">5</at>
-                 <at name="name">defaultVision</at>
-                 <at name="width">47</at>
-                 <at name="height">20</at>
-                </object>
-               </at>
-              </object>
-             </at>
-            </object>
-           </at>
-          </item>
-          <item >
-           <at name="value">
-            <object classname="com.jeta.forms.store.memento.BeanMemento">
-             <super classname="com.jeta.forms.store.memento.ComponentMemento">
-              <at name="cellconstraints">
-               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-                <at name="column">1</at>
-                <at name="row">11</at>
-                <at name="colspan">1</at>
-                <at name="rowspan">1</at>
-                <at name="halign">default</at>
-                <at name="valign">default</at>
-                <at name="insets" object="insets">0,0,0,0</at>
-               </object>
-              </at>
-              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-             </super>
-             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-             <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
-             <at name="beanproperties">
-              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-               <at name="classname">com.jeta.forms.components.label.JETALabel</at>
-               <at name="properties">
-                <object classname="com.jeta.forms.store.support.PropertyMap">
-                 <at name="border">
-                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                   <at name="borders">
-                    <object classname="java.util.LinkedList">
-                     <item >
-                      <at name="value">
-                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                        <super classname="com.jeta.forms.store.properties.BorderProperty">
-                         <at name="name">border</at>
-                        </super>
-                       </object>
-                      </at>
-                     </item>
-                    </object>
-                   </at>
-                  </object>
-                 </at>
-                 <at name="name"></at>
-                 <at name="width">82</at>
                  <at name="text">Light:</at>
                  <at name="fill">
                   <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
@@ -640,8 +410,8 @@
               <at name="cellconstraints">
                <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
                 <at name="column">3</at>
-                <at name="row">11</at>
-                <at name="colspan">1</at>
+                <at name="row">13</at>
+                <at name="colspan">4</at>
                 <at name="rowspan">1</at>
                 <at name="halign">default</at>
                 <at name="valign">default</at>
@@ -678,7 +448,7 @@
                   </object>
                  </at>
                  <at name="name">visionType</at>
-                 <at name="width">25</at>
+                 <at name="width">116</at>
                  <at name="items">
                   <object classname="com.jeta.forms.store.properties.ItemsProperty">
                    <at name="name">items</at>
@@ -709,7 +479,7 @@
               </at>
               <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
              </super>
-             <at name="id">embedded.1472787067</at>
+             <at name="id">embedded.2005533611</at>
              <at name="rowspecs">CENTER:DEFAULT:NONE</at>
              <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
              <at name="components">
@@ -937,7 +707,7 @@
               </at>
               <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
              </super>
-             <at name="id">embedded.1332504379</at>
+             <at name="id">embedded.1287749232</at>
              <at name="rowspecs">CENTER:DEFAULT:NONE</at>
              <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
              <at name="components">
@@ -1165,7 +935,7 @@
               </at>
               <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
              </super>
-             <at name="id">embedded.676837851</at>
+             <at name="id">embedded.1260916488</at>
              <at name="rowspecs">CENTER:DEFAULT:NONE</at>
              <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
              <at name="components">
@@ -1393,7 +1163,7 @@
               </at>
               <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
              </super>
-             <at name="id">embedded.1357126179</at>
+             <at name="id">embedded.2097234040</at>
              <at name="rowspecs">CENTER:DEFAULT:NONE</at>
              <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
              <at name="components">
@@ -1622,7 +1392,7 @@
               </at>
               <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
              </super>
-             <at name="id">embedded.1741867053</at>
+             <at name="id">embedded.191847041</at>
              <at name="rowspecs">CENTER:DEFAULT:NONE</at>
              <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
              <at name="components">
@@ -1833,6 +1603,356 @@
             </object>
            </at>
           </item>
+          <item >
+           <at name="value">
+            <object classname="com.jeta.forms.store.memento.BeanMemento">
+             <super classname="com.jeta.forms.store.memento.ComponentMemento">
+              <at name="cellconstraints">
+               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                <at name="column">1</at>
+                <at name="row">7</at>
+                <at name="colspan">1</at>
+                <at name="rowspan">1</at>
+                <at name="halign">default</at>
+                <at name="valign">default</at>
+                <at name="insets" object="insets">0,0,0,0</at>
+               </object>
+              </at>
+              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+             </super>
+             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+             <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+             <at name="beanproperties">
+              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+               <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+               <at name="properties">
+                <object classname="com.jeta.forms.store.support.PropertyMap">
+                 <at name="border">
+                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                   <at name="borders">
+                    <object classname="java.util.LinkedList">
+                     <item >
+                      <at name="value">
+                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                        <super classname="com.jeta.forms.store.properties.BorderProperty">
+                         <at name="name">border</at>
+                        </super>
+                       </object>
+                      </at>
+                     </item>
+                    </object>
+                   </at>
+                  </object>
+                 </at>
+                 <at name="width">83</at>
+                 <at name="name"/>
+                 <at name="text">Pixels per Cell:	</at>
+                 <at name="fill">
+                  <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                   <at name="name">fill</at>
+                  </object>
+                 </at>
+                 <at name="height">14</at>
+                </object>
+               </at>
+              </object>
+             </at>
+            </object>
+           </at>
+          </item>
+          <item >
+           <at name="value">
+            <object classname="com.jeta.forms.store.memento.BeanMemento">
+             <super classname="com.jeta.forms.store.memento.ComponentMemento">
+              <at name="cellconstraints">
+               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                <at name="column">3</at>
+                <at name="row">7</at>
+                <at name="colspan">4</at>
+                <at name="rowspan">1</at>
+                <at name="halign">default</at>
+                <at name="valign">default</at>
+                <at name="insets" object="insets">0,0,0,0</at>
+               </object>
+              </at>
+              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+             </super>
+             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+             <at name="beanclass">javax.swing.JTextField</at>
+             <at name="beanproperties">
+              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+               <at name="classname">javax.swing.JTextField</at>
+               <at name="properties">
+                <object classname="com.jeta.forms.store.support.PropertyMap">
+                 <at name="border">
+                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                   <at name="borders">
+                    <object classname="java.util.LinkedList">
+                     <item >
+                      <at name="value">
+                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                        <super classname="com.jeta.forms.store.properties.BorderProperty">
+                         <at name="name">border</at>
+                        </super>
+                       </object>
+                      </at>
+                     </item>
+                    </object>
+                   </at>
+                  </object>
+                 </at>
+                 <at name="columns">5</at>
+                 <at name="name">pixelsPerCell</at>
+                 <at name="width">116</at>
+                 <at name="height">20</at>
+                </object>
+               </at>
+              </object>
+             </at>
+            </object>
+           </at>
+          </item>
+          <item >
+           <at name="value">
+            <object classname="com.jeta.forms.store.memento.BeanMemento">
+             <super classname="com.jeta.forms.store.memento.ComponentMemento">
+              <at name="cellconstraints">
+               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                <at name="column">1</at>
+                <at name="row">9</at>
+                <at name="colspan">1</at>
+                <at name="rowspan">1</at>
+                <at name="halign">default</at>
+                <at name="valign">default</at>
+                <at name="insets" object="insets">0,0,0,0</at>
+               </object>
+              </at>
+              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+             </super>
+             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+             <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+             <at name="beanproperties">
+              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+               <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+               <at name="properties">
+                <object classname="com.jeta.forms.store.support.PropertyMap">
+                 <at name="border">
+                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                   <at name="borders">
+                    <object classname="java.util.LinkedList">
+                     <item >
+                      <at name="value">
+                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                        <super classname="com.jeta.forms.store.properties.BorderProperty">
+                         <at name="name">border</at>
+                        </super>
+                       </object>
+                      </at>
+                     </item>
+                    </object>
+                   </at>
+                  </object>
+                 </at>
+                 <at name="width">83</at>
+                 <at name="name"/>
+                 <at name="text">Vision Distance:</at>
+                 <at name="fill">
+                  <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                   <at name="name">fill</at>
+                  </object>
+                 </at>
+                 <at name="height">14</at>
+                </object>
+               </at>
+              </object>
+             </at>
+            </object>
+           </at>
+          </item>
+          <item >
+           <at name="value">
+            <object classname="com.jeta.forms.store.memento.BeanMemento">
+             <super classname="com.jeta.forms.store.memento.ComponentMemento">
+              <at name="cellconstraints">
+               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                <at name="column">3</at>
+                <at name="row">9</at>
+                <at name="colspan">4</at>
+                <at name="rowspan">1</at>
+                <at name="halign">default</at>
+                <at name="valign">default</at>
+                <at name="insets" object="insets">0,0,0,0</at>
+               </object>
+              </at>
+              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+             </super>
+             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+             <at name="beanclass">javax.swing.JTextField</at>
+             <at name="beanproperties">
+              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+               <at name="classname">javax.swing.JTextField</at>
+               <at name="properties">
+                <object classname="com.jeta.forms.store.support.PropertyMap">
+                 <at name="border">
+                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                   <at name="borders">
+                    <object classname="java.util.LinkedList">
+                     <item >
+                      <at name="value">
+                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                        <super classname="com.jeta.forms.store.properties.BorderProperty">
+                         <at name="name">border</at>
+                        </super>
+                       </object>
+                      </at>
+                     </item>
+                    </object>
+                   </at>
+                  </object>
+                 </at>
+                 <at name="columns">5</at>
+                 <at name="name">defaultVision</at>
+                 <at name="width">116</at>
+                 <at name="height">20</at>
+                </object>
+               </at>
+              </object>
+             </at>
+            </object>
+           </at>
+          </item>
+          <item >
+           <at name="value">
+            <object classname="com.jeta.forms.store.memento.BeanMemento">
+             <super classname="com.jeta.forms.store.memento.ComponentMemento">
+              <at name="cellconstraints">
+               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                <at name="column">1</at>
+                <at name="row">11</at>
+                <at name="colspan">1</at>
+                <at name="rowspan">1</at>
+                <at name="halign">default</at>
+                <at name="valign">default</at>
+                <at name="insets" object="insets">0,0,0,0</at>
+               </object>
+              </at>
+              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+             </super>
+             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+             <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+             <at name="beanproperties">
+              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+               <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+               <at name="properties">
+                <object classname="com.jeta.forms.store.support.PropertyMap">
+                 <at name="border">
+                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                   <at name="borders">
+                    <object classname="java.util.LinkedList">
+                     <item >
+                      <at name="value">
+                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                        <super classname="com.jeta.forms.store.properties.BorderProperty">
+                         <at name="name">border</at>
+                        </super>
+                       </object>
+                      </at>
+                     </item>
+                    </object>
+                   </at>
+                  </object>
+                 </at>
+                 <at name="name"></at>
+                 <at name="width">83</at>
+                 <at name="text">AI Cell Rounding:</at>
+                 <at name="fill">
+                  <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+                   <at name="name">fill</at>
+                  </object>
+                 </at>
+                 <at name="toolTipText">This controls how the AI will round the distance per cell after terrain modifiers have been applied. The default is no rounding, which may leave the cell cost as a fraction and/or not in even multiples of cell units.</at>
+                 <at name="height">14</at>
+                </object>
+               </at>
+              </object>
+             </at>
+            </object>
+           </at>
+          </item>
+          <item >
+           <at name="value">
+            <object classname="com.jeta.forms.store.memento.BeanMemento">
+             <super classname="com.jeta.forms.store.memento.ComponentMemento">
+              <at name="cellconstraints">
+               <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+                <at name="column">3</at>
+                <at name="row">11</at>
+                <at name="colspan">4</at>
+                <at name="rowspan">1</at>
+                <at name="halign">default</at>
+                <at name="valign">default</at>
+                <at name="insets" object="insets">0,0,0,0</at>
+               </object>
+              </at>
+              <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+             </super>
+             <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+             <at name="beanclass">javax.swing.JComboBox</at>
+             <at name="beanproperties">
+              <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+               <at name="classname">javax.swing.JComboBox</at>
+               <at name="properties">
+                <object classname="com.jeta.forms.store.support.PropertyMap">
+                 <at name="border">
+                  <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                   <at name="borders">
+                    <object classname="java.util.LinkedList">
+                     <item >
+                      <at name="value">
+                       <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                        <super classname="com.jeta.forms.store.properties.BorderProperty">
+                         <at name="name">border</at>
+                        </super>
+                       </object>
+                      </at>
+                     </item>
+                    </object>
+                   </at>
+                  </object>
+                 </at>
+                 <at name="name">aStarRoundingOptionsComboBox</at>
+                 <at name="width">116</at>
+                 <at name="items">
+                  <object classname="com.jeta.forms.store.properties.ItemsProperty">
+                   <at name="name">items</at>
+                  </object>
+                 </at>
+                 <at name="height">20</at>
+                </object>
+               </at>
+              </object>
+             </at>
+            </object>
+           </at>
+          </item>
          </object>
         </at>
         <at name="properties">
@@ -1850,7 +1970,7 @@
               </at>
              </object>
             </at>
-            <at name="name"></at>
+            <at name="name"/>
             <at name="fill">
              <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
               <at name="name">fill</at>
@@ -1890,7 +2010,7 @@
         <at name="cellpainters">
          <object classname="com.jeta.forms.store.support.Matrix">
           <at name="rows">
-           <object classname="[Ljava.lang.Object;" size="11">
+           <object classname="[Ljava.lang.Object;" size="13">
             <at name="item" index="0">
              <object classname="[Ljava.lang.Object;" size="11"/>
             </at>
@@ -1922,6 +2042,12 @@
              <object classname="[Ljava.lang.Object;" size="11"/>
             </at>
             <at name="item" index="10">
+             <object classname="[Ljava.lang.Object;" size="11"/>
+            </at>
+            <at name="item" index="11">
+             <object classname="[Ljava.lang.Object;" size="11"/>
+            </at>
+            <at name="item" index="12">
              <object classname="[Ljava.lang.Object;" size="11"/>
             </at>
            </object>
@@ -1962,7 +2088,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.1788815622</at>
+        <at name="id">embedded.836117767</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -2178,7 +2304,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.132530314</at>
+        <at name="id">embedded.418413223</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0)</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -2235,7 +2361,7 @@
                    <at name="name">fill</at>
                   </object>
                  </at>
-                 <at name="height">243</at>
+                 <at name="height">283</at>
                 </object>
                </at>
               </object>


### PR DESCRIPTION
 * Previously the Distance calculations relied on rounding where all diagonals internally cost 1.5 vs 1-2-1.
   Adding terrain modifier costs introduced additional decimal rounding and terrain could not always be multiplied by 1.5 but rather 1 or 2 depending.
   Additional variables and methods added to CellPoint and related classes to track costs to correct the issue.
 * New Map Option for AI rounding of cell costs, NONE, CELL_UNIT, INTEGER. More can easily be added if needed.
 * Some refactoring of variable names in AStar classes, longer but more clear IMO
 * ZoneRenderer now show blocked movements if class log debug is on (previously required manual boolean change while developing)
 * ZoneRenderer now shows raw cost without cell units while debugging when showing token Path
 * Lots of {}'s added to match style guide

Signed-off-by: JamzTheMan <JamzTheMan@gmail.com>

New map option will need documentation and word smithing...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1179)
<!-- Reviewable:end -->
