### PR TITLE
Fix grid offset issues introduced by VBL grid fix

### DIFF
--- a/src/main/java/net/rptools/maptool/model/GridlessGrid.java
+++ b/src/main/java/net/rptools/maptool/model/GridlessGrid.java
@@ -141,7 +141,7 @@ public class GridlessGrid extends Grid {
 
   @Override
   public Rectangle getBounds(CellPoint cp) {
-    return new Rectangle(cp.x + getOffsetX(), cp.y + getOffsetY(), getSize(), getSize());
+    return new Rectangle(cp.x, cp.y, getSize(), getSize());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -178,8 +178,8 @@ public abstract class HexGrid extends Grid {
     int w = shape.getBounds().width;
     int h = shape.getBounds().height;
 
-    zp.x -= w / 2 + getOffsetX();
-    zp.y -= h / 2 + getOffsetY();
+    zp.x -= w / 2;
+    zp.y -= h / 2;
 
     // System.out.println(new Rectangle(zp.x, zp.y, w, h));
     return new Rectangle(zp.x, zp.y, w, h);

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -207,15 +207,15 @@ public class IsometricGrid extends Grid {
 
   @Override
   public ZonePoint convert(CellPoint cp) {
-    double mapX = (cp.x - cp.y) * getCellWidthHalf();
-    double mapY = (cp.x + cp.y) * getCellHeightHalf();
+    double mapX = (cp.x - cp.y) * getCellWidthHalf() + getOffsetX();
+    double mapY = (cp.x + cp.y) * getCellHeightHalf() + getOffsetY();
     return new ZonePoint((int) (mapX), (int) (mapY));
   }
 
   @Override
   public ZonePoint getNearestVertex(ZonePoint point) {
-    double px = point.x - getOffsetX();
-    double py = point.y - getOffsetY() + getCellHeightHalf();
+    double px = point.x;
+    double py = point.y + getCellHeightHalf();
     ZonePoint zp = new ZonePoint((int) px, (int) py);
     return convert(convert(zp));
   }
@@ -223,8 +223,7 @@ public class IsometricGrid extends Grid {
   @Override
   public Rectangle getBounds(CellPoint cp) {
     ZonePoint zp = convert(cp);
-    return new Rectangle(
-        zp.x - getSize() + getOffsetX(), zp.y, getSize() * 2, getSize() + getOffsetY());
+    return new Rectangle(zp.x - getSize(), zp.y, getSize() * 2, getSize());
   }
 
   @Override


### PR DESCRIPTION
- Fix grid offset issues for hex and gridless grids introduced by VBL fix #1416
- Fix grid offset issue for isometric grid, already existing in 1.5.14
- Discussed in #1299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1417)
<!-- Reviewable:end -->
