### PR TITLE
Fix figure tokens visible on hidden layer when vision is off

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -3057,7 +3057,7 @@ public class ZoneRenderer extends JComponent
         // Don't bother if it's not visible
         // NOTE: Not going to use zone.isTokenVisible as it is very slow. In fact, it's faster
         // to just draw the tokens and let them be clipped
-        if (!token.isVisible() && !isGMView) {
+        if ((!token.isVisible() || token.isGMStamp()) && !isGMView) {
           continue;
         }
         if (token.isVisibleOnlyToOwner() && !AppUtil.playerOwns(token)) {
@@ -3370,10 +3370,6 @@ public class ZoneRenderer extends JComponent
       timer.start("tokenlist-7");
       // If the token is a figure and if its visible, draw all of it.
       if (!isGMView && zoneView.isUsingVision() && (token.getShape() == Token.TokenShape.FIGURE)) {
-        // Lets skip tokens on the Hidden layer
-        if (token.isGMStamp()) {
-          continue;
-        }
         Area cb = zone.getGrid().getTokenCellArea(tokenBounds);
         if (GraphicsUtil.intersects(visibleScreenArea, cb)) {
           // the cell intersects visible area so
@@ -3391,10 +3387,6 @@ public class ZoneRenderer extends JComponent
           }
         }
       } else if (!isGMView && zoneView.isUsingVision() && token.isAlwaysVisible()) {
-        // Lets skip tokens on the Hidden layer
-        if (token.isGMStamp()) {
-          continue;
-        }
         // Jamz: Always Visible tokens will get rendered again here to place on top of FoW
         Area cb = zone.getGrid().getTokenCellArea(tokenBounds);
         if (GraphicsUtil.intersects(visibleScreenArea, cb)) {


### PR DESCRIPTION
- Fix figure tokens and visible over FoW tokens being visible on the hidden layer  when vision is set to off
- Described in #1688

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1715)
<!-- Reviewable:end -->
