### PR TITLE
Give an option to SwingUtil.constrainTo to limit whether an image can…

### DIFF
--- a/src/main/java/net/rptools/lib/swing/SwingUtil.java
+++ b/src/main/java/net/rptools/lib/swing/SwingUtil.java
@@ -143,12 +143,18 @@ public class SwingUtil {
   }
 
   public static void constrainTo(Dimension dim, int size) {
+    constrainTo(dim, size, true);
+  }
+
+  public static void constrainTo(Dimension dim, int size, boolean grow) {
     boolean widthBigger = dim.width > dim.height;
 
     if (widthBigger) {
+      if (!grow) size = Math.min(size, dim.width);
       dim.height = (int) ((dim.height / (double) dim.width) * size);
       dim.width = size;
     } else {
+      if (!grow) size = Math.min(size, dim.height);
       dim.width = (int) ((dim.width / (double) dim.height) * size);
       dim.height = size;
     }

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1621,7 +1621,7 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
           imgSize = new Dimension(image.getWidth(), image.getHeight());
 
           // Size
-          SwingUtil.constrainTo(imgSize, AppPreferences.getPortraitSize());
+          SwingUtil.constrainTo(imgSize, AppPreferences.getPortraitSize(), false);
         }
 
         Dimension statSize = null;


### PR DESCRIPTION
… grow beyond its natural size.

Make portrait in overlay/statsheet not grow beyond image size.

Overload existing constrainTo since it's used in many places - all of those will continue to stretch images up for now.

Fixes #1583

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1584)
<!-- Reviewable:end -->
