### PR TITLE
Allows macro groups to be renamed via the pop-up menu.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
@@ -110,7 +110,9 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
     add(new ImportMacroSetAction());
     add(new ExportMacroSetAction());
     add(new JSeparator());
-    add(new RenameGroupAction());
+    if (areaGroup != null) {
+      add(new RenameGroupAction());
+    }
     add(new ClearGroupAction());
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
@@ -23,6 +23,7 @@ import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import net.rptools.maptool.client.AppUtil;
@@ -72,15 +73,12 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
     }
   }
 
+  private Token getToken() {
+    return MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+  }
+
   private void addActions() {
-    add(new AddMacroAction());
-    add(new JSeparator());
-    add(new ImportMacroAction());
-    add(new JSeparator());
-    add(new ImportMacroSetAction());
-    add(new ExportMacroSetAction());
-    add(new JSeparator());
-    add(new ClearGroupAction());
+    addBasicActions();
     if (!this.panelClass.equals("SelectionPanel")) {
       add(new JSeparator());
       add(new ClearPanelAction());
@@ -98,17 +96,22 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
 
   private void addCampaignActions() {
     if (MapTool.getPlayer().isGM()) {
-      add(new AddMacroAction());
-      add(new JSeparator());
-      add(new ImportMacroAction());
-      add(new JSeparator());
-      add(new ImportMacroSetAction());
-      add(new ExportMacroSetAction());
-      add(new JSeparator());
-      add(new ClearGroupAction());
+      addBasicActions();
       add(new JSeparator());
       add(new ClearPanelAction());
     }
+  }
+
+  private void addBasicActions() {
+    add(new AddMacroAction());
+    add(new JSeparator());
+    add(new ImportMacroAction());
+    add(new JSeparator());
+    add(new ImportMacroSetAction());
+    add(new ExportMacroSetAction());
+    add(new JSeparator());
+    add(new RenameGroupAction());
+    add(new ClearGroupAction());
   }
 
   private class AddMacroAction extends AbstractAction {
@@ -139,12 +142,12 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
               new MacroButtonProperties(nextToken, nextToken.getMacroNextIndex(), macroGroup);
             }
           } else if (tokenId != null) {
-            Token token = MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+            Token token = getToken();
             new MacroButtonProperties(token, token.getMacroNextIndex(), macroGroup);
           }
         }
       } else if (tokenId != null) {
-        Token token = MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+        Token token = getToken();
         new MacroButtonProperties(token, token.getMacroNextIndex(), macroGroup);
       }
     }
@@ -259,8 +262,7 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
                         }
                       }
                     } else if (tokenId != null) {
-                      Token token =
-                          MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+                      Token token = getToken();
                       for (MacroButtonProperties nextMacro : token.getMacroList(true)) {
                         if (newButtonProps.hashCodeForComparison()
                             == nextMacro.hashCodeForComparison()) {
@@ -287,8 +289,7 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
                     }
                   }
                 } else if (tokenId != null) {
-                  Token token =
-                      MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+                  Token token = getToken();
                   for (MacroButtonProperties nextMacro : token.getMacroList(true)) {
                     if (newButtonProps.hashCodeForComparison()
                         == nextMacro.hashCodeForComparison()) {
@@ -427,8 +428,7 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
                           }
                         }
                       } else if (tokenId != null) {
-                        Token token =
-                            MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+                        Token token = getToken();
                         for (MacroButtonProperties nextMacro : token.getMacroList(true)) {
                           if (nextProps.hashCodeForComparison()
                               == nextMacro.hashCodeForComparison()) {
@@ -455,8 +455,7 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
                       }
                     }
                   } else if (tokenId != null) {
-                    Token token =
-                        MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+                    Token token = getToken();
                     for (MacroButtonProperties nextMacro : token.getMacroList(true)) {
                       if (nextProps.hashCodeForComparison() == nextMacro.hashCodeForComparison()) {
                         alreadyExists = true;
@@ -589,8 +588,7 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
                       }
                       PersistenceUtil.saveMacroSet(exportList, selectedFile);
                     } else if (tokenId != null) {
-                      Token token =
-                          MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+                      Token token = getToken();
                       Boolean trusted = AppUtil.playerOwns(token);
                       List<MacroButtonProperties> exportList =
                           new ArrayList<MacroButtonProperties>();
@@ -608,8 +606,7 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
                     }
                   }
                 } else if (tokenId != null) {
-                  Token token =
-                      MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(tokenId);
+                  Token token = getToken();
                   PersistenceUtil.saveMacroSet(token.getMacroList(true), selectedFile);
                 }
               } catch (IOException ioe) {
@@ -618,6 +615,28 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
               }
             }
           });
