### PR TITLE
[lib/i18n] bundle.getString can't return null

### DIFF
--- a/src/main/java/net/rptools/lib/i18n/I18NManager.java
+++ b/src/main/java/net/rptools/lib/i18n/I18NManager.java
@@ -20,21 +20,23 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-public class I18NManager {
+public final class I18NManager {
 
-  private static List<String> bundleNameList = new CopyOnWriteArrayList<String>();
-  private static List<ResourceBundle> bundleList = new ArrayList<ResourceBundle>();
+  private static final List<String> BUNDLE_NAME_LIST = new CopyOnWriteArrayList<String>();
+  private static final List<ResourceBundle> BUNDLE_LIST = new ArrayList<ResourceBundle>();
   private static Locale locale = Locale.US;
-  private static List<LocaleChangeListener> localeListenerList =
+  private static final List<LocaleChangeListener> LOCALE_LISTENER_LIST =
       new CopyOnWriteArrayList<LocaleChangeListener>();
 
+  private I18NManager() {}
+
   public static void addBundle(String bundleName) {
-    bundleNameList.add(bundleName);
+    BUNDLE_NAME_LIST.add(bundleName);
     updateBundles();
   }
 
   public static void removeBundle(String bundleName) {
-    bundleNameList.remove(bundleName);
+    BUNDLE_NAME_LIST.remove(bundleName);
     updateBundles();
   }
 
@@ -46,31 +48,22 @@ public class I18NManager {
 
   public static String getText(String key) {
 
-    for (ResourceBundle bundle : bundleList) {
-
-      String value = bundle.getString(key);
-      if (value != null) {
-        return value;
-      }
-    }
-
-    return key;
+    return BUNDLE_LIST.stream().findFirst().map(bundle -> bundle.getString(key)).orElse(key);
   }
 
   private static synchronized void fireLocaleChanged() {
 
-    for (LocaleChangeListener listener : localeListenerList) {
+    for (LocaleChangeListener listener : LOCALE_LISTENER_LIST) {
       listener.localeChanged(locale);
     }
   }
 
   private static synchronized void updateBundles() {
 
-    bundleList.clear();
+    BUNDLE_LIST.clear();
 
-    for (String bundleName : bundleNameList) {
-
-      bundleList.add(ResourceBundle.getBundle(bundleName, locale));
+    for (String bundleName : BUNDLE_NAME_LIST) {
+      BUNDLE_LIST.add(ResourceBundle.getBundle(bundleName, locale));
     }
   }
 }


### PR DESCRIPTION
Problem

bundle.getString throws an NPE instead of returning null if string can't
be found. However, we have a null check.

Further, this class is a utility class but is not idiomatically marked as so

Solution

Remove null check. This then trivially tranforms into a more
functional-like approach.

Mark the class as final with a private ctor (and private fields).

fixes #1992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/1993)
<!-- Reviewable:end -->
