### PR TITLE
Remove superfluous ParserException declarations

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/Base64Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/Base64Functions.java
@@ -67,9 +67,8 @@ public class Base64Functions extends AbstractFunction {
    * @param functionName
    * @param parameters a list, with the message as the first element
    * @return Base64 encoded string
-   * @throws ParserException
    */
-  private Object base64Encode(String functionName, List<Object> parameters) throws ParserException {
+  private Object base64Encode(String functionName, List<Object> parameters) {
     byte[] message = parameters.get(0).toString().getBytes(StandardCharsets.UTF_8);
 
     return Base64.getEncoder().encodeToString(message);
@@ -81,9 +80,8 @@ public class Base64Functions extends AbstractFunction {
    * @param functionName
    * @param parameters a list of parameters with string to decode as first element.
    * @return String decoded from a Base64 encoded string
-   * @throws ParserException
    */
-  private Object base64Decode(String functionName, List<Object> parameters) throws ParserException {
+  private Object base64Decode(String functionName, List<Object> parameters) {
     byte[] decoded = Base64.getDecoder().decode(parameters.get(0).toString());
 
     return new String(decoded, StandardCharsets.UTF_8);

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -81,7 +81,6 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
-import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
 import org.apache.commons.lang.StringUtils;
 
@@ -1022,7 +1021,7 @@ public class InputFunction extends AbstractFunction {
   // The function that does all the work
   @Override
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
-      throws EvaluationException, ParserException {
+      throws ParserException {
     // Extract the list of specifier strings from the parameters
     // "name | value | prompt | inputType | options"
     List<String> varStrings = new ArrayList<String>();

--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -76,7 +76,7 @@ public class MacroJavaScriptBridge extends AbstractFunction {
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
-  public Object JavaScriptToMTScriptType(Object val) throws ParserException {
+  public Object JavaScriptToMTScriptType(Object val) {
     if (val == null) {
       // MTScript doesnt have a null, only empty string
       return "";

--- a/src/main/java/net/rptools/maptool/client/functions/TestFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TestFunctions.java
@@ -93,7 +93,7 @@ public class TestFunctions extends AbstractFunction {
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
-  private String runTests() throws ParserException {
+  private String runTests() {
     Set<Token> tokens = new HashSet<>();
     Set<GUID> tokenIds = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
     if (!tokenIds.isEmpty()) {
@@ -113,7 +113,7 @@ public class TestFunctions extends AbstractFunction {
     return runTests(tokens);
   }
 
-  private String runTests(Set<Token> tokens) throws ParserException {
+  private String runTests(Set<Token> tokens) {
     int i = 0;
     for (Token token : tokens) {
       i++;
@@ -124,7 +124,7 @@ public class TestFunctions extends AbstractFunction {
     return "";
   }
 
-  private void runTests(Token token) throws ParserException {
+  private void runTests(Token token) {
     Map<Integer, Object> macroPropertiesMap =
         token.getMacroPropertiesMap(MapTool.getParser().isMacroTrusted());
 

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -499,8 +499,7 @@ public class TokenMoveFunctions extends AbstractFunction {
   }
 
   private String getMovement(
-      final Token source, boolean returnFractionOnly, boolean useTerrainModifiers)
-      throws ParserException {
+      final Token source, boolean returnFractionOnly, boolean useTerrainModifiers) {
     ZoneWalker walker = null;
 
     WalkerMetric metric =

--- a/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
@@ -183,8 +183,7 @@ public class UserDefinedMacroFunctions implements Function, AdditionalFunctionDe
   }
 
   public void defineFunction(
-      Parser parser, String name, String macro, boolean ignoreOutput, boolean newVariableContext)
-      throws ParserException {
+      Parser parser, String name, String macro, boolean ignoreOutput, boolean newVariableContext) {
     if (parser.getFunction(name) != null) {
       FunctionRedefinition fr = new FunctionRedefinition();
       fr.function = parser.getFunction(name);

--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonArrayFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonArrayFunctions.java
@@ -146,9 +146,8 @@ public class JsonArrayFunctions {
    * @param o The {@link Object} to coerce into a {@link JsonArray}.
    * @return either the argument converted to a {@link JsonArray} or a {@link JsonArray} containing
    *     the object.
-   * @throws ParserException if there is an error while coercing the value to an array.
    */
-  public JsonArray coerceToJsonArray(Object o) throws ParserException {
+  public JsonArray coerceToJsonArray(Object o) {
     JsonElement jsonElement = typeConversion.asJsonElement(o);
 
     if (jsonElement.isJsonArray()) {
@@ -184,9 +183,8 @@ public class JsonArrayFunctions {
    * @param array The {@link JsonArray} top copy into the new array.
    * @param values the values to concatenate onto the end of the new array.
    * @return a new {@link JsonArray} containing the concatenated arguments.
-   * @throws ParserException If an error occurs while converting the values to json.
    */
-  public JsonArray concatenate(JsonArray array, List<?> values) throws ParserException {
+  public JsonArray concatenate(JsonArray array, List<?> values) {
     JsonArray array2 = new JsonArray();
     for (Object value : values) {
       array2.add(typeConversion.asJsonElement(value));
@@ -378,9 +376,8 @@ public class JsonArrayFunctions {
    * @param jsonArray the {@link JsonArray} to check.
    * @param value the value to check for.
    * @return <code>true</code> if the {@link}
-   * @throws ParserException if there is an error converting the value to json.
    */
-  public boolean contains(JsonArray jsonArray, Object value) throws ParserException {
+  public boolean contains(JsonArray jsonArray, Object value) {
     JsonElement jsonValue = typeConversion.asJsonElement(value);
     for (int i = 0; i < jsonArray.size(); i++) {
       if (jsonArray.get(i).equals(jsonValue)) {
@@ -737,9 +734,8 @@ public class JsonArrayFunctions {
    *
    * @param json the <code>String</code> to parse.
    * @return the parsed {@link JsonArray}.
-   * @throws ParserException if there is an error parsing the <code>String</code>.
    */
-  public JsonArray parseJsonArray(String json) throws ParserException {
+  public JsonArray parseJsonArray(String json) {
     JsonElement jsonElement = typeConversion.asJsonElement(json);
     return jsonElement.getAsJsonArray();
   }
@@ -765,9 +761,8 @@ public class JsonArrayFunctions {
    * @param jsonArray the Json array to copy and set values of.
    * @param list The list of indexes and values passed from the script.
    * @return the new JsonArray.
-   * @throws ParserException when an error occurs.
    */
-  public JsonArray set(JsonArray jsonArray, List<Object> list) throws ParserException {
+  public JsonArray set(JsonArray jsonArray, List<Object> list) {
     JsonArray newArray = shallowCopy(jsonArray);
     for (int i = 0; i < list.size(); i += 2) {
       BigDecimal index = (BigDecimal) list.get(i);

--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonObjectFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonObjectFunctions.java
@@ -46,9 +46,8 @@ public class JsonObjectFunctions {
    * @param prop the MTS string property to convert into a {@link JsonObject}.
    * @param delim the delimiter used in the string properties.
    * @return a {@link JsonObject} convert4d from the string properties.
-   * @throws ParserException if there is an error converting to json values.
    */
-  public JsonObject fromStrProp(String prop, String delim) throws ParserException {
+  public JsonObject fromStrProp(String prop, String delim) {
     String[] propsArray = prop.split(delim);
     JsonObject jsonObject = new JsonObject();
 

--- a/src/main/java/net/rptools/maptool/client/script_deprecated/ScriptManager.java
+++ b/src/main/java/net/rptools/maptool/client/script_deprecated/ScriptManager.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.script_deprecated.api.TokenApi;
-import net.rptools.parser.ParserException;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Script;
@@ -97,7 +96,7 @@ public class ScriptManager {
   private static Pattern registerPattern =
       Pattern.compile("^\\/\\/\\s*@register\\s+(.*)", Pattern.CASE_INSENSITIVE);
 
-  public static void registerFunctions(Reader reader) throws IOException, ParserException {
+  public static void registerFunctions(Reader reader) throws IOException {
     BufferedReader r = new BufferedReader(reader);
     String line;
     while ((line = r.readLine()) != null) {

--- a/src/main/java/net/rptools/maptool/client/script_deprecated/api/proxy/TokenProxy.java
+++ b/src/main/java/net/rptools/maptool/client/script_deprecated/api/proxy/TokenProxy.java
@@ -42,11 +42,11 @@ public class TokenProxy {
   }
 
   // Bars
-  public Object getBar(String bar) throws ParserException {
+  public Object getBar(String bar) {
     return TokenBarFunction.getInstance().getValue(token, bar);
   }
 
-  public void setBar(String bar, Object value) throws ParserException {
+  public void setBar(String bar, Object value) {
     TokenBarFunction.getInstance().setValue(token, bar, value);
   }
 
@@ -55,7 +55,7 @@ public class TokenProxy {
     return TokenHaloFunction.getInstance().getHalo(token).toString();
   }
 
-  public void setHalo(String color) throws ParserException {
+  public void setHalo(String color) {
     TokenHaloFunction.getInstance().setHalo(token, color);
   }
 

--- a/src/test/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversionTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversionTest.java
@@ -81,7 +81,7 @@ class JsonMTSTypeConversionTest {
   }
 
   @Test
-  void asJsonElement() throws ParserException {
+  void asJsonElement() {
     JsonObject jsonObject = new JsonObject();
     assertEquals(jsonObject, typeConversion.asJsonElement(jsonObject.toString()));
     jsonObject.add("test", new JsonPrimitive("test1"));

--- a/src/test/java/net/rptools/maptool/client/functions/json/JsonObjectFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JsonObjectFunctionsTest.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import net.rptools.parser.ParserException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +60,7 @@ class JsonObjectFunctionsTest {
   }
 
   @Test
-  void fromStrProp() throws ParserException {
+  void fromStrProp() {
     JsonObject jsonObject = jsonObjectFunctions.fromStrProp("A=1,b=7,t=3,f=hello", ",");
     assertEquals(4, jsonObject.keySet().size(), "JsonObject has 4 keys");
     assertTrue(jsonObject.has("A"), "JsonObject has key 'A'");
@@ -123,7 +122,7 @@ class JsonObjectFunctionsTest {
   }
 
   @Test
-  void toStrProp() throws ParserException {
+  void toStrProp() {
     String strProp = jsonObjectFunctions.toStringProp(jsonObject1, ",");
     assertEquals("A=1,b=2,c=null,d=true,e=false,f=hello", strProp);
     strProp = jsonObjectFunctions.toStringProp(jsonObject1, ";");


### PR DESCRIPTION
- Remove throws ParserException declarations where the exception type cannot actually be thrown
- Part of #1284

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1285)
<!-- Reviewable:end -->
