### PR TITLE
Add overlay() function to display a html overlay

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -209,6 +209,7 @@ public class MapToolLineParser {
   private enum OutputLoc { // Mutually exclusive output location
     CHAT,
     DIALOG,
+    OVERLAY,
     DIALOG5,
     FRAME,
     FRAME5
@@ -357,6 +358,8 @@ public class MapToolLineParser {
     DIALOG5("dialog5", 1, 2, "\"\""),
     // HTML webView
     FRAME5("frame5", 1, 2, "\"\""),
+    // HTML overlay
+    OVERLAY("overlay", 0, 1, "\"\""),
     // Run for another token
     TOKEN("token", 1, 1);
 
@@ -517,6 +520,10 @@ public class MapToolLineParser {
       matcher.region(start, endOfString);
       List<String> paramList = new ArrayList<String>();
       boolean lastItem = false; // true if last match ended in ")"
+      if (")".equals(optionString.substring(start))) {
+        lastItem = true;
+        start += 1;
+      }
 
       while (!lastItem) {
         if (matcher.find()) {
@@ -1028,6 +1035,11 @@ public class MapToolLineParser {
                   frameOpts = option.getParsedParam(1, resolver, tokenInContext).toString();
                   outputTo = OutputLoc.FRAME5;
                   break;
+                case OVERLAY:
+                  codeType = CodeType.CODEBLOCK;
+                  outputTo = OutputLoc.OVERLAY;
+                  frameOpts = option.getParsedParam(0, resolver, tokenInContext).toString();
+                  break;
                   ///////////////////////////////////////////////////
                   // CODE OPTIONS
                   ///////////////////////////////////////////////////
@@ -1423,6 +1435,9 @@ public class MapToolLineParser {
             case DIALOG:
               HTMLFrameFactory.show(
                   frameName, false, false, frameOpts, expressionBuilder.toString());
+              break;
+            case OVERLAY:
+              MapTool.getFrame().getHtmlOverlay().updateContents(expressionBuilder.toString());
               break;
             case CHAT:
               builder.append(expressionBuilder);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlay.java
@@ -1,0 +1,181 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.htmlframe;
+
+import java.awt.*;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.*;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.TooManyListenersException;
+import javax.swing.*;
+import javax.swing.text.*;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.ScreenPoint;
+import net.rptools.maptool.client.TransferableHelper;
+import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.ZonePoint;
+
+/** Represents the transparent HTML overlay over the map. */
+public class HTMLOverlay extends HTMLPane implements DropTargetListener {
+  /** The default rule for an invisible body tag. */
+  private static final String CSS_RULE_BODY =
+      "body { font-family: sans-serif; font-size: %dpt; background: none}";
+
+  public HTMLOverlay() {
+    super();
+    setFocusable(false);
+    setHighlighter(null);
+    setOpaque(false);
+    addMouseListeners();
+    setCaretColor(new Color(0, 0, 0, 0)); // invisible, needed or it shows in DnD operations
+
+    setTransferHandler(new TransferableHelper()); // set the Drag & Drop handler
+    try {
+      getDropTarget().addDropTargetListener(this);
+    } catch (TooManyListenersException e1) {
+      // Should never happen because the transfer handler fixes this problem.
+    }
+  }
+
+  /**
+   * Return the rule for an invisible body.
+   *
+   * @return the rule
+   */
+  @Override
+  public String getRuleBody() {
+    return String.format(CSS_RULE_BODY, AppPreferences.getFontSize());
+  }
+
+  @Override
+  public void dragEnter(DropTargetDragEvent dtde) {}
+
+  @Override
+  public void dragOver(DropTargetDragEvent dtde) {}
+
+  @Override
+  public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+  @Override
+  public void dragExit(DropTargetEvent dte) {}
+
+  /**
+   * Add the tokens to the current zone renderer if a token is dropped on the overlay.
+   *
+   * @param dtde the event of the drop
+   */
+  @Override
+  public void drop(DropTargetDropEvent dtde) {
+    ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
+    Point point = SwingUtilities.convertPoint(this, dtde.getLocation(), zr);
+
+    ZonePoint zp = new ScreenPoint((int) point.getX(), (int) point.getY()).convertToZone(zr);
+    TransferableHelper th = (TransferableHelper) getTransferHandler();
+    List<Token> tokens = th.getTokens();
+    if (tokens != null && !tokens.isEmpty()) {
+      zr.addTokens(tokens, zp, th.getConfigureTokens(), false);
+    }
+  }
+
+  /** Add the mouse listeners to forward the mouse events to the current ZoneRenderer. */
+  private void addMouseListeners() {
+    addMouseWheelListener(this::passMouseEvent);
+    addMouseMotionListener(
+        new MouseMotionAdapter() {
+          @Override
+          public void mouseMoved(MouseEvent e) {
+            passMouseEvent(e);
+          }
+
+          @Override
+          public void mouseDragged(MouseEvent e) {
+            passMouseEvent(e);
+          }
+        });
+    addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mousePressed(MouseEvent e) {
+            passMouseEvent(e, true);
+          }
+
+          @Override
+          public void mouseClicked(MouseEvent e) {
+            passMouseEvent(e, true);
+          }
+
+          @Override
+          public void mouseEntered(MouseEvent e) {
+            passMouseEvent(e);
+          }
+
+          @Override
+          public void mouseReleased(MouseEvent e) {
+            passMouseEvent(e);
+          }
+
+          @Override
+          public void mouseExited(MouseEvent e) {
+            passMouseEvent(e);
+          }
+        });
+  }
+
+  /**
+   * Passes a mouse event to the ZoneRenderer. If checking for transparency, only forwards the event
+   * if it happened over a transparent pixel.
+   *
+   * @param e the mouse event to forward
+   * @param checkForTransparency whether to check for transparency
+   */
+  private void passMouseEvent(MouseEvent e, boolean checkForTransparency) {
+    SwingUtilities.invokeLater(
+        () -> {
+          if (checkForTransparency && isOpaque(e.getPoint())) {
+            return; // don't forward
+          }
+          Component c = MapTool.getFrame().getCurrentZoneRenderer();
+          c.dispatchEvent(SwingUtilities.convertMouseEvent(e.getComponent(), e, c));
+        });
+  }
+
+  /**
+   * Passes a mouse event to the ZoneRenderer.
+   *
+   * @param e the mouse event to forward
+   */
+  private void passMouseEvent(MouseEvent e) {
+    passMouseEvent(e, false);
+  }
+
+  /**
+   * Returns true if the pixel of the component at the point is opaque.
+   *
+   * @param p the point
+   * @return true if the pixel is opaque
+   */
+  public boolean isOpaque(Point p) {
+    Rectangle rect = getBounds();
+    BufferedImage img = new BufferedImage(rect.width, rect.height, BufferedImage.TYPE_INT_ARGB);
+    paintAll(img.createGraphics());
+    return new Color(img.getRGB(p.x, p.y), true).getAlpha() != 0;
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
@@ -95,12 +95,52 @@ public class HTMLPane extends JEditorPane {
     ToolTipManager.sharedInstance().registerComponent(this);
   }
 
+  /** @return the rule for the body tag */
+  public String getRuleBody() {
+    return String.format(CSS_RULE_BODY, AppPreferences.getFontSize());
+  }
+
   public void addActionListener(ActionListener listener) {
     actionListeners = AWTEventMulticaster.add(actionListeners, listener);
   }
 
   public void removeActionListener(ActionListener listener) {
     actionListeners = AWTEventMulticaster.remove(actionListeners, listener);
+  }
+
+  /**
+   * Set the default cursor of the editor kit.
+   *
+   * @param cursor the cursor to set
+   */
+  public void setEditorKitDefaultCursor(Cursor cursor) {
+    editorKit.setDefaultCursor(cursor);
+  }
+
+  /**
+   * Flush the pane, set the new html, and set the caret to zero.
+   *
+   * @param html the html to set
+   */
+  public void updateContents(final String html) {
+    EventQueue.invokeLater(
+        new Runnable() {
+          public void run() {
+            editorKit.flush();
+            setText(html);
+            setCaretPosition(0);
+          }
+        });
+  }
+
+  /** Flushes any caching for the panel. */
+  public void flush() {
+    EventQueue.invokeLater(
+        new Runnable() {
+          public void run() {
+            editorKit.flush();
+          }
+        });
   }
 
   /**
@@ -188,7 +228,7 @@ public class HTMLPane extends JEditorPane {
         style.removeStyle(s);
       }
 
-      style.addRule(String.format(CSS_RULE_BODY, AppPreferences.getFontSize()));
+      style.addRule(getRuleBody());
       style.addRule(CSS_RULE_DIV);
       style.addRule(CSS_RULE_SPAN);
       parse.parse(new StringReader(text), new ParserCallBack(), true);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanel.java
@@ -15,7 +15,6 @@
 package net.rptools.maptool.client.ui.htmlframe;
 
 import java.awt.BorderLayout;
-import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -24,7 +23,6 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
-import net.rptools.maptool.client.swing.MessagePanelEditorKit;
 
 /** Represents the JPanel holding the HTML pane. */
 public class HTMLPanel extends JPanel implements HTMLPanelInterface {
@@ -69,25 +67,13 @@ public class HTMLPanel extends JPanel implements HTMLPanelInterface {
    */
   @Override
   public void updateContents(final String html) {
-    EventQueue.invokeLater(
-        new Runnable() {
-          public void run() {
-            ((MessagePanelEditorKit) pane.getEditorKit()).flush();
-            pane.setText(html);
-            pane.setCaretPosition(0);
-          }
-        });
+    pane.updateContents(html);
   }
 
   /** Flushes any caching for the panel. */
   @Override
   public void flush() {
-    EventQueue.invokeLater(
-        new Runnable() {
-          public void run() {
-            ((MessagePanelEditorKit) pane.getEditorKit()).flush();
-          }
-        });
+    pane.flush();
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
+++ b/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
@@ -70,6 +70,7 @@ public class MapToolScriptSyntax extends MapToolScriptTokenMaker {
     "hide",
     "if",
     "macro",
+    "overlay",
     "r",
     "result",
     "s",

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -4523,6 +4523,7 @@ public class ZoneRenderer extends JComponent
    *
    * @see java.awt.dnd.DropTargetListener#dragEnter(java.awt.dnd. DropTargetDragEvent )
    */
+  @Override
   public void dragEnter(DropTargetDragEvent dtde) {}
 
   /*
@@ -4530,6 +4531,7 @@ public class ZoneRenderer extends JComponent
    *
    * @see java.awt.dnd.DropTargetListener#dragExit(java.awt.dnd.DropTargetEvent)
    */
+  @Override
   public void dragExit(DropTargetEvent dte) {}
 
   /*
@@ -4537,9 +4539,18 @@ public class ZoneRenderer extends JComponent
    *
    * @see java.awt.dnd.DropTargetListener#dragOver (java.awt.dnd.DropTargetDragEvent)
    */
+  @Override
   public void dragOver(DropTargetDragEvent dtde) {}
 
-  private void addTokens(
+  /**
+   * Adds tokens at a given zone point coordinates.
+   *
+   * @param tokens the list of tokens to add
+   * @param zp the zone point where to add the tokens
+   * @param configureTokens the list indicating if each token is to be configured
+   * @param showDialog whether to display a token edit dialog
+   */
+  public void addTokens(
       List<Token> tokens, ZonePoint zp, List<Boolean> configureTokens, boolean showDialog) {
     GridCapabilities gridCaps = zone.getGrid().getCapabilities();
     boolean isGM = MapTool.getPlayer().isGM();
@@ -4739,6 +4750,7 @@ public class ZoneRenderer extends JComponent
    *
    * @see java.awt.dnd.DropTargetListener#drop (java.awt.dnd.DropTargetDropEvent)
    */
+  @Override
   public void drop(DropTargetDropEvent dtde) {
     ZonePoint zp =
         new ScreenPoint((int) dtde.getLocation().getX(), (int) dtde.getLocation().getY())
@@ -4767,6 +4779,7 @@ public class ZoneRenderer extends JComponent
    *
    * @see java.awt.dnd.DropTargetListener#dropActionChanged (java.awt.dnd.DropTargetDragEvent)
    */
+  @Override
   public void dropActionChanged(DropTargetDragEvent dtde) {}
 
   /** ZONE MODEL CHANGE LISTENER */
@@ -4860,7 +4873,10 @@ public class ZoneRenderer extends JComponent
       custom = createCustomCursor("image/cursor.png", "Group");
       cursor = custom;
     }
+    // overlay and ZoneRenderer should have same cursor as map
     super.setCursor(cursor);
+    MapTool.getFrame().getHtmlOverlay().setEditorKitDefaultCursor(cursor);
+    MapTool.getFrame().getHtmlOverlay().setCursor(cursor);
   }
 
   private Cursor custom = null;


### PR DESCRIPTION
- Add function overlay() to display a transparent html 3.2 overlay over the map
- Function is used similarly to frame() and dialog(), with [overlay():{ myhtml }] used to display "myhtml"
- Discussed in #1425

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1438)
<!-- Reviewable:end -->
