### PR TITLE
Fixes the title not filling all the space.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -1247,6 +1247,8 @@ public class InputFunction extends AbstractFunction {
     gbc.fill = GridBagConstraints.HORIZONTAL;
     gbc.gridx = 0;
     gbc.gridy = 0;
+    gbc.weightx = 1.0;
+
     GridBagLayout gbl = new GridBagLayout();
     for (Component c : jop.getComponents()) {
       gbl.setConstraints(c, gbc);


### PR DESCRIPTION
Tested with all the 3 cases in the bug report, and works as expected.

Refers to #1441

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1459)
<!-- Reviewable:end -->
