### PR TITLE
Fix NPE if no map is available after player closes token editor

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -628,7 +628,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       getPropertyTable().getCellEditor().stopCellEditing();
     }
     // Commit the changes to the token properties
-    if (!super.commit()) {
+    // If no map available, cancel the commit. Fixes #1646.
+    if (!super.commit() || MapTool.getFrame().getCurrentZoneRenderer() == null) {
       return false;
     }
     // SIZE


### PR DESCRIPTION
- Fix a NPE if the player no longer has access to any map after the token editor is closed
- Fix #1646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1708)
<!-- Reviewable:end -->
