### PR TITLE
Add json support to input PROPS for label and value

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
@@ -134,12 +134,7 @@ public class DrawingMiscFunctions extends DrawingFunctions {
 
     JsonElement json = null;
 
-    try {
-      json = JSONMacroFunctions.getInstance().asJsonElement(pointsString);
-    } catch (ParserException e) {
-      // If parsing fails do nothing as previous code was also ignoring it and it would break
-      // macro compatibility to change this.
-    }
+    json = JSONMacroFunctions.getInstance().asJsonElement(pointsString);
 
     ArrayList<Map<String, Integer>> pathPoints = new ArrayList<>();
     if (json != null && json.isJsonArray()) {

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import de.muntjak.tinylookandfeel.TinyComboBoxButton;
 import java.awt.Color;
 import java.awt.Component;
@@ -389,12 +390,7 @@ public class InputFunction extends AbstractFunction {
       List<String> ret = new ArrayList<String>();
       if (valueString != null) {
         if ("json".equalsIgnoreCase(delim)) {
-          JsonElement json = null;
-          try {
-            json = JSONMacroFunctions.getInstance().asJsonElement(valueString);
-          } catch (ParserException ignored) {
-            // if can't parse, keep json a null
-          }
+          JsonElement json = JSONMacroFunctions.getInstance().asJsonElement(valueString);
           if (json != null && json.isJsonArray()) {
             for (JsonElement ele : json.getAsJsonArray()) {
               ret.add(ele.getAsString().trim());
@@ -786,11 +782,22 @@ public class InputFunction extends AbstractFunction {
 
     /** Creates a subpanel with controls for each property. */
     public JComponent createPropsControl(VarSpec vs) {
-      // Get the key/value pairs from the property string
       Map<String, String> map = new HashMap<String, String>();
+      JsonElement jsonElement = JSONMacroFunctions.getInstance().asJsonElement(vs.value);
       List<String> oldKeys = new ArrayList<String>();
-      List<String> oldKeysNormalized = new ArrayList<String>();
-      StrPropFunctions.parse(vs.value, map, oldKeys, oldKeysNormalized, ";");
+
+      if (jsonElement instanceof JsonObject) {
+        // Get the key/value pairs from the JsonObject
+        JsonObject jsonObject = (JsonObject) jsonElement;
+        for (String key : jsonObject.keySet()) {
+          map.put(key.toUpperCase(), jsonObject.get(key).getAsString());
+          oldKeys.add(key);
+        }
+      } else {
+        // Get the key/value pairs from the property string
+        List<String> oldKeysNormalized = new ArrayList<String>();
+        StrPropFunctions.parse(vs.value, map, oldKeys, oldKeysNormalized, ";");
+      }
 
       // Create list of VarSpecs for the subpanel
       List<VarSpec> varSpecs = new ArrayList<VarSpec>();

--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -457,7 +457,7 @@ public class MacroFunctions extends AbstractFunction {
     try {
       jobj =
           JSONMacroFunctions.getInstance().asJsonElement(param.get(0).toString()).getAsJsonObject();
-    } catch (ParserException | IllegalStateException e) {
+    } catch (IllegalStateException e) {
       jobj = null;
     }
 

--- a/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
@@ -279,8 +279,6 @@ public class MacroLinkFunction extends AbstractFunction {
           .getAsString();
     } catch (UnsupportedEncodingException e) {
       throw new ParserException(e);
-    } catch (ParserException e) {
-      return argsToStrPropList(str);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -198,11 +198,7 @@ public class TokenMoveFunctions extends AbstractFunction {
       final Zone zone, final Token tokenInContext, final Token target, final String pathString) {
 
     JsonElement json = null;
-    try {
-      json = JSONMacroFunctions.getInstance().asJsonElement(pathString);
-    } catch (ParserException e) {
-      // Ignore parsing error to maintain macro compatibility
-    }
+    json = JSONMacroFunctions.getInstance().asJsonElement(pathString);
 
     ArrayList<Map<String, Integer>> pathPoints = new ArrayList<Map<String, Integer>>();
     if (json != null && json.isJsonArray()) {
@@ -635,11 +631,7 @@ public class TokenMoveFunctions extends AbstractFunction {
 
   private List<Map<String, Integer>> convertJSONStringToList(final String pointsString) {
     JsonElement json = null;
-    try {
-      json = JSONMacroFunctions.getInstance().asJsonElement(pointsString);
-    } catch (ParserException e) {
-      // Do nothing on parse error to maintain compatibility with existing macro code.
-    }
+    json = JSONMacroFunctions.getInstance().asJsonElement(pointsString);
 
     ArrayList<Map<String, Integer>> pathPoints = new ArrayList<Map<String, Integer>>();
     if (json != null && json.isJsonArray()) {

--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -958,7 +958,7 @@ public class JSONMacroFunctions extends AbstractFunction {
    * @param o the object to convert.
    * @return the json representation..
    */
-  public JsonElement asJsonElement(Object o) throws ParserException {
+  public JsonElement asJsonElement(Object o) {
     return typeConversion.asJsonElement(o);
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
@@ -90,7 +90,7 @@ class JsonMTSTypeConversion {
    * @param o the object tp convert to a {@link JsonElement}.
    * @return a {@link JsonElement} version of the object.
    */
-  JsonElement asJsonElement(Object o) throws ParserException {
+  JsonElement asJsonElement(Object o) {
     if (o instanceof JsonElement) {
       return (JsonElement) o;
     }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1644,13 +1644,9 @@ public class Token extends BaseModel implements Cloneable {
     }
     // First we try convert it to a JSON object.
     if (val.toString().trim().startsWith("[") || val.toString().trim().startsWith("{")) {
-      try {
-        JsonElement json = JSONMacroFunctions.getInstance().asJsonElement(val.toString());
-        if (json.isJsonObject() || json.isJsonArray()) {
-          return json;
-        }
-      } catch (ParserException e) {
-        // Ignore exception to maintain compatibility with existing macros.
+      JsonElement json = JSONMacroFunctions.getInstance().asJsonElement(val.toString());
+      if (json.isJsonObject() || json.isJsonArray()) {
+        return json;
       }
     }
     try {


### PR DESCRIPTION
- Add json support to input() props: a json object can now hold the labels and values instead of a string property list.   Discussed in #1278
- Remove ParserException try/catch for cases where no ParserException could be thrown #1284

- Example:
[H: a = json.set("{}","one",1,"two",2)]
[H: input(strformat("test|%{a}|Test|PROPS"))]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1283)
<!-- Reviewable:end -->
