### PR TITLE
Fixes incorrect ordering of CSS when the CSS is loaded from a macro button (eg CSS@lib:css)

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -358,7 +358,7 @@ public class HTMLWebViewManager {
     // Deal with CSS and events of <link>.
     nodeList = doc.getElementsByTagName("link");
     for (int i = 0; i < nodeList.getLength(); i++) {
-      fixLink(nodeList.item(i).getAttributes(), nodeCSS, doc);
+      fixLink(nodeList.item(i), nodeCSS, doc);
     }
 
     // Set the title if using <title>.
@@ -410,6 +410,9 @@ public class HTMLWebViewManager {
     if (!scrollReset) {
       scrollTo(scrollX, scrollY);
     }
+    String html = (String) webEngine.executeScript("document.documentElement.outerHTML");
+    System.out.println(html);
+
   }
 
   /**
@@ -433,11 +436,13 @@ public class HTMLWebViewManager {
    * href, the CSS sheet is attached at the end of the refNode. If the href instead starts with
    * "macro", register the href as a callback macro.
    *
-   * @param attr the attributes of the link tag
+   * @param node the node for the link tag
    * @param refNode the node to append the new CSS rules to
    * @param doc the document to update with the modified link
    */
-  private void fixLink(NamedNodeMap attr, Node refNode, Document doc) {
+  private void fixLink(Node node, Node refNode, Document doc) {
+
+    NamedNodeMap attr = node.getAttributes();
     Node rel = attr.getNamedItem("rel");
     Node type = attr.getNamedItem("type");
     Node href = attr.getNamedItem("href");
@@ -454,8 +459,8 @@ public class HTMLWebViewManager {
           Element styleNode = doc.createElement("style");
           Text styleContent = doc.createTextNode(cssText);
           styleNode.appendChild(styleContent);
-          // Append the style sheet node to the refNode
-          refNode.appendChild(styleNode);
+          // Replace the link node with a style node containing the contents.
+          node.getParentNode().replaceChild(styleNode, node);
         } catch (ParserException e) {
           // Do nothing
         }

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -358,7 +358,7 @@ public class HTMLWebViewManager {
     // Deal with CSS and events of <link>.
     nodeList = doc.getElementsByTagName("link");
     for (int i = 0; i < nodeList.getLength(); i++) {
-      fixLink(nodeList.item(i), nodeCSS, doc);
+      fixLink(nodeList.item(i), doc);
     }
 
     // Set the title if using <title>.
@@ -410,8 +410,6 @@ public class HTMLWebViewManager {
     if (!scrollReset) {
       scrollTo(scrollX, scrollY);
     }
-    String html = (String) webEngine.executeScript("document.documentElement.outerHTML");
-    System.out.println(html);
   }
 
   /**
@@ -436,10 +434,9 @@ public class HTMLWebViewManager {
    * "macro", register the href as a callback macro.
    *
    * @param node the node for the link tag
-   * @param refNode the node to append the new CSS rules to
    * @param doc the document to update with the modified link
    */
-  private void fixLink(Node node, Node refNode, Document doc) {
+  private void fixLink(Node node, Document doc) {
 
     NamedNodeMap attr = node.getAttributes();
     Node rel = attr.getNamedItem("rel");
@@ -458,8 +455,8 @@ public class HTMLWebViewManager {
           Element styleNode = doc.createElement("style");
           Text styleContent = doc.createTextNode(cssText);
           styleNode.appendChild(styleContent);
-          // Replace the link node with a style node containing the contents.
-          node.getParentNode().replaceChild(styleNode, node);
+          // Insert the style node before the link.
+          node.getParentNode().insertBefore(styleNode, node);
         } catch (ParserException e) {
           // Do nothing
         }

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -412,7 +412,6 @@ public class HTMLWebViewManager {
     }
     String html = (String) webEngine.executeScript("document.documentElement.outerHTML");
     System.out.println(html);
-
   }
 
   /**


### PR DESCRIPTION
Does what it says on the tin
closes #1853

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1854)
<!-- Reviewable:end -->
