### PR TITLE
Fix MapTool incorrectly handling Units per Cell for some locales

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapPropertiesDialog.java
@@ -259,7 +259,8 @@ public class MapPropertiesDialog extends JDialog {
 
   private void copyZoneToUI() {
     getNameTextField().setText(zone.getName());
-    getDistanceTextField().setText(Double.toString(zone.getUnitsPerCell()));
+    // Localizes units per cell, using the proper separator. Fixes #507.
+    getDistanceTextField().setText(StringUtil.formatDecimal(zone.getUnitsPerCell(), 1));
     getPixelsPerCellTextField().setText(Integer.toString(zone.getGrid().getSize()));
     getDefaultVisionTextField().setText(Integer.toString(zone.getTokenVisionDistance()));
     getHexVerticalRadio().setSelected(zone.getGrid() instanceof HexGridVertical);

--- a/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
@@ -1212,7 +1212,9 @@ public class PreferencesDialog extends JDialog {
     forceFacingArrowCheckBox.setSelected(AppPreferences.getForceFacingArrow());
     backgroundsStartSnapToGridCheckBox.setSelected(AppPreferences.getBackgroundsStartSnapToGrid());
     defaultGridSizeTextField.setText(Integer.toString(AppPreferences.getDefaultGridSize()));
-    defaultUnitsPerCellTextField.setText(Double.toString(AppPreferences.getDefaultUnitsPerCell()));
+    // Localizes units per cell, using the proper separator. Fixes #507.
+    defaultUnitsPerCellTextField.setText(
+        StringUtil.formatDecimal(AppPreferences.getDefaultUnitsPerCell(), 1));
     defaultVisionDistanceTextField.setText(
         Integer.toString(AppPreferences.getDefaultVisionDistance()));
     statsheetPortraitSize.setText(Integer.toString(AppPreferences.getPortraitSize()));

--- a/src/main/java/net/rptools/maptool/util/StringUtil.java
+++ b/src/main/java/net/rptools/maptool/util/StringUtil.java
@@ -23,10 +23,26 @@ import java.util.List;
 /** @author Tylere */
 public class StringUtil {
   private static NumberFormat nf = NumberFormat.getNumberInstance();
+  private static final int MIN_FRACTION_DIGITS = 0;
 
   public static String formatDecimal(double value) {
     String result1;
     result1 = nf.format(value); // On a separate line to allow for breakpoints
+    return result1;
+  }
+
+  /**
+   * Format a number using the locale.
+   *
+   * @param value the double to format
+   * @param minFractionDigits the minimum number of fraction digits to be shown
+   * @return the formated number
+   */
+  public static String formatDecimal(double value, int minFractionDigits) {
+    nf.setMinimumFractionDigits(minFractionDigits);
+    String result1;
+    result1 = nf.format(value); // On a separate line to allow for breakpoints
+    nf.setMinimumFractionDigits(MIN_FRACTION_DIGITS);
     return result1;
   }
 


### PR DESCRIPTION
- Fix Preferences, Map Properties dialogs incorrectly displaying Units per Cell using the period decimal separator instead of the locale appropriate one
- Fix #507

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1692)
<!-- Reviewable:end -->
