### PR TITLE
Fix bug in parsing of list elements that contain spaces. 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
@@ -87,9 +87,9 @@ public class StrListFunctions extends AbstractFunction {
 
   private static Pattern PATTERN_FOR_EMPTY_SEPARATOR = Pattern.compile("(.)()", Pattern.DOTALL);
   private static Pattern PATTERN_FOR_COMMA_SEPARATOR =
-      Pattern.compile("\\s*(\\S*?)\\s*\\,|\\s*(\\S*)\\s*", Pattern.DOTALL);
+      Pattern.compile("\\s*(.*?)\\s*\\,|\\s*(.*?)\\s*$", Pattern.DOTALL);
   private static Pattern PATTERN_FOR_SEMICOLON_SEPARATOR =
-      Pattern.compile("\\s*(\\S*?)\\s*\\;|\\s*(\\S*)\\s*", Pattern.DOTALL);
+      Pattern.compile("\\s*(.*?)\\s*\\;|\\s*(.*?)\\s*$", Pattern.DOTALL);
 
   /**
    * Parses a list.
@@ -114,7 +114,7 @@ public class StrListFunctions extends AbstractFunction {
       // This pattern needs to be compiled with the DOTALL flag or line terminators might
       // cause premature termination of the matcher.find() operations...
       String escDelim = fullyQuoteString(delim);
-      pattern = Pattern.compile("\\s*(\\S*?)\\s*" + escDelim + "|\\s*(\\S*)\\s*", Pattern.DOTALL);
+      pattern = Pattern.compile("\\s*(.*?)\\s*" + escDelim + "|\\s*(.*?)\\s*$", Pattern.DOTALL);
     }
 
     Matcher matcher = pattern.matcher(listStr);

--- a/src/test/java/net/rptools/maptool/client/functions/StrListFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/StrListFunctionsTest.java
@@ -52,6 +52,12 @@ public class StrListFunctionsTest {
   public void testListGet() throws ParameterException {
 
     setDelim(",");
+    assertEquals("Wild Magic Surge", listGet(0, "Wild Magic Surge"));
+    setDelim(";");
+    assertEquals("Sild Wagic Murge", listGet(1, "Wild Magic Surge;   Sild Wagic Murge"));
+    assertEquals("", listGet(2, "Wild Magic Surge;   Sild Wagic Murge;"));
+
+    setDelim(",");
     assertEquals("one", listGet(0, "one,two,three"));
     assertEquals("two", listGet(1, "    one,two,three  "));
     assertEquals("three", listGet(2, "one,   two,three   "));
@@ -112,6 +118,13 @@ public class StrListFunctionsTest {
   public void testListAppend() throws ParameterException {
 
     setDelim(",");
+    assertEquals(
+        "one or the other, something with space",
+        listAppend("one or the other", "something with space"));
+    assertEquals(
+        "one or the other,, something with space",
+        listAppend("one or the other,", "something with space"));
+
     assertEquals("one", listAppend("", "one"));
     assertEquals("one, two", listAppend("one", "two"));
     assertEquals("one,   two, three", listAppend("one,   two", "three"));
@@ -152,6 +165,9 @@ public class StrListFunctionsTest {
   public void testListCount() throws ParameterException {
 
     setDelim(",");
+    assertEquals(big(4), listCount("one, two, three and four, five"));
+    assertEquals(big(5), listCount("one, two, three and four, five,"));
+
     assertEquals(big(0), listCount(""));
     assertEquals(big(1), listCount("one"));
     assertEquals(big(2), listCount("one,   two"));
@@ -170,6 +186,9 @@ public class StrListFunctionsTest {
 
   @Test
   public void testListFind() throws ParameterException {
+
+    setDelim(",");
+    assertEquals(big(1), listFind("one,     two with spaces , three", "two with spaces"));
 
     setDelim(",");
     assertEquals(big(-1), listFind("", "foo"));
@@ -298,6 +317,11 @@ public class StrListFunctionsTest {
 
   @Test
   public void testListSort() throws ParameterException {
+
+    setDelim(",");
+    assertEquals(
+        "a and 1, b and 2, c and 3, d and 4", listSort(" d and 4, a and 1,  b and 2  ,c and 3"));
+
     setDelim(",");
     assertEquals("", listSort(""));
     assertEquals("a, b, c, d", listSort("d,a,b,c"));


### PR DESCRIPTION
Add unit tests that cover cases of spaces in elements.

#1972

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1973)
<!-- Reviewable:end -->
