### PR TITLE
Change overlays to sort by name instead of the hashcode of name

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -50,11 +50,11 @@ public class HTMLOverlayPanel extends JFXPanel {
   /** The logger. */
   private static final Logger log = LogManager.getLogger(HTMLOverlayManager.class);
 
-  /** The ordered set of the overlays. Ordered by Z order and then by hashcode of the name. */
+  /** The ordered set of the overlays. Ordered by Z order and then by name. */
   private final ConcurrentSkipListSet<HTMLOverlayManager> overlays =
       new ConcurrentSkipListSet<>(
           Comparator.comparingInt(HTMLOverlayManager::getZOrder)
-              .thenComparingInt(overlayManager -> overlayManager.getName().hashCode()));
+              .thenComparing(HTMLOverlayManager::getName));
 
   /** The StackPane holding all the overlays. */
   private StackPane root;


### PR DESCRIPTION
- Change comparison from hashcode of the name to the name itself. The hashcode is not unique and could therefore cause issue if two overlays have the same hashcode but different names
- Discussed in #1669

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1852)
<!-- Reviewable:end -->
