### PR TITLE
Add parameter scrollreset to dialog, frame, dialog5, frame5

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1438,7 +1438,9 @@ public class MapToolLineParser {
                   frameName, false, false, frameOpts, expressionBuilder.toString());
               break;
             case OVERLAY:
-              MapTool.getFrame().getHtmlOverlay().updateContents(expressionBuilder.toString());
+              MapTool.getFrame()
+                  .getHtmlOverlay()
+                  .updateContents(expressionBuilder.toString(), true);
               break;
             case CHAT:
               builder.append(expressionBuilder);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLDialog.java
@@ -175,6 +175,7 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
    * @param input whether submitting the form closes it
    * @param temp whether the frame is temporary
    * @param closeButton whether the close button is to be displayed
+   * @param scrollReset whether the scrollbar should be reset
    * @param isHTML5 whether the frame should support HTML5
    * @param value a value to be returned by getDialogProperties()
    * @param html the HTML to display in the dialog
@@ -189,6 +190,7 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       boolean input,
       boolean temp,
       boolean closeButton,
+      boolean scrollReset,
       boolean isHTML5,
       Object value,
       String html) {
@@ -199,7 +201,8 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       dialog = new HTMLDialog(MapTool.getFrame(), name, frame, width, height, isHTML5);
       dialogs.put(name, dialog);
     }
-    dialog.updateContents(html, title, frame, input, temp, closeButton, isHTML5, value);
+    dialog.updateContents(
+        html, title, frame, input, temp, closeButton, scrollReset, isHTML5, value);
 
     // dialog.canResize = false;
     if (!dialog.isVisible()) {
@@ -307,6 +310,7 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
    * @param input whether to close the dialog on form submit
    * @param temp whether to make the dialog temporary
    * @param closeButton whether to show a close button
+   * @param scrollReset whether the scrollbar should be reset
    * @param isHTML5 whether to make the dialog HTML5 (JavaFX)
    * @param val the value held in the frame
    */
@@ -317,6 +321,7 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       boolean input,
       boolean temp,
       boolean closeButton,
+      boolean scrollReset,
       boolean isHTML5,
       Object val) {
     if (this.isHTML5 != isHTML5) {
@@ -336,7 +341,7 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
     this.setTitle(title);
     macroCallbacks.clear();
     updateButton(closeButton);
-    panel.updateContents(html);
+    panel.updateContents(html, scrollReset);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -97,6 +97,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * @param width the width of the frame in pixels.
    * @param height the height of the frame in pixels.
    * @param temp whether the frame should be temporary.
+   * @param scrollReset whether the scrollbar should be reset.
    * @param isHTML5 whether it should use HTML5 (JavaFX) or HTML 3.2 (Swing).
    * @param val a value that can be returned by getFrameProperties().
    * @param html the html to display in the frame.
@@ -109,6 +110,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       int width,
       int height,
       boolean temp,
+      boolean scrollReset,
       boolean isHTML5,
       Object val,
       String html) {
@@ -129,7 +131,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       // Jamz: why undock frames to center them?
       if (!frame.isDocked()) center(name);
     }
-    frame.updateContents(html, title, tabTitle, temp, isHTML5, val);
+    frame.updateContents(html, title, tabTitle, temp, scrollReset, isHTML5, val);
     return frame;
   }
 
@@ -225,11 +227,18 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * @param title the title of the frame
    * @param tabTitle the tabTitle of the frame
    * @param temp whether the frame is temporary
