### PR TITLE
Use new option in dicelib to only evaluate with a deterministic outco…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -631,7 +631,7 @@ public class MapToolLineParser {
       Object retval = params[index];
       // No parsing is done if the param isn't a String (e.g. it's already a BigDecimal)
       if (params[index] instanceof String) {
-        Result result = parseExpression(res, tokenInContext, (String) params[index]);
+        Result result = parseExpression(res, tokenInContext, (String) params[index], false);
         retval = result.getValue();
       }
       return retval;
@@ -854,7 +854,7 @@ public class MapToolLineParser {
                   outputOpts.add("w");
                   for (int i = 0; i < option.getParamCount(); i++) {
                     String arg =
-                        parseExpression(resolver, tokenInContext, option.getStringParam(i))
+                        parseExpression(resolver, tokenInContext, option.getStringParam(i), false)
                             .getValue()
                             .toString();
                     if (arg.trim().startsWith("[")) {
@@ -952,7 +952,7 @@ public class MapToolLineParser {
                     String listDelim = option.getStringParam(3);
                     if (listDelim.trim().startsWith("\"")) {
                       listDelim =
-                          parseExpression(resolver, tokenInContext, listDelim)
+                          parseExpression(resolver, tokenInContext, listDelim, false)
                               .getValue()
                               .toString();
                     }
@@ -1147,7 +1147,7 @@ public class MapToolLineParser {
                     (loopCondition == null) ? null : String.format("if(%s, 1, 0)", loopCondition);
                 // Stop loop if the while condition is false
                 try {
-                  Result result = parseExpression(resolver, tokenInContext, hackCondition);
+                  Result result = parseExpression(resolver, tokenInContext, hackCondition, false);
                   loopConditionValue = ((Number) result.getValue()).intValue();
                   if (loopConditionValue == 0) {
                     doLoop = false;
@@ -1161,7 +1161,7 @@ public class MapToolLineParser {
             // Output the loop separator
             if (doLoop && iteration != 0 && output != Output.NONE) {
               expressionBuilder.append(
-                  parseExpression(resolver, tokenInContext, loopSep).getValue());
+                  parseExpression(resolver, tokenInContext, loopSep, false).getValue());
             }
 
             if (!doLoop) {
@@ -1182,7 +1182,7 @@ public class MapToolLineParser {
               }
               Result result = null;
               try {
-                result = parseExpression(resolver, tokenInContext, hackCondition);
+                result = parseExpression(resolver, tokenInContext, hackCondition, false);
               } catch (Exception e) {
                 throw doError(
                     I18N.getText(
@@ -1328,10 +1328,10 @@ public class MapToolLineParser {
                      * TODO: If you're adding a new formatting option, add a new case to build the output
                      */
                   case NONE:
-                    parseExpression(resolver, tokenInContext, rollBranch);
+                    parseExpression(resolver, tokenInContext, rollBranch, false);
                     break;
                   case RESULT:
-                    result = parseExpression(resolver, tokenInContext, rollBranch);
+                    result = parseExpression(resolver, tokenInContext, rollBranch, false);
                     output_text = result != null ? result.getValue().toString() : "";
                     if (!this.isMacroTrusted()) {
                       output_text =
@@ -1349,7 +1349,7 @@ public class MapToolLineParser {
                   case TOOLTIP:
                     String tooltip = rollBranch + " = ";
                     output_text = null;
-                    result = parseExpression(resolver, tokenInContext, rollBranch);
+                    result = parseExpression(resolver, tokenInContext, rollBranch, true);
                     tooltip += result.getDetailExpression();
                     if (text == null) {
                       output_text = result.getValue().toString();
@@ -1359,7 +1359,9 @@ public class MapToolLineParser {
                       }
                       resolver.setVariable("roll.result", result.getValue());
                       output_text =
-                          parseExpression(resolver, tokenInContext, text).getValue().toString();
+                          parseExpression(resolver, tokenInContext, text, false)
+                              .getValue()
+                              .toString();
                     }
                     tooltip = tooltip.replaceAll("'", "&#39;");
                     expressionBuilder.append(
@@ -1387,9 +1389,9 @@ public class MapToolLineParser {
                  */
               case MACRO:
                 // [MACRO("macroName@location"): args]
-                result = parseExpression(resolver, tokenInContext, macroName);
+                result = parseExpression(resolver, tokenInContext, macroName, false);
                 String callName = result.getValue().toString();
-                result = parseExpression(resolver, tokenInContext, rollBranch);
+                result = parseExpression(resolver, tokenInContext, rollBranch, false);
                 String macroArgs = result.getValue().toString();
 
                 try {
@@ -1471,7 +1473,7 @@ public class MapToolLineParser {
           }
         } else if (match.getMatch().startsWith("{")) {
           roll = match.getRoll();
-          Result result = parseExpression(resolver, tokenInContext, roll);
+          Result result = parseExpression(resolver, tokenInContext, roll, false);
           if (isMacroTrusted()) {
             builder.append(result != null ? result.getValue().toString() : "");
           } else {
@@ -1518,15 +1520,19 @@ public class MapToolLineParser {
     }
   }
 
-  public Result parseExpression(String expression) throws ParserException {
-    return parseExpression(null, expression);
+  public Result parseExpression(String expression, boolean makeDeterministic)
+      throws ParserException {
+    return parseExpression(null, expression, makeDeterministic);
   }
 
-  public Result parseExpression(Token tokenInContext, String expression) throws ParserException {
-    return parseExpression(new MapToolVariableResolver(tokenInContext), tokenInContext, expression);
+  public Result parseExpression(Token tokenInContext, String expression, boolean makeDeterministic)
+      throws ParserException {
+    return parseExpression(
+        new MapToolVariableResolver(tokenInContext), tokenInContext, expression, makeDeterministic);
   }
 
-  public Result parseExpression(VariableResolver resolver, Token tokenInContext, String expression)
+  public Result parseExpression(
+      VariableResolver resolver, Token tokenInContext, String expression, boolean makeDeterministic)
       throws ParserException {
     if (parserRecurseDepth > maxRecursionDepth) {
       parserRecurseDepth = 0;
@@ -1539,7 +1545,8 @@ public class MapToolLineParser {
         String b = " ".repeat(Math.max(0, parserRecurseDepth - 1)) + expression;
         log.debug(b);
       }
-      Result res = createParser(resolver, tokenInContext != null).evaluate(expression);
+      Result res =
+          createParser(resolver, tokenInContext != null).evaluate(expression, makeDeterministic);
       rolled.addAll(res.getRolled());
       newRolls.addAll(res.getRolled());
 
@@ -1595,7 +1602,7 @@ public class MapToolLineParser {
   public String expandRoll(MapToolVariableResolver resolver, Token tokenInContext, String roll)
       throws ParserException {
     try {
-      Result result = parseExpression(resolver, tokenInContext, roll);
+      Result result = parseExpression(resolver, tokenInContext, roll, true);
       StringBuilder sb = new StringBuilder();
 
       if (result.getDetailExpression().equals(result.getValue().toString())) {

--- a/src/main/java/net/rptools/maptool/client/macro/impl/SetTokenPropertyMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/SetTokenPropertyMacro.java
@@ -78,7 +78,7 @@ public class SetTokenPropertyMacro implements Macro {
     for (Token token : selectedTokenSet) {
       for (String command : commands) {
         try {
-          MapTool.getParser().parseExpression(token, command);
+          MapTool.getParser().parseExpression(token, command, false);
         } catch (ParserException e) {
           MapTool.addLocalMessage(I18N.getText("msg.error.evaluatingExpr", e.getMessage()));
           break;


### PR DESCRIPTION
…me IF the detailed expression is actually used (i.e., TOOLTIP, expandRoll). That turns off the whole deterministic AST building in dicelib when not needed. It also avoids the associated flattening of variables (e.g., json array) when all that counts is the result, e.g. in a macro loop.

This still works

```
/roll 1d6 + 4
* nmeier rolls: 1d6 + 4 => 5 + 4 = 9

```
With this change the example macro in #1898 that appends 10k elements to a json.array does that in a loop as true list appends now.

This reduces the runtime of that example macro from ~11-12s to 4-5s on my machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1968)
<!-- Reviewable:end -->
