### PR TITLE
Issue1317 hi res mouse wheel fixes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/GridTool.java
@@ -63,7 +63,7 @@ public class GridTool extends DefaultTool {
   private static enum Size {
     Increase,
     Decrease
-  };
+  }
 
   private final JSpinner gridSizeSpinner;
   private final JTextField gridOffsetXTextField;
@@ -110,6 +110,7 @@ public class GridTool extends DefaultTool {
     colorWell = (JETAColorWell) controlPanel.getComponentByName("colorWell");
     colorWell.addActionListener(
         new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             copyControlPanelToGrid();
           }
@@ -118,6 +119,7 @@ public class GridTool extends DefaultTool {
     JButton closeButton = (JButton) controlPanel.getComponentByName("closeButton");
     closeButton.addActionListener(
         new ActionListener() {
+          @Override
           @SuppressWarnings("deprecation")
           public void actionPerformed(ActionEvent e) {
             resetTool();
@@ -342,6 +344,10 @@ public class GridTool extends DefaultTool {
    */
   @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
+    // Fix for hi-res mice
+    if (e.getWheelRotation() == 0) {
+      return;
+    }
     ZoneRenderer renderer = (ZoneRenderer) e.getSource();
     if (SwingUtil.isControlDown(e)) {
       if (e.getWheelRotation() > 0) {
@@ -361,6 +367,7 @@ public class GridTool extends DefaultTool {
   private void resetZoomSlider() {
     EventQueue.invokeLater(
         new Runnable() {
+          @Override
           public void run() {
             lastZoomIndex = zoomSliderStopCount / 2;
             zoomSlider.setValue(lastZoomIndex);
@@ -404,6 +411,7 @@ public class GridTool extends DefaultTool {
       this.size = size;
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       ZoneRenderer renderer = (ZoneRenderer) e.getSource();
       adjustGridSize(renderer, size);
@@ -416,7 +424,7 @@ public class GridTool extends DefaultTool {
     Right,
     Up,
     Down
-  };
+  }
 
   private class GridOffsetAction extends AbstractAction {
     private static final long serialVersionUID = 6664327737774374442L;
@@ -426,6 +434,7 @@ public class GridTool extends DefaultTool {
       this.direction = direction;
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       ZoneRenderer renderer = (ZoneRenderer) e.getSource();
       switch (direction) {
@@ -447,6 +456,7 @@ public class GridTool extends DefaultTool {
   }
 
   private class ZoomChangeListener extends MouseAdapter implements ChangeListener {
+    @Override
     public void stateChanged(ChangeEvent e) {
       int delta = zoomSlider.getValue() - lastZoomIndex;
       if (delta == 0) {
@@ -475,22 +485,28 @@ public class GridTool extends DefaultTool {
   ////
   // ACTIONS
   private class UpdateGridListener implements KeyListener, ChangeListener, FocusListener {
+    @Override
     public void keyPressed(KeyEvent e) {}
 
+    @Override
     public void keyReleased(KeyEvent e) {
       copyControlPanelToGrid();
     }
 
+    @Override
     public void keyTyped(KeyEvent e) {}
 
+    @Override
     public void stateChanged(ChangeEvent e) {
       copyControlPanelToGrid();
     }
 
+    @Override
     public void focusLost(FocusEvent e) {
       copyControlPanelToGrid();
     }
 
+    @Override
     public void focusGained(FocusEvent e) {}
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/JScrollPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/JScrollPopupMenu.java
@@ -50,6 +50,10 @@ public class JScrollPopupMenu extends JPopupMenu {
         new MouseWheelListener() {
           @Override
           public void mouseWheelMoved(MouseWheelEvent event) {
+            // Fix for hi-res mice
+            if (event.getWheelRotation() == 0) {
+              return;
+            }
             JScrollBar scrollBar = getScrollBar();
             int amount =
                 (event.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL)
@@ -90,12 +94,14 @@ public class JScrollPopupMenu extends JPopupMenu {
     this.maximumVisibleRows = maximumVisibleRows;
   }
 
+  @Override
   public void paintChildren(Graphics g) {
     Insets insets = getInsets();
     g.clipRect(insets.left, insets.top, getWidth(), getHeight() - insets.top - insets.bottom);
     super.paintChildren(g);
   }
 
+  @Override
   protected void addImpl(Component comp, Object constraints, int index) {
     super.addImpl(comp, constraints, index);
 
@@ -104,6 +110,7 @@ public class JScrollPopupMenu extends JPopupMenu {
     }
   }
 
+  @Override
   public void remove(int index) {
     // can't remove the scrollbar
     ++index;
@@ -115,6 +122,7 @@ public class JScrollPopupMenu extends JPopupMenu {
     }
   }
 
+  @Override
   public void show(Component invoker, int x, int y) {
     JScrollBar scrollBar = getScrollBar();
     if (scrollBar.isVisible()) {

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdjustGridPanel.java
@@ -43,7 +43,7 @@ public class AdjustGridPanel extends JComponent
   private static enum Direction {
     Increase,
     Decrease
-  };
+  }
 
   public static final String PROPERTY_GRID_OFFSET_X = "gridOffsetX";
   public static final String PROPERTY_GRID_OFFSET_Y = "gridOffsetY";
@@ -398,6 +398,10 @@ public class AdjustGridPanel extends JComponent
   // MOUSE WHEEL LISTENER
   @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
+    // Fix for hi-res mice
+    if (e.getWheelRotation() == 0) {
+      return;
+    }
     if (SwingUtil.isControlDown(e)) {
 
       double oldScale = scale.getScale();

--- a/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/adjustgrid/AdvancedAdjustGridPanel.java
@@ -459,7 +459,7 @@ public class AdvancedAdjustGridPanel extends JComponent
   public void mouseWheelMoved(MouseWheelEvent e) {
     if (e.getWheelRotation() < 0) {
       scale.zoomIn(e.getX(), e.getY());
-    } else {
+    } else if (e.getWheelRotation() > 0) {
       scale.zoomOut(e.getX(), e.getY());
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
@@ -137,9 +137,12 @@ public class AssetPanel extends JComponent {
         new MouseWheelListener() {
           @Override
           public void mouseWheelMoved(MouseWheelEvent e) {
+            int steps = e.getWheelRotation();
+            if (steps == 0) {
+              return;
+            }
             if (SwingUtil.isControlDown(e) || e.isMetaDown()) { // XXX Why either one?
               e.consume();
-              int steps = e.getWheelRotation();
               imagePanel.setGridSize(imagePanel.getGridSize() + steps);
               thumbnailPreviewSlider.setValue(imagePanel.getGridSize());
             } else {

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
@@ -38,6 +38,8 @@ import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Token.TokenShape;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.util.ImageManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Support class used by the token editor dialog on the "Properties" tab to allow a token's image to
@@ -48,6 +50,7 @@ import net.rptools.maptool.util.ImageManager;
  * @author trevor
  */
 public class TokenLayoutPanel extends JPanel {
+  private static final Logger log = LogManager.getLogger(TokenLayoutPanel.class);
   private Token token;
   private int dragOffsetX;
   private int dragOffsetY;
@@ -58,11 +61,12 @@ public class TokenLayoutPanel extends JPanel {
         new MouseWheelListener() {
           @Override
           public void mouseWheelMoved(MouseWheelEvent e) {
+            int wheelMovement = e.getWheelRotation();
             // Not for snap-to-scale
-            if (!token.isSnapToScale()) {
+            if (!token.isSnapToScale() || wheelMovement == 0) {
               return;
             }
-            double delta = e.getWheelRotation() > 0 ? -.1 : .1;
+            double delta = wheelMovement > 0 ? -.1 : .1;
             if (SwingUtil.isShiftDown(e)) {
               // Nothing yet, as changing the facing isn't the right way to handle it --
               // the image itself really should be rotated. And it's probably better to
@@ -73,6 +77,7 @@ public class TokenLayoutPanel extends JPanel {
               // a way of reducing round off error from multiple rotations).
             }
             double scale = token.getSizeScale() + delta;
+            log.debug(() -> "wheel=" + wheelMovement + ", delta=" + delta);
 
             // Range
             scale = Math.max(.1, scale);

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenVblPanel.java
@@ -93,8 +93,11 @@ public class TokenVblPanel extends JPanel {
     addMouseWheelListener(
         e -> {
           // TODO: Zooming panel should zoom in at mouse cursor #mathishard
-
-          double delta = e.getWheelRotation() > 0 ? -.25 : .25;
+          int wheelMovement = e.getWheelRotation();
+          if (wheelMovement == 0) {
+            return;
+          }
+          double delta = wheelMovement > 0 ? -.25 : .25;
           scale += delta;
           scale = Math.max(1, scale);
           scale = Math.min(100, scale);
@@ -199,8 +202,7 @@ public class TokenVblPanel extends JPanel {
   protected void paintComponent(Graphics g) {
     Dimension panelSize = getSize();
     Dimension panelUsableSize =
-        new Dimension(
-            (int) Math.round(panelSize.width - 10), (int) Math.round(panelSize.height - 10));
+        new Dimension(Math.round(panelSize.width - 10), Math.round(panelSize.height - 10));
 
     Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
 
@@ -341,7 +343,7 @@ public class TokenVblPanel extends JPanel {
     float offset = 1.0f;
 
     text += ": " + NumberFormat.getInstance().format(count);
-    ;
+
     yPos = panelSize.height - yPos;
 
     g2d.setColor(Color.BLACK);


### PR DESCRIPTION
Closes #1317 

Hi-res mice can return 0 from `getWheelMovement()` even though the wheel has moved.  Unfortunately, multiple places in MapTool call that function without checking for zero.

The most obvious effects are the ones that with the largest scale factor for mouse movement:  map zooming and the token layout panel (on the Config tab of the token editor).

Tested with Apple MagicMouse 2 and Apple trackpad; however, I have no experience with other hi-res mice.  (See [this link](https://docs.microsoft.com/en-us/windows/win32/dxtecharts/taking-advantage-of-high-dpi-mouse-movement) for how Windows handles hi-res mice.  Note that Java uses the WM_MOUSEMOVE approach documented at that page.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1500)
<!-- Reviewable:end -->
