### PR TITLE
FIx NPE if starting server with port over 65535

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2131,6 +2131,10 @@ public class AppActions {
                   StartServerDialogPreferences serverProps =
                       new StartServerDialogPreferences(); // data retrieved from
                   // Preferences.userRoot()
+                  if (serverProps.getPort() == 0 || serverProps.getPort() > 65535) {
+                    MapTool.showError("ServerDialog.error.port.outOfRange");
+                    return;
+                  }
 
                   ServerPolicy policy = new ServerPolicy();
                   policy.setAutoRevealOnMovement(serverProps.isAutoRevealOnMovement());

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -554,6 +554,7 @@ Preferences.label.chat.macrolinks                 = Suppress ToolTips for MacroL
 Preferences.label.chat.macrolinks.tooltip         = MacroLinks show normally tooltips that state informations about the link target. This is a anti cheating device. This options let you disable this tooltips for aesthetic reasons.
 
 ServerDialog.error.port                = You must enter a numeric port.
+ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.


### PR DESCRIPTION
- Add error message if user attempts to start server with port over 65535
- Fix #1784, fixes MAPTOOL-16K

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1785)
<!-- Reviewable:end -->