+   * @param scrollReset whether the scrollbar should be reset
    * @param isHTML5 whether the frame should support HTML5 (JavaFX)
    * @param val the value to put in the frame
    */
   public void updateContents(
-      String html, String title, String tabTitle, boolean temp, boolean isHTML5, Object val) {
+      String html,
+      String title,
+      String tabTitle,
+      boolean temp,
+      boolean scrollReset,
+      boolean isHTML5,
+      Object val) {
     if (this.isHTML5 != isHTML5) {
       this.isHTML5 = isHTML5;
       panel.removeFromContainer(this); // remove previous panel
@@ -241,7 +250,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
     setTabTitle(tabTitle);
     setTemporary(temp);
     setValue(val);
-    panel.updateContents(html);
+    panel.updateContents(html, scrollReset);
   }
 
   /** Run all callback macros for "onChangeSelection". */

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -52,6 +52,7 @@ public class HTMLFrameFactory {
     Object frameValue = null;
     boolean hasFrame = true;
     boolean closeButton = true;
+    boolean scrollReset = false;
 
     if (properties != null && !properties.isEmpty()) {
       String[] opts = properties.split(";");
@@ -113,6 +114,10 @@ public class HTMLFrameFactory {
           } catch (NumberFormatException e) {
             // Ignoring the value; shouldn't we warn the user?
           }
+        } else if (keyLC.equals("scrollreset")) {
+          if (Integer.parseInt(value) == 1) {
+            scrollReset = true;
+          }
         } else if (keyLC.equals("value")) {
           frameValue = value;
         } else if (keyLC.equals("tabtitle")) {
@@ -123,7 +128,7 @@ public class HTMLFrameFactory {
     if (tabTitle == null) tabTitle = title; // if tabTitle not set, make it same as title
     if (isFrame) {
       HTMLFrame.showFrame(
-          name, title, tabTitle, width, height, temporary, isHTML5, frameValue, html);
+          name, title, tabTitle, width, height, temporary, scrollReset, isHTML5, frameValue, html);
     } else {
       HTMLDialog.showDialog(
           name,
@@ -134,6 +139,7 @@ public class HTMLFrameFactory {
           input,
           temporary,
           closeButton,
+          scrollReset,
           isHTML5,
           frameValue,
           html);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlay.java
@@ -296,9 +296,9 @@ public class HTMLOverlay extends HTMLJFXPanel implements HTMLPanelContainer {
   }
 
   @Override
-  public void updateContents(final String html) {
+  public void updateContents(final String html, boolean scrollReset) {
     macroCallbacks.clear(); // clear the old callbacks
-    super.updateContents(html);
+    super.updateContents(html, true);
     getDropTarget().setActive(false); // disables drop on overlay, drop goes to map
     if ("".equals(html)) {
       closeRequest(); // turn off the overlay

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
+import javax.swing.text.DefaultCaret;
 import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLDocument;
@@ -121,13 +122,17 @@ public class HTMLPane extends JEditorPane {
    * Flush the pane, set the new html, and set the caret to zero.
    *
    * @param html the html to set
+   * @param scrollReset whether the scrollbar should be reset
    */
-  public void updateContents(final String html) {
+  public void updateContents(final String html, boolean scrollReset) {
     EventQueue.invokeLater(
-        new Runnable() {
-          public void run() {
-            editorKit.flush();
-            setText(html);
+        () -> {
+          DefaultCaret caret = (DefaultCaret) getCaret();
+          caret.setUpdatePolicy(
+              scrollReset ? DefaultCaret.UPDATE_WHEN_ON_EDT : DefaultCaret.NEVER_UPDATE);
+          editorKit.flush();
+          setText(html);
+          if (scrollReset) {
             setCaretPosition(0);
           }
         });

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanel.java
@@ -45,7 +45,7 @@ public class HTMLPanel extends JPanel implements HTMLPanelInterface {
     } else {
       add(pane, BorderLayout.CENTER);
     }
-    updateContents("");
+    updateContents("", false);
 
     // ESCAPE closes the window
     pane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
@@ -60,14 +60,9 @@ public class HTMLPanel extends JPanel implements HTMLPanelInterface {
             });
   }
 
-  /**
-   * Update the contents of the panel.
-   *
-   * @param html The HTML to display.
-   */
   @Override
-  public void updateContents(final String html) {
-    pane.updateContents(html);
+  public void updateContents(final String html, boolean scrollReset) {
+    pane.updateContents(html, scrollReset);
   }
 
   /** Flushes any caching for the panel. */

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanelInterface.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanelInterface.java
@@ -23,8 +23,9 @@ interface HTMLPanelInterface {
    * Update the HTML content and the close button.
    *
    * @param html the html to load.
+   * @param scrollreset whether the scroll bar should be reset.
    */
-  void updateContents(final String html);
+  void updateContents(final String html, boolean scrollreset);
 
   /** Flush the Panel. */
   void flush();


### PR DESCRIPTION
- Add parameter scrollreset to dialog(), frame(), dialog5(), and frame5(). If set to 0 (false) on a non-temporary frame or dialog, the scrolling location is kept when the frame is updated with new content
- Default behavior: don't reset the scrolling
- Close #1528

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1531)
<!-- Reviewable:end -->
