### PR TITLE
Removes the empty space at the bottom of input() dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -1086,6 +1086,8 @@ public class InputFunction extends AbstractFunction {
 
     // UI step 3 - show the dialog
     JOptionPane jop = new JOptionPane(ip, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION);
+    fixLayoutForTabPanes(jop);
+
     JDialog dlg = jop.createDialog(MapTool.getFrame(), dialogTitle);
 
     // Set up callbacks needed for desired runtime behavior
@@ -1217,6 +1219,23 @@ public class InputFunction extends AbstractFunction {
 
     // for debugging:
     // return debugOutput(varSpecs);
+  }
+
+  /**
+   * This is a workaround to fix the excessive space introduced when using multiple tabs (see issue
+   * #198)
+   */
+  private void fixLayoutForTabPanes(JOptionPane jop) {
+    GridBagConstraints gbc = new GridBagConstraints();
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    gbc.gridx = 0;
+    gbc.gridy = 0;
+    GridBagLayout gbl = new GridBagLayout();
+    for (Component c : jop.getComponents()) {
+      gbl.setConstraints(c, gbc);
+      gbc.gridy += 1;
+    }
+    jop.setLayout(gbl);
   }
 
   @Override


### PR DESCRIPTION
The solution found was to change the LayoutManager in the JOptionPane to a GridBagLaout, and
set the proper constraints on the existing components in the new LayoutManager.

Refers to #198

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1289)
<!-- Reviewable:end -->
