### PR TITLE
Fix createMacro() throwing NPE if playerEditable is specified

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -476,7 +476,15 @@ public class MacroFunctions extends AbstractFunction {
     }
 
     MacroButtonProperties mbp = new MacroButtonProperties(token.getMacroNextIndex());
+
+    mbp.setLabel(label);
+    mbp.setSaveLocation("Token");
     mbp.setCommand(command);
+
+    // Token Id is used in the exception messages of setMacroProps
+    mbp.setTokenId(token);
+
+    // Sets the props, if any
     if (prop != null) {
       setMacroProps(mbp, prop, delim);
     }
@@ -485,10 +493,6 @@ public class MacroFunctions extends AbstractFunction {
     if (!MapTool.getParser().isMacroTrusted()) {
       mbp.setAllowPlayerEdits(true);
     }
-
-    mbp.setLabel(label);
-    mbp.setSaveLocation("Token");
-    mbp.setTokenId(token);
 
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.saveMacro, mbp);
     return BigDecimal.valueOf(mbp.getIndex());


### PR DESCRIPTION
- Fix createMacro() throwing a null pointer exception if playerEditable is among the properties defined and the player is not a GM
- Issue discussed in #1938

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1957)
<!-- Reviewable:end -->
