### PR TITLE
Improve Macro performance

### DIFF
--- a/src/main/java/net/rptools/maptool/model/GUID.java
+++ b/src/main/java/net/rptools/maptool/model/GUID.java
@@ -170,6 +170,16 @@ public class GUID extends Object implements Serializable, Comparable<GUID> {
     return new GUID(newGUID).getBytes();
   }
 
+  /**
+   * A fast check for whether a given argument is not a GUID.
+   *
+   * @param arg
+   * @return whether arg is not GUID (returning false != isGUID)
+   */
+  public static boolean isNotGUID(String arg) {
+    return arg.length() != GUID.GUID_LENGTH * 2;
+  }
+
   public static void main(String[] args) throws Exception {
     for (int i = 0; i < 10; i++) {
       GUID guid = new GUID();

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1432,10 +1432,7 @@ public class Zone extends BaseModel {
    */
   public Token getTokenByName(String name) {
     for (Token token : getAllTokens()) {
-      if (StringUtil.isEmpty(token.getName())) {
-        continue;
-      }
-      if (token.getName().equalsIgnoreCase(name)) {
+      if (name.equalsIgnoreCase(token.getName())) {
         return token;
       }
     }
@@ -1449,18 +1446,20 @@ public class Zone extends BaseModel {
    * @return token that matches the identifier or <code>null</code>
    */
   public Token resolveToken(String identifier) {
-    Token token = getTokenByName(identifier);
 
-    if (token == null) {
-      token = getTokenByGMName(identifier);
+    // try fast lookup first for an identifier that might be a GUID len=16
+    if (!GUID.isNotGUID(identifier)) {
+      try {
+        return getToken(GUID.valueOf(identifier));
+      } catch (Exception e) {
+        // wasn't a GUID afterall, OK to ignore
+      }
     }
 
+    // look at (GM)name
+    Token token = getTokenByName(identifier);
     if (token == null) {
-      try {
-        token = getToken(GUID.valueOf(identifier));
-      } catch (Exception e) {
-        // indication of not a GUID, OK to ignore
-      }
+      token = getTokenByGMName(identifier);
     }
     return token;
   }


### PR DESCRIPTION
#1898

4. Make GUID based token lookup work fast as a GUID can be ruled in/out instead of always looking at all token names first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1903)
<!-- Reviewable:end -->
