### PR TITLE
Fix deleting a token resets the impersonated token panel

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -834,7 +834,7 @@ public class AppActions {
    * the set exist in the zone, or because the user doesn't have permission to delete the tokens)
    * then the {@link MapTool#SND_INVALID_OPERATION} sound is played.
    *
-   * <p>If any tokens<i>are</i> deleted, then the selection set for the zone is cleared.
+   * <p>If any tokens <i>are</i> deleted, then the selection set for the zone is cleared.
    *
    * @param zone the {@link Zone} the tokens belong to.
    * @param tokenSet a {code Set} containing ght ID's of the tokens to cut.
@@ -850,7 +850,7 @@ public class AppActions {
    * the set exist in the zone, or because the user doesn't have permission to delete the tokens)
    * then the {@link MapTool#SND_INVALID_OPERATION} sound is played.
    *
-   * <p>If any tokens<i>are</i> deleted, then the selection set for the zone is cleared.
+   * <p>If any tokens <i>are</i> deleted, then the selection set for the zone is cleared.
    *
    * @param zone the {@link Zone} the tokens belong to.
    * @param tokenSet a {code Set} containing ght ID's of the tokens to cut.
@@ -866,7 +866,7 @@ public class AppActions {
    * the set exist in the zone, or because the user doesn't have permission to delete the tokens)
    * then the {@link MapTool#SND_INVALID_OPERATION} sound is played.
    *
-   * <p>If any tokens<i>are</i> deleted, then the selection set for the zone is cleared.
+   * <p>If any tokens <i>are</i> deleted, then the selection set for the zone is cleared.
    *
    * @param copy whether the tokens should be copied and deleted (cut) or just deleted
    * @param zone the {@link Zone} the tokens belong to.

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolDockListener.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolDockListener.java
@@ -106,10 +106,10 @@ public class MapToolDockListener implements DockableFrameListener {
    */
   private void updatePanels(String panel) {
     if (MapTool.getFrame() != null) {
-      if (panel == "SELECTION") {
+      if (panel.equals("SELECTION")) {
         MapTool.getFrame().getSelectionPanel().reset();
       }
-      if (panel == "IMPERSONATED") {
+      if (panel.equals("IMPERSONATED")) {
         MapTool.getFrame().getImpersonatePanel().reset();
       }
     }

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -169,7 +169,7 @@ public class CommandPanel extends JPanel implements Observer {
       identityGUID = token.getId();
       identityName = token.getName();
       avatarPanel.setImage(ImageManager.getImageAndWait(token.getImageAssetId()));
-      setCharacterLabel("Speaking as: " + getIdentity());
+      setCharacterLabel(I18N.getText("panel.Impersonate.identity", getIdentity()));
     } else {
       identityGUID = null;
       identityName = null;
@@ -210,7 +210,7 @@ public class CommandPanel extends JPanel implements Observer {
       setIdentityImpl(token);
       // For the name to be used, even if there is no such token
       identityName = identity;
-      setCharacterLabel("Speaking as: " + getIdentity());
+      setCharacterLabel(I18N.getText("panel.Impersonate.identity", getIdentity()));
     }
     HTMLFrameFactory.impersonateToken();
   }

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
@@ -38,7 +38,6 @@ import net.rptools.maptool.model.ModelChangeEvent;
 import net.rptools.maptool.model.ModelChangeListener;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
-import net.rptools.maptool.model.Zone.Event;
 
 @SuppressWarnings("serial")
 public abstract class AbstractMacroPanel extends JPanel
@@ -97,6 +96,7 @@ public abstract class AbstractMacroPanel extends JPanel
     this.panelClass = panelClass;
   }
 
+  /** @return the token on the current map corresponding to the stored token id. */
   public Token getToken() {
     if (this.tokenId == null) {
       return null;
@@ -188,12 +188,8 @@ public abstract class AbstractMacroPanel extends JPanel
 
   // currently only used for Impersonate/Selection panels to refresh when the token is removed or a
   // macro changes
-  public void modelChanged(ModelChangeEvent event) {
-    if (event.eventType == Token.ChangeEvent.MACRO_CHANGED
-        || event.eventType == Event.TOKEN_REMOVED) {
-      reset();
-    }
-  }
+  @Override
+  public void modelChanged(ModelChangeEvent event) {}
 
   public void handleAppEvent(AppEvent event) {
     Zone oldZone = (Zone) event.getOldValue();

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
@@ -27,9 +27,7 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.MapToolFrame;
 import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.GUID;
-import net.rptools.maptool.model.MacroButtonProperties;
-import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.*;
 
 public class ImpersonatePanel extends AbstractMacroPanel {
   private boolean currentlyImpersonating = false;
@@ -138,6 +136,37 @@ public class ImpersonatePanel extends AbstractMacroPanel {
   public void reset() {
     clear();
     init();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void modelChanged(ModelChangeEvent event) {
+    if (event.eventType == Token.ChangeEvent.MACRO_CHANGED
+        || event.eventType == Zone.Event.TOKEN_REMOVED) {
+      // Only resets if the impersonated token is among those changed/deleted
+      boolean impersonatedChanged;
+      if (event.getArg() instanceof List<?>) {
+        impersonatedChanged = isImpersonatedAmongList((List<Token>) event.getArg());
+      } else {
+        impersonatedChanged = isTokenImpersonated((Token) event.getArg());
+      }
+      if (impersonatedChanged) {
+        reset();
+      }
+    }
+  }
+
+  private boolean isTokenImpersonated(Token token) {
+    return token != null && getTokenId() != null && token.getId().equals(getTokenId());
+  }
+
+  private boolean isImpersonatedAmongList(List<Token> list) {
+    for (Token token : list) {
+      if (isTokenImpersonated(token)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
@@ -31,7 +31,9 @@ import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.MacroButtonProperties;
+import net.rptools.maptool.model.ModelChangeEvent;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Zone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -118,6 +120,14 @@ public class SelectionPanel extends AbstractMacroPanel {
       if (log.isDebugEnabled()) log.debug(results);
     }
     MapTool.getEventDispatcher().addListener(this, MapTool.ZoneEvent.Activated);
+  }
+
+  @Override
+  public void modelChanged(ModelChangeEvent event) {
+    if (event.eventType == Token.ChangeEvent.MACRO_CHANGED
+        || event.eventType == Zone.Event.TOKEN_REMOVED) {
+      reset();
+    }
   }
 
   private void populateCommonButtons(List<Token> tokenList) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -68,6 +68,7 @@ public class Token extends BaseModel implements Cloneable {
 
   private static final Logger log = LogManager.getLogger(Token.class);
 
+  /** The unique GUID of the token. */
   private GUID id = new GUID();
 
   public static final String FILE_EXTENSION = "rptok";
@@ -1797,7 +1798,7 @@ public class Token extends BaseModel implements Cloneable {
       macroPropertiesMap.put(macro.getIndex(), macro);
 
       // Allows the token macro panels to update only if a macro changes
-      fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, id));
+      fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, this));
     }
   }
 
@@ -1824,7 +1825,7 @@ public class Token extends BaseModel implements Cloneable {
     MapTool.serverCommand().putToken(getZoneRenderer().getZone().getId(), this);
 
     // Lets the token macro panels update only if a macro changes
-    fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, id));
+    fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, this));
   }
 
   public void deleteMacroButtonProperty(MacroButtonProperties prop) {
@@ -1834,7 +1835,7 @@ public class Token extends BaseModel implements Cloneable {
     // timing problem.
 
     // Lets the token macro panels update only if a macro changes
-    fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, id));
+    fireModelChangeEvent(new ModelChangeEvent(this, ChangeEvent.MACRO_CHANGED, this));
   }
 
   public void setSpeechMap(Map<String, String> map) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1770,6 +1770,7 @@ panel.Global.description                      = Dockable window showing macros s
 panel.Impersonate                             = Impersonate
 panel.Impersonate.description                 = Dockable window showing the macros stored on the currently impersonated token.
 panel.Impersonate.button.impersonateSelected  = Impersonate Selected
+panel.Impersonate.identity                    = Speaking as: {0}
 panel.Initiative                              = Initiative
 panel.Initiative.description                  = Dockable window for managing combat initiative.
 panel.Library                                 = Library


### PR DESCRIPTION
- Change so that a panel reset is not triggered by deleting a token that isn't impersonated
- Fix #1658

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1659)
<!-- Reviewable:end -->
