### PR TITLE
Points to the latest version of maptool-resources with the additional maps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ dependencies {
 
     implementation 'net.rptools.decktool:decktool:1.0.b1'
 
-    implementation 'net.rptools.maptool.resource:maptool.resource:1.0.b18'
+    implementation 'net.rptools.maptool-resources:maptool-resources:1.4.0.1'
     implementation 'com.github.RPTools:parser:1.5.5'
 
     implementation 'jide-common:jide-common:3.2.3'


### PR DESCRIPTION
Up to now, maptool depends from maptool.resource=1.0b18, which is here:

http://maptool.craigs-stuff.net/repo/net/rptools/maptool/resource/maptool.resource/1.0.b18/

but, apparently, the maptool-resource project is building maptool-resources package, which is then stored in:

http://maptool.craigs-stuff.net/repo/net/rptools/maptool-resources/maptool-resources/1.4.0.1/

This PR fixes it.

Refers to #1309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1310)
<!-- Reviewable:end -->
