### PR TITLE
Fix macro calls on GM panel from a trusted context not being trusted

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1701,7 +1701,7 @@ public class MapToolLineParser {
         throw new ParserException(I18N.getText("lineParser.unknownCampaignMacro", macroName));
       }
       macroBody = mbp.getCommand();
-      macroContext = new MapToolMacroContext(macroName, "Gm", MapTool.getPlayer().isGM());
+      macroContext = new MapToolMacroContext(macroName, "Gm", MapTool.getParser().isMacroTrusted());
     } else if (macroLocation.equalsIgnoreCase("GLOBAL")) {
       macroContext = new MapToolMacroContext(macroName, "global", MapTool.getPlayer().isGM());
       MacroButtonProperties mbp = null;

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AbstractButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AbstractButtonGroup.java
@@ -194,7 +194,7 @@ public abstract class AbstractButtonGroup extends JPanel
   public void mouseReleased(MouseEvent event) {
     Token token = getToken();
     if (SwingUtilities.isRightMouseButton(event)) {
-      if (getPanelClass() == "CampaignPanel" && !MapTool.getPlayer().isGM()) {
+      if (getPanelClass().equals("CampaignPanel") && !MapTool.getPlayer().isGM()) {
         return;
       }
       // open button group menu


### PR DESCRIPTION
- Fix calling a macro on the GM panel from a protected macro not giving the macro the trusted status if the player is not a GM
- Close #1812

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1817)
<!-- Reviewable:end -->
