### PR TITLE
Report correct argument number when rejecting non-numeric parameters …

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
@@ -99,9 +99,9 @@ public class MathFunctions extends AbstractFunction {
               "macro.function.general.tooManyParam", functionName, maxParams, param.size()));
     }
 
-    int i = 0;
     List<BigDecimal> outVals = new ArrayList<>();
-    for (Object o : param) {
+    for (int i = 0; i < param.size(); i++) {
+      Object o = param.get(i);
       if (o instanceof BigDecimal) {
         outVals.add((BigDecimal) o);
       } else {


### PR DESCRIPTION
…from math.* functions.

Fixes rptools/maptool#1831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1832)
<!-- Reviewable:end -->
