### PR TITLE
Allow macros to unset token images - e.g. setTokenImage("") 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -259,12 +259,12 @@ public class TokenImage extends AbstractFunction {
   }
 
   private static void setPortrait(Token token, String assetName) throws ParserException {
-    MD5Key md5key = getMD5Key(assetName, SET_PORTRAIT);
+    MD5Key md5key = "".equals(assetName) ? null : getMD5Key(assetName, SET_PORTRAIT);
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.setPortraitImage, md5key);
   }
 
   private static void setHandout(Token token, String assetName) throws ParserException {
-    MD5Key md5key = getMD5Key(assetName, SET_HANDOUT);
+    MD5Key md5key = "".equals(assetName) ? null : getMD5Key(assetName, SET_HANDOUT);
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.setCharsheetImage, md5key);
   }
 


### PR DESCRIPTION
instead of getting illegal argument type runtime exception.

Fixes #1597

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1598)
<!-- Reviewable:end -->
