### PR TITLE
Add get/setTokenLayoutProps macro functions

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -154,6 +154,7 @@ public class Token extends BaseModel implements Cloneable {
     setImageAsset,
     setPortraitImage,
     setCharsheetImage,
+    setLayout,
     clearLightSources,
     removeLightSource,
     addLightSource,
@@ -1925,10 +1926,16 @@ public class Token extends BaseModel implements Cloneable {
     return new Point(anchorX, anchorY);
   }
 
+  /** @return the scale of the token layout */
   public double getSizeScale() {
     return sizeScale;
   }
 
+  /**
+   * Set the scale of the token layout
+   *
+   * @param scale the scale of the token
+   */
   public void setSizeScale(double scale) {
     sizeScale = scale;
   }
@@ -2423,6 +2430,10 @@ public class Token extends BaseModel implements Cloneable {
         break;
       case setCharsheetImage:
         setCharsheetImage((MD5Key) parameters[0]);
+        break;
+      case setLayout:
+        setSizeScale((Double) parameters[0]);
+        setAnchor((int) parameters[1], (int) parameters[2]);
         break;
       case clearLightSources:
         if (hasLightSources()) {


### PR DESCRIPTION
- Add getTokenLayoutProps(delim, tokenID, mapName) to return a jsonArray or String Property List containing the scale, xOffset, and yOffset of a layout. Default delim is ",".
- Add setTokenLayoutProps(scale, xOffset, yOffset, tokenID, mapName) to set the token layout. If the scale/xOffset/yOffset is set to the empty string "" then it will not be changed
- Close #979

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1402)
<!-- Reviewable:end -->
