### PR TITLE
Add white list for CDNS and Google Fonts for frame5/dialog5/Overlays

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -123,7 +123,19 @@ public class HTMLWebViewManager {
 
   /** Meta-tag that blocks external file access. */
   private static final String SCRIPT_BLOCK_EXT =
-      "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src asset:; style-src 'unsafe-inline'; script-src 'unsafe-inline' 'unsafe-eval'\">\n";
+      "<meta http-equiv=\"Content-Security-Policy\" "
+          + "content=\" "
+          + " default-src asset: "
+          + " https://code.jquery.com " // JQuery CDN
+          + " https://cdn.jsdelivr.net " // JSDelivr CDN
+          + " https://stackpath.bootstrapcdn.com " // Bootstrap CDN
+          + " https://unpkg.com " // unpkg CDN
+          + " https://cdnjs.cloudflare.com " // CloudFlare JS CDN
+          + " https://ajax.googleapis.com " // Google CDN
+          + " https://fonts.googleapis.com  https://fonts.gstatic.com " // Google Fonts
+          + " 'unsafe-inline' 'unsafe-eval' ; "
+          + " font-src https://fonts.gstatic.com 'self'"
+          + "\">\n";
 
   /** The default rule for the body tag. */
   static final String CSS_BODY =


### PR DESCRIPTION
**White lists the following CDNs**
- JQuery CDN (https://code.jquery.com)
- JSDelivr CDN (https://cdn.jsdelivr.net)
- Bootstrap CDN (https://stackpath.bootstrapcdn.com)
- unpkg CDN (https://unpkg.com)
- CloudFlare JS CDN (https://cdnjs.cloudflare.com)
- Google CDN (https://ajax.googleapis.com)

**Also white lists google fonts**
- https://fonts.googleapis.com
- https://fonts.gstatic.com

Fixes #1728

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1729)
<!-- Reviewable:end -->
