### PR TITLE
Refactors SysInfo, to gather debug info asynchronously

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -78,6 +78,7 @@ import net.rptools.maptool.client.ui.PreviewPanelFileChooser;
 import net.rptools.maptool.client.ui.StartServerDialog;
 import net.rptools.maptool.client.ui.StartServerDialogPreferences;
 import net.rptools.maptool.client.ui.StaticMessageDialog;
+import net.rptools.maptool.client.ui.SysInfoDialog;
 import net.rptools.maptool.client.ui.assetpanel.AssetPanel;
 import net.rptools.maptool.client.ui.assetpanel.Directory;
 import net.rptools.maptool.client.ui.campaignproperties.CampaignPropertiesDialog;
@@ -116,7 +117,6 @@ import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool.util.PersistenceUtil;
 import net.rptools.maptool.util.PersistenceUtil.PersistedCampaign;
 import net.rptools.maptool.util.PersistenceUtil.PersistedMap;
-import net.rptools.maptool.util.SysInfo;
 import net.rptools.maptool.util.UPnPUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -2968,7 +2968,7 @@ public class AppActions {
 
         @Override
         protected void executeAction(java.awt.event.ActionEvent e) {
-          SysInfo.createAndShowGUI((String) getValue(Action.NAME));
+          SysInfoDialog.createAndShowGUI((String) getValue(Action.NAME));
         }
       };
 

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -40,7 +40,8 @@ import net.rptools.maptool.model.SightType;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.ServerPolicy;
-import net.rptools.maptool.util.SysInfo;
+import net.rptools.maptool.util.MapToolSysInfoProvider;
+import net.rptools.maptool.util.SysInfoProvider;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
@@ -50,8 +51,16 @@ public class getInfoFunction extends AbstractFunction {
   /** The singleton instance. */
   private static final getInfoFunction instance = new getInfoFunction();
 
+  private SysInfoProvider sysInfoProvider;
+
   private getInfoFunction() {
     super(1, 1, "getInfo");
+    sysInfoProvider = new MapToolSysInfoProvider();
+  }
+
+  // the following is here mostly for testing purpose, until we find a better way to inject
+  protected void setSysInfoProvider(SysInfoProvider sysInfoProvider) {
+    this.sysInfoProvider = sysInfoProvider;
   }
 
   /**
@@ -212,9 +221,8 @@ public class getInfoFunction extends AbstractFunction {
    */
   private JsonObject getServerInfo() {
     ServerPolicy sp = MapTool.getServerPolicy();
-    JsonObject sinfo = sp.toJSON();
 
-    return (sinfo);
+    return sp.toJSON();
   }
 
   /**
@@ -342,7 +350,6 @@ public class getInfoFunction extends AbstractFunction {
    * @throws ParserException if an error occurs.
    */
   private JsonObject getDebugInfo() throws ParserException {
-    SysInfo info = new SysInfo();
-    return info.getSysInfoJSON();
+    return sysInfoProvider.getSysInfoJSON();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -33,7 +33,7 @@ import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.functions.getInfoFunction;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Player;
-import net.rptools.maptool.util.SysInfo;
+import net.rptools.maptool.util.MapToolSysInfoProvider;
 import net.rptools.parser.ParserException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -191,7 +191,7 @@ public class MapToolEventQueue extends EventQueue {
     boolean hostingServer = MapTool.isHostingServer();
     Sentry.getContext().addTag("hosting", String.valueOf(MapTool.isHostingServer()));
 
-    Sentry.getContext().addExtra("System Info", new SysInfo().getSysInfoJSON());
+    Sentry.getContext().addExtra("System Info", new MapToolSysInfoProvider().getSysInfoJSON());
 
     addGetInfoToSentry("campaign");
 

--- a/src/main/java/net/rptools/maptool/client/ui/SysInfoDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/SysInfoDialog.java
@@ -1,0 +1,102 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui;
+
+import java.awt.*;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import javax.swing.*;
+import net.rptools.lib.image.ImageUtil;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.util.MapToolSysInfoProvider;
+import net.rptools.maptool.util.SysInfoProvider;
+
+/**
+ * Retrieves certain characteristics of the execution environment for the purposes of problem
+ * determination and diagnostics. This class is invoked via the Help menu, Gather Debug Info... menu
+ * option.
+ *
+ * @author frank
+ */
+public class SysInfoDialog {
+  private static JDialog frame;
+  private JTextArea infoTextArea;
+  private SysInfoProvider sysInfoProvider = new MapToolSysInfoProvider();
+
+  private Container createContentPane() {
+    JPanel contentPane = new JPanel(new BorderLayout());
+    contentPane.setOpaque(true);
+
+    infoTextArea = new JTextArea(5, 30);
+    infoTextArea.setEditable(false);
+    infoTextArea.setLineWrap(true);
+    infoTextArea.setWrapStyleWord(true);
+    infoTextArea.setFont(new Font("Monospaced", Font.PLAIN, 13));
+    infoTextArea.setText("Gathering information, please wait...");
+    EventQueue.invokeLater(new InfoTextSwingWorker());
+
+    JScrollPane scrollPane = new JScrollPane(infoTextArea);
+    scrollPane.setHorizontalScrollBarPolicy(31);
+    scrollPane.setVerticalScrollBarPolicy(22);
+    scrollPane.setViewportView(infoTextArea);
+
+    contentPane.add(scrollPane, "Center");
+    return contentPane;
+  }
+
+  private class InfoTextSwingWorker extends SwingWorker<List<String>, Void> {
+
+    @Override
+    protected List<String> doInBackground() {
+      return sysInfoProvider.getInfo();
+    }
+
+    @Override
+    protected void done() {
+      try {
+        infoTextArea.setText("");
+        for (String row : get()) {
+          infoTextArea.append(row);
+        }
+      } catch (InterruptedException ignore) {
+      } catch (ExecutionException e) {
+        MapTool.showError("Gathering Debug Information", e);
+      }
+    }
+  }
+
+  public static void createAndShowGUI(String title) {
+    if (frame != null) {
+      frame
+          .dispose(); // This is so that the memory characteristics are queried each time this frame
+      // is displayed.
+      frame = null;
+    }
+    frame = new JDialog(MapTool.getFrame(), title);
+    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+
+    SysInfoDialog sysInfoDialog = new SysInfoDialog();
+    frame.setContentPane(sysInfoDialog.createContentPane());
+    try {
+      Image img = ImageUtil.getImage("net/rptools/maptool/client/image/maptool_icon.png");
+      frame.setIconImage(img);
+    } catch (Exception ex) {
+      MapTool.showError("While retrieving MapTool logo image?!", ex);
+    }
+    frame.setSize(550, 640);
+    frame.setLocationByPlatform(true);
+    frame.setVisible(true);
+  }
+}

--- a/src/main/java/net/rptools/maptool/util/MapToolSysInfoProvider.java
+++ b/src/main/java/net/rptools/maptool/util/MapToolSysInfoProvider.java
@@ -201,7 +201,7 @@ public class MapToolSysInfoProvider implements SysInfoProvider {
       String routerIP = getRouterIP();
       appendInfo("Default Gateway: " + routerIP);
     } catch (SocketException se) {
-      appendInfo("*** Could net get list of network interfaces ***");
+      appendInfo("*** Could not get list of network interfaces ***");
       log.error(se);
     }
   }

--- a/src/main/java/net/rptools/maptool/util/MapToolSysInfoProvider.java
+++ b/src/main/java/net/rptools/maptool/util/MapToolSysInfoProvider.java
@@ -15,13 +15,9 @@
 package net.rptools.maptool.util;
 
 import com.google.gson.JsonObject;
-import java.awt.BorderLayout;
-import java.awt.Container;
 import java.awt.DisplayMode;
-import java.awt.Font;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -33,20 +29,10 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.text.DecimalFormat;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
+import java.util.*;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import net.rptools.lib.image.ImageUtil;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.MemoryStatusBar;
@@ -57,24 +43,14 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/**
- * Retrieves certain characteristics of the execution environment for the purposes of problem
- * determination and diagnostics. This class is invoked via the Help menu, Gather Debug Info... menu
- * option.
- *
- * @author frank
- */
-public class SysInfo {
-  private static final Logger log = LogManager.getLogger(SysInfo.class);
+public class MapToolSysInfoProvider implements SysInfoProvider {
+  private static final Logger log = LogManager.getLogger(MapToolSysInfoProvider.class);
+
   private static final DecimalFormat format = new DecimalFormat("#,##0.#");
+  private static String os = "";
+  private List<String> rows = new ArrayList<>();
 
-  private static JDialog frame;
-  private JTextArea infoTextArea;
-  private JScrollPane scrollPane;
-  private static String os = new String();
-  private static String hostIP = new String();
-  private static String routerIP = new String();
-
+  @Override
   public JsonObject getSysInfoJSON() {
     JsonObject info = new JsonObject();
 
@@ -121,7 +97,7 @@ public class SysInfo {
   }
 
   private void appendInfo(String s) {
-    infoTextArea.append(s + "\n");
+    rows.add(s + "\n");
   }
 
   private void getMapToolInfo(Properties p) {
@@ -176,6 +152,7 @@ public class SysInfo {
     appendInfo("OS Name........: " + p.getProperty("os.name"));
     appendInfo("OS Version.....: " + p.getProperty("os.version"));
     appendInfo("OS Architecture: " + p.getProperty("os.arch"));
+    os = p.getProperty("os.name");
     if (os.contains("Windows")) {
       appendInfo("Processor......: " + env.get("PROCESSOR_IDENTIFIER"));
     }
@@ -188,24 +165,6 @@ public class SysInfo {
     appendInfo("User Name: " + p.getProperty("user.name"));
     appendInfo("User Home: " + p.getProperty("user.home"));
     appendInfo("User Dir.: " + p.getProperty("user.dir"));
-  }
-
-  private void getInfo() {
-    clearInfo();
-    Properties p = System.getProperties();
-
-    getMapToolInfo(p);
-    getJavaInfo(p);
-    getOsInfo(p);
-    getNetworkInterfaces();
-    getLocaleInfo();
-    getEncodingInfo();
-    getDisplayInfo();
-    getIGDs();
-  }
-
-  private void clearInfo() {
-    this.infoTextArea.setText("");
   }
 
   private static String getEncoding() {
@@ -232,16 +191,18 @@ public class SysInfo {
       }
 
       try {
-        hostIP = InetAddress.getLocalHost().getHostAddress();
+        String hostIP = InetAddress.getLocalHost().getHostAddress();
         appendInfo("Host Address...: " + hostIP);
       } catch (UnknownHostException ex) {
         appendInfo("Host Address...: failed");
+        log.error(ex);
       }
 
-      routerIP = getRouterIP();
+      String routerIP = getRouterIP();
       appendInfo("Default Gateway: " + routerIP);
     } catch (SocketException se) {
       appendInfo("*** Could net get list of network interfaces ***");
+      log.error(se);
     }
   }
 
@@ -291,6 +252,7 @@ public class SysInfo {
         }
       }
     } catch (IOException ex) {
+      log.error(ex);
       return "Failed";
     }
     return "Unknown";
@@ -305,6 +267,7 @@ public class SysInfo {
       IGDs = InternetGatewayDevice.getDevices(discoveryTimeout);
     } catch (IOException ex) {
       appendInfo("\tError scanning for IGDs.");
+      log.error(ex);
     }
 
     if (IGDs != null)
@@ -319,65 +282,27 @@ public class SysInfo {
         try {
           appendInfo("External IP.: " + igd.getExternalIPAddress());
         } catch (UPNPResponseException ex) {
-          MapTool.showError("UPNPResponseException", ex);
+          appendInfo("UPNPResponseException" + ex);
+          log.error(ex);
         } catch (IOException ex) {
-          MapTool.showError("IOException", ex);
+          appendInfo("IOException" + ex);
+          log.error(ex);
         }
         appendInfo("");
       }
     else appendInfo("\tNo IGDs Found!");
   }
 
-  private Container createContentPane() {
-    JPanel contentPane = new JPanel(new BorderLayout());
-    contentPane.setOpaque(true);
-
-    this.infoTextArea = new JTextArea(5, 30);
-    this.infoTextArea.setEditable(false);
-    this.infoTextArea.setLineWrap(true);
-    this.infoTextArea.setWrapStyleWord(true);
-    this.infoTextArea.setFont(new Font("Monospaced", 0, 13));
-
-    this.scrollPane = new JScrollPane(this.infoTextArea);
-    this.scrollPane.setHorizontalScrollBarPolicy(31);
-    this.scrollPane.setVerticalScrollBarPolicy(22);
-    this.scrollPane.setViewportView(this.infoTextArea);
-
-    contentPane.add(this.scrollPane, "Center");
-
-    new Thread(this::getInfo).start();
-
-    return contentPane;
-  }
-
-  public static void createAndShowGUI(String title) {
-    if (frame != null) {
-      frame
-          .dispose(); // This is so that the memory characteristics are queried each time this frame
-      // is displayed.
-      frame = null;
-    }
-    frame = new JDialog(MapTool.getFrame(), title);
-    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-
-    SysInfo demo = new SysInfo();
-    // frame.setJMenuBar(demo.createMenuBar());
-    frame.setContentPane(demo.createContentPane());
-    try {
-      Image img = ImageUtil.getImage("net/rptools/maptool/client/image/maptool_icon.png");
-      frame.setIconImage(img);
-      // URL url =
-      // MapTool.class.getClassLoader().getResource("net/rptools/maptool/client/image/maptool_icon.png");
-      // Toolkit tk = Toolkit.getDefaultToolkit();
-      // if (url != null) {
-      // Image img = tk.createImage(url);
-      // frame.setIconImage(img);
-      // }
-    } catch (Exception ex) {
-      MapTool.showError("While retrieving MapTool logo image?!", ex);
-    }
-    frame.setSize(550, 640);
-    frame.setLocationByPlatform(true);
-    frame.setVisible(true);
+  public List<String> getInfo() {
+    Properties p = System.getProperties();
+    getMapToolInfo(p);
+    getJavaInfo(p);
+    getOsInfo(p);
+    getNetworkInterfaces();
+    getLocaleInfo();
+    getEncodingInfo();
+    getDisplayInfo();
+    getIGDs();
+    return rows;
   }
 }

--- a/src/main/java/net/rptools/maptool/util/SysInfo.java
+++ b/src/main/java/net/rptools/maptool/util/SysInfo.java
@@ -85,7 +85,6 @@ public class SysInfo {
     JsonObject os = new JsonObject();
 
     Properties p = System.getProperties();
-    Map<String, String> env = System.getenv();
 
     // maptool info
     mt.addProperty("version", MapTool.getVersion());
@@ -213,8 +212,7 @@ public class SysInfo {
     final byte[] bytes = {'D'};
     final InputStream inputStream = new ByteArrayInputStream(bytes);
     final InputStreamReader reader = new InputStreamReader(inputStream);
-    final String encoding = reader.getEncoding();
-    return encoding;
+    return reader.getEncoding();
   }
 
   private void getNetworkInterfaces() {
@@ -347,7 +345,8 @@ public class SysInfo {
 
     contentPane.add(this.scrollPane, "Center");
 
-    getInfo();
+    new Thread(this::getInfo).start();
+
     return contentPane;
   }
 

--- a/src/main/java/net/rptools/maptool/util/SysInfoProvider.java
+++ b/src/main/java/net/rptools/maptool/util/SysInfoProvider.java
@@ -1,0 +1,24 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.util;
+
+import com.google.gson.JsonObject;
+import java.util.List;
+
+public interface SysInfoProvider {
+  JsonObject getSysInfoJSON();
+
+  List<String> getInfo();
+}

--- a/src/test/java/net/rptools/maptool/client/functions/GetInfoFunctionTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/GetInfoFunctionTest.java
@@ -1,0 +1,83 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.JsonObject;
+import java.util.Collections;
+import java.util.List;
+import net.rptools.maptool.util.SysInfoProvider;
+import net.rptools.parser.ParserException;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+public class GetInfoFunctionTest {
+
+  @Test
+  public void debugInfo() throws ParserException {
+    getInfoFunction function = getInfoFunction.getInstance();
+    List<Object> params = Collections.singletonList("debug");
+
+    JsonObject json = (JsonObject) function.childEvaluate(null, "ignored", params);
+
+    assertNotNull(json);
+
+    JsonObject maptool = json.get("maptool").getAsJsonObject();
+    assertEquals("DEVELOPMENT", maptool.get("version").getAsString());
+    assertNotNull(maptool.get("max mem avail"));
+    assertNotNull(maptool.get("max mem used"));
+
+    JsonObject java = json.get("java").getAsJsonObject();
+    assertNotNull(java.get("vendor"));
+    assertNotNull(java.get("home"));
+    assertNotNull(java.get("version"));
+
+    JsonObject locale = json.get("locale").getAsJsonObject();
+    assertNotNull(locale.get("country"));
+    assertNotNull(locale.get("language"));
+    assertNotNull(locale.get("locale"));
+    assertNotNull(locale.get("variant"));
+
+    JsonObject os = json.get("os").getAsJsonObject();
+    assertNotNull(os.get("name"));
+    assertNotNull(os.get("version"));
+    assertNotNull(os.get("arch"));
+  }
+
+  @Test
+  public void setSysInfoJsonProvider() throws ParserException {
+    getInfoFunction function = getInfoFunction.getInstance();
+
+    function.setSysInfoProvider(getDummyProvider());
+
+    assertNull(function.childEvaluate(null, "ignored", Collections.singletonList("debug")));
+  }
+
+  @NotNull
+  private SysInfoProvider getDummyProvider() {
+    return new SysInfoProvider() {
+      @Override
+      public JsonObject getSysInfoJSON() {
+        return null;
+      }
+
+      @Override
+      public List<String> getInfo() {
+        return null;
+      }
+    };
+  }
+}

--- a/src/test/java/net/rptools/maptool/util/SysInfoTest.java
+++ b/src/test/java/net/rptools/maptool/util/SysInfoTest.java
@@ -1,0 +1,22 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.util;
+
+import org.junit.jupiter.api.Test;
+
+public class SysInfoTest {
+  @Test
+  public void getSysInfoJSON() {}
+}


### PR DESCRIPTION
The refactoring is actually about splitting the SysInfo class so that the code for handling the GUI
is in one class and the code for dealing with gathering information is in another class.

Also, it creates an interface (SysInfoProvider) so that the GUI depends from that.

The function getInfoFunction, which was also depending on SysInfo, now only depends on
MapToolSysInfoProvider, the concrete implementation of SysInfoProvider. This allows to test
the "debug" function there (added a couple of unit tests to ensure everything still works).

Refers to #1313 & #126

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1312)
<!-- Reviewable:end -->
