### PR TITLE
Fix user data directory message when running MapTool twice

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLJFXPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLJFXPanel.java
@@ -235,7 +235,10 @@ public class HTMLJFXPanel extends JFXPanel implements HTMLPanelInterface {
    * @param event the error event
    */
   private static void showError(WebErrorEvent event) {
-    MapTool.addMessage(TextMessage.me(null, event.getMessage()));
+    // Hide error "User data directory is already in use", directory not used anyway
+    if (event.getEventType() != WebErrorEvent.USER_DATA_DIRECTORY_ALREADY_IN_USE) {
+      MapTool.addMessage(TextMessage.me(null, event.getMessage()));
+    }
   }
 
   /** @return the CSS rule for the body tag. */


### PR DESCRIPTION
- Hide "user data directory is already in use" error message, as the user data directory is not used anyway
- Close #1501

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1502)
<!-- Reviewable:end -->
