### PR TITLE
Fix for json.path.read() turning numbers into strings.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
@@ -64,9 +64,9 @@ class JsonMTSTypeConversion {
         return val;
       }
     } else if (val instanceof Double) {
-      return BigDecimal.valueOf((Double)val);
+      return BigDecimal.valueOf((Double) val);
     } else if (val instanceof Integer) {
-      return BigDecimal.valueOf((Integer)val);
+      return BigDecimal.valueOf((Integer) val);
     } else {
       return val.toString();
     }

--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
@@ -65,6 +65,8 @@ class JsonMTSTypeConversion {
       }
     } else if (val instanceof Double) {
       return BigDecimal.valueOf((Double)val);
+    } else if (val instanceof Integer) {
+      return BigDecimal.valueOf((Integer)val);
     } else {
       return val.toString();
     }

--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
@@ -63,6 +63,8 @@ class JsonMTSTypeConversion {
       } else {
         return val;
       }
+    } else if (val instanceof Double) {
+      return BigDecimal.valueOf((Double)val);
     } else {
       return val.toString();
     }


### PR DESCRIPTION
Fix for #1326 .  Values returned by functions (min(), max(), sum(), etc.) in json.parth.read() were coming back as strings.
```
[H: a = json.set("{}","mods", '[
            {
                "name": "mod1",
                "type": "type1",
                "value": 1
            },
            {
                "name": "mod2",
                "type": "type1",
                "value": 2
            },
            {
                "name": "mod3",
                "type": "type1",
                "value": 3
            },
            {
                "name": "mod4",
                "type": "type2",
                "value": 4
            }]'
)]
[r: values = json.path.read(a,"mods..[?(@.type == 'type1')]value")]<br>
Max: [R: json.path.read(values,"max()")]<br>
Min: [R: json.path.read(values,"min()")]<br>
Avg: [R: json.path.read(values,"avg()")]<br>
Len: [R: json.path.read(values,"length()")]<br>
Sum: [R: json.path.read(values,"sum()")]<br>
StdDev: [R: json.path.read(values,"stddev()")]
```
Returns:
```
[1,2,3] 
Max: 3.0 
Min: 1.0 
Avg: 2.0 
Len: 3 
Sum: 6.0
StdDev: 0.8164965809277263
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1327)
<!-- Reviewable:end -->
