### PR TITLE
Fix unenclosed parentheses in Campaign Property throwing exception

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -286,7 +286,13 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
         // (Really should handle nested parens here)
         int index = line.indexOf("(");
         if (index > 0) {
-          String shortName = line.substring(index + 1, line.lastIndexOf(")")).trim();
+          int indexClose = line.lastIndexOf(")");
+          // Check for unenclosed parentheses. Fix #1575.
+          if (indexClose < index) {
+            MapTool.showError(I18N.getText("CampaignPropertyDialog.error.parenthesis", line));
+            throw new IllegalArgumentException("Missing parenthesis");
+          }
+          String shortName = line.substring(index + 1, indexClose).trim();
           if (shortName.length() > 0) {
             property.setShortName(shortName);
           }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -106,6 +106,8 @@ Button.rescan   = Rescan
 Label.optional  = Optional
 Label.options   = Options
 
+CampaignPropertyDialog.error.parenthesis              = Missing right parenthesis ")" in the following property: {0}
+
 ConnectToServerDialog.msg.headingServer               = Server Name
 ConnectToServerDialog.msg.headingVersion              = Version
 ConnectToServerDialog.msg.title                       = Connect to Server


### PR DESCRIPTION
- Add error message when a property does not have a right parenthesis
- Fix #1575
- Example:

Missing right parenthesis ")" in the following property: Strength (Str

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1576)
<!-- Reviewable:end -->
