### PR TITLE
Fix players can't call trusted token macros through macroLinks

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1537,12 +1537,8 @@ public class MapToolLineParser {
     try {
       parserRecurseDepth++;
       if (log.isDebugEnabled()) {
-        StringBuilder b = new StringBuilder();
-        for (int i = 1; i < parserRecurseDepth; i++) {
-          b.append(' ');
-        }
-        b.append(expression);
-        log.debug(b.toString());
+        String b = " ".repeat(Math.max(0, parserRecurseDepth - 1)) + expression;
+        log.debug(b);
       }
       Result res = createParser(resolver, tokenInContext != null).evaluate(expression);
       rolled.addAll(res.getRolled());
@@ -1672,15 +1668,17 @@ public class MapToolLineParser {
       // Unqualified names are not allowed.
       throw new ParserException(I18N.getText("lineParser.invalidMacroLoc", macroName));
     } else if (macroLocation.equalsIgnoreCase("TOKEN")) {
-      macroContext = new MapToolMacroContext(macroName, "token", MapTool.getPlayer().isGM());
-      // Search token for the macro
+      boolean trusted = false;
       if (tokenInContext != null) {
-        MacroButtonProperties buttonProps = tokenInContext.getMacro(macroName, false);
-        if (buttonProps == null) {
+        // Search token for the macro
+        MacroButtonProperties mbp = tokenInContext.getMacro(macroName, false);
+        if (mbp == null) {
           throw new ParserException(I18N.getText("lineParser.atTokenNotFound", macroName));
         }
-        macroBody = buttonProps.getCommand();
+        macroBody = mbp.getCommand();
+        trusted = !mbp.getAllowPlayerEdits();
       }
+      macroContext = new MapToolMacroContext(macroName, "token", trusted);
     } else if (macroLocation.equalsIgnoreCase("CAMPAIGN")) {
       MacroButtonProperties mbp = null;
       for (MacroButtonProperties m : MapTool.getCampaign().getMacroButtonPropertiesArray()) {


### PR DESCRIPTION
- Change @token macros launched via macroLinks to be trusted if they are not player editable
- Fix #1935

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1941)
<!-- Reviewable:end -->
