### PR TITLE
deactivates all horizontal scrolling on macOS, even if shift is down

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -28,7 +28,6 @@ import java.io.PrintStream;
 import java.util.Collections;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
-
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
@@ -89,9 +88,7 @@ public class MapToolEventQueue extends EventQueue {
       } else if (event instanceof MouseWheelEvent) {
         MouseWheelEvent mwe = (MouseWheelEvent) event;
         if (AppUtil.MAC_OS_X && mwe.isShiftDown()) {
-          // issue 1317: ignore ALL horizontal movement, *even if* the physical Shift is held down.
-          // This means only vertical movement will be recognized and the user will have
-          // to hold down the Shift key to effect it.
+          // issue 1317: ignore ALL horizontal movement on macOS, *even if* the physical Shift is held down.
           return;
         }
       }

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -28,6 +28,8 @@ import java.io.PrintStream;
 import java.util.Collections;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+
+import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.functions.getInfoFunction;
@@ -86,7 +88,7 @@ public class MapToolEventQueue extends EventQueue {
         }
       } else if (event instanceof MouseWheelEvent) {
         MouseWheelEvent mwe = (MouseWheelEvent) event;
-        if (mwe.isShiftDown() && MapToolEventQueue.shiftState != 1) {
+        if (AppUtil.MAC_OS_X && mwe.isShiftDown()) {
           // issue 1317: ignore ALL horizontal movement, *even if* the physical Shift is held down.
           // This means only vertical movement will be recognized and the user will have
           // to hold down the Shift key to effect it.

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -88,7 +88,8 @@ public class MapToolEventQueue extends EventQueue {
       } else if (event instanceof MouseWheelEvent) {
         MouseWheelEvent mwe = (MouseWheelEvent) event;
         if (AppUtil.MAC_OS_X && mwe.isShiftDown()) {
-          // issue 1317: ignore ALL horizontal movement on macOS, *even if* the physical Shift is held down.
+          // issue 1317: ignore ALL horizontal movement on macOS, *even if* the physical Shift is
+          // held down.
           return;
         }
       }


### PR DESCRIPTION
Interim fix for #1317. 

I’m not 100% sure this doesn’t also deactivate horizontal mouse wheel events on Windows and Linux. Please test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1707)
<!-- Reviewable:end -->
