### PR TITLE
Fix transferVBL not being permitted to run if called by GM in chat

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -2058,10 +2058,11 @@ public class MapToolLineParser {
    */
   public void enterContext(MapToolMacroContext context) {
     // First time through set our trusted path to same as first context.
-    // Any subsequent trips through we only change trusted path if conext
+    // Any subsequent trips through we only change trusted path if context
     // is not trusted (if context == null on subsequent calls we dont change
     // anything as trusted context will remain the same as it was before the call).
     if (contextStack.size() == 0) {
+      // The path is untrusted if any typing is involved, including GM's
       macroPathTrusted = context == null ? false : context.isTrusted();
       macroButtonIndex = context == null ? -1 : context.getMacroButtonIndex();
     } else if (context != null) {

--- a/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
@@ -51,7 +51,7 @@ public class ExportDataFunctions extends AbstractFunction {
   @Override
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException {
-    if (!MapTool.getParser().isMacroPathTrusted())
+    if (!MapTool.getParser().isMacroTrusted())
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
     if (!AppPreferences.getAllowExternalMacroAccess())

--- a/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
@@ -60,7 +60,7 @@ public class HeroLabFunctions extends AbstractFunction {
     if (functionName.equals("herolab.getInfo")) {
       Token token;
 
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() == 1) {
@@ -89,7 +89,7 @@ public class HeroLabFunctions extends AbstractFunction {
 
       return token.getHeroLabData().getInfo();
     } else if (functionName.equals("herolab.getStatBlock")) {
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() > 2)
@@ -133,7 +133,7 @@ public class HeroLabFunctions extends AbstractFunction {
     } else if (functionName.equals("herolab.hasChanged")) {
       Token token;
 
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() == 1) {
@@ -165,7 +165,7 @@ public class HeroLabFunctions extends AbstractFunction {
     } else if (functionName.equals("herolab.refresh")) {
       Token token;
 
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() == 1) {
@@ -216,7 +216,7 @@ public class HeroLabFunctions extends AbstractFunction {
       }
 
     } else if (functionName.equals("herolab.XPath")) {
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() > 2)
@@ -261,7 +261,7 @@ public class HeroLabFunctions extends AbstractFunction {
         return new BigDecimal(result).stripTrailingZeros().toPlainString();
       else return result;
     } else if (functionName.equals("herolab.getImage")) {
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() > 2)
@@ -310,7 +310,7 @@ public class HeroLabFunctions extends AbstractFunction {
     } else if (functionName.equals("herolab.isMinion")) {
       Token token;
 
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() == 1) {
@@ -342,7 +342,7 @@ public class HeroLabFunctions extends AbstractFunction {
     } else if (functionName.equals("herolab.getMasterName")) {
       Token token;
 
-      if (!MapTool.getParser().isMacroPathTrusted())
+      if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
       if (parameters.size() == 1) {

--- a/src/main/java/net/rptools/maptool/client/functions/LogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LogFunctions.java
@@ -61,7 +61,7 @@ public class LogFunctions extends AbstractFunction {
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException {
 
-    if (!MapTool.getParser().isMacroPathTrusted()) {
+    if (!MapTool.getParser().isMacroTrusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
 

--- a/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
@@ -74,7 +74,7 @@ public class RESTfulFunctions extends AbstractFunction {
   public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException {
 
-    if (!MapTool.getParser().isMacroPathTrusted()) {
+    if (!MapTool.getParser().isMacroTrusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
 

--- a/src/main/java/net/rptools/maptool/client/functions/VBL_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/VBL_Functions.java
@@ -318,7 +318,7 @@ public class VBL_Functions extends AbstractFunction {
                 "macro.function.general.notenoughparms", functionName, 1, parameters.size()));
       }
 
-      if (!MapTool.getParser().isMacroPathTrusted()) {
+      if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
       }
 


### PR DESCRIPTION
- Fix functions not being permitted to run if called by GM in chat: export data functions, hero lab functions, log functions, RESTful functions, and transferVBL
- Close #1814

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1816)
<!-- Reviewable:end -->
