### PR TITLE
Fix sight given personal light after Campaign Properties edit

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -483,7 +483,6 @@ public class CampaignPropertiesDialog extends JDialog {
         int offset = 0;
         double pLightRange = 0;
 
-        personalLight = new LightSource();
         for (String arg : args) {
           assert arg.length() > 0; // The split() uses "one or more spaces", removing empty strings
           try {


### PR DESCRIPTION
- Fix all sight types being given a blank LightSource object as a personal light source after any edit to the Campaign Properties
- Discussed in #1893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1902)
<!-- Reviewable:end -->
