### PR TITLE
Fix incorrect drag offsets for native-size object/background tokens

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -408,8 +408,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         Rectangle tokenBounds = token.getBounds(renderer.getZone());
 
         if (token.isSnapToGrid() && getZone().getGrid().getCapabilities().isSnapToGridSupported()) {
-          dragOffsetX = (pos.x - tokenBounds.x) - (tokenBounds.width / 2);
-          dragOffsetY = (pos.y - tokenBounds.y) - (tokenBounds.height / 2);
+          dragOffsetX = (pos.x - tokenBounds.x) - ((int) getZone().getGrid().getCellWidth() / 2);
+          dragOffsetY = (pos.y - tokenBounds.y) - ((int) getZone().getGrid().getCellHeight() / 2);
         } else {
           dragOffsetX = pos.x - tokenBounds.x;
           dragOffsetY = pos.y - tokenBounds.y;


### PR DESCRIPTION
- Fix incorrect drag offsets for native-sized object/background tokens bug created by #1475
- Fix identified by @Phergus
- Fix #1469

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1476)
<!-- Reviewable:end -->
