### PR TITLE
Fix selection changes resulting in impersonation panel reset

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPopupMenu.java
@@ -225,12 +225,15 @@ public class MacroButtonPopupMenu extends JPopupMenu {
               }
             }
           } else {
-            button.getToken().deleteMacroButtonProperty(button.getProperties());
+            int index = button.getProperties().getIndex();
+            Token token = button.getToken();
+            MapTool.serverCommand().updateTokenProperty(token, Token.Update.deleteMacro, index);
           }
-          MapTool.getFrame().getSelectionPanel().reset();
         } else if (button.getToken() != null) {
           if (AppUtil.playerOwns(button.getToken())) {
-            button.getToken().deleteMacroButtonProperty(button.getProperties());
+            int index = button.getProperties().getIndex();
+            Token token = button.getToken();
+            MapTool.serverCommand().updateTokenProperty(token, Token.Update.deleteMacro, index);
           }
         }
       }

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
@@ -28,6 +28,7 @@ import net.rptools.maptool.client.ui.MapToolFrame;
 import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.*;
+import net.rptools.maptool.model.Zone.Event;
 
 public class ImpersonatePanel extends AbstractMacroPanel {
   private boolean currentlyImpersonating = false;
@@ -138,11 +139,19 @@ public class ImpersonatePanel extends AbstractMacroPanel {
     init();
   }
 
+  /** Resets the panel only if no token is impersonated. */
+  public void resetIfNotImpersonating() {
+    if (!currentlyImpersonating || getToken() == null) {
+      reset();
+    }
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public void modelChanged(ModelChangeEvent event) {
-    if (event.eventType == Token.ChangeEvent.MACRO_CHANGED
-        || event.eventType == Zone.Event.TOKEN_REMOVED) {
+    if (event.eventType == Event.TOKEN_MACRO_CHANGED
+        || event.eventType == Event.TOKEN_REMOVED
+        || event.eventType == Event.TOKEN_PANEL_CHANGED) {
       // Only resets if the impersonated token is among those changed/deleted
       boolean impersonatedChanged;
       if (event.getArg() instanceof List<?>) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
@@ -124,9 +124,26 @@ public class SelectionPanel extends AbstractMacroPanel {
 
   @Override
   public void modelChanged(ModelChangeEvent event) {
-    if (event.eventType == Token.ChangeEvent.MACRO_CHANGED
-        || event.eventType == Zone.Event.TOKEN_REMOVED) {
-      reset();
+    if (event.eventType == Zone.Event.TOKEN_REMOVED
+        || event.eventType == Zone.Event.TOKEN_MACRO_CHANGED) {
+      // Only resets if one of the selected tokens is among those changed/deleted.
+      ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
+      if (zr != null && !zr.getSelectedTokenSet().isEmpty()) {
+        if (event.getArg() instanceof List<?>) {
+          List<Token> tokenList = (List<Token>) event.getArg();
+          for (Token token : tokenList) {
+            if (zr.getSelectedTokenSet().contains(token.getId())) {
+              reset();
+              break;
+            }
+          }
+        } else {
+          Token token = (Token) event.getArg();
+          if (zr.getSelectedTokenSet().contains(token.getId())) {
+            reset();
+          }
+        }
+      }
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -359,9 +359,13 @@ public class ZoneRenderer extends JComponent
     // repaintDebouncer.dispatch();
   }
 
-  /** Resets the token panels, fire onTokenSelection, repaints. */
+  /**
+   * Resets the token panels, fire onTokenSelection, repaints. The impersonation panel is only reset
+   * if no token is currently impersonated.
+   */
   public void updateAfterSelection() {
-    MapTool.getFrame().resetTokenPanels();
+    MapTool.getFrame().getSelectionPanel().reset();
+    MapTool.getFrame().getImpersonatePanel().resetIfNotImpersonating();
     HTMLFrameFactory.selectedListChanged();
     repaintDebouncer.dispatch();
   }

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -349,7 +349,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     if (saveLocation.equals("Token") && tokenId != null) {
       Token token = getToken();
       if (token != null) {
-        token.saveMacroButtonProperty(this);
+        MapTool.serverCommand().updateTokenProperty(token, Token.Update.saveMacro, this);
       } else {
         MapTool.showError(I18N.getText("msg.error.macro.buttonNullToken", getLabel(), tokenId));
       }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -85,7 +85,9 @@ public class Zone extends BaseModel {
     LABEL_CHANGED,
     TOPOLOGY_CHANGED,
     INITIATIVE_LIST_CHANGED,
-    BOARD_CHANGED
+    BOARD_CHANGED,
+    TOKEN_MACRO_CHANGED, // a token macro changed
+    TOKEN_PANEL_CHANGED // the panel appearance changed
   }
 
   /** The type of layer (TOKEN, GM, OBJECT or BACKGROUND). */
@@ -813,6 +815,24 @@ public class Zone extends BaseModel {
    */
   public void tokenChanged(Token token) {
     fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_CHANGED, token));
+  }
+
+  /**
+   * Fire the event TOKEN_MACRO_CHANGED.
+   *
+   * @param token the token that had its macro changed
+   */
+  public void tokenMacroChanged(Token token) {
+    fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_MACRO_CHANGED, token));
+  }
+
+  /**
+   * Fire the event TOKEN_PANEL_CHANGED.
+   *
+   * @param token the token that had its panel appearance changed
+   */
+  public void tokenPanelChanged(Token token) {
+    fireModelChangeEvent(new ModelChangeEvent(this, Event.TOKEN_PANEL_CHANGED, token));
   }
 
   /**


### PR DESCRIPTION
- Fix selection changes resulting in impersonation panel being reset even if the token impersonated hasn't changed
- Change so that impersonated panel is reset if the macros of the impersonated token changes, or if the name, gm name, or token picture change
- Fix #1666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1671)
<!-- Reviewable:end -->
