### PR TITLE
Remove unused dependencies found by gradlelint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,8 +156,8 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.12.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.12.1'	// Bridges v1 to v2 for other code in other libs
 
-    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
-    implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
+    runtimeOnly group: 'commons-logging', name: 'commons-logging', version: '1.2'   // Dependency of jxpath
+    runtimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'         // Required to load class org.slf4j.impl.StaticLoggerBinder
 
     // For Sentry bug reporting
     implementation group: 'io.sentry', name: 'sentry', version: '1.7.29'
@@ -171,52 +171,42 @@ dependencies {
     // using jitpack.io for now
     // implementation 'net.rptools.clientserver:clientserver:1.4.0.+'
     implementation 'com.github.RPTools:clientserver:1.4.0.0'
-    implementation 'org.hibernate:antlr:2.7.5H3'
 
-    implementation 'commons-beanutils:commons-beanutils:1.9.4'
+    runtimeOnly 'commons-beanutils:commons-beanutils:1.9.4' // Dependency of jxpath
     implementation 'commons-io:commons-io:2.6'
-    implementation 'commons-jxpath:commons-jxpath:1.3'
+    runtimeOnly 'commons-jxpath:commons-jxpath:1.3'         // Required by the DiscoveryListener daemon
     implementation 'commons-lang:commons-lang:2.6'
     implementation 'commons-net:commons-net:3.6'
     implementation 'commons-cli:commons-cli:1.4'
 
-    implementation 'net.rptools.decktool:decktool:1.0.b1'
 
-    implementation 'net.rptools.maptool.resource:maptool.resource:1.0.b18'
+    runtimeOnly 'net.rptools.maptool.resource:maptool.resource:1.0.b18'
     implementation 'com.github.RPTools:parser:1.5.5'
 
     implementation 'jide-common:jide-common:3.2.3'
-    implementation 'jide-components:jide-components:3.2.3'
-    implementation 'jide-dialogs:jide-dialogs:3.2.3'
     implementation 'jide-dock:jide-dock:3.2.3'
-    implementation 'jide-editor:jide-editor:3.2.3'
     implementation 'jide-grids:jide-grids:3.2.3'
-    implementation 'jide-properties:jide-properties:3.2.3'
-    implementation 'jide-shortcut:jide-shortcut:3.2.3'
+    runtimeOnly 'jide-properties:jide-properties:3.2.3'
 
     implementation 'org.eclipse.jetty:jetty-server:9.4.25.v20191220'
-    implementation 'org.eclipse.jetty:jetty-servlet:9.4.25.v20191220'
     implementation 'org.eclipse.jetty:jetty-webapp:9.4.25.v20191220'
-    implementation 'org.eclipse.jetty:jetty-continuation:9.4.25.v20191220'
     implementation 'org.eclipse.jetty.websocket:websocket-server:9.4.25.v20191220'
-    implementation 'org.eclipse.jetty.websocket:websocket-client:9.4.25.v20191220'
     implementation 'org.eclipse.jetty.websocket:websocket-servlet:9.4.25.v20191220'
     implementation 'org.eclipse.jetty.websocket:websocket-api:9.4.25.v20191220'
 
-    implementation 'net.sf.ezmorph:ezmorph:1.0.6'
+    runtimeOnly    'net.sf.ezmorph:ezmorph:1.0.6'                                       // Dependency of json-lib
     implementation 'net.sf.json-lib:json-lib:2.4:jdk15'
 
     implementation 'org.reflections:reflections:0.9.11'
     implementation 'com.caucho.hessian:hessian:3.1.6'
     implementation 'de.huxhorn.sulky:de.huxhorn.sulky.3rdparty.jlayer:1.0'
     implementation 'org.mozilla:rhino:1.7.12'
-    implementation 'ca.odell.renderpack:renderpack:1.2004'
     implementation 'net.tsc.servicediscovery:servicediscovery:1.0.b5'
     implementation 'org.swinglabs:swing-worker:1.2'
     implementation 'net.sbbi.upnp:upnplib:1.0.9-nodebug'
     implementation 'com.withay:withay-util:1.0'
-    implementation 'xmlpull:xmlpull:1.1.3.1'
-    implementation 'xpp3:xpp3_min:1.1.4c'
+    runtimeOnly    'xmlpull:xmlpull:1.1.3.1'                                            // Dependency of xstream
+    runtimeOnly    'xpp3:xpp3_min:1.1.4c'                                               // Dependency of xstream
     implementation 'com.thoughtworks.xstream:xstream:1.4.11.1'
     implementation 'yasb:yasb:0.2-21012007'
     implementation 'de.muntjak.tinylookandfeel:tinylaf-nocp:1.4.0'
@@ -225,14 +215,14 @@ dependencies {
 
     // For PDF image extraction
     implementation 'org.apache.pdfbox:pdfbox:2.0.18'
-    implementation 'org.bouncycastle:bcmail-jdk15on:1.64'								// To decrypt passworded/secured pdf's
-    implementation 'com.github.jai-imageio:jai-imageio-core:1.4.0'						// For pdf image extraction, specifically for jpeg2000 (jpx) support.
-    implementation 'com.github.jai-imageio:jai-imageio-jpeg2000:1.3.0'					// For pdf image extraction, specifically for jpeg2000 (jpx) support.
+    runtimeOnly 'org.bouncycastle:bcmail-jdk15on:1.64'                                  // To decrypt passworded/secured pdf's with PDFBox
+    runtimeOnly 'com.github.jai-imageio:jai-imageio-core:1.4.0'                         // Dependency of jai-imageio-jpeg2000
+    implementation 'com.github.jai-imageio:jai-imageio-jpeg2000:1.3.0'                  // For pdf image extraction, specifically for jpeg2000 (jpx) support.
 
-    // Image processing lib
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
+    // Image processing lib. Dependency of ImageIO.
+    runtimeOnly group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    runtimeOnly group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    runtimeOnly group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
 
     // For syntax highlighting in macro editor
     implementation group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '3.0.8'		// https://mvnrepository.com/artifact/com.fifesoft/rsyntaxtextarea
@@ -259,9 +249,6 @@ dependencies {
     //testCompile 'junit:junit:4.12'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
-
-    // For mocking features during unit tests
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
 
     // sourceControl gitRepository currently not producing classpath for Eclipse
     // using jitpack.io for now


### PR DESCRIPTION
- Remove 11 unused dependencies found by gradlelint
- Change to runtimeOnly: jide-shortcut, maptool.resource, commons-logging, commons-beanutils, slf4j-simple, jxpath, commons-jxpath, ezmorph, jai-imageio-core, imageio-core, imageio-jpeg, imageio-psd, xpp3_min, xmlpull, and bcmail-jdk15on
- #1056 for a general discussion of dependencies removal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1195)
<!-- Reviewable:end -->
