### PR TITLE
Adds missing throw statements

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1286,10 +1286,11 @@ public class MapToolLineParser {
                       }
                     }
                     if (!foundMatch) {
-                      doError(I18N.getText("lineParser.switchNoMatch", caseTarget), opts, roll);
+                      throw doError(
+                          I18N.getText("lineParser.switchNoMatch", caseTarget), opts, roll);
                     }
                   } else {
-                    doError("lineParser.switchError", opts, roll);
+                    throw doError("lineParser.switchError", opts, roll);
                   }
 
                   break;


### PR DESCRIPTION
With the following test case:
```
[h: m = 2]
[switch(m):
case 1: x = 2
]
```

we now obtain the following error message:

```
    SWITCH option found no match for "2".
       Statement options (if any): switch(m)
       Statement Body : case 1: x = 2
```
Fixes #1460

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1461)
<!-- Reviewable:end -->
