### PR TITLE
Fix escaped quotes in light segments of getInfo("campaign") json

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -297,7 +297,7 @@ public class getInfoFunction extends AbstractFunction {
         // }
         JsonArray lightList = new JsonArray();
         for (Light light : ls.getLightList()) {
-          lightList.add(gson.toJson(light));
+          lightList.add(gson.toJsonTree(light));
         }
         linfo.add("light segments", lightList);
         ltinfo.add(linfo);


### PR DESCRIPTION
- Fix quotes in light segments array of Light definitions of `getInfo("campaign")` being escaped
- Fix #1799

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1800)
<!-- Reviewable:end -->
