### PR TITLE
Fix snap/unsnap resulting in jumpiness

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -16,7 +16,6 @@ package net.rptools.maptool.client.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Cursor;
-import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Image;
 import java.awt.event.ActionEvent;
@@ -806,23 +805,15 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
         if (token == null) {
           continue;
         }
-        token.setSnapToGrid(!snapToGrid);
-        Grid grid = zone.getGrid();
-        Dimension offset = grid.getCellOffset();
-        if (token.isSnapToGrid()) {
-          if (grid.getCapabilities().isSnapToGridSupported()) {
-            ZonePoint zp = new ZonePoint(token.getX() - offset.width, token.getY() - offset.height);
-            zp = grid.convert(grid.convert(zp));
-            token.setX(zp.x);
-            token.setY(zp.y);
-          }
+        ZonePoint zp;
+        if (snapToGrid) {
+          zp = token.getUnsnappedPoint(zone);
         } else {
-          // If SnapToGrid is now off, change the (x,y) coordinates based on the cell offset being
-          // used by the grid
-          token.setX(token.getX() + offset.width);
-          token.setY(token.getY() + offset.height);
+          zp = token.getSnappedPoint(zone);
         }
-        MapTool.serverCommand().putToken(renderer.getZone().getId(), token);
+        // Updates both snap-to-grid and new location in one command
+        Token.Update update = Token.Update.setSnapToGridAndXY;
+        MapTool.serverCommand().updateTokenProperty(token, update, !snapToGrid, zp.x, zp.y);
       }
     }
   }

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -237,7 +237,7 @@ public abstract class Grid implements Cloneable {
   }
 
   /** @return the difference in pixels between the center of a cell and its converted zonepoint. */
-  public abstract Point getCenterOffset();
+  public abstract Point2D.Double getCenterOffset();
 
   /**
    * @return The offset required to translate from the center of a cell to the top right (x_min,

--- a/src/main/java/net/rptools/maptool/model/GridlessGrid.java
+++ b/src/main/java/net/rptools/maptool/model/GridlessGrid.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.model;
 
-import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Area;
@@ -177,7 +176,7 @@ public class GridlessGrid extends Grid {
   }
 
   @Override
-  public Point getCenterOffset() {
-    return new Point(0, 0);
+  public Point2D.Double getCenterOffset() {
+    return new Point2D.Double(0, 0);
   }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -84,8 +84,8 @@ public abstract class HexGrid extends Grid {
   }
 
   @Override
-  public Point getCenterOffset() {
-    return new Point(0, 0);
+  public Point2D.Double getCenterOffset() {
+    return new Point2D.Double(0, 0);
   }
 
   /** minorRadius / edgeLength */

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -18,7 +18,6 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
@@ -101,8 +100,8 @@ public class IsometricGrid extends Grid {
   }
 
   @Override
-  public Point getCenterOffset() {
-    return new Point(0, (int) getCellHeight() / 2);
+  public Point2D.Double getCenterOffset() {
+    return new Point2D.Double(0, getCellHeight() / 2);
   }
 
   public double getCellWidthHalf() {

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -19,7 +19,6 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
-import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Area;
@@ -102,8 +101,8 @@ public class SquareGrid extends Grid {
   }
 
   @Override
-  public Point getCenterOffset() {
-    return new Point((int) getCellWidth() / 2, (int) getCellHeight() / 2);
+  public Point2D.Double getCenterOffset() {
+    return new Point2D.Double(getCellWidth() / 2, getCellHeight() / 2);
   }
 
   public SquareGrid(boolean faceEdges, boolean faceVertices) {


### PR DESCRIPTION
- Fix so that unsnapping a snapped token no longer makes the token jump
- Fix so that unsnapping a snapped token and resnapping it no longer makes the token jump
- Change so snap/unsnapping the token only updates the relevant properties instead of sending the whole token to clients
- Fix #1653, although the exact way a token is snapped to the grid could be tweaked

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1682)
<!-- Reviewable:end -->
