### PR TITLE
Macro Performance - improve strfunctions (3) and fix jsonarrays being flattened unnecessarily (5)

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -973,8 +973,7 @@ public class MapToolLineParser {
 
                     // If we still dont have a list treat it list a string list
                     if (foreachList == null) {
-                      foreachList = new ArrayList<String>();
-                      StrListFunctions.parse(listString, foreachList, listDelim);
+                      foreachList = StrListFunctions.toList(listString, listDelim);
                     }
                     loopCount = foreachList.size();
 

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -1031,8 +1031,7 @@ public class InputFunction extends AbstractFunction {
         continue;
       }
       // Multiple vars can be packed into a string, separated by "##"
-      List<String> substrings = new ArrayList<String>();
-      StrListFunctions.parse(paramStr, substrings, "##");
+      List<String> substrings = StrListFunctions.toList(paramStr, "##");
       for (String varString : substrings) {
         if (StringUtils.isEmpty(paramStr)) {
           continue;

--- a/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
@@ -184,8 +184,7 @@ public class MathFunctions extends AbstractFunction {
       String functionName, List<Object> param) throws ParserException {
     checkParamNumber(functionName, param, 1, 2);
     String delim = (param.size() > 1) ? param.get(1).toString() : ",";
-    List<String> stringList = new ArrayList<>();
-    StrListFunctions.parse(param.get(0).toString(), stringList, delim);
+    List<String> stringList = StrListFunctions.toList(param.get(0).toString(), delim);
     if (stringList.size() == 0) {
       throw new ParserException(
           I18N.getText("macro.function.general.listCannotBeEmpty", functionName, 1));

--- a/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
@@ -27,6 +27,7 @@ import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.ParameterException;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
 
 /**
  * Implements various string utility functions. <br>
@@ -65,41 +66,76 @@ public class StrListFunctions extends AbstractFunction {
     return instance;
   }
 
+  public abstract static class ListVisitor {
+    public abstract boolean visit(int pos, int start, int end);
+  }
+
+  public static ArrayList<String> toList(String listStr, String delim) {
+    ArrayList<String> list = new ArrayList<String>();
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int start, int end) {
+            list.add(listStr.substring(start, end));
+            return true;
+          }
+        });
+    return list;
+  }
+
+  private static Pattern PATTERN_FOR_EMPTY_SEPARATOR = Pattern.compile("(.)()", Pattern.DOTALL);
+  private static Pattern PATTERN_FOR_COMMA_SEPARATOR =
+      Pattern.compile("\\s*(\\S*?)\\s*\\,|\\s*(\\S*)\\s*", Pattern.DOTALL);
+  private static Pattern PATTERN_FOR_SEMICOLON_SEPARATOR =
+      Pattern.compile("\\s*(\\S*?)\\s*\\;|\\s*(\\S*)\\s*", Pattern.DOTALL);
+
   /**
    * Parses a list.
    *
    * @param listStr has the form "item1, item2, ..."
-   * @param list is populated with the list items.
    * @param delim is the list delimiter to use.
+   * @param visitor callback to receive list elements
+   * @return number of visits performed
    */
-  public static void parse(String listStr, List<String> list, String delim) {
-    if (StringUtils.isEmpty(listStr.trim())) return; // null strings have zero entries
-    String patt;
-    if (delim.equalsIgnoreCase("")) {
-      patt = "(.)()";
+  public static int parse(String listStr, String delim, ListVisitor visitor) {
+
+    if (StringUtils.isBlank(listStr)) return 0; // null strings have zero entries
+
+    Pattern pattern;
+    if (delim.isEmpty()) {
+      pattern = PATTERN_FOR_EMPTY_SEPARATOR;
+    } else if (",".equals(delim)) {
+      pattern = PATTERN_FOR_COMMA_SEPARATOR;
+    } else if (";".equals(delim)) {
+      pattern = PATTERN_FOR_SEMICOLON_SEPARATOR;
     } else {
+      // This pattern needs to be compiled with the DOTALL flag or line terminators might
+      // cause premature termination of the matcher.find() operations...
       String escDelim = fullyQuoteString(delim);
-      patt = "(.*?)" + escDelim + "|(.*)";
+      pattern = Pattern.compile("\\s*(\\S*?)\\s*" + escDelim + "|\\s*(\\S*)\\s*", Pattern.DOTALL);
     }
-    // This pattern needs to be compiled with the DOTALL flag or line terminators might
-    // cause premature termination of the matcher.find() operations...
-    Pattern pattern = Pattern.compile(patt, Pattern.DOTALL);
+
     Matcher matcher = pattern.matcher(listStr);
     boolean lastItem = false;
+    int index = 0;
     while (matcher.find()) {
       if (!lastItem) {
-        String grp = matcher.group(1);
-        if (grp == null) {
-          grp = matcher.group(2);
+        int from = matcher.start(1), to = matcher.end(1);
+        if (from < 0) {
+          from = matcher.start(2);
+          to = matcher.end(2);
           // We're here because there was no trailing delimiter in this match.
           // In this case, the next match will be empty, but we don't want to grab it.
           // (We do grab the final empty match if the string ended with the delimiter.)
           // This flag will prevent that.
           lastItem = true;
         }
-        list.add(grp.trim());
+        if (!visitor.visit(index++, from, to)) break;
       }
     }
+    return index;
   }
 
   /**
@@ -127,28 +163,25 @@ public class StrListFunctions extends AbstractFunction {
     String listStr = parameters.get(0).toString().trim();
     String lastParam = parameters.get(parameters.size() - 1).toString();
 
-    ArrayList<String> list = new ArrayList<String>();
-
-    if ("listGet".equalsIgnoreCase(functionName))
-      retval = listGet(parameters, listStr, lastParam, list);
+    if ("listGet".equalsIgnoreCase(functionName)) retval = listGet(parameters, listStr, lastParam);
     else if ("listDelete".equalsIgnoreCase(functionName))
-      retval = listDelete(parameters, listStr, lastParam, list);
+      retval = listDelete(parameters, listStr, lastParam);
     else if ("listCount".equalsIgnoreCase(functionName))
-      retval = listCount(parameters, listStr, lastParam, list);
+      retval = listCount(parameters, listStr, lastParam);
     else if ("listFind".equalsIgnoreCase(functionName))
-      retval = listFind(parameters, listStr, lastParam, list);
+      retval = listFind(parameters, listStr, lastParam);
     else if ("listContains".equalsIgnoreCase(functionName))
-      retval = listContains(parameters, listStr, lastParam, list);
+      retval = listContains(parameters, listStr, lastParam);
     else if ("listAppend".equalsIgnoreCase(functionName))
-      retval = listAppend(parameters, listStr, lastParam, list);
+      retval = listAppend(parameters, listStr, lastParam);
     else if ("listInsert".equalsIgnoreCase(functionName))
-      retval = listInsert(parameters, listStr, lastParam, list);
+      retval = listInsert(parameters, listStr, lastParam);
     else if ("listReplace".equalsIgnoreCase(functionName))
-      retval = listReplace(parameters, listStr, lastParam, list);
+      retval = listReplace(parameters, listStr, lastParam);
     else if ("listSort".equalsIgnoreCase(functionName))
-      retval = listSort(parameters, listStr, lastParam, list);
+      retval = listSort(parameters, listStr, lastParam);
     else if ("listFormat".equalsIgnoreCase(functionName))
-      retval = listFormat(parameters, listStr, lastParam, list);
+      retval = listFormat(parameters, listStr, lastParam);
 
     return retval;
   }
@@ -159,15 +192,11 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the elements
    * @return The item at position <code>index</code>, or <code>""</code> if out of bounds.
    * @throws ParameterException if an error occurs.
    */
-  public Object listGet(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listGet(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 2;
     int maxParams = minParams + 1;
@@ -177,21 +206,30 @@ public class StrListFunctions extends AbstractFunction {
         maxParams,
         parameters,
         new Class[] {null, BigDecimal.class, String.class});
-    if (parameters.size() == maxParams) delim = lastParam;
-    parse(listStr, list, delim);
+    String delim = parameters.size() == maxParams ? lastParam : ",";
 
     int index = ((BigDecimal) parameters.get(1)).intValue();
-    if (index >= 0 && index < list.size()) {
-      String value = list.get(index);
-      if (value != null) {
-        // convert to numeric value if possible
-        Integer intval = strToInt(value);
-        retval = (intval == null) ? value : new BigDecimal(intval);
-      } else {
-        retval = "";
-      }
+    final StringBuffer retval = new StringBuffer();
+
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            if (pos == index) {
+              retval.append(listStr, from, to);
+              return false;
+            }
+            return true;
+          }
+        });
+
+    if (retval.length() > 0) {
+      Integer intval = strToInt(retval.toString());
+      if (intval != null) return new BigDecimal(intval);
     }
-    return retval;
+    return retval.toString();
   }
 
   /**
@@ -200,15 +238,11 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return A new list with the item at position <code>index</code> deleted.
    * @throws ParameterException if an error occurs.
    */
-  public Object listDelete(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listDelete(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 2;
     int maxParams = minParams + 1;
@@ -218,27 +252,34 @@ public class StrListFunctions extends AbstractFunction {
         maxParams,
         parameters,
         new Class[] {null, BigDecimal.class, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
 
+    String delim = (parameters.size() == maxParams) ? lastParam : ",";
     int index = ((BigDecimal) parameters.get(1)).intValue();
     StringBuilder sb = new StringBuilder();
-    boolean inRange = (index >= 0 && index < list.size());
-    for (int i = 0; i < list.size(); i++) {
-      if (i != index) {
-        sb.append(list.get(i));
-        sb.append(delim);
-        sb.append(" ");
-      }
-    }
-    if (list.size() > (inRange ? 1 : 0)) {
-      // Delete the last delimiter and space
-      sb.delete(sb.length() - 1 - delim.length(), sb.length());
-    }
-    retval = sb.toString();
-    return retval;
+
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            if (pos < index) {
+              if (pos > 0) {
+                sb.append(delim);
+              }
+              sb.append(listStr, from, to);
+              return true;
+            }
+            if (pos == index) return true;
+            if (index > 0) {
+              sb.append(delim);
+            }
+            sb.append(listStr, from, listStr.length());
+            return false;
+          }
+        });
+
+    return sb.toString();
   }
 
   /**
@@ -247,27 +288,32 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return The number of entries in the list.
    * @throws ParameterException if an error occurs.
    */
-  public Object listCount(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listCount(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 1;
     int maxParams = minParams + 1;
     checkVaryingParameters(
         "listCount()", minParams, maxParams, parameters, new Class[] {null, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
+    String delim = (parameters.size() == maxParams) ? lastParam : ",";
 
-    retval = new BigDecimal(list.size());
-    return retval;
+    MutableInt count = new MutableInt(0);
+
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            count.increment();
+            return true;
+          }
+        });
+
+    return new BigDecimal(count.intValue());
   }
 
   /**
@@ -276,35 +322,37 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return The index of the first occurence of <code>target</code>, or -1 if not found.
    * @throws ParameterException when an error occurs.
    */
-  public Object listFind(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listFind(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 2;
     int maxParams = minParams + 1;
     checkVaryingParameters(
         "listFind()", minParams, maxParams, parameters, new Class[] {null, null, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
+    String delim = (parameters.size() == maxParams) ? lastParam : ",";
 
     String target = parameters.get(1).toString().trim();
-    int index;
-    for (index = 0; index < list.size(); index++) {
-      if (target.equalsIgnoreCase(list.get(index))) {
-        break;
-      }
-    }
-    if (index == list.size()) index = -1;
-    retval = new BigDecimal(index);
-    return retval;
+
+    MutableInt retVal = new MutableInt(-1);
+
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            if (target.equalsIgnoreCase(listStr.substring(from, to))) {
+              retVal.setValue(pos);
+              return false;
+            }
+            return true;
+          }
+        });
+
+    return new BigDecimal(retVal.intValue());
   }
 
   /**
@@ -313,34 +361,36 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return Number of occurrences of <code>target</code> in <code>list</code>.
    * @throws ParameterException when an error occurs.
    */
-  public Object listContains(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listContains(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 2;
     int maxParams = minParams + 1;
     checkVaryingParameters(
         "listContains()", minParams, maxParams, parameters, new Class[] {null, null, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
+    String delim = (parameters.size() == maxParams) ? lastParam : ",";
 
     String target = parameters.get(1).toString().trim();
-    int numMatches = 0;
-    for (int index = 0; index < list.size(); index++) {
-      if (target.equalsIgnoreCase(list.get(index))) {
-        numMatches++;
-      }
-    }
-    retval = new BigDecimal(numMatches);
-    return retval;
+
+    MutableInt retval = new MutableInt(0);
+
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            if (target.equalsIgnoreCase(listStr.substring(from, to))) {
+              retval.increment();
+            }
+            return true;
+          }
+        });
+
+    return new BigDecimal(retval.intValue());
   }
 
   /**
@@ -349,35 +399,22 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return A new list with <code>target</code> appended.
    * @throws ParameterException when an error occurs.
    */
-  public Object listAppend(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listAppend(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 2;
     int maxParams = minParams + 1;
     checkVaryingParameters(
         "listAppend()", minParams, maxParams, parameters, new Class[] {null, null, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
 
+    String delim = parameters.size() == maxParams ? lastParam : ",";
     String target = parameters.get(1).toString().trim();
-    StringBuilder sb = new StringBuilder();
-    for (String item : list) {
-      sb.append(item);
-      sb.append(delim);
-      sb.append(" ");
-    }
-    sb.append(target);
-    retval = sb.toString();
-    return retval;
+
+    if (!StringUtils.isEmpty(listStr)) return listStr + delim + " " + target;
+    return target;
   }
 
   /**
@@ -386,16 +423,12 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return A new list with <code>target</code> inserted before the item at position <code>index
    *     </code>
    * @throws ParameterException when an error occurs.
    */
-  public Object listInsert(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listInsert(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 3;
     int maxParams = minParams + 1;
@@ -405,35 +438,43 @@ public class StrListFunctions extends AbstractFunction {
         maxParams,
         parameters,
         new Class[] {null, BigDecimal.class, null, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
 
+    String delim = parameters.size() == maxParams ? lastParam : ",";
     int index = ((BigDecimal) parameters.get(1)).intValue();
     String target = parameters.get(2).toString().trim();
-    StringBuilder sb = new StringBuilder();
-    if (list.size() == 0) {
-      if (index == 0) {
-        retval = target;
+
+    StringBuilder retValue = new StringBuilder();
+
+    int len =
+        parse(
+            listStr,
+            delim,
+            new ListVisitor() {
+              @Override
+              public boolean visit(int pos, int from, int to) {
+                if (pos > 0) {
+                  retValue.append(delim).append(" ");
+                }
+                if (pos == index) {
+                  retValue.append(target);
+                  retValue.append(delim).append(" ");
+                  retValue.append(listStr, from, listStr.length());
+                  return false;
+                }
+                retValue.append(listStr, from, to);
+                return true;
+              }
+            });
+
+    // still need to append?
+    if (len == index) {
+      if (retValue.length() > 0) {
+        retValue.append(delim).append(" ");
       }
-    } else {
-      for (int i = 0; i < list.size() + 1; i++) {
-        if (i == index) {
-          sb.append(target);
-          sb.append(delim);
-          sb.append(" ");
-        }
-        if (i < list.size()) {
-          sb.append(list.get(i));
-          sb.append(delim);
-          sb.append(" ");
-        }
-      }
-      sb.delete(sb.length() - 1 - delim.length(), sb.length()); // remove the trailing ", "
-      retval = sb.toString();
+      retValue.append(target);
     }
-    return retval;
+
+    return retValue.toString();
   }
 
   /**
@@ -442,15 +483,11 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
-   * @return A new list with the entry at <code>index</code> repaced by <code>target</code>
+   * @return A new list with the entry at <code>index</code> replaced by <code>target</code>
    * @throws ParameterException when an error occurs.
    */
-  public Object listReplace(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listReplace(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 3;
     int maxParams = minParams + 1;
@@ -460,29 +497,34 @@ public class StrListFunctions extends AbstractFunction {
         maxParams,
         parameters,
         new Class[] {null, BigDecimal.class, null, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
 
-    if (list.size() == 0) // can't replace if there are no entries
-    return retval;
+    String delim = parameters.size() == maxParams ? lastParam : ",";
 
     int index = ((BigDecimal) parameters.get(1)).intValue();
     String target = parameters.get(2).toString().trim();
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < list.size(); i++) {
-      if (i == index) {
-        sb.append(target);
-      } else {
-        sb.append(list.get(i));
-      }
-      sb.append(delim);
-      sb.append(" ");
-    }
-    sb.delete(sb.length() - 1 - delim.length(), sb.length()); // remove the trailing ", "
-    retval = sb.toString();
-    return retval;
+
+    StringBuilder retValue = new StringBuilder();
+
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            if (pos > 0) {
+              retValue.append(delim).append(" ");
+            }
+            if (pos == index) {
+              retValue.append(target);
+              retValue.append(listStr, to, listStr.length());
+              return false;
+            }
+            retValue.append(listStr, from, to);
+            return true;
+          }
+        });
+
+    return retValue.toString();
   }
 
   /**
@@ -491,15 +533,11 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return A new sorted list
    * @throws ParameterException if the number of parameters is incorrect
    */
-  public Object listSort(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listSort(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 2;
     int maxParams = minParams + 1;
@@ -511,27 +549,23 @@ public class StrListFunctions extends AbstractFunction {
         new Class[] {null, String.class, String.class});
 
     // Check params and parse the list
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
+    String delim = parameters.size() == maxParams ? lastParam : ",";
     String sortStr = (String) parameters.get(1);
-    parse(listStr, list, delim);
+
+    ArrayList<String> list = toList(listStr, delim);
 
     // Sort the list appropriately and construct the new list string
     Collections.sort(list, new strComp(sortStr));
 
-    StringBuilder sb = new StringBuilder();
+    StringBuilder retVal = new StringBuilder();
     int size = list.size();
     for (int i = 0; i < size; i++) {
-      sb.append(list.get(i));
+      retVal.append(list.get(i));
       if (i < size - 1) {
-        sb.append(delim);
-        sb.append(" ");
+        retVal.append(delim).append(" ");
       }
     }
-    retval = sb.toString();
-
-    return retval;
+    return retVal.toString();
   }
 
   /**
@@ -540,15 +574,11 @@ public class StrListFunctions extends AbstractFunction {
    * @param parameters the parameters of the function call
    * @param listStr the String of the list
    * @param lastParam the last parameter
-   * @param list the list that will contain the parsed element
    * @return A string containing the formatted list.
    * @throws ParameterException if an error occurs.
    */
-  public Object listFormat(
-      List<Object> parameters, String listStr, String lastParam, List<String> list)
+  public Object listFormat(List<Object> parameters, String listStr, String lastParam)
       throws ParameterException {
-    Object retval = "";
-    String delim = ",";
 
     int minParams = 4;
     int maxParams = minParams + 1;
@@ -558,31 +588,32 @@ public class StrListFunctions extends AbstractFunction {
         maxParams,
         parameters,
         new Class[] {null, String.class, String.class, String.class, String.class});
-    if (parameters.size() == maxParams) {
-      delim = lastParam;
-    }
-    parse(listStr, list, delim);
+
+    String delim = parameters.size() == maxParams ? delim = lastParam : ",";
 
     String listFormat = parameters.get(1).toString();
     String entryFormat = parameters.get(2).toString();
     String separator = parameters.get(3).toString();
 
     StringBuilder sb = new StringBuilder();
-    boolean firstEntry = true;
-    for (String item : list) {
-      item = fullyQuoteString(item);
-      if (firstEntry) {
-        firstEntry = false;
-      } else {
-        sb.append(separator);
-      }
-      String entry = entryFormat;
-      entry = entry.replaceAll("\\%item", item);
-      sb.append(entry);
-    }
 
-    retval = listFormat.replaceFirst("\\%list", sb.toString());
-    return retval;
+    parse(
+        listStr,
+        delim,
+        new ListVisitor() {
+          @Override
+          public boolean visit(int pos, int from, int to) {
+            if (pos > 0) {
+              sb.append(separator);
+            }
+            String entry = fullyQuoteString(listStr.substring(from, to));
+            entry = entryFormat.replaceAll("\\%item", entry);
+            sb.append(entry);
+            return true;
+          }
+        });
+
+    return listFormat.replaceFirst("\\%list", sb.toString());
   }
 
   /** Custom comparator for string sorting */

--- a/src/main/java/net/rptools/maptool/client/functions/StrPropFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StrPropFunctions.java
@@ -498,8 +498,7 @@ public class StrPropFunctions extends AbstractFunction {
       throw new ParameterException(
           I18N.getText("macro.function.strPropFromVar.wrongArgs", varStyleString));
     }
-    List<String> varList = new ArrayList<String>();
-    StrListFunctions.parse(parameters.get(0).toString(), varList, ",");
+    List<String> varList = StrListFunctions.toList(parameters.get(0).toString(), ",");
     StringBuilder sb = new StringBuilder();
     int i = 0;
     int varListSize = varList.size();

--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -33,6 +33,7 @@ import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 
 /** Class used to implement Json related functions in MT script. */
 public class JSONMacroFunctions extends AbstractFunction {
@@ -281,7 +282,8 @@ public class JSONMacroFunctions extends AbstractFunction {
           FunctionUtil.checkNumberParam(functionName, args, 2, UNLIMITED_PARAMETERS);
           // Special case if first argument is empty string it represents an empty array
           JsonArray jsonArray;
-          if (args.get(0).toString().length() == 0) {
+          Object arg = args.get(0);
+          if (arg instanceof String && StringUtils.isEmpty(((String) arg))) {
             jsonArray = new JsonArray();
           } else {
             jsonArray = jsonArrayFunctions.coerceToJsonArray(args.get(0));

--- a/src/test/java/net/rptools/maptool/client/functions/StrListFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/StrListFunctionsTest.java
@@ -1,0 +1,330 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import net.rptools.parser.function.ParameterException;
+import org.junit.jupiter.api.Test;
+
+public class StrListFunctionsTest {
+
+  private final StrListFunctions funcs = new StrListFunctions();
+  private String delim = ",";
+
+  private List<Object> toParms(Object... parms) {
+    ArrayList result = new ArrayList<Object>();
+    for (Object arg : parms) {
+      if (arg instanceof Integer) arg = new BigDecimal((Integer) arg);
+      result.add(arg);
+    }
+    return result;
+  }
+
+  private BigDecimal big(int i) {
+    return new BigDecimal(i);
+  }
+
+  private Object listGet(int i, String listStr) throws ParameterException {
+    return funcs.listGet(toParms("listGet()", i, delim), listStr, delim);
+  }
+
+  private void setDelim(String delim) {
+    this.delim = delim;
+  }
+
+  @Test
+  public void testListGet() throws ParameterException {
+
+    setDelim(",");
+    assertEquals("one", listGet(0, "one,two,three"));
+    assertEquals("two", listGet(1, "    one,two,three  "));
+    assertEquals("three", listGet(2, "one,   two,three   "));
+    assertEquals("", listGet(3, "one,      two,   three"));
+    assertEquals("", listGet(0, ""));
+
+    assertEquals("", listGet(0, ""));
+    assertEquals("x", listGet(0, "x"));
+    assertEquals("b", listGet(1, "a,b"));
+    assertEquals(big(1), listGet(0, "1"));
+    assertEquals(big(1), listGet(1, "0,1"));
+
+    setDelim(";");
+    assertEquals("", listGet(0, ""));
+    assertEquals("x", listGet(0, "x"));
+    assertEquals("b", listGet(1, "a;b"));
+    assertEquals(big(1), listGet(0, "1"));
+    assertEquals(big(1), listGet(1, "0;1"));
+  }
+
+  private Object listDelete(int i, String listStr) throws ParameterException {
+    return funcs.listDelete(toParms("listDelete()", i, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListDelete() throws ParameterException {
+
+    setDelim(",");
+    assertEquals("two,  three", listDelete(0, "one,   two,  three"));
+    assertEquals("one,three", listDelete(1, "one,two,three"));
+    assertEquals("one,two", listDelete(2, "one,two,  three    "));
+    assertEquals("one,two,three", listDelete(-1, "one,two,three"));
+    assertEquals("one,two,three", listDelete(3, "one,   two   ,   three"));
+    assertEquals(",", listDelete(0, ",,"));
+    assertEquals(",", listDelete(1, ",,"));
+    assertEquals(",", listDelete(2, ",,"));
+    assertEquals("", listDelete(0, ""));
+
+    assertEquals("", listDelete(0, ""));
+    assertEquals("", listDelete(0, "x"));
+    assertEquals("b", listDelete(0, "a,b"));
+    assertEquals("a", listDelete(1, "a,b"));
+    assertEquals("a,b", listDelete(2, "a,b"));
+
+    setDelim(";");
+    assertEquals("", listDelete(0, ""));
+    assertEquals("", listDelete(0, "x"));
+    assertEquals("b", listDelete(0, "a;b"));
+    assertEquals("a", listDelete(1, "a;b"));
+    assertEquals("a;b", listDelete(2, "a;b"));
+  }
+
+  private Object listAppend(String listStr, Object element) throws ParameterException {
+    return funcs.listAppend(toParms("listAppend()", element, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListAppend() throws ParameterException {
+
+    setDelim(",");
+    assertEquals("one", listAppend("", "one"));
+    assertEquals("one, two", listAppend("one", "two"));
+    assertEquals("one,   two, three", listAppend("one,   two", "three"));
+
+    assertEquals("a", listAppend("", "a"));
+    assertEquals("0", listAppend("", "0"));
+    assertEquals("x, y", listAppend("x", "y"));
+    assertEquals("x, 1", listAppend("x", 1));
+    assertEquals(
+        "a,b, c",
+        listAppend("a,b", "c")); // This is a change from old behavior that would parse listStr
+    assertEquals(
+        "1,b, 2", listAppend("1,b", 2)); // .. ","pletely to construct a well formatted string. That
+    assertEquals(
+        ",, z",
+        listAppend(",", "z")); // .. spends a lot of cycles and I don't know the benefit atm.
+
+    setDelim(";");
+    assertEquals("a", listAppend("", "a"));
+    assertEquals("0", listAppend("", "0"));
+    assertEquals("x; y", listAppend("x", "y"));
+    assertEquals("x; 1", listAppend("x", 1));
+    assertEquals(
+        "a;b; c",
+        listAppend("a;b", "c")); // This is a change from old behavior that would parse listStr
+    assertEquals(
+        "1;b; 2", listAppend("1;b", 2)); // .. ","pletely to construct a well formatted string. That
+    assertEquals(
+        ";; z",
+        listAppend(";", "z")); // .. spends a lot of cycles and I don't know the benefit atm.
+  }
+
+  private Object listCount(String listStr) throws ParameterException {
+    return funcs.listCount(toParms("listCount()", delim), listStr, delim);
+  }
+
+  @Test
+  public void testListCount() throws ParameterException {
+
+    setDelim(",");
+    assertEquals(big(0), listCount(""));
+    assertEquals(big(1), listCount("one"));
+    assertEquals(big(2), listCount("one,   two"));
+    assertEquals(big(2), listCount(","));
+
+    setDelim(";");
+    assertEquals(big(0), listCount(""));
+    assertEquals(big(1), listCount("one"));
+    assertEquals(big(2), listCount("one;two"));
+    assertEquals(big(2), listCount(";"));
+  }
+
+  private Object listFind(String listStr, String element) throws ParameterException {
+    return funcs.listFind(toParms("listFind()", element, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListFind() throws ParameterException {
+
+    setDelim(",");
+    assertEquals(big(-1), listFind("", "foo"));
+    assertEquals(big(0), listFind("one", "one"));
+    assertEquals(big(1), listFind("one,     two, three", "two"));
+    assertEquals(big(2), listFind("    one, two, three    ", "three"));
+
+    assertEquals(big(0), listFind(",", ""));
+    assertEquals(big(0), listFind("x", "x"));
+    assertEquals(big(1), listFind("a,b", "b"));
+    assertEquals(big(-1), listFind("a,b", "c"));
+    assertEquals(big(1), listFind("a,0,b", "0"));
+    assertEquals(big(-1), listFind("a,0,b", "1"));
+
+    setDelim(";");
+    assertEquals(big(0), listFind(";", ""));
+    assertEquals(big(0), listFind("x", "x"));
+    assertEquals(big(1), listFind("a;b", "b"));
+    assertEquals(big(-1), listFind("a;b", "c"));
+    assertEquals(big(1), listFind("a;0;b", "0"));
+    assertEquals(big(-1), listFind("a;0;b", "1"));
+  }
+
+  private Object listContains(String listStr, String element) throws ParameterException {
+    return funcs.listContains(toParms("listContains()", element, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListContains() throws ParameterException {
+    setDelim(",");
+    assertEquals(big(0), listContains("", "foo"));
+    assertEquals(big(1), listContains("one, two, three", "one"));
+    assertEquals(big(1), listContains("one, two, three", "two"));
+    assertEquals(big(1), listContains("one, two, three", "three"));
+    assertEquals(big(2), listContains("one,     two, three, two", "two"));
+    assertEquals(big(3), listContains("    one, two, three, two, four, two    ", "two"));
+
+    setDelim(";");
+    assertEquals(big(0), listContains("", "foo"));
+    assertEquals(big(1), listContains("one; two; three", "one"));
+    assertEquals(big(1), listContains("one;two;three", "two"));
+  }
+
+  private Object listInsert(String listStr, int index, Object element) throws ParameterException {
+    return funcs.listInsert(toParms("listInsert()", index, element, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListInsert() throws ParameterException {
+
+    setDelim(",");
+    assertEquals("", listInsert("", -1, "inserted"));
+    assertEquals("inserted", listInsert("", 0, "inserted"));
+    assertEquals("", listInsert("", 1, "inserted"));
+    assertEquals("", listInsert("", 2, "inserted"));
+
+    assertEquals("inserted, one,two", listInsert("one,two", 0, "inserted"));
+    assertEquals("one, inserted, two", listInsert("one,two", 1, "inserted"));
+    assertEquals("one, two, inserted", listInsert("one,two", 2, "inserted"));
+
+    assertEquals("x", listInsert("", 0, "x"));
+    assertEquals("", listInsert("", 1, "x"));
+    assertEquals("5", listInsert("", 0, 5));
+    assertEquals("y, x", listInsert("x", 0, "y"));
+    assertEquals("x, 5", listInsert("x", 1, 5));
+    assertEquals("x", listInsert("x", 2, "y"));
+    assertEquals("3, a, b", listInsert("a, b", 0, 3));
+    assertEquals("a, b, c", listInsert("a,b", 2, "c"));
+    assertEquals("a, b", listInsert("a, b", 3, "c"));
+
+    setDelim(";");
+    assertEquals("x", listInsert("", 0, "x"));
+    assertEquals("", listInsert("", 1, "x"));
+    assertEquals("5", listInsert("", 0, 5));
+    assertEquals("y; x", listInsert("x", 0, "y"));
+    assertEquals("x; 5", listInsert("x", 1, 5));
+    assertEquals("x", listInsert("x", 2, "y"));
+    assertEquals("3; a; b", listInsert("a; b", 0, 3));
+    assertEquals("a; b; c", listInsert("a;b", 2, "c"));
+    assertEquals("a; b", listInsert("a; b", 3, "c"));
+  }
+
+  private Object listReplace(String listStr, int index, Object element) throws ParameterException {
+    return funcs.listReplace(toParms("listReplace()", index, element, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListReplace() throws ParameterException {
+
+    setDelim(",");
+    assertEquals("", listReplace("", 0, "replaced"));
+    assertEquals("replaced", listReplace("one", 0, "replaced"));
+    assertEquals("replaced, two", listReplace("one, two", 0, "replaced"));
+    assertEquals("one, replaced, three", listReplace("one, two, three", 1, "replaced"));
+    assertEquals("one, two, replaced", listReplace("one, two, three", 2, "replaced"));
+    assertEquals("one, two, three", listReplace("one, two, three", 3, "replaced"));
+
+    assertEquals("", listReplace("", 0, "a"));
+    assertEquals("", listReplace("", 0, 55));
+    assertEquals("3", listReplace("x", 0, 3));
+    assertEquals("x", listReplace("x", 1, "y"));
+    assertEquals("a,", listReplace(",", 0, "a"));
+    assertEquals("a, ", listReplace(" , ", 0, "a"));
+    assertEquals(", b", listReplace(",", 1, "b"));
+    assertEquals(", ", listReplace(",", 2, "c"));
+    assertEquals("a, d", listReplace("a,b", 1, "d"));
+
+    setDelim(";");
+    assertEquals("", listReplace("", 0, "a"));
+    assertEquals("", listReplace("", 0, 55));
+    assertEquals("3", listReplace("x", 0, 3));
+    assertEquals("x", listReplace("x", 1, "y"));
+    assertEquals("a;", listReplace(";", 0, "a"));
+    assertEquals("; b", listReplace(";", 1, "b"));
+    assertEquals("; ", listReplace(";", 2, "c"));
+    assertEquals("a; d", listReplace("a;b", 1, "d"));
+  }
+
+  private Object listSort(String listStr, String sortType) throws ParameterException {
+    return funcs.listSort(toParms("listSort()", sortType, delim), listStr, delim);
+  }
+
+  private Object listSort(String listStr) throws ParameterException {
+    return funcs.listSort(toParms("listSort()", delim), listStr, delim);
+  }
+
+  @Test
+  public void testListSort() throws ParameterException {
+    setDelim(",");
+    assertEquals("", listSort(""));
+    assertEquals("a, b, c, d", listSort("d,a,b,c"));
+    assertEquals("a", listSort("         a   "));
+
+    assertEquals("M1, M10, M3", listSort("M3, M10, M1", "A"));
+    assertEquals("M3, M10, M1", listSort("M3, M10, M1", "A-"));
+    assertEquals("M1, M3, M10", listSort("M3,M10,M1", "N+"));
+    assertEquals("M10, M3, M1", listSort("M3,M10,M1", "N-"));
+
+    setDelim(";");
+    assertEquals("M1; M10; M3", listSort("M3; M10; M1", "A"));
+    assertEquals("M3; M10; M1", listSort("M3; M10; M1", "A-"));
+    assertEquals("M1; M3; M10", listSort("M3;M10;M1", "N+"));
+    assertEquals("M10; M3; M1", listSort("M3;M10;M1", "N-"));
+  }
+
+  private Object listFormat(
+      String delim, String listStr, String listFormat, String entryFormat, String entrySep)
+      throws ParameterException {
+    return funcs.listFormat(
+        toParms("listFormat()", listFormat, entryFormat, entrySep, delim), listStr, delim);
+  }
+
+  @Test
+  public void testListFormat() throws ParameterException {
+    assertEquals("[[(a)...(b)...(c)]]", listFormat(",", "a,b,c", "[[%list]]", "(%item)", "..."));
+    assertEquals("[[(a)...(b)...(c)]]", listFormat(";", "a;b;c", "[[%list]]", "(%item)", "..."));
+  }
+}


### PR DESCRIPTION
The string parsing doesn't generate a fully parsed temporary string-list. Functions like append do the appending in one step. Functions that don't have to loop the full list (e.g. get(0)/remove(3)) don't walk the full list.

With sufficient large lists I've seen 3-5x perf improvement.

Added unit test class.

Important to consider as discussed: any pretty formatted string (VALUE+SEPARATOR+SPACE+VALUE+SEPARATOR+SPACE+...) stays pretty formatted. Any non-pretty string (e.g. "a,b, c,d") is not guaranteed to be reformatted (i.e. "a, b, c, d").

Suggestion for #1898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1920)
<!-- Reviewable:end -->
