### PR TITLE
Add list delimiter option to input

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.functions;
 
+import com.google.gson.JsonElement;
 import de.muntjak.tinylookandfeel.TinyComboBoxButton;
 import java.awt.Color;
 import java.awt.Component;
@@ -70,6 +71,7 @@ import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.InputFunction.InputType.OptionException;
+import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.ui.htmlframe.HTMLPane;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
@@ -146,7 +148,10 @@ public class InputFunction extends AbstractFunction {
     // The regexp for the option strings is strict: no spaces, and trailing semicolon required.
     // @formatter: off
     TEXT(false, false, "WIDTH=16;SPAN=FALSE;"),
-    LIST(true, false, "VALUE=NUMBER;TEXT=TRUE;ICON=FALSE;ICONSIZE=50;SELECT=0;SPAN=FALSE;"),
+    LIST(
+        true,
+        false,
+        "VALUE=NUMBER;TEXT=TRUE;ICON=FALSE;ICONSIZE=50;SELECT=0;SPAN=FALSE;DELIMITER=,;"),
     CHECK(false, false, "SPAN=FALSE;"),
     RADIO(true, false, "ORIENT=V;VALUE=NUMBER;SELECT=0;SPAN=FALSE;"),
     LABEL(false, false, "TEXT=TRUE;ICON=FALSE;ICONSIZE=50;SPAN=FALSE;"),
@@ -164,7 +169,7 @@ public class InputFunction extends AbstractFunction {
 
       defaultOptions = new OptionMap();
       Pattern pattern =
-          Pattern.compile("(\\w+)=([\\w-]+)\\;"); // no spaces allowed, semicolon required
+          Pattern.compile("(\\w+)=([\\w-,]+)\\;"); // no spaces allowed, semicolon required
       Matcher matcher = pattern.matcher(nameval);
       while (matcher.find()) {
         defaultOptions.put(matcher.group(1).toUpperCase(), matcher.group(2).toUpperCase());
@@ -191,7 +196,7 @@ public class InputFunction extends AbstractFunction {
     public OptionMap parseOptionString(String s) throws OptionException {
       OptionMap ret = new OptionMap();
       ret.putAll(defaultOptions); // copy the default values first
-      Pattern pattern = Pattern.compile("\\s*(\\w+)\\s*\\=\\s*([\\w-]+)\\s*");
+      Pattern pattern = Pattern.compile("\\s*(\\w+)\\s*=\\s*([^ ]+)\\s*");
       Matcher matcher = pattern.matcher(s);
       while (matcher.find()) {
         String key = matcher.group(1);
@@ -350,22 +355,37 @@ public class InputFunction extends AbstractFunction {
       this.optionValues = inputType.parseOptionString(options);
 
       if (inputType != null && inputType.isValueComposite)
-        this.valueList = parseStringList(this.value);
+        this.valueList = parseStringList(this.value, this.optionValues.get("DELIMITER"));
     }
 
     /**
      * Parses a string into a list of values, for composite types. <br>
      * Before calling, the <code>inputType</code> and <code>value</code> must be set. <br>
      * After calling, the <code>listIndex</code> member is adjusted if necessary.
+     *
+     * @param valueString the string list
+     * @param delim the delimiter
      */
-    public List<String> parseStringList(String valueString) {
+    public List<String> parseStringList(String valueString, String delim) {
       List<String> ret = new ArrayList<String>();
       if (valueString != null) {
-        String[] values = valueString.split(",");
-        int i = 0;
-        for (String s : values) {
-          ret.add(s.trim());
-          i++;
+        if ("json".equalsIgnoreCase(delim)) {
+          JsonElement json = null;
+          try {
+            json = JSONMacroFunctions.getInstance().asJsonElement(valueString);
+          } catch (ParserException ignored) {
+            // if can't parse, keep json a null
+          }
+          if (json != null && json.isJsonArray()) {
+            for (JsonElement ele : json.getAsJsonArray()) {
+              ret.add(ele.getAsString().trim());
+            }
+          }
+        } else {
+          String[] values = valueString.split(delim);
+          for (String s : values) {
+            ret.add(s.trim());
+          }
         }
       }
       return ret;


### PR DESCRIPTION
- Add option DELIMITER for drop-down lists in input.
- Default DELIMITER value is a comma, as before
- DELIMITER can't have spaces
- DELIMITER can be set to json, in which case a json array should be used instead of a list
- Close #1210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1211)
<!-- Reviewable:end -->