+    }
+  }
+
+  private class RenameGroupAction extends AbstractAction {
+
+    public RenameGroupAction() {
+      putValue(Action.NAME, I18N.getText("action.macro.renameGroup"));
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent event) {
+      String newMacroGroupName =
+          JOptionPane.showInputDialog(I18N.getText("panel.NewGroupName"), macroGroup);
+      if (!newMacroGroupName.equals(macroGroup)) {
+        if (panelClass.equals("CampaignPanel")
+            || panelClass.equals("GlobalPanel")
+            || panelClass.equals("GmPanel")) {
+          areaGroup.getPanel().renameMacroGroup(macroGroup, newMacroGroupName);
+        } else if (tokenId != null) {
+          getToken().renameMacroGroup(macroGroup, newMacroGroupName);
+        }
+      }
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
@@ -129,6 +129,22 @@ public abstract class AbstractMacroPanel extends JPanel
 
   public abstract void reset();
 
+  protected abstract List<MacroButtonProperties> getMacroButtonProperties();
+
+  protected void postChangeMacroButtonProperties(MacroButtonProperties properties) {
+    /* we do nothing, by default */
+  }
+
+  public void renameMacroGroup(String oldMacroGroup, String newMacroGroup) {
+    for (MacroButtonProperties properties : getMacroButtonProperties()) {
+      if (properties.getGroup().equals(oldMacroGroup)) {
+        properties.setGroup(newMacroGroup);
+        postChangeMacroButtonProperties(properties);
+      }
+    }
+    reset();
+  }
+
   // SCROLLABLE
   public Dimension getPreferredScrollableViewportSize() {
     return getPreferredSize();

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/CampaignPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/CampaignPanel.java
@@ -41,6 +41,11 @@ public class CampaignPanel extends AbstractMacroPanel {
     init();
   }
 
+  @Override
+  protected List<MacroButtonProperties> getMacroButtonProperties() {
+    return MapTool.getCampaign().getMacroButtonPropertiesArray();
+  }
+
   public static void deleteButtonGroup(String macroGroup) {
     AbstractButtonGroup.clearHotkeys(MapTool.getFrame().getCampaignPanel(), macroGroup);
     List<MacroButtonProperties> campProps = MapTool.getCampaign().getMacroButtonPropertiesArray();

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/GlobalPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/GlobalPanel.java
@@ -38,6 +38,16 @@ public class GlobalPanel extends AbstractMacroPanel {
     init();
   }
 
+  @Override
+  protected List<MacroButtonProperties> getMacroButtonProperties() {
+    return MacroButtonPrefs.getButtonProperties();
+  }
+
+  @Override
+  protected void postChangeMacroButtonProperties(MacroButtonProperties properties) {
+    MacroButtonPrefs.savePreferences(properties);
+  }
+
   public static void deleteButtonGroup(String macroGroup) {
     AbstractButtonGroup.clearHotkeys(MapTool.getFrame().getGlobalPanel(), macroGroup);
     for (MacroButtonProperties nextProp : MacroButtonPrefs.getButtonProperties()) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/GmPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/GmPanel.java
@@ -46,6 +46,11 @@ public class GmPanel extends AbstractMacroPanel {
     init();
   }
 
+  @Override
+  protected List<MacroButtonProperties> getMacroButtonProperties() {
+    return getGmMacroButtonArray();
+  }
+
   public static void deleteButtonGroup(String macroGroup) {
     AbstractButtonGroup.clearHotkeys(getGmPanel(), macroGroup);
     List<MacroButtonProperties> campProps = getGmMacroButtonArray();

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
@@ -28,6 +28,7 @@ import net.rptools.maptool.client.ui.MapToolFrame;
 import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.MacroButtonProperties;
 import net.rptools.maptool.model.Token;
 
 public class ImpersonatePanel extends AbstractMacroPanel {
@@ -137,6 +138,12 @@ public class ImpersonatePanel extends AbstractMacroPanel {
   public void reset() {
     clear();
     init();
+  }
+
+  @Override
+  protected List<MacroButtonProperties> getMacroButtonProperties() {
+    /* this is not going to be called for this panel */
+    return null;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
@@ -199,4 +199,10 @@ public class SelectionPanel extends AbstractMacroPanel {
     clear();
     init();
   }
+
+  @Override
+  protected List<MacroButtonProperties> getMacroButtonProperties() {
+    /* not used for the moment by this one */
+    return null;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2200,6 +2200,19 @@ public class Token extends BaseModel implements Cloneable {
     MapTool.getFrame().resetTokenPanels();
   }
 
+  public void renameMacroGroup(String oldMacroGroup, String newMacroGroup) {
+    List<MacroButtonProperties> tempMacros = new ArrayList<>(getMacroList(true));
+
+    for (MacroButtonProperties nextProp : tempMacros) {
+      if (oldMacroGroup.equals(nextProp.getGroup())) {
+        nextProp.setGroup(newMacroGroup);
+      }
+    }
+    MapTool.serverCommand()
+        .putToken(MapTool.getFrame().getCurrentZoneRenderer().getZone().getId(), this);
+    MapTool.getFrame().resetTokenPanels();
+  }
+
   public static final Comparator<Token> COMPARE_BY_NAME =
       new Comparator<Token>() {
         public int compare(Token o1, Token o2) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -364,6 +364,7 @@ action.macro.importSet                        = Import Macro Set...
 action.macro.importSetToSelected              = Import Macro Set to Selected...
 action.macro.importToSelected                 = Import Macro to Selected...
 action.macro.new                              = Add New Macro
+action.macro.renameGroup                      = Rename Macro Group...
 action.macro.reset                            = Reset
 action.macro.runForEachSelected               = Run for Each Selected
 action.macroEditor.gotoLine                   = &Go to Line...
@@ -1278,6 +1279,7 @@ panel.MapExplorer.View.PLAYERS                = Players
 # MapExplorer panel -- these *are* used as they are content within the
 # panel, not the title or the string used internally to reference the panel.
 panel.MapExplorer.View.TOKENS                 = Tokens
+panel.NewGroupName                            = New Group Name
 panel.Selected                                = Selected
 panel.Selected.description                    = Dockable window showing the macros on the currently selected token(s).
 panel.Selected.tooltip.deslectAll             = Deselect all tokens
@@ -1287,6 +1289,7 @@ panel.Selected.tooltip.revertToPrevious       = Revert to previous selection
 panel.Selected.tooltip.selectAll              = Select all tokens on the map
 panel.Tables                                  = Tables
 panel.Tables.description                      = Dockable window for managing the tables in the current campaign.
+
 
 prefs.language.override.tooltip = Select a language for the MapTool interface.
 


### PR DESCRIPTION
Fixes #368

Tests done:
- renamed macro group in Global, GmPanel, Campaign, Selected and Impersonated
- renamed macro group when multiple tokens are selected

Also refactors code a little, to reduce some duplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1509)
<!-- Reviewable:end -->
