### PR TITLE
Fixes the missing thumbnails for token problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ workbench.xmi
 
 # Keystore
 build-resources/rptools-keystore
+/log.html
+/report.html
+/output.xml

--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -603,13 +603,12 @@ public class PackedFile implements AutoCloseable {
     ZipEntry entry = new ZipEntry(path);
     ZipFile zipFile = getZipFile();
 
-    try (InputStream in = zipFile.getInputStream(entry)) {
-      if (in == null) throw new FileNotFoundException(path);
-      String type = FileUtil.getContentType(in);
-      if (log.isDebugEnabled() && type != null)
-        log.debug("FileUtil.getContentType() returned " + type);
-      return in;
-    }
+    InputStream in = zipFile.getInputStream(entry);
+    if (in == null) throw new FileNotFoundException(path);
+    String type = FileUtil.getContentType(in);
+    if (log.isDebugEnabled() && type != null)
+      log.debug("FileUtil.getContentType() returned " + type);
+    return in;
   }
 
   public void close() {

--- a/src/test/java/net/rptools/lib/swing/preference/net/rptools/lib/io/PackedFileTest.java
+++ b/src/test/java/net/rptools/lib/swing/preference/net/rptools/lib/io/PackedFileTest.java
@@ -1,0 +1,56 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.lib.swing.preference.net.rptools.lib.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import net.rptools.lib.io.PackedFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class PackedFileTest {
+
+  public static final String A_PATH_TXT = "a_path.txt";
+  public static final String PACKED_TEST_FILE = "packedTestFile";
+  private static int counter = 1;
+
+  @Test
+  public void emptySave(@TempDir File tempDir) throws IOException {
+    File f = new File(tempDir, PACKED_TEST_FILE);
+    PackedFile pf = new PackedFile(f);
+    pf.save();
+    assertTrue(f.exists());
+  }
+
+  @Test
+  public void saveWithOneResource(@TempDir File tempDir) throws IOException {
+    File f = new File(tempDir, PACKED_TEST_FILE);
+    String test_content = "some content";
+    try (PackedFile pf = new PackedFile(f)) {
+      pf.putFile(A_PATH_TXT, test_content.getBytes());
+      pf.save();
+    }
+
+    try (PackedFile loaded = new PackedFile(f)) {
+      InputStream is = loaded.getFileAsInputStream(A_PATH_TXT);
+      String s = new String(is.readAllBytes());
+      assertEquals(test_content, s);
+    }
+  }
+}


### PR DESCRIPTION
getFileAsInputStream was using a try with resources, so it was always returning a closed InputStream.

Also, added a couple of unit tests as a starting point for properly testing this class.

Refers to #1215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1308)
<!-- Reviewable:end -->
