### PR TITLE
Back out titlebar mods that push java look and feel.

### DIFF
--- a/src/main/java/net/rptools/lib/swing/SwingUtil.java
+++ b/src/main/java/net/rptools/lib/swing/SwingUtil.java
@@ -346,21 +346,6 @@ public class SwingUtil {
     }
   }
 
-  public static void setDefaultLookAndFeelDecorated(boolean set) {
-    JFrame.setDefaultLookAndFeelDecorated(set);
-    JDialog.setDefaultLookAndFeelDecorated(set);
-  }
-
-  public static void setUndecorated(JFrame frame) {
-    frame.setUndecorated(true);
-    frame.getRootPane().setWindowDecorationStyle(JRootPane.NONE);
-  }
-
-  public static void setUndecorated(JDialog dialog) {
-    dialog.setUndecorated(true);
-    dialog.getRootPane().setWindowDecorationStyle(JRootPane.NONE);
-  }
-
   public static boolean isMaximized(JFrame frame) {
     return frame.getExtendedState() == JFrame.MAXIMIZED_BOTH;
   }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1749,8 +1749,6 @@ public class MapTool {
           });
       LookAndFeelFactory.installJideExtension(LookAndFeelFactory.XERTO_STYLE);
 
-      SwingUtil.setDefaultLookAndFeelDecorated(true);
-
       configureJide();
     } catch (Exception e) {
       MapTool.showError("msg.error.lafSetup", e);

--- a/src/main/java/net/rptools/maptool/client/swing/SplashScreen.java
+++ b/src/main/java/net/rptools/maptool/client/swing/SplashScreen.java
@@ -25,7 +25,6 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.paint.Color;
 import javax.swing.JFrame;
-import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.util.CreateVersionedInstallSplash;
 
 public class SplashScreen extends JFrame {
@@ -36,7 +35,7 @@ public class SplashScreen extends JFrame {
     Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
     final JFXPanel fxPanel = new JFXPanel();
 
-    SwingUtil.setUndecorated(this);
+    setUndecorated(true);
     setType(Type.UTILITY);
 
     add(fxPanel);

--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 import javax.swing.*;
 import net.rptools.lib.FileUtil;
 import net.rptools.lib.image.ImageUtil;
-import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.AppActions.OpenUrlAction;
 import net.rptools.maptool.client.AppConstants;
@@ -351,11 +350,9 @@ public class AppMenuBar extends JMenuBar {
             if (button.isSelected()) {
               button.setToolTipText(unhidetooltip);
               toolbarPanel.setVisible(false);
-              if (SwingUtil.isMaximized(frame)) frame.showWindowDecorations(false);
             } else {
               button.setToolTipText(hidetooltip);
               toolbarPanel.setVisible(true);
-              frame.showWindowDecorations(true);
             }
           }
         });

--- a/src/main/java/net/rptools/maptool/client/ui/AssetViewerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AssetViewerDialog.java
@@ -53,7 +53,7 @@ public class AssetViewerDialog extends JDialog {
     this.assetId = assetId;
     setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     setLayout(new GridLayout());
-    SwingUtil.setUndecorated(this);
+    setUndecorated(true);
 
     add(new InnerPanel());
   }

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -488,10 +488,6 @@ public class MapToolFrame extends DefaultDockableHolder
     setChatTypingLabelColor(AppPreferences.getChatNotificationColor());
   }
 
-  public void showWindowDecorations(boolean decorations) {
-    getRootPane().setWindowDecorationStyle(decorations ? JRootPane.FRAME : JRootPane.NONE);
-  }
-
   public ChatNotificationTimers getChatNotificationTimers() {
     return chatTyperTimers;
   }
@@ -1739,7 +1735,7 @@ public class MapToolFrame extends DefaultDockableHolder
 
   public class FullScreenFrame extends JFrame {
     public FullScreenFrame() {
-      SwingUtil.setUndecorated(this);
+      setUndecorated(true);
     }
   }
 


### PR DESCRIPTION
 The change to push more Java LnF caused bad Mac as well as Windows experience as the native titlebar offers functionality like snap and better performance when dragging.

Backout of titlebar mods, Change to make splash screen not appear in taskbar with the default java icon remains. 

Fixes #1752

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1756)
<!-- Reviewable:end -->
