### PR TITLE
Fix Edit Token Dialog not displaying correct properties

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -108,17 +108,9 @@ import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.GenericDialog;
 import net.rptools.maptool.client.ui.zone.vbl.TokenVBL;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.AssetManager;
-import net.rptools.maptool.model.Association;
-import net.rptools.maptool.model.Grid;
-import net.rptools.maptool.model.HeroLabData;
-import net.rptools.maptool.model.ObservableList;
-import net.rptools.maptool.model.Player;
-import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.Token.TerrainModifierOperation;
 import net.rptools.maptool.model.Token.Type;
-import net.rptools.maptool.model.TokenFootprint;
-import net.rptools.maptool.model.TokenProperty;
 import net.rptools.maptool.model.Zone.Layer;
 import net.rptools.maptool.util.ExtractHeroLab;
 import net.rptools.maptool.util.FunctionUtil;
@@ -297,8 +289,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     // Updates the Property Type list.
     updatePropertyTypeCombo();
 
-    // Set the selected item in the Property Type list. Also triggers a itemStateChanged event
+    // Set the selected item in Property Type list. Triggers a itemStateChanged event if index != 0
     getPropertyTypeCombo().setSelectedItem(token.getPropertyType());
+
+    // If index == 0, the itemStateChanged event wasn't triggered, so we update. Fix #1504
+    if (getPropertyTypeCombo().getSelectedIndex() == 0) {
+      updatePropertiesTable((String) getPropertyTypeCombo().getSelectedItem());
+    }
 
     getSightTypeCombo()
         .setSelectedItem(
@@ -499,7 +496,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
   /** Initializes the Property Type dropdown list. */
   public void initPropertyTypeCombo() {
-    updatePropertiesTable((String) getPropertyTypeCombo().getSelectedItem());
     getPropertyTypeCombo()
         .addItemListener(
             new ItemListener() {


### PR DESCRIPTION
- Fix edit token dialog not displaying the correct properties if the token property type is the first in the property type list
- Fix #1504, #1667

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1672)
<!-- Reviewable:end -->
