### PR TITLE
Fix pressing Enter losing focus in HTML5 frame and dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -754,7 +754,7 @@ public class CommandPanel extends JPanel implements Observer {
             actionObject,
             new AbstractAction() {
               public void actionPerformed(ActionEvent event) {
-                requestFocus();
+                requestFocusInWindow();
               }
             });
   }


### PR DESCRIPTION
- Fix pressing the Enter key leading to focus going to the chat box.
- Close #1456

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1457)
<!-- Reviewable:end -->
