### PR TITLE
Issue1317 hi res mouse wheel fixes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -86,9 +86,10 @@ public class MapToolEventQueue extends EventQueue {
         }
       } else if (event instanceof MouseWheelEvent) {
         MouseWheelEvent mwe = (MouseWheelEvent) event;
-        if (mwe.isShiftDown() && MapToolEventQueue.shiftState == 0) {
-          // issue 413: horizontal scrolling too sensitive on macOS w/ SuperMouse; ignore completely
-          // The user can still hold the Shift key down to activate horizontal scrolling.
+        if (mwe.isShiftDown() && MapToolEventQueue.shiftState != 1) {
+          // issue 1317: ignore ALL horizontal movement, *even if* the physical Shift is held down.
+          // This means only vertical movement will be recognized and the user will have
+          // to hold down the Shift key to effect it.
           return;
         }
       }


### PR DESCRIPTION
Second try; closes #1317 

Modifies operation slightly based on @mrkwnzl feedback.  All (physical) horizontal movement is ignored.  However, using the Shift key with vertical movement emulates horizontal.  This only applies to OSes that turn on the Shift key modifier to indicate horizontal scrolling.  (macOS is only known culprit.)  Tested as shown in user screencast (with both mouse and trackpad; see issue) and works well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1508)
<!-- Reviewable:end -->
