### PR TITLE
Json string as array fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -160,7 +160,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.length":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 1);
-          JsonElement json = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement json = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           if (json.isJsonObject()) {
             return jsonObjectFunctions.length(json.getAsJsonObject());
           } else {
@@ -170,7 +170,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.fields":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 2);
-          JsonElement json = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement json = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           String delim = args.size() > 1 ? args.get(1).toString() : ",";
 
           if (json.isJsonObject()) {
@@ -182,7 +182,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.toVars":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 3);
-          JsonElement json = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement json = FunctionUtil.paramConvertedToJson(functionName, args, 0);
 
           if (json.isJsonObject()) {
             String prefix = args.size() > 1 ? args.get(1).toString() : "";
@@ -199,7 +199,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.toList":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 2);
-          JsonElement json = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement json = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           String delim = args.size() > 1 ? args.get(1).toString() : ",";
 
           if (json.isJsonArray()) {
@@ -225,7 +225,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.toStrProp":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 2);
-          JsonElement jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           String delim = args.size() > 1 ? args.get(1).toString() : DEFAULT_STRING_PROP_DELIM;
           if (jsonElement.isJsonArray()) {
             return jsonArrayFunctions.toStringProp(jsonElement.getAsJsonArray(), delim);
@@ -294,7 +294,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.remove":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, 2);
-          JsonElement jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           if (jsonElement.isJsonArray()) {
             int index = FunctionUtil.paramAsInteger(functionName, args, 1, true);
             return jsonArrayFunctions.remove(jsonElement.getAsJsonArray(), index);
@@ -306,7 +306,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.indent":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 2);
-          JsonElement jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           int indentSize = 2;
           if (args.size() > 1) {
             indentSize = FunctionUtil.paramAsInteger(functionName, args, 1, true);
@@ -316,7 +316,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.contains":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, 2);
-          JsonElement jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           boolean contains;
           if (jsonElement.isJsonArray()) {
             contains = jsonArrayFunctions.contains(jsonElement.getAsJsonArray(), args.get(1));
@@ -329,7 +329,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.sort":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, UNLIMITED_PARAMETERS);
-          JsonArray jsonArray = FunctionUtil.paramAsJsonArray(functionName, args, 0);
+          JsonArray jsonArray = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
           boolean sortAscending = true;
           if (args.size() > 1) {
             if (args.get(1).toString().startsWith("d")) {
@@ -357,13 +357,13 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.shuffle":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 1);
-          JsonArray jsonArray = FunctionUtil.paramAsJsonArray(functionName, args, 0);
+          JsonArray jsonArray = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
           return jsonArrayFunctions.shuffle(jsonArray);
         }
       case "json.reverse":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 1);
-          JsonArray jsonArray = FunctionUtil.paramAsJsonArray(functionName, args, 0);
+          JsonArray jsonArray = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
           return jsonArrayFunctions.reverse(jsonArray);
         }
       case "json.evaluate":
@@ -371,22 +371,13 @@ public class JSONMacroFunctions extends AbstractFunction {
           FunctionUtil.blockUntrustedMacro(functionName);
           FunctionUtil.checkNumberParam(functionName, args, 1, 1);
           MapToolVariableResolver resolver = (MapToolVariableResolver) parser.getVariableResolver();
-          return jsonEvaluateArg(resolver, args.get(0));
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
+          return jsonEvaluate(jsonElement, resolver);
         }
       case "json.isEmpty":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 1);
-          JsonElement jsonElement;
-          try {
-            jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
-          } catch (ParserException pe) {
-            // If we cant convert it to a JsonArray/JsonObject then treat like array with single
-            // value
-            jsonElement = new JsonArray();
-            if (args.get(0).toString().length() != 0) { // empty string == empty array
-              jsonElement.getAsJsonArray().add(typeConversion.asJsonElement(args.get(0)));
-            }
-          }
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
 
           boolean empty;
           if (jsonElement.isJsonArray()) {
@@ -399,8 +390,8 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.equals":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, 2);
-          JsonElement jsonElement1 = FunctionUtil.paramAsJson(functionName, args, 0);
-          JsonElement jsonElement2 = FunctionUtil.paramAsJson(functionName, args, 1);
+          JsonElement jsonElement1 = FunctionUtil.paramConvertedToJson(functionName, args, 0);
+          JsonElement jsonElement2 = FunctionUtil.paramConvertedToJson(functionName, args, 1);
           return jsonElement1.equals(jsonElement2) ? BigDecimal.ONE : BigDecimal.ZERO;
         }
       case "json.count":
@@ -410,7 +401,7 @@ public class JSONMacroFunctions extends AbstractFunction {
           if (args.size() > 2) {
             start = FunctionUtil.paramAsInteger(functionName, args, 2, true);
           }
-          JsonArray jsonArray = FunctionUtil.paramAsJsonArray(functionName, args, 0);
+          JsonArray jsonArray = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
           JsonElement value = asJsonElement(args.get(1));
 
           return BigDecimal.valueOf(jsonArrayFunctions.count(jsonArray, value, start));
@@ -418,7 +409,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.indexOf":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, 3);
-          JsonArray jsonArray = FunctionUtil.paramAsJsonArray(functionName, args, 0);
+          JsonArray jsonArray = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
           JsonElement value = asJsonElement(args.get(1));
           int start = 0;
           if (args.size() > 2) {
@@ -429,9 +420,9 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.merge":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
-          JsonElement jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
+          JsonElement jsonElement = FunctionUtil.paramConvertedToJson(functionName, args, 0);
           if (jsonElement.isJsonArray()) {
-            return jsonArrayFunctions.merge(paramsAsJsonArrays(functionName, args));
+            return jsonArrayFunctions.merge(paramsConvertedToJsonArrays(functionName, args));
           } else {
             return jsonObjectFunctions.merge(paramsAsJsonObjects(functionName, args));
           }
@@ -439,7 +430,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.unique":
         {
           FunctionUtil.checkNumberParam(functionName, args, 1, 1);
-          JsonArray jsonArray = FunctionUtil.paramAsJsonArray(functionName, args, 0);
+          JsonArray jsonArray = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
 
           return jsonArrayFunctions.unique(jsonArray);
         }
@@ -448,7 +439,7 @@ public class JSONMacroFunctions extends AbstractFunction {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
           JsonElement jsonElement = FunctionUtil.paramAsJson(functionName, args, 0);
           if (jsonElement.isJsonArray()) {
-            List<JsonArray> arrays = (paramsAsJsonArrays(functionName, args));
+            List<JsonArray> arrays = (paramsConvertedToJsonArrays(functionName, args));
             return jsonArrayFunctions.removeAll(arrays.get(0), arrays.subList(1, arrays.size()));
           } else {
             List<JsonObject> objects = paramsAsJsonObjects(functionName, args);
@@ -459,13 +450,13 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.union":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
-          List<JsonElement> elements = paramsAsJsonElements(functionName, args);
+          List<JsonElement> elements = paramsConvertedToJsonElements(functionName, args);
           return jsonArrayFunctions.union(elements);
         }
       case "json.intersection":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
-          List<JsonElement> elements = paramsAsJsonElements(functionName, args);
+          List<JsonElement> elements = paramsConvertedToJsonElements(functionName, args);
           return jsonArrayFunctions.intersection(elements);
         }
       case "json.difference":
@@ -477,14 +468,14 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.isSubset":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
-          List<JsonElement> elements = paramsAsJsonElements(functionName, args);
+          List<JsonElement> elements = paramsConvertedToJsonElements(functionName, args);
           return jsonArrayFunctions.isSubset(elements) ? BigDecimal.ONE : BigDecimal.ZERO;
         }
       case "json.removeFirst":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
-          JsonArray removeFrom = FunctionUtil.paramAsJsonArray(functionName, args, 0);
-          JsonArray toRemove = FunctionUtil.paramAsJsonArray(functionName, args, 1);
+          JsonArray removeFrom = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
+          JsonArray toRemove = FunctionUtil.paramConvertedToJsonArray(functionName, args, 1);
           return jsonArrayFunctions.removeFirst(removeFrom, toRemove);
         }
       case "json.rolls":
@@ -504,8 +495,8 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.objrolls":
         {
           FunctionUtil.checkNumberParam(functionName, args, 3, 3);
-          JsonArray names = FunctionUtil.paramAsJsonArray(functionName, args, 0);
-          JsonArray stats = FunctionUtil.paramAsJsonArray(functionName, args, 1);
+          JsonArray names = FunctionUtil.paramConvertedToJsonArray(functionName, args, 0);
+          JsonArray stats = FunctionUtil.paramConvertedToJsonArray(functionName, args, 1);
           JsonArray rollArray;
           String rollString; // = args.get(2).toString();
           boolean isArrayOfRolls;
@@ -639,7 +630,25 @@ public class JSONMacroFunctions extends AbstractFunction {
 
     return arrays;
   }
+  /**
+   * Returns the parameter list as a list of {@link JsonArray}s. If the parameter is not a json
+   * object/array and is an empty string it will result in a 0 sized JsonArray, otherwise the value
+   * will result in a JsonArray containing that value.
+   *
+   * @param functionName The name of the MT Script function that was called.
+   * @param params The parameters to extract as {@link JsonArray}s.
+   * @return The list of {@link JsonArray}s.
+   * @throws ParserException if the parameters can not be converted to {@link JsonArray}s.
+   */
+  private List<JsonArray> paramsConvertedToJsonArrays(String functionName, List<Object> params)
+      throws ParserException {
+    List<JsonArray> arrays = new ArrayList<>();
+    for (int i = 0; i < params.size(); i++) {
+      arrays.add(FunctionUtil.paramConvertedToJsonArray(functionName, params, i));
+    }
 
+    return arrays;
+  }
   /**
    * Returns the parameter list as a list of {@link JsonObject}s.
    *
@@ -671,6 +680,26 @@ public class JSONMacroFunctions extends AbstractFunction {
     List<JsonElement> elements = new ArrayList<>();
     for (int i = 0; i < params.size(); i++) {
       elements.add(FunctionUtil.paramAsJson(functionName, params, i));
+    }
+
+    return elements;
+  }
+
+  /**
+   * Returns the parameter list as a list of {@link JsonElement}s. If the parameter is not a json
+   * object/array and is an empty string it * will result in a 0 sized JsonArray, otherwise the
+   * value will result * in a JsonArray containing that value. *
+   *
+   * @param functionName The name of the MT Script function that was called.
+   * @param params The parameters to extract as {@link JsonElement}s.
+   * @return The list of {@link JsonElement}s.
+   * @throws ParserException if the parameters can not be converted to {@link JsonElement}s.
+   */
+  private List<JsonElement> paramsConvertedToJsonElements(String functionName, List<Object> params)
+      throws ParserException {
+    List<JsonElement> elements = new ArrayList<>();
+    for (int i = 0; i < params.size(); i++) {
+      elements.add(FunctionUtil.paramConvertedToJson(functionName, params, i));
     }
 
     return elements;

--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -462,7 +462,7 @@ public class JSONMacroFunctions extends AbstractFunction {
       case "json.difference":
         {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
-          List<JsonElement> elements = paramsAsJsonElements(functionName, args);
+          List<JsonElement> elements = paramsConvertedToJsonElements(functionName, args);
           return jsonArrayFunctions.difference(elements);
         }
       case "json.isSubset":

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -353,6 +353,54 @@ public class FunctionUtil {
   }
 
   /**
+   * Return the jsonElement value of a parameter. Throws a <code>ParserException</code> if the
+   * parameter can't be converted to a jsonArray.
+   *
+   * @param functionName this is used in the exception message
+   * @param parameters the list of parameters
+   * @param index the index of the parameter to return as jsonArray
+   * @return the parameter as a jsonArray
+   */
+  public static JsonElement paramConvertedToJson(
+      String functionName, List<Object> parameters, int index) {
+    try {
+      return paramAsJson(functionName, parameters, index);
+    } catch (ParserException e) {
+      JsonArray json = new JsonArray();
+      Object val = parameters.get(index);
+      if (val.toString().length() > 0) {
+        if (val instanceof Number) {
+          json.add((Number) val);
+        } else {
+          json.add(val.toString());
+        }
+      }
+
+      return json;
+    }
+  }
+
+  /**
+   * Return the jsonObject or jsonArray value of a parameter. if the parameter can't be converted to
+   * a json. Then an empty json array will be returned if its an empty string, otherwise a a
+   * JsonArray containing the argument will be returned.
+   *
+   * @param functionName this is used in the exception message
+   * @param parameters the list of parameters
+   * @param index the index of the parameter to return as Json
+   * @return the parameter as a jsonObject or jsonArray
+   * @throws ParserException if the parameter can't be converted to jsonObject or jsonArray
+   */
+  public static JsonArray paramConvertedToJsonArray(
+      String functionName, List<Object> parameters, int index) throws ParserException {
+    JsonElement json = paramConvertedToJson(functionName, parameters, index);
+    if (!json.isJsonArray()) {
+      throw new ParserException(I18N.getText(KEY_NOT_JSON_ARRAY, functionName, index + 1));
+    } else {
+      return json.getAsJsonArray();
+    }
+  }
+  /**
    * Convert an object into a boolean value. Never returns an error.
    *
    * @param value Convert this object. Must be {@link Boolean}, {@link BigDecimal}, or will have its


### PR DESCRIPTION
Changes to multiple functions so that an empty string will be treated as an empty array and other non json values will be treated as a json array with a size of 1.

This change affects
json.length
json.fields
json.toVars
json.toList
json.toStrProp
json.remove
json.indent
json.contain
json.sort
json.shuffle
json.reverse
json.evaluate
json.isEmpty
json.equals
json.count
json.indexOf
json.merge
json.unique
json.removeAll
json.union
json.intersection
json.union
json.isSubset
json.removeFirst
json.objRolls
json.difference

Some functions will now accept "" as an empty json array as well as "non empty string" where they previously failed with "" so they are more consistent with other functions. I don't see excepting these instead of throwing an unrecoverable error being too much of a backwards compatibility issue.

Fixes #1177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1180)
<!-- Reviewable:end -->
