### PR TITLE
Fix NPE Draw Explorer when no element visible and user presses DEL. 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -247,28 +247,21 @@ public class MapToolFrame extends DefaultDockableHolder
         EventQueue.invokeLater(
             new Runnable() {
               public void run() {
+                TreePath[] selection = tree.getSelectionPaths();
+                Set<GUID> selectedDrawSet = new HashSet<GUID>();
+                if (selection != null) {
+                  for (TreePath path : selection) {
+                    if (path.getLastPathComponent() instanceof DrawnElement) {
+                      DrawnElement de = (DrawnElement) path.getLastPathComponent();
+                      selectedDrawSet.add(de.getDrawable().getId());
+                    }
+                  }
+                }
+                if (selectedDrawSet.isEmpty()) return;
                 // check to see if this is the required action
                 if (!MapTool.confirmDrawDelete()) {
                   return;
                 }
-                TreePath[] selection = tree.getSelectionPaths();
-                if (selection == null || selection.length == 0) {
-                  return;
-                }
-                DrawnElement firstElement = null;
-                Set<GUID> selectedDrawSet = new HashSet<GUID>();
-                boolean topLevelOnly = true;
-                for (TreePath path : selection) {
-                  if (path.getPathCount() != 3) topLevelOnly = false;
-                  if (path.getLastPathComponent() instanceof DrawnElement) {
-                    DrawnElement de = (DrawnElement) path.getLastPathComponent();
-                    if (firstElement == null) {
-                      firstElement = de;
-                    }
-                    selectedDrawSet.add(de.getDrawable().getId());
-                  }
-                }
-
                 for (GUID id : selectedDrawSet) {
                   MapTool.serverCommand().undoDraw(getCurrentZoneRenderer().getZone().getId(), id);
                 }


### PR DESCRIPTION
Don't show warning unless there's a selection with at least one draw node.

Fixes #1788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1794)
<!-- Reviewable:end -->
