### PR TITLE
Add "Lock Player Token Editor" option to Tool menu

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2059,6 +2059,29 @@ public class AppActions {
         }
       };
 
+  /** Toggle to enable / disable player use of the token editor. */
+  public static final Action TOGGLE_TOKEN_EDITOR_LOCK =
+      new AdminClientAction() {
+        {
+          init("action.toggleTokenEditorLock");
+        }
+
+        @Override
+        public boolean isSelected() {
+          return MapTool.getServerPolicy().isTokenEditorLocked();
+        }
+
+        @Override
+        protected void executeAction(ActionEvent e) {
+
+          ServerPolicy policy = MapTool.getServerPolicy();
+          policy.setIsTokenEditorLocked(!policy.isTokenEditorLocked());
+
+          MapTool.updateServerPolicy(policy);
+          MapTool.getServer().updateServerPolicy(policy);
+        }
+      };
+
   public static final Action START_SERVER =
       new ClientAction() {
         {

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -985,6 +985,8 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       // Jamz: Bug fix, we don't support editing multiple tokens here.
       if (selectedTokenSet.size() > 1) {
         setEnabled(false);
+      } else if (!MapTool.getPlayer().isGM() && MapTool.getServerPolicy().isTokenEditorLocked()) {
+        setEnabled(false);
       }
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -196,6 +196,7 @@ public class AppMenuBar extends JMenuBar {
     menu.add(new JMenuItem(AppActions.ENFORCE_ZONE));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_LINK_PLAYER_VIEW, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_MOVEMENT_LOCK, menu));
+    menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_TOKEN_EDITOR_LOCK, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_ZOOM_LOCK, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_ENFORCE_NOTIFICATION, menu));
 

--- a/src/main/java/net/rptools/maptool/server/ServerPolicy.java
+++ b/src/main/java/net/rptools/maptool/server/ServerPolicy.java
@@ -26,6 +26,7 @@ import net.rptools.maptool.client.walker.WalkerMetric;
 public class ServerPolicy {
   private boolean strictTokenMovement;
   private boolean isMovementLocked;
+  private boolean isTokenEditorLocked;
   private boolean playersCanRevealVision;
   private boolean gmRevealsVisionForUnownedTokens;
   private boolean useIndividualViews;
@@ -66,6 +67,14 @@ public class ServerPolicy {
 
   public void setIsMovementLocked(boolean locked) {
     isMovementLocked = locked;
+  }
+
+  public boolean isTokenEditorLocked() {
+    return isTokenEditorLocked;
+  }
+
+  public void setIsTokenEditorLocked(boolean locked) {
+    isTokenEditorLocked = locked;
   }
 
   public void setPlayersCanRevealVision(boolean flag) {
@@ -212,6 +221,8 @@ public class ServerPolicy {
     sinfo.addProperty(
         "auto reveal on movement", isAutoRevealOnMovement() ? BigDecimal.ONE : BigDecimal.ZERO);
     sinfo.addProperty("movement locked", isMovementLocked() ? BigDecimal.ONE : BigDecimal.ZERO);
+    sinfo.addProperty(
+        "token editor locked", isTokenEditorLocked() ? BigDecimal.ONE : BigDecimal.ZERO);
     sinfo.addProperty(
         "restricted impersonation", isRestrictedImpersonation() ? BigDecimal.ONE : BigDecimal.ZERO);
     sinfo.addProperty(

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -472,6 +472,8 @@ action.toggleDrawMeasurements.description     = When selected the drawing tools 
 action.toggleMovementLock                     = &Lock Player Movement
 action.toggleMovementLock.accel               = shift L
 action.toggleMovementLock.description         = Locks movement for player-owned tokens.
+action.toggleTokenEditorLock                  = Lock Player Token Editor
+action.toggleTokenEditorLock.description      = Locks access to the Token Editor.
 action.toggleNewZonesHaveFOW                  = New Maps have Fog of War
 action.toggleTokensStartSnapToGrid            = Tokens Start Snap to Grid
 # Edit Menu

--- a/src/main/resources/net/rptools/maptool/language/macro_descriptions/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/macro_descriptions/i18n.properties
@@ -6191,6 +6191,7 @@ The <code>getInfo("client")</code> function returns the names of all Lib: tokens
   "initiative owner permissions": 0,\
   "players can reveal": 0,\
   "movement locked": 0,\
+  "token editor locked": 0,\
   "tooltips for default roll format": 1,\
   "individual views": 0,\
   "players receive campaign macros": 0,\


### PR DESCRIPTION
- Add toggle to enable / disable player use of the token editor
- Close #975

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1556)
<!-- Reviewable:end -->
