### PR TITLE
Update to parser 1.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ dependencies {
     implementation 'net.rptools.decktool:decktool:1.0.b1'
     implementation 'com.github.RPTools:clientserver:1.4.0.0'
     implementation 'com.github.RPTools:maptool-resources:1.6.0'
-    implementation 'com.github.RPTools:parser:1.7.1'
+    implementation 'com.github.RPTools:parser:1.8.0'
     implementation 'com.github.RPTools:dicelib:1.6.3'
 
     // Currently hosted on nerps.net/repo


### PR DESCRIPTION
Update build to use parser 1.8.0.  Issue #2019.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2020)
<!-- Reviewable:end -->
