### PR TITLE
macOS mouse wheel fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -233,6 +233,7 @@ public class AppUpdate {
 
     Runnable updatethread =
         new Runnable() {
+          @Override
           public void run() {
             try (InputStream stream = assetDownloadURL.openStream()) {
               ProgressMonitorInputStream pmis =

--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -449,6 +449,7 @@ public class MapToolVariableResolver extends MapVariableResolver {
       this.token = token;
     }
 
+    @Override
     public void run() {
       MapTool.serverCommand().putToken(zoneId, token);
     }

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -14,16 +14,24 @@
  */
 package net.rptools.maptool.client.swing;
 
-import com.jidesoft.dialog.JideOptionPane;
-import io.sentry.Sentry;
-import io.sentry.event.UserBuilder;
 import java.awt.AWTEvent;
 import java.awt.EventQueue;
+import java.awt.event.MouseWheelEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Collections;
+
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.jidesoft.dialog.JideOptionPane;
+
+import io.sentry.Sentry;
+import io.sentry.event.UserBuilder;
+import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.functions.getInfoFunction;
@@ -31,8 +39,6 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Player;
 import net.rptools.maptool.util.SysInfo;
 import net.rptools.parser.ParserException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class MapToolEventQueue extends EventQueue {
   private static final Logger log = LogManager.getLogger(MapToolEventQueue.class);
@@ -45,7 +51,14 @@ public class MapToolEventQueue extends EventQueue {
   @Override
   protected void dispatchEvent(AWTEvent event) {
     try {
-      super.dispatchEvent(event);
+      if (event instanceof MouseWheelEvent
+          && AppUtil.MAC_OS_X
+          && ((MouseWheelEvent) event).isShiftDown()) {
+        // System.out.println("Ignoring: " + event.paramString());
+        // ignore this event
+      } else {
+        super.dispatchEvent(event);
+      }
     } catch (StackOverflowError soe) {
       log.error(soe, soe);
       optionPane.setTitle(I18N.getString("MapToolEventQueue.stackOverflow.title")); // $NON-NLS-1$

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -16,6 +16,9 @@ package net.rptools.maptool.client.swing;
 
 import java.awt.AWTEvent;
 import java.awt.EventQueue;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseWheelEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -31,7 +34,6 @@ import com.jidesoft.dialog.JideOptionPane;
 
 import io.sentry.Sentry;
 import io.sentry.event.UserBuilder;
-import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.functions.getInfoFunction;
@@ -47,18 +49,46 @@ public class MapToolEventQueue extends EventQueue {
           I18N.getString("MapToolEventQueue.details"), // $NON-NLS-1$
           JOptionPane.ERROR_MESSAGE,
           JideOptionPane.CLOSE_OPTION);
+  /**
+   * This field must only ever be accessed from the EDT.  Otherwise, a separate thread
+   * could access it to determine the state of the `Shift` key only to have the EDT
+   * progress to a different event such that the state is outdated.
+   * 
+   * An `int` is used to allow for future implementations to include the location
+   * of the key, i.e., Left-Shift or Right-Shift via event.getKeyLocation().
+   */
+  public static int shiftState = 0;
+  public static final int ALL_MODIFIERS_EXC_SHIFT = InputEvent.CTRL_DOWN_MASK |
+			InputEvent.ALT_DOWN_MASK | InputEvent.META_DOWN_MASK | InputEvent.ALT_GRAPH_DOWN_MASK;
 
   @Override
   protected void dispatchEvent(AWTEvent event) {
     try {
-      if (event instanceof MouseWheelEvent
-          && AppUtil.MAC_OS_X
-          && ((MouseWheelEvent) event).isShiftDown()) {
-        // System.out.println("Ignoring: " + event.paramString());
-        // ignore this event
-      } else {
+		if (event instanceof KeyEvent) {
+			KeyEvent ke = (KeyEvent) event;
+			if (ke.getKeyCode() == KeyEvent.VK_SHIFT) {
+				switch (ke.getID()) {
+				case KeyEvent.KEY_PRESSED:	MapToolEventQueue.shiftState = 1; break;
+				case KeyEvent.KEY_RELEASED:	MapToolEventQueue.shiftState = 0; break;
+				}
+				// log.info("shiftState set to " + MapToolEventQueue.shiftState);
+			}
+		} else if (event instanceof FocusEvent) {
+			FocusEvent fe = (FocusEvent) event;
+			if (fe.getID() == FocusEvent.FOCUS_LOST) {
+				// When we lose focus, assume the Shift key is released.
+				MapToolEventQueue.shiftState = 0;
+				// log.info("shiftState forced off (focus lost)");
+			}
+		} else if (event instanceof MouseWheelEvent) {
+			MouseWheelEvent mwe = (MouseWheelEvent) event;
+			if (mwe.isShiftDown() && MapToolEventQueue.shiftState == 0) {
+				int all_mods = mwe.getModifiersEx() & MapToolEventQueue.ALL_MODIFIERS_EXC_SHIFT;
+				event = new MouseWheelEvent(mwe.getComponent(), mwe.getID(), mwe.getWhen(), all_mods, mwe.getX(), mwe.getY(), mwe.getXOnScreen(), mwe.getYOnScreen(), 1, mwe.isPopupTrigger(), mwe.getScrollType(), mwe.getScrollAmount(), mwe.getWheelRotation(), mwe.getPreciseWheelRotation());
+				// log.info("shiftModifier forced off");
+			}
+        }
         super.dispatchEvent(event);
-      }
     } catch (StackOverflowError soe) {
       log.error(soe, soe);
       optionPane.setTitle(I18N.getString("MapToolEventQueue.stackOverflow.title")); // $NON-NLS-1$

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -81,6 +81,7 @@ public abstract class DefaultTool extends Tool
 
   ////
   // Mouse
+  @Override
   public void mousePressed(MouseEvent e) {
     // Potential map dragging
     if (SwingUtilities.isRightMouseButton(e)) {
@@ -89,6 +90,7 @@ public abstract class DefaultTool extends Tool
     }
   }
 
+  @Override
   public void mouseReleased(MouseEvent e) {
     if (isDraggingMap && isRightMouseButton(e)) {
       renderer.maybeForcePlayersView();
@@ -102,6 +104,7 @@ public abstract class DefaultTool extends Tool
    *
    * @see java.awt.event.MouseListener#mouseClicked(java.awt.event.MouseEvent)
    */
+  @Override
   public void mouseClicked(MouseEvent e) {}
 
   /*
@@ -109,6 +112,7 @@ public abstract class DefaultTool extends Tool
    *
    * @see java.awt.event.MouseListener#mouseEntered(java.awt.event.MouseEvent)
    */
+  @Override
   public void mouseEntered(MouseEvent e) {}
 
   /*
@@ -116,6 +120,7 @@ public abstract class DefaultTool extends Tool
    *
    * @see java.awt.event.MouseListener#mouseExited(java.awt.event.MouseEvent)
    */
+  @Override
   public void mouseExited(MouseEvent e) {}
 
   ////
@@ -125,6 +130,7 @@ public abstract class DefaultTool extends Tool
    *
    * @see java.awt.event.MouseMotionListener#mouseMoved(java.awt.event.MouseEvent)
    */
+  @Override
   public void mouseMoved(MouseEvent e) {
     if (renderer == null) {
       return;
@@ -141,6 +147,7 @@ public abstract class DefaultTool extends Tool
     }
   }
 
+  @Override
   public void mouseDragged(MouseEvent e) {
     int mX = e.getX();
     int mY = e.getY();
@@ -178,6 +185,7 @@ public abstract class DefaultTool extends Tool
 
   ////
   // Mouse Wheel
+  @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
     // Fix for High Resolution Mouse Wheels
     if (e.getWheelRotation() == 0) {
@@ -279,8 +287,8 @@ public abstract class DefaultTool extends Tool
     }
     // ZOOM
     if (!AppState.isZoomLocked()) {
-      boolean direction = e.getWheelRotation() > 0;
-      direction = isKeyDown('z') ? !direction : direction;
+      boolean direction = e.getWheelRotation() < 0;
+      direction = isKeyDown('z') ? direction : !direction; // XXX Why check for this?
       if (direction) {
         renderer.zoomOut(e.getX(), e.getY());
       } else {

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -124,6 +124,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
               Zone.Layer.TOKEN, Zone.Layer.GM, Zone.Layer.OBJECT, Zone.Layer.BACKGROUND
             },
             new LayerSelectionListener() {
+              @Override
               public void layerSelected(Layer layer) {
                 if (renderer != null) {
                   renderer.setActiveLayer(layer);
@@ -863,6 +864,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_R, AppActions.menuShortcut),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             if (renderer.getSelectedTokenSet().isEmpty()) {
               return;
@@ -880,6 +882,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_D, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             if (!isDraggingToken) {
               return;
@@ -891,6 +894,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD5, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             if (!isDraggingToken) {
               return;
@@ -904,6 +908,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, false);
           }
@@ -911,6 +916,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, false);
           }
@@ -918,6 +924,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, false);
           }
@@ -925,6 +932,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, false);
           }
@@ -932,6 +940,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, -1, false);
           }
@@ -939,6 +948,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, -1, false);
           }
@@ -946,6 +956,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 1, false);
           }
@@ -953,6 +964,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 1, false);
           }
@@ -961,6 +973,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, true);
           }
@@ -968,6 +981,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, true);
           }
