### PR TITLE
Add "DELIMITER" default to input radio lists

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -157,7 +157,7 @@ public class InputFunction extends AbstractFunction {
         false,
         "VALUE=NUMBER;TEXT=TRUE;ICON=FALSE;ICONSIZE=50;SELECT=0;SPAN=FALSE;DELIMITER=,;"),
     CHECK(false, false, "SPAN=FALSE;"),
-    RADIO(true, false, "ORIENT=V;VALUE=NUMBER;SELECT=0;SPAN=FALSE;"),
+    RADIO(true, false, "ORIENT=V;VALUE=NUMBER;SELECT=0;SPAN=FALSE;DELIMITER=,;"),
     LABEL(false, false, "TEXT=TRUE;ICON=FALSE;ICONSIZE=50;SPAN=FALSE;"),
     PROPS(false, true, "SETVARS=NONE;SPAN=FALSE;"),
     TAB(false, true, "SELECT=FALSE;");


### PR DESCRIPTION
- Fix bug where radio delimiter was missing, generating a NPE
- Issue mentionned in #1210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1233)
<!-- Reviewable:end -->
