### PR TITLE
Rptools 1831

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
@@ -106,7 +106,8 @@ public class MathFunctions extends AbstractFunction {
         outVals.add((BigDecimal) o);
       } else {
         throw new ParserException(
-            I18N.getText("macro.function.general.argumentTypeN", functionName, i, o.toString()));
+            I18N.getText(
+                "macro.function.general.argumentTypeN", functionName, i + 1, o.toString()));
       }
     }
 


### PR DESCRIPTION
Using 1-indexed argument positions for better consistency with most other error messages.

Fixes rptools/maptool#1831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1833)
<!-- Reviewable:end -->
