### PR TITLE
Improve token image handling

### DIFF
--- a/src/main/java/net/rptools/lib/image/ImageUtil.java
+++ b/src/main/java/net/rptools/lib/image/ImageUtil.java
@@ -318,31 +318,6 @@ public class ImageUtil {
     }
   }
 
-  public static BufferedImage rgbToGrayscale(BufferedImage image) {
-    if (image == null) {
-      return null;
-    }
-    BufferedImage returnImage =
-        new BufferedImage(image.getWidth(), image.getHeight(), pickBestTransparency(image));
-    for (int y = 0; y < image.getHeight(); y++) {
-      for (int x = 0; x < image.getWidth(); x++) {
-        int encodedPixel = image.getRGB(x, y);
-
-        int alpha = (encodedPixel >> 24) & 0xff;
-        int red = (encodedPixel >> 16) & 0xff;
-        int green = (encodedPixel >> 8) & 0xff;
-        int blue = (encodedPixel) & 0xff;
-
-        int average = (int) ((red + blue + green) / 3.0);
-
-        // y = 0.3R + 0.59G + 0.11B luminance formula
-        int value = (alpha << 24) + (average << 16) + (average << 8) + average;
-        returnImage.setRGB(x, y, value);
-      }
-    }
-    return returnImage;
-  }
-
   private static final int[][] outlineNeighborMap = {
     {0, -1, 100}, // N
     {1, 0, 100}, // E

--- a/src/main/java/net/rptools/maptool/util/ImageManager.java
+++ b/src/main/java/net/rptools/maptool/util/ImageManager.java
@@ -18,10 +18,7 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -31,6 +28,8 @@ import net.rptools.lib.image.ImageUtil;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetAvailableListener;
 import net.rptools.maptool.model.AssetManager;
+import org.apache.commons.collections4.map.AbstractReferenceMap;
+import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,7 +49,10 @@ public class ImageManager {
   /** Cache of images loaded for assets. */
   private static final Map<MD5Key, BufferedImage> imageMap = new HashMap<MD5Key, BufferedImage>();
 
-  private static final Map<MD5Key, byte[]> textureMap = new HashMap<MD5Key, byte[]>();
+  /** Additional Soft-reference Cache of images that allows best . */
+  private static final Map<MD5Key, BufferedImage> backupImageMap =
+      new ReferenceMap(
+          AbstractReferenceMap.ReferenceStrength.HARD, AbstractReferenceMap.ReferenceStrength.SOFT);
 
   /**
    * The unknown image, a "?" is used for all situations where the image will eventually appear e.g.
@@ -201,6 +203,14 @@ public class ImageManager {
       if (image != null && image != TRANSFERING_IMAGE) {
         return image;
       }
+
+      // check if the soft reference still resolves image
+      image = backupImageMap.get(assetId);
+      if (image != null) {
+        imageMap.put(assetId, image);
+        return image;
+      }
+
       // Make note that we're currently processing it
       imageMap.put(assetId, TRANSFERING_IMAGE);
 
@@ -233,7 +243,6 @@ public class ImageManager {
   public static void flushImage(MD5Key assetId) {
     // LATER: investigate how this effects images that are already in progress
     imageMap.remove(assetId);
-    textureMap.remove(assetId);
   }
 
   /**
@@ -322,6 +331,7 @@ public class ImageManager {
       synchronized (imageLoaderMutex) {
         // Replace placeholder with actual image
         imageMap.put(asset.getId(), image);
+        backupImageMap.put(asset.getId(), image);
         notifyObservers(asset, image);
       }
     }


### PR DESCRIPTION
Keep soft references to loaded images so they don't have to be re-regenerated unless the VM is looking for memory to garbage collect. This makes switching between zones faster.

Don't generate a gray image when dragging tokens - use an alpha composite instead. This improves select/drag performance and uses less memory.
This is a bit more tricky as playing with the Graphics2D state can affect rendering of the next token. There's more opportunity to use a simple transformation for flip/flip-iso which are still being generated.

Fixes #1801

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1802)
<!-- Reviewable:end -->
