### PR TITLE
Fix quote symbols created by [if(0), code:{}]

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1257,8 +1257,10 @@ public class MapToolLineParser {
                   Matcher testMatcher = Pattern.compile(testRegex).matcher(roll);
                   if (testMatcher.find()) { // verifies that roll body is well-formed
                     rollBranch = testMatcher.group(1 + whichBranch);
-                    if (rollBranch == null)
-                      rollBranch = "''"; // quick-and-dirty way to get no output
+                    if (rollBranch == null) {
+                      // Produces no output. If codeblock, empty string to fix #1876.
+                      rollBranch = codeType == CodeType.CODEBLOCK ? "" : "''";
+                    }
                     rollBranch = rollBranch.trim();
                   } else {
                     throw doError("lineParser.ifError", opts, roll);


### PR DESCRIPTION
- Fix unwanted quote symbols been produced as output when using the [if] condition together with the CODE argument when the condition is false and no second branch is defined
- Fix #1876

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1877)
<!-- Reviewable:end -->
