### PR TITLE
Fix jumpy tokens on all layers

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -532,17 +532,15 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
           renderer.selectToken(token.getId());
           renderer.updateAfterSelection();
         }
-        // Dragging offset for currently selected token
+        // ZonePoint dragged to
         ZonePoint pos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
-        Rectangle tokenBounds = token.getBounds(renderer.getZone());
 
-        if (token.isSnapToGrid() && getZone().getGrid().getCapabilities().isSnapToGridSupported()) {
-          dragOffsetX = (pos.x - tokenBounds.x) - (tokenBounds.width / 2);
-          dragOffsetY = (pos.y - tokenBounds.y) - (tokenBounds.height / 2);
-        } else {
-          dragOffsetX = pos.x - tokenBounds.x;
-          dragOffsetY = pos.y - tokenBounds.y;
-        }
+        // Offset specific to the token
+        Point tokenOffset = token.getDragOffset(getZone());
+
+        // Dragging offset for currently selected token
+        dragOffsetX = pos.x - tokenOffset.x;
+        dragOffsetY = pos.y - tokenOffset.y;
       }
     } else {
       if (SwingUtilities.isLeftMouseButton(e)) {
@@ -797,9 +795,6 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
         if (isMovingWithKeys) {
           return;
         }
-        Grid grid = getZone().getGrid();
-        TokenFootprint tf = tokenUnderMouse.getFootprint(grid);
-        Rectangle r = tf.getBounds(grid);
         ZonePoint last = renderer.getLastWaypoint(tokenUnderMouse.getId());
         if (last == null) {
           // This makes no sense to me. Why create a fake last point that is
@@ -879,17 +874,14 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
    */
   public boolean handleDragToken(ZonePoint zonePoint, int dx, int dy) {
     Grid grid = renderer.getZone().getGrid();
+    // Always correct for offset. Fix #1589
+    zonePoint.translate(-dragOffsetX, -dragOffsetY);
     // For snapped dragging
     if (tokenBeingDragged.isSnapToGrid()
         && grid.getCapabilities().isSnapToGridSupported()
         && AppPreferences.getTokensSnapWhileDragging()) {
       // Convert the zone point to a cell point and back to force the snap to grid on drag
       zonePoint = grid.convert(grid.convert(zonePoint));
-    } else {
-      // Non-snapped while dragging.  Snaps when mouse-button released.
-      if (!(grid instanceof SquareGrid) || !tokenBeingDragged.isSnapToGrid()) {
-        zonePoint.translate(-dragOffsetX, -dragOffsetY);
-      }
     }
     CellPoint cellUnderMouse = grid.convert(zonePoint);
     MapTool.getFrame().getCoordinateStatusBar().update(cellUnderMouse.x, cellUnderMouse.y);

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -421,25 +421,14 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
           renderer.selectToken(token.getId());
           renderer.updateAfterSelection();
         }
-        // Dragging offset for currently selected token
+        // Position on the zone of the click
         ZonePoint pos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
-        Rectangle tokenBounds = token.getBounds(renderer.getZone());
 
-        int snapOffsetX = 0;
-        int snapOffsetY = 0;
-        if (token.isSnapToGrid() && getZone().getGrid().getCapabilities().isSnapToGridSupported()) {
-          if (token.isBackgroundStamp() || token.isSnapToScale()) {
-            // Snaps to the top left corner
-            snapOffsetX = (int) getZone().getGrid().getCellWidth() / 2;
-            snapOffsetY = (int) getZone().getGrid().getCellHeight() / 2;
-          } else {
-            // Snaps to the center
-            snapOffsetX = tokenBounds.width / 2;
-            snapOffsetY = tokenBounds.height / 2;
-          }
-        }
-        dragOffsetX = pos.x - tokenBounds.x - snapOffsetX;
-        dragOffsetY = pos.y - tokenBounds.y - snapOffsetY;
+        // Offset specific to the token
+        Point tokenOffset = token.getDragOffset(getZone());
+
+        dragOffsetX = pos.x - tokenOffset.x;
+        dragOffsetY = pos.y - tokenOffset.y;
       }
     } else {
       if (SwingUtilities.isLeftMouseButton(e)) {
@@ -855,7 +844,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
    */
   public boolean handleDragToken(ZonePoint zonePoint) {
     // TODO: Optimize this (combine with calling code)
-    if (tokenBeingDragged.isSnapToGrid()) {
+    if (tokenBeingDragged.isSnapToGrid()
+        && getZone().getGrid().getCapabilities().isSnapToGridSupported()) {
       zonePoint.translate(-dragOffsetX, -dragOffsetY);
       CellPoint cellUnderMouse = renderer.getZone().getGrid().convert(zonePoint);
       zonePoint = renderer.getZone().getGrid().convert(cellUnderMouse);

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -236,6 +236,9 @@ public abstract class Grid implements Cloneable {
     return 0;
   }
 
+  /** @return the difference in pixels between the center of a cell and its converted zonepoint. */
+  public abstract Point getCenterOffset();
+
   /**
    * @return The offset required to translate from the center of a cell to the top right (x_min,
    *     y_min) of the cell's bounding rectangle. Used for non-square grids only.<br>

--- a/src/main/java/net/rptools/maptool/model/GridlessGrid.java
+++ b/src/main/java/net/rptools/maptool/model/GridlessGrid.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.model;
 
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Area;
@@ -173,5 +174,10 @@ public class GridlessGrid extends Grid {
   @Override
   public double getCellHeight() {
     return getSize();
+  }
+
+  @Override
+  public Point getCenterOffset() {
+    return new Point(0, 0);
   }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -83,6 +83,11 @@ public abstract class HexGrid extends Grid {
     }
   }
 
+  @Override
+  public Point getCenterOffset() {
+    return new Point(0, 0);
+  }
+
   /** minorRadius / edgeLength */
   private double hexRatio = REGULAR_HEX_RATIO;
   /**

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -18,6 +18,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
@@ -97,6 +98,11 @@ public class IsometricGrid extends Grid {
   @Override
   public double getCellHeight() {
     return getSize();
+  }
+
+  @Override
+  public Point getCenterOffset() {
+    return new Point(0, (int) getCellHeight() / 2);
   }
 
   public double getCellWidthHalf() {

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -19,6 +19,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Area;
@@ -98,6 +99,11 @@ public class SquareGrid extends Grid {
       boolean faceVertices = AppPreferences.getFaceVertex();
       setFacings(faceEdges, faceVertices);
     }
+  }
+
+  @Override
+  public Point getCenterOffset() {
+    return new Point((int) getCellWidth() / 2, (int) getCellHeight() / 2);
   }
 
   public SquareGrid(boolean faceEdges, boolean faceVertices) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1510,6 +1510,32 @@ public class Token extends BaseModel implements Cloneable {
     return footprintBounds;
   }
 
+  /**
+   * Returns the drag offset of the token.
+   *
+   * @param zone the zone where the token is dragged
+   * @return a point representing the offset
+   */
+  public Point getDragOffset(Zone zone) {
+    Grid grid = zone.getGrid();
+    int offsetX, offsetY;
+    if (isSnapToGrid() && grid.getCapabilities().isSnapToGridSupported()) {
+      if (isBackgroundStamp() || isSnapToScale()) {
+        Point centerOffset = grid.getCenterOffset();
+        offsetX = getX() + centerOffset.x;
+        offsetY = getY() + centerOffset.y;
+      } else {
+        Rectangle tokenBounds = getBounds(zone);
+        offsetX = tokenBounds.x + tokenBounds.width / 2;
+        offsetY = tokenBounds.y + tokenBounds.height / 2;
+      }
+    } else {
+      offsetX = getX();
+      offsetY = getY();
+    }
+    return new Point(offsetX, offsetY);
+  }
+
   /** @return the String of the sightType */
   public String getSightType() {
     return sightType;

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -731,6 +731,10 @@ public class Token extends BaseModel implements Cloneable {
     return getLayer() == Zone.Layer.BACKGROUND;
   }
 
+  public boolean isOnTokenLayer() {
+    return getLayer() == Zone.Layer.TOKEN;
+  }
+
   public boolean isStamp() {
     switch (getLayer()) {
       case BACKGROUND:
@@ -1520,7 +1524,7 @@ public class Token extends BaseModel implements Cloneable {
     Grid grid = zone.getGrid();
     int offsetX, offsetY;
     if (isSnapToGrid() && grid.getCapabilities().isSnapToGridSupported()) {
-      if (isBackgroundStamp() || isSnapToScale()) {
+      if (isBackgroundStamp() || isSnapToScale() || isOnTokenLayer()) {
         Point centerOffset = grid.getCenterOffset();
         offsetX = getX() + centerOffset.x;
         offsetY = getY() + centerOffset.y;


### PR DESCRIPTION
- Fix jumpy tokens on all layers
- Fix for all grids: square, iso, hex, and gridless
- Fix for snap-to-grid, and non snap-to-grid tokens
- Fix for snap-to-size, and non snap-to-size tokens
- Described in #1589

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1599)
<!-- Reviewable:end -->
