### PR TITLE
Fix duplicated entries in Find/Replace menu

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MacroButtonDialog.java
@@ -108,7 +108,7 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
   private static final String READY = I18N.getText("Label.ready");
   private static final String SAVED = I18N.getText("Label.saved");
 
-  private static HashSet<String> openMacroList = new HashSet<String>(4);
+  private static final HashSet<String> openMacroList = new HashSet<String>(4);
 
   public MacroButtonDialog() {
     super(MapTool.getFrame(), "", true);
@@ -205,6 +205,11 @@ public class MacroButtonDialog extends JDialog implements SearchListener {
   @Override
   public String getSelectedText() {
     return macroEditorRSyntaxTextArea.getSelectedText();
+  }
+
+  /** @return whether the macro dialog is already opened. */
+  public static boolean isMacroDialogOpen(String id) {
+    return openMacroList.contains(id);
   }
 
   private void installHotKeyCombo() {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPopupMenu.java
@@ -167,8 +167,13 @@ public class MacroButtonPopupMenu extends JPopupMenu {
       putValue(Action.NAME, I18N.getText("action.macro.edit"));
     }
 
+    @Override
     public void actionPerformed(ActionEvent event) {
-      new MacroButtonDialog().show(button);
+      String macroUUID = button.getProperties().getMacroUUID();
+      // Don't create new dialog is it is already opened. Fixes #1426 and #1495.
+      if (!MacroButtonDialog.isMacroDialogOpen(macroUUID)) {
+        new MacroButtonDialog().show(button);
+      }
     }
   }
 


### PR DESCRIPTION
- Fix editing a macro which is already being edited creates new Find/Replace entries in Edit menu
- Fix NPE when closing MapTool after creating duplicated find/replace entries
- Fix #1426 and fix #1495

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1825)
<!-- Reviewable:end -->
