### PR TITLE
Rehost JDK used for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - cd ..
   - mkdir java
   - cd java
-  - wget http://www.nerps.net/jdk10/jdk-10.0.2_osx-x64_bin.dmg
+  - wget http://maptool.craigs-stuff.net/java/jdk-10.0.2_osx-x64_bin.dmg
   - MOUNTDEV=$(hdiutil mount jdk-10.0.2_osx-x64_bin.dmg | awk '/dev.disk/{print$1}')
   - echo $MOUNTDEV
   - MOUNTDIR="$(mount | grep JDK | awk '{$1=$2="";sub(" [(].*","");sub("^  ","");print}')"


### PR DESCRIPTION
Rehost the JDK used for travis CI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1290)
<!-- Reviewable:end -->
