### PR TITLE
Add Macro function to convert Markdown to HTML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,6 +268,10 @@ dependencies {
     implementation 'com.github.RPTools:dicelib:1.6.0'
 
 
+
+    // flexmark markdown parsing / conversion
+    implementation 'com.vladsch.flexmark:flexmark-all:0.61.12'
+
     // Noise Generator
     implementation 'com.github.cwisniew:NoiseLib:1.0.0-rc3' // The most recent version, 1.0.0 is build for a later java version: major version 55 is newer than 54, the highest major version supported by this compiler
 

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -131,7 +131,8 @@ public class MapToolLineParser {
               Base64Functions.getInstance(),
               TokenTerrainModifierFunctions.getInstance(),
               TestFunctions.getInstance(),
-              TextLabelFunctions.getInstance())
+              TextLabelFunctions.getInstance(),
+              new MarkDownFunctions())
           .collect(Collectors.toList());
 
   /** Name and Source or macros that come from chat. */

--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -169,6 +169,11 @@ public class MapToolVariableResolver extends MapVariableResolver {
         return new JsonPrimitive(false);
     }
 
+    // MT Script doesnt have much in the way of types.
+    if (name.startsWith(MarkDownFunctions.MARKDOWN_PREFIX)) {
+      return new MarkDownFunctions().getMTSTypeLabel(name);
+    }
+
     Object result = null;
     if (tokenInContext != null) {
 

--- a/src/main/java/net/rptools/maptool/client/functions/MarkDownFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MarkDownFunctions.java
@@ -14,11 +14,17 @@
  */
 package net.rptools.maptool.client.functions;
 
+import com.vladsch.flexmark.ext.definition.DefinitionExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.ext.toc.TocExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.ParserEmulationProfile;
 import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.data.MutableDataHolder;
 import com.vladsch.flexmark.util.data.MutableDataSet;
+import com.vladsch.flexmark.util.misc.Extension;
+import java.util.ArrayList;
 import java.util.List;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.util.FunctionUtil;
@@ -51,11 +57,28 @@ public class MarkDownFunctions extends AbstractFunction {
     if (args.size() > 1) {
       profile = getParserType(args.get(1).toString());
     } else {
-      profile = ParserEmulationProfile.MULTI_MARKDOWN;
+      profile = ParserEmulationProfile.GITHUB_DOC;
     }
 
+    List<Extension> extensions = new ArrayList<>();
     MutableDataHolder options = new MutableDataSet();
-    options.setFrom(profile);
+
+    if (profile == ParserEmulationProfile.GITHUB_DOC) {
+      extensions.add(TablesExtension.create());
+      extensions.add(TaskListExtension.create());
+      extensions.add(DefinitionExtension.create());
+      extensions.add(TocExtension.create());
+      options
+          .set(com.vladsch.flexmark.parser.Parser.SPACE_IN_LINK_URLS, true)
+          .setFrom(ParserEmulationProfile.GITHUB_DOC)
+          .set(TablesExtension.COLUMN_SPANS, false)
+          .set(TablesExtension.APPEND_MISSING_COLUMNS, true)
+          .set(TablesExtension.DISCARD_EXTRA_COLUMNS, true)
+          .set(TablesExtension.HEADER_SEPARATOR_COLUMN_MATCH, true)
+          .set(com.vladsch.flexmark.parser.Parser.EXTENSIONS, extensions);
+    } else {
+      options.setFrom(profile);
+    }
 
     var mdParser = com.vladsch.flexmark.parser.Parser.builder(options).build();
     HtmlRenderer renderer = HtmlRenderer.builder(options).build();

--- a/src/main/java/net/rptools/maptool/client/functions/MarkDownFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MarkDownFunctions.java
@@ -1,0 +1,100 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.ParserEmulationProfile;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.data.MutableDataHolder;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import java.util.List;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.util.FunctionUtil;
+import net.rptools.parser.Parser;
+import net.rptools.parser.ParserException;
+import net.rptools.parser.function.AbstractFunction;
+
+/*
+ * This software copyright by various authors including the RPTools.net development team, and licensed under the LGPL Version 3 or, at your option, any later version.
+ *
+ * Portions of this software were originally covered under the Apache Software License, Version 1.1 or Version 2.0.
+ *
+ * See the file LICENSE elsewhere in this distribution for license details.
+ */
+public class MarkDownFunctions extends AbstractFunction {
+
+  /** The prefix used for MarkDown types in MTS Script. */
+  public static final String MARKDOWN_PREFIX = "markdown.type.";
+
+  /** Creates a new {@code MarkDownFunctions} instance. */
+  public MarkDownFunctions() {
+    super(0, 2, "markdownToHTML");
+  }
+
+  @Override
+  public Object childEvaluate(Parser parser, String functionName, List<Object> args)
+      throws ParserException {
+    FunctionUtil.checkNumberParam(functionName, args, 1, 2);
+    ParserEmulationProfile profile;
+    if (args.size() > 1) {
+      profile = getParserType(args.get(1).toString());
+    } else {
+      profile = ParserEmulationProfile.MULTI_MARKDOWN;
+    }
+
+    MutableDataHolder options = new MutableDataSet();
+    options.setFrom(profile);
+
+    var mdParser = com.vladsch.flexmark.parser.Parser.builder(options).build();
+    HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+
+    String markdownText = args.get(0).toString();
+
+    Node document = mdParser.parse(markdownText);
+
+    return renderer.render(document);
+  }
+
+  /**
+   * Returns a {@link ParserEmulationProfile} based on the value passed from the MTS Parser.
+   *
+   * @param name The name of the the MarkDown type starting with {@link #MARKDOWN_PREFIX} with the
+   *     {@link String} value of {@link ParserEmulationProfile}.
+   * @return the {@link ParserEmulationProfile} used to parse the markdown.
+   * @throws ParserException if the {@code name} is invalid.
+   */
+  private ParserEmulationProfile getParserType(String name) throws ParserException {
+    String val = name.trim().replace(MARKDOWN_PREFIX, "");
+    try {
+      return ParserEmulationProfile.valueOf(val);
+    } catch (IllegalArgumentException ex) {
+      throw new ParserException(I18N.getText("macro.function.markdown.unknownType", val));
+    }
+  }
+
+  /**
+   * Returns a value that can be used in MT Script to specify the type of markdown to parse.
+   *
+   * @param name The name of the the MarkDown type.
+   * @return the {@link ParserEmulationProfile} used to parse the markdown.
+   * @throws ParserException if the {@code name} is invalid.
+   */
+  public Object getMTSTypeLabel(String name) throws ParserException {
+    ParserEmulationProfile profile = getParserType(name);
+    // If the above was able to convert properly return the string as is, otherwise allow the parser
+    // error bubble up
+    return name;
+  }
+}

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1554,6 +1554,9 @@ macro.function.tokenBarFunction.unknownBar         = Error with function "{0}": 
 # {0} = value the user passed.
 macro.function.varsFromstrProp.wrongArgs           = varsFromStrProp called with 3 arguments, but second argument "{0}" was not one of NONE, SUFFIXED, or UNSUFFIXED.
 
+
+macro.function.markdown.unknownType                = Unknown Markdown type {0}.
+
 # Macro Link
 macroLink.error.running = Error running macro link.
 macroLink.error.tooltip.bad.href = Invalid or missing HREF


### PR DESCRIPTION
Adds a new function `markdownToHTML()` which takes formatted Markdown text and returns formatted HTML. 

fixes #1765


Usage:
`markdownToHTML(<markdownText>)`
`markdownToHTML(<markdownText>, <markdownType>)`


Its expected that the first version will be enough for most cases (unless you specifically need something one of the others has). 

Valid MarkDown Types
- markdown.type.COMMONMARK
- markdown.type.FIXED_INDENT
- markdown.type.KRAMDOWN
- markdown.type.MARKDOWN
- markdown.type.GITHUB_DOC
- markdown.type.GITHUB
- markdown.type.MULTI_MARKDOWN
- markdown.type.PEGDOWN
- markdown.type.PEGDOWN_STRICT



Attached is a (tiny) test campaign

[test-markdown-func.zip](https://github.com/RPTools/maptool/files/4593938/test-markdown-func.zip)

Which produces the following


![image](https://user-images.githubusercontent.com/73173/81311080-19428100-90c4-11ea-831c-e87728723399.png)


![image](https://user-images.githubusercontent.com/73173/81311102-2495ac80-90c4-11ea-8a75-ae74605727fa.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1766)
<!-- Reviewable:end -->
