### PR TITLE
Add macro stack trace to error messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ dependencies {
     implementation 'net.rptools.decktool:decktool:1.0.b1'
     implementation 'com.github.RPTools:clientserver:1.4.0.0'
     implementation 'com.github.RPTools:maptool-resources:1.6.0'
-    implementation 'com.github.RPTools:parser:1.5.5'
+    implementation 'com.github.RPTools:parser:1.6.0'
     implementation 'com.github.RPTools:dicelib:1.6.0'
 
     // Currently hosted on nerps.net/repo

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -98,6 +98,7 @@ import net.rptools.maptool.util.StringUtil;
 import net.rptools.maptool.util.UPnPUtil;
 import net.rptools.maptool.util.UserJvmOptions;
 import net.rptools.maptool.webapi.MTWebAppServer;
+import net.rptools.parser.ParserException;
 import net.tsc.servicediscovery.ServiceAnnouncer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -877,6 +878,21 @@ public class MapTool {
    */
   public static void addLocalMessage(String message) {
     addMessage(TextMessage.me(null, message));
+  }
+
+  /**
+   * Adds an error message that includes the macro stack trace.
+   *
+   * @param e the ParserException to display the error of
+   */
+  public static void addErrorMessage(ParserException e) {
+    MapTool.addLocalMessage(e.getMessage());
+
+    String[] macroStackTrace = e.getMacroStackTrace();
+    if (macroStackTrace.length > 0) {
+      MapTool.addLocalMessage(
+          I18N.getText("msg.error.trace", String.join(" &lt;&lt;&lt; ", macroStackTrace)));
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1414,6 +1414,9 @@ public class MapToolLineParser {
                   if (!catchAssert) throw assertEx;
                   MapTool.addLocalMessage(assertEx.getMessage());
                   output_text = "";
+                } catch (ParserException e) {
+                  e.addMacro(callName);
+                  throw e;
                 }
 
                 if (output != Output.NONE) {

--- a/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
@@ -475,7 +475,9 @@ public class MacroLinkFunction extends AbstractFunction {
       } catch (AbortFunctionException e) {
         // Do nothing
       } catch (ParserException e) {
-        MapTool.addLocalMessage(e.getMessage());
+        e.addMacro(macroName);
+        e.addMacro("macroLink");
+        MapTool.addErrorMessage(e);
       }
     }
   }

--- a/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
@@ -135,6 +135,9 @@ public class UserDefinedMacroFunctions implements Function, AdditionalFunctionDe
                   funcDef.macroName,
                   macroArgs,
                   funcDef.newVariableContext);
+    } catch (ParserException e) {
+      e.addMacro(funcDef.macroName);
+      throw e;
     } finally {
       currentFunction.pop();
     }

--- a/src/main/java/net/rptools/maptool/client/macro/MacroManager.java
+++ b/src/main/java/net/rptools/maptool/client/macro/MacroManager.java
@@ -130,6 +130,10 @@ public class MacroManager {
   public static void executeMacro(String command, MapToolMacroContext macroExecutionContext) {
     MacroContext context = new MacroContext();
     context.addTransform(command);
+    String macroButtonName =
+        macroExecutionContext == null
+            ? "chat"
+            : macroExecutionContext.getName() + "@" + macroExecutionContext.getSource();
 
     try {
       command = preprocess(command);
@@ -158,12 +162,7 @@ public class MacroManager {
         Macro macro = getRegisteredMacro(key);
         MacroDefinition def = macro.getClass().getAnnotation(MacroDefinition.class);
 
-        boolean trustedPath =
-            macroExecutionContext == null ? false : macroExecutionContext.isTrusted();
-        String macroButtonName =
-            macroExecutionContext == null
-                ? "<chat>"
-                : macroExecutionContext.getName() + "@" + macroExecutionContext.getSource();
+        boolean trustedPath = macroExecutionContext != null && macroExecutionContext.isTrusted();
 
         // Preprocess line if required.
         if (def == null || def.expandRolls()) {
@@ -206,7 +205,8 @@ public class MacroManager {
       MapTool.addLocalMessage(afe.getMessage());
       return;
     } catch (ParserException e) {
-      MapTool.addLocalMessage(e.getMessage());
+      e.addMacro(macroButtonName);
+      MapTool.addErrorMessage(e);
       // These are not errors to worry about as they are usually user input errors so no need to log
       // them.
       return;

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1711,6 +1711,7 @@ msg.error.toolCannotInstantiate               = Could not instantiate tool class
 msg.error.toolConstructorFailed               = Failed in constructor of tool: {0}
 msg.error.toolNeedPublicConstructor           = Constructor must be public for tool: {0}
 msg.error.toolNeedValidConstructor            = Class must have a public constructor with a Toolbox argument for tool: {0}
+msg.error.trace                               = Error trace : {0}
 msg.error.unableToCreateClientIdFile          = Can''t create the client id file.
 msg.error.unableToCreateDataDir               = Can''t create the data directory "{0}".  Try manually specifying the data directory by setting the environment variable "MAPTOOL_DATADIR".  Search our forums for that name if you need help.
 msg.error.unableToReadClientIdFile            = Can''t read the client id file.


### PR DESCRIPTION
- Add error message of the form `Error trace : print@Campaign <<< link@Campaign <<< test@campaign`
- Close #1861
- Requires a parser update. In the meanwhile, can be tested by changing the following line in `build.gradle`:

`implementation 'com.github.RPTools:parser:1.8.0'`
to
`implementation 'com.github.Merudo:parser:1.8.0'`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1925)
<!-- Reviewable:end -->