@@ -975,6 +989,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, true);
           }
@@ -982,6 +997,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, true);
           }
@@ -989,6 +1005,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, -1, true);
           }
@@ -996,6 +1013,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, -1, true);
           }
@@ -1003,6 +1021,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 1, true);
           }
@@ -1010,6 +1029,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 1, true);
           }
@@ -1017,6 +1037,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_T, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             cycleSelectedToken(1);
           }
@@ -1024,6 +1045,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.SHIFT_DOWN_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             cycleSelectedToken(-1);
           }
@@ -1031,6 +1053,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, false);
           }
@@ -1038,6 +1061,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, false);
           }
@@ -1045,6 +1069,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, false);
           }
@@ -1052,6 +1077,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, false);
           }
@@ -1059,6 +1085,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, 1, true);
           }
@@ -1066,6 +1093,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(1, 0, true);
           }
@@ -1073,6 +1101,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(-1, 0, true);
           }
@@ -1080,6 +1109,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     actionMap.put(
         KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.SHIFT_MASK),
         new AbstractAction() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             handleKeyMove(0, -1, true);
           }
@@ -1174,6 +1204,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
    *
    * @see net.rptools.maptool.client.ZoneOverlay#paintOverlay(net.rptools.maptool .client.ZoneRenderer, java.awt.Graphics2D)
    */
