### PR TITLE
Fix button formaction being ignored in frame5 / dialog5

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -569,8 +569,11 @@ public class HTMLWebViewManager {
     }
     if (form == null) return;
 
+    // formAction can override action
+    String formAction = target.getAttribute("formaction");
+    String action = (formAction == null || "".equals(formAction)) ? form.getAction() : formAction;
+
     // Check for non-macrolinktext action
-    String action = form.getAction();
     if (action == null || action.startsWith("javascript:")) {
       return;
     }


### PR DESCRIPTION
- Change so that button formaction will override the action of the form
- Fix #1878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1879)
<!-- Reviewable:end -->
