### PR TITLE
Fixes problem with extension not being always added to Campaign filename in Export and Save

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -122,6 +122,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jdesktop.swingworker.SwingWorker;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This class acts as a container for a wide variety of {@link Action}s that are used throughout the
@@ -2575,26 +2576,7 @@ public class AppActions {
 
     int saveStatus = chooser.showSaveDialog(MapTool.getFrame());
     if (saveStatus == JFileChooser.APPROVE_OPTION) {
-      File campaignFile = chooser.getSelectedFile();
-
-      if (campaignFile.exists() && !MapTool.confirm("msg.confirm.overwriteExistingCampaign")) {
-        return;
-      }
-
-      String _extension = AppConstants.CAMPAIGN_FILE_EXTENSION;
-
-      if (!campaignFile.getName().toLowerCase().endsWith(_extension)) {
-        campaignFile = new File(campaignFile.getAbsolutePath() + _extension);
-      }
-
-      doSaveCampaign(campaign, campaignFile, callback);
-
-      AppState.setCampaignFile(campaignFile);
-      AppPreferences.setSaveDir(campaignFile.getParentFile());
-      AppMenuBar.getMruManager().addMRUCampaign(AppState.getCampaignFile());
-      if (MapTool.isHostingServer() || MapTool.isPersonalServer()) {
-        MapTool.serverCommand().setCampaignName(AppState.getCampaignName());
-      }
+      saveAndUpdateCampaignName(callback, campaign, null, chooser.getSelectedFile());
     }
   }
 
@@ -2604,22 +2586,32 @@ public class AppActions {
     MapTool.getCampaign().setExportCampaignDialog(dialog);
 
     if (dialog.getSaveStatus() == JFileChooser.APPROVE_OPTION) {
-      Campaign campaign = MapTool.getCampaign();
-      File campaignFile = dialog.getCampaignFile();
-
-      if (campaignFile.exists() && !MapTool.confirm("msg.confirm.overwriteExistingCampaign")) {
-        return;
-      }
-
-      doSaveCampaign(campaign, campaignFile, null, dialog.getVersionText());
-
-      AppState.setCampaignFile(campaignFile);
-      AppPreferences.setSaveDir(campaignFile.getParentFile());
-      AppMenuBar.getMruManager().addMRUCampaign(AppState.getCampaignFile());
-      if (MapTool.isHostingServer() || MapTool.isPersonalServer()) {
-        MapTool.serverCommand().setCampaignName(AppState.getCampaignName());
-      }
+      saveAndUpdateCampaignName(
+          null, MapTool.getCampaign(), dialog.getVersionText(), dialog.getCampaignFile());
     }
+  }
+
+  private static void saveAndUpdateCampaignName(
+      Observer callback, Campaign campaign, String campaignVersion, File selectedFile) {
+    File campaignFile = getFileWithExtension(selectedFile, AppConstants.CAMPAIGN_FILE_EXTENSION);
+    if (campaignFile.exists() && !MapTool.confirm("msg.confirm.overwriteExistingCampaign")) {
+      return;
+    }
+    doSaveCampaign(campaign, campaignFile, callback, campaignVersion);
+    AppState.setCampaignFile(campaignFile);
+    AppPreferences.setSaveDir(campaignFile.getParentFile());
+    AppMenuBar.getMruManager().addMRUCampaign(AppState.getCampaignFile());
+    if (MapTool.isHostingServer() || MapTool.isPersonalServer()) {
+      MapTool.serverCommand().setCampaignName(AppState.getCampaignName());
+    }
+  }
+
+  @NotNull
+  private static File getFileWithExtension(File file, String extension) {
+    if (!file.getName().toLowerCase().endsWith(extension)) {
+      file = new File(file.getAbsolutePath() + extension);
+    }
+    return file;
   }
 
   public static final DeveloperClientAction SAVE_MAP_AS =
@@ -2646,9 +2638,7 @@ public class AppActions {
               File mapFile = chooser.getSelectedFile();
               // Jamz: Bug fix, would not add extension if map name had a . in it...
               // Lets do a better job and actually check the end of the file name for the extension
-              if (!mapFile.getName().toLowerCase().endsWith(AppConstants.MAP_FILE_EXTENSION)) {
-                mapFile = new File(mapFile.getAbsolutePath() + AppConstants.MAP_FILE_EXTENSION);
-              }
+              mapFile = getFileWithExtension(mapFile, AppConstants.MAP_FILE_EXTENSION);
               PersistenceUtil.saveMap(zr.getZone(), mapFile);
               AppPreferences.setSaveDir(mapFile.getParentFile());
               MapTool.showInformation("msg.info.mapSaved");

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -122,7 +122,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jdesktop.swingworker.SwingWorker;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This class acts as a container for a wide variety of {@link Action}s that are used throughout the
@@ -2606,7 +2605,6 @@ public class AppActions {
     }
   }
 
-  @NotNull
   private static File getFileWithExtension(File file, String extension) {
     if (!file.getName().toLowerCase().endsWith(extension)) {
       file = new File(file.getAbsolutePath() + extension);

--- a/src/test/java/net/rptools/maptool/client/AppStateTest.java
+++ b/src/test/java/net/rptools/maptool/client/AppStateTest.java
@@ -1,0 +1,37 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+public class AppStateTest {
+
+  @Test
+  public void getCampaignName_nullIsDefault() {
+    AppState.setCampaignFile(null);
+
+    assertEquals("Default", AppState.getCampaignName());
+  }
+
+  @Test
+  public void getCampaignName_shortName_properExtension() {
+    AppState.setCampaignFile(new File("c1.cmpgn"));
+
+    assertEquals("c1", AppState.getCampaignName());
+  }
+}


### PR DESCRIPTION
This is a fix for #1269. Since code between Export As and Save As is very similar, it has been
refactored out as much as possible.

This also fixes a problem in the Save As function: if you try to save the campaign as c1, it checks
if c1 exists, but then saves it as c1.cmpgn. Fixed.

Manual test cases:
Test Cases:

Export:
- existing file, no extension => OK
- not existing file, extension => OK
- not existing file, no extension => OK
- existing file, extension => OK

Save:
- existing file, no extension => OK
- not existing file, extension => OK
- not existing file, no extension => OK
- existing file, extension => OK

Refers to #1269

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1294)
<!-- Reviewable:end -->
