### PR TITLE
Fix for #1720 - trim() campaign property names with default values

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -296,9 +296,9 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
           if (shortName.length() > 0) {
             property.setShortName(shortName);
           }
-          line = line.substring(0, index).trim();
+          line = line.substring(0, index);
         }
-        property.setName(line);
+        property.setName(line.trim());
         // Since property names are not case-sensitive, let's make sure that we don't
         // already have this name represented somewhere in the list.
         String old = caseCheck.get(line);


### PR DESCRIPTION
Moved the trim() of the property name outside of the if() that was parsing out the short name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1721)
<!-- Reviewable:end -->
