### PR TITLE
Use rendering hints for zone and portrait rendering 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1828,6 +1828,8 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
                         AppStyle.panelTexture.getWidth(),
                         AppStyle.panelTexture.getHeight())));
             statsG.fill(bounds);
+            statsG.setRenderingHint(
+                RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
             statsG.drawImage(image, bounds.x, bounds.y, imgSize.width, imgSize.height, this);
             AppStyle.miniMapBorder.paintAround(statsG, bounds);
             AppStyle.shadowBorder.paintWithin(statsG, bounds);


### PR DESCRIPTION
Images are more pleasant when zoomed: Token and Portrait image 

Quick fix only, doesn't address any of the spread out rendering hint logic.

I'm surprised noone noticed this. I don't have display scaling on as far as I can see - this seems to be completely due to the graphics2d rendering hints unless I'm missing something.

Obvious concern: is there a machine that get images scaled like this through their imaging pipeline?

Fixes #1709

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1716)
<!-- Reviewable:end -->
