### PR TITLE
Fix Entire Map screenshots incorrect when zoom != 100%

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ExportDialog.java
@@ -839,9 +839,15 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
       }
     }
 
+    // Rescale the bounds to match the view scale
+    double scale = renderer.getScale();
+    extents.setLocation((int) (extents.x * scale), (int) (extents.y * scale));
+    extents.setSize((int) (extents.width * scale), (int) (extents.height * scale));
+
     // Setup the renderer to use the new extents
     Scale s = new Scale();
     s.setOffset(-extents.x, -extents.y);
+    s.setScale(scale);
     renderer.setZoneScale(s);
     renderer.setBounds(extents);
 


### PR DESCRIPTION
- Fix Entire Map screenshots being incorrect when the zoom level isn't equal to 100%
- Discussed in #1948

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1952)
<!-- Reviewable:end -->