+  @Override
   public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
     if (selectionBoundBox != null) {
       if (renderer.isAutoResizeStamp()) {

--- a/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
@@ -244,6 +244,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("runButton");
     button.addActionListener(
         new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             save(false);
 
@@ -263,6 +264,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("applyButton");
     button.addActionListener(
         new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             save(false);
           }
@@ -273,6 +275,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("okButton");
     button.addActionListener(
         new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             save(true);
           }
@@ -285,6 +288,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
     JButton button = (JButton) panel.getButton("cancelButton");
     button.addActionListener(
         new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             cancel();
           }
@@ -439,14 +443,17 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
         .getDocument()
         .addDocumentListener(
             new DocumentListener() {
+              @Override
               public void changedUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
 
+              @Override
               public void removeUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }
 
+              @Override
               public void insertUpdate(DocumentEvent e) {
                 status.setText("Ready");
               }

--- a/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
@@ -228,6 +228,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction(tokensView, this, true);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       Token sourceToken = zone.getToken(tokID);
@@ -260,6 +261,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.fow.party", this, true);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       ZoneRenderer renderer = getRenderer();
       Zone zone = renderer.getZone();
@@ -298,6 +300,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.fow.global", this, true);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       Area area = zone.getExposedArea();
@@ -321,6 +324,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.fow.clearselected", this, true);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (MapTool.getServerPolicy().isUseIndividualFOW()) {
         Zone zone = getRenderer().getZone();
@@ -345,6 +349,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.expose.visible", this, true);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       FogUtil.exposeVisibleArea(getRenderer(), selectedTokenSet, true);
       getRenderer().repaint();
@@ -358,6 +363,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction("token.popup.menu.expose.currentonly", this, true);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       FogUtil.exposePCArea(getRenderer());
     }
@@ -371,6 +377,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       setEnabled(getTokenUnderMouse().getLastPath() != null);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       FogUtil.exposeLastPath(getRenderer(), selectedTokenSet);
       getRenderer().repaint();
@@ -567,6 +574,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       addActionListener(this);
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void actionPerformed(ActionEvent e) {
       for (GUID guid : tokenSet) {
@@ -625,6 +633,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(Action.NAME, name);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = renderer.getZone();
       for (GUID guid : tokenSet) {
@@ -661,6 +670,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(Action.NAME, name);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Color color = showColorChooserDialog();
       if (color != null) {
@@ -735,6 +745,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(NAME, bar);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       String name = (String) getValue(NAME);
       JSlider slider = new JSlider(0, 100);
@@ -746,6 +757,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       hide.putClientProperty("JSlider", slider);
       hide.addChangeListener(
           new ChangeListener() {
+            @Override
             public void stateChanged(ChangeEvent e) {
               JSlider js = (JSlider) ((JCheckBox) e.getSource()).getClientProperty("JSlider");
               js.setEnabled(!((JCheckBox) e.getSource()).isSelected());
@@ -829,6 +841,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
      *
      * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
      */
+    @Override
     public void actionPerformed(ActionEvent aE) {
       ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
       for (GUID tokenGUID : selectedTokenSet) {
@@ -858,6 +871,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       I18N.setAction(aName, this);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       InitiativeList init = MapTool.getFrame().getInitiativePanel().getList();
@@ -896,6 +910,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
   private class AllOwnershipAction extends AbstractAction {
     private static final long serialVersionUID = -2995489619896660807L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
 
@@ -913,6 +928,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
   private class RemoveAllOwnershipAction extends AbstractAction {
     private static final long serialVersionUID = -6767778461889310579L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
 
@@ -933,6 +949,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       putValue(Action.NAME, "Show Path");
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       for (GUID tokenGUID : selectedTokenSet) {
         Token token = getRenderer().getZone().getToken(tokenGUID);
@@ -964,6 +981,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       }
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Zone zone = getRenderer().getZone();
       for (GUID tokenGUID : selectedTokenSet) {
@@ -1013,6 +1031,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       this.macro = macro;
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Set<Token> guidSet = new HashSet<Token>();
       for (GUID tokenID : selectedTokenSet) {
@@ -1031,6 +1050,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
       this.speech = speech;
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       String identity = getTokenUnderMouse().getName();
       String command = "/im " + identity + ":" + speech;

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
@@ -83,6 +83,7 @@ public class AdjustGridPanel extends JComponent
         .put(
             "zoomOut",
             new AbstractAction() {
+              @Override
               public void actionPerformed(ActionEvent e) {
                 zoomOut();
               }
@@ -93,6 +94,7 @@ public class AdjustGridPanel extends JComponent
         .put(
             "zoomIn",
             new AbstractAction() {
+              @Override
               public void actionPerformed(ActionEvent e) {
                 zoomIn();
               }
@@ -104,6 +106,7 @@ public class AdjustGridPanel extends JComponent
         .put(
             "zoomReset",
             new AbstractAction() {
+              @Override
               public void actionPerformed(ActionEvent e) {
                 zoomReset();
               }
@@ -299,12 +302,16 @@ public class AdjustGridPanel extends JComponent
 
   ////
   // MOUSE LISTENER
+  @Override
   public void mouseClicked(MouseEvent e) {}
 
+  @Override
   public void mouseEntered(MouseEvent e) {}
 
+  @Override
   public void mouseExited(MouseEvent e) {}
 
+  @Override
   public void mousePressed(MouseEvent e) {
 
     mouseX = e.getX();
@@ -322,10 +329,12 @@ public class AdjustGridPanel extends JComponent
     dragOffsetY = y % gridSize;
   }
 
+  @Override
   public void mouseReleased(MouseEvent e) {}
 
   ////
   // MOUSE MOTION LISTENER
+  @Override
   public void mouseDragged(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
@@ -365,6 +374,7 @@ public class AdjustGridPanel extends JComponent
     }
   }
 
+  @Override
   public void mouseMoved(MouseEvent e) {
 
     Dimension imgSize = getScaledImageSize();
@@ -386,8 +396,8 @@ public class AdjustGridPanel extends JComponent
 
   ////
   // MOUSE WHEEL LISTENER
+  @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
-
     if (SwingUtil.isControlDown(e)) {
 
       double oldScale = scale.getScale();

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
@@ -28,9 +28,11 @@ import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
+
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
+
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.ui.Scale;
 
@@ -461,8 +463,6 @@ public class AdvancedAdjustGridPanel extends JComponent
       scale.zoomIn(e.getX(), e.getY());
     } else {
       scale.zoomOut(e.getX(), e.getY());
-    } else {
-      scale.zoomIn(e.getX(), e.getY());
     }
 
     repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
@@ -79,6 +79,7 @@ public class AdvancedAdjustGridPanel extends JComponent
         .put(
             "zoomOut",
             new AbstractAction() {
+              @Override
               public void actionPerformed(ActionEvent e) {
                 zoomOut();
               }
@@ -89,6 +90,7 @@ public class AdvancedAdjustGridPanel extends JComponent
         .put(
             "zoomIn",
             new AbstractAction() {
+              @Override
               public void actionPerformed(ActionEvent e) {
                 zoomIn();
               }
@@ -100,6 +102,7 @@ public class AdvancedAdjustGridPanel extends JComponent
         .put(
             "zoomReset",
             new AbstractAction() {
+              @Override
               public void actionPerformed(ActionEvent e) {
                 zoomReset();
               }
@@ -354,12 +357,16 @@ public class AdvancedAdjustGridPanel extends JComponent
 
   ////
   // MOUSE LISTENER
+  @Override
   public void mouseClicked(MouseEvent e) {}
 
+  @Override
   public void mouseEntered(MouseEvent e) {}
 
+  @Override
   public void mouseExited(MouseEvent e) {}
 
+  @Override
   public void mousePressed(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
@@ -399,6 +406,7 @@ public class AdvancedAdjustGridPanel extends JComponent
     }
   }
 
+  @Override
   public void mouseReleased(MouseEvent e) {
     draggingHandle = null;
 
@@ -407,6 +415,7 @@ public class AdvancedAdjustGridPanel extends JComponent
 
   ////
   // MOUSE MOTION LISTENER
+  @Override
   public void mouseDragged(MouseEvent e) {
 
     if (SwingUtilities.isLeftMouseButton(e)) {
@@ -424,6 +433,7 @@ public class AdvancedAdjustGridPanel extends JComponent
     repaint();
   }
 
+  @Override
   public void mouseMoved(MouseEvent e) {
 
     Dimension imgSize = getScaledImageSize();
@@ -445,9 +455,11 @@ public class AdvancedAdjustGridPanel extends JComponent
 
   ////
   // MOUSE WHEEL LISTENER
+  @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
-
-    if (e.getWheelRotation() > 0) {
+    if (e.getWheelRotation() < 0) {
+      scale.zoomIn(e.getX(), e.getY());
+    } else {
       scale.zoomOut(e.getX(), e.getY());
     } else {
       scale.zoomIn(e.getX(), e.getY());

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
@@ -28,11 +28,9 @@ import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
-
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
-
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.ui.Scale;
 

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
@@ -125,8 +125,9 @@ public class AssetPanel extends JComponent {
 
     imagePanel.addMouseWheelListener(
         new MouseWheelListener() {
+          @Override
           public void mouseWheelMoved(MouseWheelEvent e) {
-            if (SwingUtil.isControlDown(e) || e.isMetaDown()) {
+            if (SwingUtil.isControlDown(e) || e.isMetaDown()) { // XXX Why either one?
               e.consume();
               int steps = e.getWheelRotation();
               imagePanel.setGridSize(imagePanel.getGridSize() + steps);
@@ -214,14 +215,17 @@ public class AssetPanel extends JComponent {
           .getDocument()
           .addDocumentListener(
               new DocumentListener() {
+                @Override
                 public void changedUpdate(DocumentEvent e) {
                   // no op
                 }
 
+                @Override
                 public void insertUpdate(DocumentEvent e) {
                   updateFilter();
                 }
 
+                @Override
                 public void removeUpdate(DocumentEvent e) {
                   updateFilter();
                 }
@@ -242,6 +246,7 @@ public class AssetPanel extends JComponent {
           new JCheckBox(I18N.getText("panel.Asset.ImageModel.checkbox.searchSubDir1"), false);
       globalSearchField.addActionListener(
           new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ev) {
               updateFilter();
             }
@@ -287,6 +292,7 @@ public class AssetPanel extends JComponent {
 
       thumbnailPreviewSlider.setUI(
           new MetalSliderUI() {
+            @Override
             protected void scrollDueToClickInTrack(int direction) {
               int value = thumbnailPreviewSlider.getValue();
 
@@ -327,6 +333,7 @@ public class AssetPanel extends JComponent {
           new Timer(
               500,
               new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                   ImageFileImagePanelModel model = (ImageFileImagePanelModel) imagePanel.getModel();
                   if (model == null) {

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -263,6 +263,7 @@ public class TokenStatesController
   }
 
   /** @see java.awt.event.ItemListener#itemStateChanged(java.awt.event.ItemEvent) */
+  @Override
   public void itemStateChanged(ItemEvent e) {
     changedUpdate(null);
   }
@@ -272,6 +273,7 @@ public class TokenStatesController
    *
    * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
    */
+  @Override
   public void actionPerformed(ActionEvent e) {
     String name = ((JComponent) e.getSource()).getName();
     JList<Object> list = formPanel.getList(STATES);
@@ -357,6 +359,7 @@ public class TokenStatesController
     } // endif
   }
 
+  @Override
   public void stateChanged(ChangeEvent e) {
     String name = ((JComponent) e.getSource()).getName();
     JList<Object> list = formPanel.getList(STATES);
@@ -422,6 +425,7 @@ public class TokenStatesController
    *
    * @see javax.swing.event.DocumentListener#changedUpdate(javax.swing.event.DocumentEvent)
    */
+  @Override
   public void changedUpdate(DocumentEvent e) {
     String text = formPanel.getText(IMAGE);
     boolean hasImage =
@@ -442,11 +446,13 @@ public class TokenStatesController
   }
 
   /** @see javax.swing.event.DocumentListener#insertUpdate(javax.swing.event.DocumentEvent) */
+  @Override
   public void insertUpdate(DocumentEvent e) {
     changedUpdate(e);
   }
 
   /** @see javax.swing.event.DocumentListener#removeUpdate(javax.swing.event.DocumentEvent) */
+  @Override
   public void removeUpdate(DocumentEvent e) {
     changedUpdate(e);
   }
@@ -456,6 +462,7 @@ public class TokenStatesController
    *
    * @see javax.swing.event.ListSelectionListener#valueChanged(javax.swing.event.ListSelectionEvent)
    */
+  @Override
   public void valueChanged(ListSelectionEvent e) {
     if (e.getValueIsAdjusting()) return;
     int selected = formPanel.getList(STATES).getSelectedIndex();
@@ -567,14 +574,17 @@ public class TokenStatesController
      */
     Icon icon =
         new Icon() {
+          @Override
           public int getIconHeight() {
             return ICON_SIZE + 2;
           }
 
+          @Override
           public int getIconWidth() {
             return ICON_SIZE + 2;
           }
 
+          @Override
           public void paintIcon(Component c, java.awt.Graphics g, int x, int y) {
             g.setColor(Color.BLACK);
             g.drawRect(x, y, ICON_SIZE + 2, ICON_SIZE + 2);

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
@@ -56,6 +56,7 @@ public class TokenLayoutPanel extends JPanel {
   public TokenLayoutPanel() {
     addMouseWheelListener(
         new MouseWheelListener() {
+          @Override
           public void mouseWheelMoved(MouseWheelEvent e) {
             // Not for snap-to-scale
             if (!token.isSnapToScale()) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
@@ -46,6 +46,7 @@ public class TokenVblPanel extends JPanel {
   public TokenVblPanel() {
     addMouseWheelListener(
         new MouseWheelListener() {
+          @Override
           public void mouseWheelMoved(MouseWheelEvent e) {
             // Not for snap-to-scale
             if (!token.isSnapToScale()) {
@@ -68,6 +69,7 @@ public class TokenVblPanel extends JPanel {
           @Override
           public void mousePressed(MouseEvent e) {}
 
+          @Override
           public void mouseReleased(MouseEvent e) {}
 
           @Override

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -322,6 +322,7 @@ public class InitiativePanel extends JPanel
     }
     EventQueue.invokeLater(
         new Runnable() {
+          @Override
           public void run() {
             model.setList(list);
             if (menuButton != null && menuButton.getAction() == NEXT_ACTION)
@@ -459,6 +460,7 @@ public class InitiativePanel extends JPanel
   /**
    * @see javax.swing.event.ListSelectionListener#valueChanged(javax.swing.event.ListSelectionEvent)
    */
+  @Override
   public void valueChanged(ListSelectionEvent e) {
     if (e != null && e.getValueIsAdjusting()) return;
     TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
@@ -486,6 +488,7 @@ public class InitiativePanel extends JPanel
    *-------------------------------------------------------------------------------------------*/
 
   /** @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent) */
+  @Override
   public void propertyChange(PropertyChangeEvent evt) {
     if (evt.getPropertyName().equals(InitiativeList.ROUND_PROP)) {
       String text = list.getRound() < 0 ? "" : Integer.toString(list.getRound());
@@ -521,6 +524,7 @@ public class InitiativePanel extends JPanel
    * @see
    *     net.rptools.maptool.model.ModelChangeListener#modelChanged(net.rptools.maptool.model.ModelChangeEvent)
    */
+  @Override
   public void modelChanged(ModelChangeEvent event) {
     if (event.getEvent().equals(Event.INITIATIVE_LIST_CHANGED)) {
       if ((Zone) event.getModel() == zone) {
@@ -542,6 +546,7 @@ public class InitiativePanel extends JPanel
   /** This action will advance initiative to the next token in the list. */
   public final Action NEXT_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           list.nextInitiative();
         };
@@ -550,6 +555,7 @@ public class InitiativePanel extends JPanel
   /** This action will reverse initiative to the previous token in the list. */
   public final Action PREV_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           list.prevInitiative();
         };
@@ -558,6 +564,7 @@ public class InitiativePanel extends JPanel
   /** This action will remove the selected token from the list. */
   public final Action REMOVE_TOKEN_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
@@ -569,6 +576,7 @@ public class InitiativePanel extends JPanel
   /** This action will turn the selected token's initiative on and off. */
   public final Action TOGGLE_HOLD_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
@@ -579,6 +587,7 @@ public class InitiativePanel extends JPanel
   /** This action will make the selected token the current token. */
   public final Action MAKE_CURRENT_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
@@ -589,6 +598,7 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action SHOW_TOKENS_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           showTokens = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
@@ -601,6 +611,7 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action SHOW_TOKEN_STATES_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           showTokenStates = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
@@ -613,6 +624,7 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action SHOW_INIT_STATE =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           showInitState = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
@@ -625,6 +637,7 @@ public class InitiativePanel extends JPanel
   /** This action toggles the display of token images. */
   public final Action INIT_STATE_SECOND_LINE =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           initStateSecondLine = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           displayList.setCellRenderer(
@@ -637,6 +650,7 @@ public class InitiativePanel extends JPanel
   /** This action sorts the tokens in the list. */
   public final Action SORT_LIST_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           list.sort();
         };
@@ -645,6 +659,7 @@ public class InitiativePanel extends JPanel
   /** This action will set the initiative state of the currently selected token. */
   public final Action SET_INIT_STATE_VALUE =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
@@ -665,6 +680,7 @@ public class InitiativePanel extends JPanel
   /** This action will clear the initiative state of the currently selected token. */
   public final Action CLEAR_INIT_STATE_VALUE =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           TokenInitiative ti = (TokenInitiative) displayList.getSelectedValue();
           if (ti == null) return;
@@ -675,6 +691,7 @@ public class InitiativePanel extends JPanel
   /** This action will remove all tokens from the initiative panel. */
   public final Action REMOVE_ALL_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           clearTokens();
         };
@@ -683,6 +700,7 @@ public class InitiativePanel extends JPanel
   /** This action will add all tokens in the zone to this initiative panel. */
   public final Action ADD_ALL_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           list.insertTokens(list.getZone().getTokens());
         };
@@ -691,6 +709,7 @@ public class InitiativePanel extends JPanel
   /** This action will add all PC tokens in the zone to this initiative panel. */
   public final Action ADD_PCS_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           List<Token> tokens = new ArrayList<Token>();
           for (Token token : list.getZone().getTokens()) {
@@ -703,6 +722,7 @@ public class InitiativePanel extends JPanel
   /** This action will hide all initiative items with NPC tokens from players */
   public final Action TOGGLE_HIDE_NPC_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           list.setHideNPC(!list.isHideNPC());
           if (list.isHideNPC() != hideNPCMenuItem.isSelected())
@@ -715,6 +735,7 @@ public class InitiativePanel extends JPanel
    */
   public final Action TOGGLE_OWNER_PERMISSIONS_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           boolean op = !MapTool.getCampaign().isInitiativeOwnerPermissions();
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
@@ -728,6 +749,7 @@ public class InitiativePanel extends JPanel
    */
   public final Action TOGGLE_MOVEMENT_LOCK_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           boolean op = !MapTool.getCampaign().isInitiativeMovementLock();
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
@@ -739,6 +761,7 @@ public class InitiativePanel extends JPanel
   /** This action will reset the round counter for the initiative panel. */
   public final Action RESET_COUNTER_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           if (!MapTool.getPlayer().isGM()) {
             return;
@@ -774,6 +797,7 @@ public class InitiativePanel extends JPanel
       if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
         SwingUtilities.invokeLater(
             new Runnable() {
+              @Override
               public void run() {
                 if (displayList.getSelectedValue() != null) {
                   // Show the selected token on the map.

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
@@ -106,6 +106,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will turn the selected token's initiative on and off. */
   public final Action TOGGLE_HOLD_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setHolding(!ti.isHolding());
         };
@@ -114,6 +115,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will make the token under the mouse the current token. */
   public final Action MAKE_CURRENT_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           list.setCurrent(list.indexOf(tokenInitiativeUnderMouse));
@@ -123,6 +125,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will set the initiative state of the currently selected token. */
   public final Action SET_INIT_STATE_VALUE =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           String message = I18N.getText("initPanel.enterState");
           String defaultValue = "";
@@ -146,6 +149,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will set the initiative state of the currently selected token. */
   public final Action CLEAR_INIT_STATE_VALUE =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           for (TokenInitiative ti : selectedTokenInitiatives) ti.setState(null);
         };
@@ -154,6 +158,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will remove the selected token from the list. */
   public final Action REMOVE_TOKEN_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           InitiativePanel ip = MapTool.getFrame().getInitiativePanel();
@@ -169,6 +174,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will move a token up one space */
   public final Action MOVE_UP_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           int index = list.indexOf(tokenInitiativeUnderMouse);
@@ -179,6 +185,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will move a token up one space */
   public final Action MOVE_DOWN_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           InitiativeList list = getRenderer().getZone().getInitiativeList();
           int index = list.indexOf(tokenInitiativeUnderMouse);
@@ -189,6 +196,7 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
   /** This action will center the selected token on the map and select it. */
   public final Action CENTER_ACTION =
       new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           Token token = tokenInitiativeUnderMouse.getToken();
           getRenderer().centerOn(new ZonePoint(token.getX(), token.getY()));


### PR DESCRIPTION
Fixes #413 

There's one strange aspect of this.  The _inertial scrolling_ on the Mac means that I can "spin the mouse wheel" (so to speak; I'm actually using a touch sensitive surface) while changing the facing, and if I release the Shift key, the inertial scrolling doesn't stop so the action switches to changing the zoom level instead.  Those folks with a Mac should try it; it's difficult to describe if you're not familiar with inertial scrolling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1182)
<!-- Reviewable:end -->
