### PR TITLE
Feature GRID support for Hexes

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -60,6 +60,7 @@ public abstract class Grid implements Cloneable {
    * least 9 pixels horizontally and vertically are required.
    */
   public static final int MIN_GRID_SIZE = 9;
+
   public static final int MAX_GRID_SIZE = 350;
   protected static final Logger log = LogManager.getLogger();
   protected static final int CIRCLE_SEGMENTS = 60;
@@ -113,7 +114,7 @@ public abstract class Grid implements Cloneable {
    * <p>If both are false, tokens on that grid will not be able to rotate with the mouse and
    * keyboard controls for setting facing.
    *
-   * @param faceEdges    - Tokens can face edges.
+   * @param faceEdges - Tokens can face edges.
    * @param faceVertices - Tokens can face vertices.
    */
   public void setFacings(boolean faceEdges, boolean faceVertices) {
@@ -236,13 +237,13 @@ public abstract class Grid implements Cloneable {
 
   /**
    * @return The offset required to translate from the center of a cell to the top right (x_min,
-   * y_min) of the cell's bounding rectangle. Used for non-square grids only.<br>
-   * <br>
-   * Why? Because mySquareGrid.convert(CellPoint cp) returns a ZonePoint in the top right
-   * corner(x_min, y_min) of the square-cell, whereas myHexGrid.convert(CellPoint cp) returns a
-   * ZonePoint in the center of the hex-cell. Thus adding the CellOffset allows us to position the
-   * ZonePoint returned by myHexGrid.convert(CellPoint cp) in an equivalent position to that
-   * returned by mySquareGrid.convert(CellPoint cp)....I think ;)
+   *     y_min) of the cell's bounding rectangle. Used for non-square grids only.<br>
+   *     <br>
+   *     Why? Because mySquareGrid.convert(CellPoint cp) returns a ZonePoint in the top right
+   *     corner(x_min, y_min) of the square-cell, whereas myHexGrid.convert(CellPoint cp) returns a
+   *     ZonePoint in the center of the hex-cell. Thus adding the CellOffset allows us to position
+   *     the ZonePoint returned by myHexGrid.convert(CellPoint cp) in an equivalent position to that
+   *     returned by mySquareGrid.convert(CellPoint cp)....I think ;)
    */
   public Dimension getCellOffset() {
     return NO_DIM;
@@ -312,8 +313,9 @@ public abstract class Grid implements Cloneable {
 
   /**
    * @return The size of the grid<br>
-   * <br>
-   * *<i>SquareGrid</i> - edge length<br> *<i>HexGrid</i> - edge to edge diameter
+   *     <br>
+   *     *<i>SquareGrid</i> - edge length<br>
+   *     *<i>HexGrid</i> - edge to edge diameter
    */
   public int getSize() {
     return size;
@@ -323,8 +325,8 @@ public abstract class Grid implements Cloneable {
    * Sets the grid size and creates the grid cell shape
    *
    * @param size The size of the grid<br>
-   *             <i>SquareGrid</i> - edge length<br>
-   *             <i>HexGrid</i> - edge to edge diameter
+   *     <i>SquareGrid</i> - edge length<br>
+   *     <i>HexGrid</i> - edge to edge diameter
    */
   public void setSize(int size) {
     this.size = constrainSize(size);
@@ -335,11 +337,11 @@ public abstract class Grid implements Cloneable {
   /**
    * Called by SightType and Light class to return a vision area based upon a specified distance
    *
-   * @param shape          CIRCLE, GRID, SQUARE or CONE
-   * @param token          Used to position the shape and to provide footprint
-   * @param range          As specified in the vision or light definition
-   * @param arcAngle       Only used by cone
-   * @param offsetAngle    Arc distance from facing, only used by cone
+   * @param shape CIRCLE, GRID, SQUARE or CONE
+   * @param token Used to position the shape and to provide footprint
+   * @param range As specified in the vision or light definition
+   * @param arcAngle Only used by cone
+   * @param offsetAngle Arc distance from facing, only used by cone
    * @param scaleWithToken used to increase the area based on token footprint
    * @return Area
    */
@@ -446,8 +448,8 @@ public abstract class Grid implements Cloneable {
    * Return the cell distance between two cells. Does not take into account terrain or VBL.
    * Overridden by Hex &amp; Gridless grids.
    *
-   * @param cellA   the first cell
-   * @param cellB   the second cell
+   * @param cellA the first cell
+   * @param cellB the second cell
    * @param wmetric the walker metric
    * @return the distance (in cells) between the two cells
    */
@@ -474,12 +476,10 @@ public abstract class Grid implements Cloneable {
     for (int i = 0; i < 6; i++) {
       if (i == 0) {
         hexPath.moveTo(
-            x + radius * Math.cos(i * 2 * Math.PI / 6),
-            y + radius * Math.sin(i * 2 * Math.PI / 6));
+            x + radius * Math.cos(i * 2 * Math.PI / 6), y + radius * Math.sin(i * 2 * Math.PI / 6));
       } else {
         hexPath.lineTo(
-            x + radius * Math.cos(i * 2 * Math.PI / 6),
-            y + radius * Math.sin(i * 2 * Math.PI / 6));
+            x + radius * Math.cos(i * 2 * Math.PI / 6), y + radius * Math.sin(i * 2 * Math.PI / 6));
       }
     }
 
@@ -502,8 +502,8 @@ public abstract class Grid implements Cloneable {
    * Draws the grid scaled to the renderer's scale and within the renderer's boundaries.
    *
    * @param renderer the {@link ZoneRenderer} that represents the screen view.
-   * @param g        the {@link Graphics2D} class used for drawing.
-   * @param bounds   the bounds of the drawing area.
+   * @param g the {@link Graphics2D} class used for drawing.
+   * @param bounds the bounds of the drawing area.
    */
   public void draw(ZoneRenderer renderer, Graphics2D g, Rectangle bounds) {
     // Do nothing
@@ -525,18 +525,16 @@ public abstract class Grid implements Cloneable {
    *
    * @param length the second settable dimension
    */
-  public void setSecondDimension(double length) {
-  }
+  public void setSecondDimension(double length) {}
 
   /**
    * Installs a list of which which actions go with which keystrokes for the purpose of moving the
    * token.
    *
-   * @param callback  The object whose methods are invoked when the event occurs
+   * @param callback The object whose methods are invoked when the event occurs
    * @param actionMap the map of existing keystrokes we want to add ourselves to
    */
-  public abstract void installMovementKeys(PointerTool
-      callback, Map<KeyStroke, Action> actionMap);
+  public abstract void installMovementKeys(PointerTool callback, Map<KeyStroke, Action> actionMap);
 
   public abstract void uninstallMovementKeys(Map<KeyStroke, Action> actionMap);
 
@@ -563,12 +561,11 @@ public abstract class Grid implements Cloneable {
    *       </code>.
    * </ol>
    *
-   * @param token       token whose movement is being validated; passed in case token state is
-   *                    needed
+   * @param token token whose movement is being validated; passed in case token state is needed
    * @param areaToCheck destination area to check, measured in ZonePoint units
-   * @param dirx        direction token is traveling along the X axis
-   * @param diry        direction token is traveling along the Y axis
-   * @param exposedFog  area in which fog has been cleared away
+   * @param dirx direction token is traveling along the X axis
+   * @param diry direction token is traveling along the Y axis
+   * @param exposedFog area in which fog has been cleared away
    * @return true or false whether the token may move into the area
    */
   public boolean validateMove(
@@ -621,7 +618,7 @@ public abstract class Grid implements Cloneable {
    * Check the middle region by subdividing into 3x3 and checking to see if at least 6 are open.
    *
    * @param regionToCheck rectangular region to check for hard fog
-   * @param fog           defines areas where fog is currently covering the background
+   * @param fog defines areas where fog is currently covering the background
    * @return {@code true} if at least 6 regions are open.
    */
   public boolean checkCenterRegion(Rectangle regionToCheck, Area fog) {
@@ -662,8 +659,8 @@ public abstract class Grid implements Cloneable {
    * open.
    *
    * @param regionToCheck rectangular region to check for hard fog
-   * @param fog           defines areas where fog is currently covering the background
-   * @param tolerance     the number of open regions to check for.
+   * @param fog defines areas where fog is currently covering the background
+   * @param tolerance the number of open regions to check for.
    * @return {code true} if there are at least {@code tolerance} open regions.
    */
   public boolean checkRegion(Rectangle regionToCheck, Area fog, int tolerance) {
@@ -708,9 +705,9 @@ public abstract class Grid implements Cloneable {
    * reference to the same object as the region to divide (also not checked).
    *
    * @param regionToDivide region to subdivide
-   * @param column         column in the 3x3 grid
-   * @param row            row in the 3x3 grid
-   * @param destination    one of nine possible pieces represented as a Rectangle
+   * @param column column in the 3x3 grid
+   * @param row row in the 3x3 grid
+   * @param destination one of nine possible pieces represented as a Rectangle
    */
   private void oneThird(Rectangle regionToDivide, int column, int row, Rectangle destination) {
     int width = regionToDivide.width * column / 3;
@@ -730,14 +727,14 @@ public abstract class Grid implements Cloneable {
   /**
    * Returns an Area with a given radius that is shaped and aligned to the current grid
    *
-   * @param token          token which to center the grid area on
-   * @param range          range in units grid area extends out to
+   * @param token token which to center the grid area on
+   * @param range range in units grid area extends out to
    * @param scaleWithToken whether grid area should expand by the size of the token
-   * @param visionRange    token's vision in pixels
+   * @param visionRange token's vision in pixels
    * @return the {@link Area} conforming to the current grid layout
    */
-  protected Area getGridArea(Token token, double range, boolean scaleWithToken,
-      double visionRange) {
+  protected Area getGridArea(
+      Token token, double range, boolean scaleWithToken, double visionRange) {
 
     final Area visibleArea;
 
@@ -752,7 +749,8 @@ public abstract class Grid implements Cloneable {
       }
 
       if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > 50) {
-        log.debug("Excessive time to generate {}r grid light, took {}ms",
+        log.debug(
+            "Excessive time to generate {}r grid light, took {}ms",
             gridRadius,
             stopwatch.elapsed(TimeUnit.MILLISECONDS));
       }
@@ -770,10 +768,10 @@ public abstract class Grid implements Cloneable {
    * Returns a combined Area where radius included the tokens footprint. e.g. a 15ft light on a Huge
    * token radiates 15ft from all sides of the token.
    *
-   * @param token      token to generate area from
+   * @param token token to generate area from
    * @param gridRadius distance from token edge to generate area
    * @return the {@link Area} conforming to the current grid layout scaled to include the tokens
-   * size
+   *     size
    */
   protected Area getScaledGridArea(Token token, int gridRadius) {
     final double offsetX = token.getX() + token.getFootprint(this).getBounds(this).getWidth() / 2;
@@ -840,7 +838,7 @@ public abstract class Grid implements Cloneable {
    *
    * @param radius The maximum radius to generate the ring of cell points for this range
    * @return a {@link HashSet<Point>} that includes all cells that only equal in distance to the
-   * given radius
+   *     given radius
    */
   protected HashSet<Point> generateRing(int radius) {
     return generateRadius(radius, radius);

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -49,6 +49,7 @@ public abstract class HexGrid extends Grid {
 
   /** One DirectionCalculator object is shared by all instances of this hex grid class. */
   private static final DirectionCalculator calculator = new DirectionCalculator();
+
   private static final GridCapabilities GRID_CAPABILITIES =
       new GridCapabilities() {
         public boolean isPathingSupported() {
@@ -309,7 +310,9 @@ public abstract class HexGrid extends Grid {
     }
 
     ZonePoint snappedZP = convertCP(cp.x, cp.y);
-    if (!exposedFog.contains(snappedZP.x, snappedZP.y)) { return false; }
+    if (!exposedFog.contains(snappedZP.x, snappedZP.y)) {
+      return false;
+    }
 
     // The next step is to check the triangle that covers the hex face we are leaving from and teh
     // one we
@@ -326,7 +329,9 @@ public abstract class HexGrid extends Grid {
     result = checkOneSlice(snappedZP, direction, exposedFog);
 
     // If this one is false, don't bother checking the other one...
-    if (!result) { return false; }
+    if (!result) {
+      return false;
+    }
 
     snappedZP.translate(-dirx, -diry);
     cp = convert(snappedZP); // takes grid orientation and cellOffset into account
@@ -459,11 +464,15 @@ public abstract class HexGrid extends Grid {
     if (offsetZpV < 0) {
       if (Math.abs(xSect) % 2 == 1) {
         ySect = (int) ((offsetZpV - minorRadius) / (2 * minorRadius)) - 1;
-      } else { ySect = (int) (offsetZpV / (2 * minorRadius)) - 1; }
+      } else {
+        ySect = (int) (offsetZpV / (2 * minorRadius)) - 1;
+      }
     } else {
       if (Math.abs(xSect) % 2 == 1) {
         ySect = (int) ((offsetZpV - minorRadius) / (2 * minorRadius));
-      } else { ySect = (int) (offsetZpV / (2 * minorRadius)); }
+      } else {
+        ySect = (int) (offsetZpV / (2 * minorRadius));
+      }
     }
     int xPxl = Math.abs((int) (offsetZpU - xSect * (edgeProjection + edgeLength)));
     int yPxl = Math.abs((int) (offsetZpV - ySect * (2 * minorRadius)));
@@ -557,8 +566,10 @@ public abstract class HexGrid extends Grid {
     final HashSet<Point> points = generateRing(gridRadius);
     Area gridArea = new Area();
 
-    // HACK! Hex cellShape is ever so off from grid so adding them to a single Area can produce gap artifacts in the rendering
-    // TODO: Look at cellShape and see if it needs adjusting, and if so what does that affect downstream if anything?
+    // HACK! Hex cellShape is ever so off from grid so adding them to a single Area can produce gap
+    // artifacts in the rendering
+    // TODO: Look at cellShape and see if it needs adjusting, and if so what does that affect
+    // downstream if anything?
     final double hexScale = 1.025;
 
     for (Point point : points) {
@@ -660,12 +671,12 @@ public abstract class HexGrid extends Grid {
       // pieSlices = null; // debugging -- forces the following IF statement to always be true
       if (pieSlices == null) {
         double[][] coords = {
-            {0, 0, -114, 0, -57, -100}, // NW
-            {0, 0, -57, -100, 57, -100}, // N
-            {0, 0, 57, -100, 114, 0}, // NE
-            {0, 0, 114, 0, 57, 100}, // SE
-            {0, 0, 57, 100, -57, 100}, // S
-            {0, 0, -57, 100, -114, 0}, // SW
+          {0, 0, -114, 0, -57, -100}, // NW
+          {0, 0, -57, -100, 57, -100}, // N
+          {0, 0, 57, -100, 114, 0}, // NE
+          {0, 0, 114, 0, 57, 100}, // SE
+          {0, 0, 57, 100, -57, 100}, // S
+          {0, 0, -57, 100, -114, 0}, // SW
         };
         pieSlices = new Shape[6];
         for (int i = 0; i < 6; i++) {

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -51,7 +51,7 @@ import net.rptools.maptool.model.TokenFootprint.OffsetTranslator;
 public class HexGridHorizontal extends HexGrid {
 
   private static final int[] ALL_ANGLES =
-      new int[]{-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
+      new int[] {-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
   private static final OffsetTranslator OFFSET_TRANSLATOR =
       new OffsetTranslator() {
         public void translate(CellPoint originPoint, CellPoint offsetPoint) {
@@ -97,7 +97,7 @@ public class HexGridHorizontal extends HexGrid {
   /**
    * Set available facings based on the passed parameters.
    *
-   * @param faceEdges    - Tokens can face cell faces if true.
+   * @param faceEdges - Tokens can face cell faces if true.
    * @param faceVertices - Tokens can face cell vertices if true.
    */
   @Override
@@ -105,11 +105,11 @@ public class HexGridHorizontal extends HexGrid {
     if (faceEdges && faceVertices) {
       FACING_ANGLES = ALL_ANGLES;
     } else if (!faceEdges && faceVertices) {
-      FACING_ANGLES = new int[]{-150, -90, -30, 30, 90, 150};
+      FACING_ANGLES = new int[] {-150, -90, -30, 30, 90, 150};
     } else if (faceEdges && !faceVertices) {
-      FACING_ANGLES = new int[]{-120, -60, 0, 60, 120, 180};
+      FACING_ANGLES = new int[] {-120, -60, 0, 60, 120, 180};
     } else {
-      FACING_ANGLES = new int[]{90};
+      FACING_ANGLES = new int[] {90};
     }
   }
 
@@ -123,7 +123,9 @@ public class HexGridHorizontal extends HexGrid {
     int dx = x2 - x1;
     int dy = y2 - y1;
 
-    if (Integer.signum(dx) == Integer.signum(dy)) { return Math.abs(dx + dy); } else {
+    if (Integer.signum(dx) == Integer.signum(dy)) {
+      return Math.abs(dx + dy);
+    } else {
       return Math.max(Math.abs(dx), Math.abs(dy));
     }
   }

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -18,6 +18,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.event.KeyEvent;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
 import java.awt.geom.GeneralPath;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.Action;
 import javax.swing.KeyStroke;
 import net.rptools.maptool.client.AppPreferences;
@@ -48,17 +50,8 @@ import net.rptools.maptool.model.TokenFootprint.OffsetTranslator;
  */
 public class HexGridHorizontal extends HexGrid {
 
-  /*
-   * Facings are set when a new map is created with a particular grid and these facings affect all maps with the same grid. Other maps with different grids will remain the same.
-   *
-   * Facings are set when maps are loaded to the current preferences.
-   */
-  private static int[]
-      FACING_ANGLES; // = new int[] {-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
   private static final int[] ALL_ANGLES =
-      new int[] {-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
-  private static List<TokenFootprint> footprintList;
-
+      new int[]{-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
   private static final OffsetTranslator OFFSET_TRANSLATOR =
       new OffsetTranslator() {
         public void translate(CellPoint originPoint, CellPoint offsetPoint) {
@@ -67,6 +60,15 @@ public class HexGridHorizontal extends HexGrid {
           }
         }
       };
+  /*
+   * Facings are set when a new map is created with a particular grid and these facings affect all maps with the same grid. Other maps with different grids will remain the same.
+   *
+   * Facings are set when maps are loaded to the current preferences.
+   */
+  private static int[]
+      FACING_ANGLES; // = new int[] {-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
+  private static List<TokenFootprint> footprintList;
+  private static Map<Integer, Area> gridShapeCache = new ConcurrentHashMap<>();
 
   public HexGridHorizontal() {
     super();
@@ -82,10 +84,20 @@ public class HexGridHorizontal extends HexGrid {
     setFacings(faceEdges, faceVertices);
   }
 
+  @Override
+  public boolean isHexHorizontal() {
+    return true;
+  }
+
+  @Override
+  protected synchronized Map<Integer, Area> getGridShapeCache() {
+    return gridShapeCache;
+  }
+
   /**
    * Set available facings based on the passed parameters.
    *
-   * @param faceEdges - Tokens can face cell faces if true.
+   * @param faceEdges    - Tokens can face cell faces if true.
    * @param faceVertices - Tokens can face cell vertices if true.
    */
   @Override
@@ -93,11 +105,11 @@ public class HexGridHorizontal extends HexGrid {
     if (faceEdges && faceVertices) {
       FACING_ANGLES = ALL_ANGLES;
     } else if (!faceEdges && faceVertices) {
-      FACING_ANGLES = new int[] {-150, -90, -30, 30, 90, 150};
+      FACING_ANGLES = new int[]{-150, -90, -30, 30, 90, 150};
     } else if (faceEdges && !faceVertices) {
-      FACING_ANGLES = new int[] {-120, -60, 0, 60, 120, 180};
+      FACING_ANGLES = new int[]{-120, -60, 0, 60, 120, 180};
     } else {
-      FACING_ANGLES = new int[] {90};
+      FACING_ANGLES = new int[]{90};
     }
   }
 
@@ -111,8 +123,9 @@ public class HexGridHorizontal extends HexGrid {
     int dx = x2 - x1;
     int dy = y2 - y1;
 
-    if (Integer.signum(dx) == Integer.signum(dy)) return Math.abs(dx + dy);
-    else return Math.max(Math.abs(dx), Math.abs(dy));
+    if (Integer.signum(dx) == Integer.signum(dy)) { return Math.abs(dx + dy); } else {
+      return Math.max(Math.abs(dx), Math.abs(dy));
+    }
   }
 
   @Override
@@ -128,7 +141,7 @@ public class HexGridHorizontal extends HexGrid {
    *	4		5		6
    *		1	-	3
    *
-   * @formatter:off
+   * @formatter:on
    * (non-Javadoc)
    * @see net.rptools.maptool.model.Grid#installMovementKeys(net.rptools.maptool.client.tool.PointerTool, java.util.Map)
    */
@@ -296,5 +309,30 @@ public class HexGridHorizontal extends HexGrid {
     double mapX = (newX - newY) * getVRadius();
     double mapY = ((newX + newY) * heightHalf) + heightHalf;
     return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
+  }
+
+  @Override
+  protected AffineTransform getGridOffset(Token token) {
+    // Adjust to grid if token is an even number of grid cells
+    double footprintWidth = token.getFootprint(this).getBounds(this).getWidth();
+    double footprintHeight = token.getFootprint(this).getBounds(this).getHeight();
+    double shortFootprintSide =
+        (footprintWidth < footprintHeight) ? footprintWidth : footprintHeight;
+
+    final AffineTransform at = new AffineTransform();
+    final double coordinateOffsetX;
+    final double coordinateOffsetY;
+
+    if ((shortFootprintSide / getSize()) % 2 != 0) {
+      coordinateOffsetX = -getCellWidth();
+      coordinateOffsetY = getCellOffsetU() * 2;
+    } else {
+      coordinateOffsetX = getCellWidth() * -1.5;
+      coordinateOffsetY = getCellHeight() * -1.375;
+    }
+
+    at.translate(coordinateOffsetX, coordinateOffsetY);
+
+    return at;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -52,7 +52,7 @@ import net.rptools.maptool.model.TokenFootprint.OffsetTranslator;
 public class HexGridVertical extends HexGrid {
 
   private static final int[] ALL_ANGLES =
-      new int[]{-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
+      new int[] {-150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150, 180};
   private static final OffsetTranslator OFFSET_TRANSLATOR =
       new OffsetTranslator() {
         public void translate(CellPoint originPoint, CellPoint offsetPoint) {
@@ -100,7 +100,9 @@ public class HexGridVertical extends HexGrid {
     int dx = x2 - x1;
     int dy = y2 - y1;
 
-    if (Integer.signum(dx) == Integer.signum(dy)) { return Math.abs(dx + dy); } else {
+    if (Integer.signum(dx) == Integer.signum(dy)) {
+      return Math.abs(dx + dy);
+    } else {
       return Math.max(Math.abs(dx), Math.abs(dy));
     }
   }
@@ -110,11 +112,11 @@ public class HexGridVertical extends HexGrid {
     if (faceEdges && faceVertices) {
       FACING_ANGLES = ALL_ANGLES;
     } else if (!faceEdges && faceVertices) {
-      FACING_ANGLES = new int[]{-120, -60, 0, 60, 120, 180};
+      FACING_ANGLES = new int[] {-120, -60, 0, 60, 120, 180};
     } else if (faceEdges && !faceVertices) {
-      FACING_ANGLES = new int[]{-150, -90, -30, 30, 90, 150};
+      FACING_ANGLES = new int[] {-150, -90, -30, 30, 90, 150};
     } else {
-      FACING_ANGLES = new int[]{90};
+      FACING_ANGLES = new int[] {90};
     }
   }
 


### PR DESCRIPTION
* Fixed getShapedArea(...) so it now returns the an Area that conforms to the current grid shape when GRID is passed in as the shape type.
* In other words, Hexes are now supported!
* Also fixes improper cache mechanism, each grid type now has it's own cache and Area is resized appropriately when different grid sizes are used for the same light. 
* If Grid class logging is put into DEBUG mode, it will turn caching OFF on purpose. It's a way to eliminate cache if a bug is found and to test generation of the Area's better.

Partially closes #643 (suggest that issue is updated to reflect Hex is now a supported grid type)

*Note: Isometric shape is NOT supported as IsometricGrid @override's getShapedArea from Grid class and will need to be refactored at a later date.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1275)
<!-- Reviewable:end -->
