### PR TITLE
Fix Draw Explorer depending on pen width when foreground is invisible

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
@@ -147,7 +147,7 @@ public class DrawablesPanel extends JComponent {
       Rectangle drawnBounds = new Rectangle(element.getDrawable().getBounds());
       // Handle pen size
       Pen pen = element.getPen();
-      int penSize = (int) pen.getThickness();
+      int penSize = pen.getForegroundMode() == Pen.MODE_TRANSPARENT ? 0 : (int) pen.getThickness();
       drawnBounds.setRect(
           drawnBounds.getX() - penSize,
           drawnBounds.getY() - penSize,


### PR DESCRIPTION
- Fix #1408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1409)
<!-- Reviewable:end -->
