### PR TITLE
Add some chat preferences to the output of getInfo("client"), and a p…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -171,6 +171,10 @@ public class getInfoFunction extends AbstractFunction {
     cinfo.addProperty("show portrait", AppPreferences.getShowPortrait());
     cinfo.addProperty("show stat sheet", AppPreferences.getShowStatSheet());
     cinfo.addProperty("file sync directory", AppPreferences.getFileSyncPath());
+    cinfo.addProperty("show avatar in chat", AppPreferences.getShowAvatarInChat());
+    cinfo.addProperty(
+        "suppress tooltips for macroLinks", AppPreferences.getSuppressToolTipsForMacroLinks());
+    cinfo.addProperty("use tooltips for inline rolls", AppPreferences.getUseToolTipForInlineRoll());
     cinfo.addProperty("version", MapTool.getVersion());
     cinfo.addProperty(
         "isFullScreen", MapTool.getFrame().isFullScreen() ? BigDecimal.ONE : BigDecimal.ZERO);

--- a/src/main/java/net/rptools/maptool/server/ServerPolicy.java
+++ b/src/main/java/net/rptools/maptool/server/ServerPolicy.java
@@ -258,6 +258,9 @@ public class ServerPolicy {
     sinfo.addProperty(
         "hosting server", MapTool.isHostingServer() ? BigDecimal.ONE : BigDecimal.ZERO);
 
+    sinfo.addProperty(
+        "personal server", MapTool.isPersonalServer() ? BigDecimal.ONE : BigDecimal.ZERO);
+
     return sinfo;
   }
 }


### PR DESCRIPTION
…ersonal server indicator to getInfo("server").

#### Added to `getInfo("client")`:
- show avatar in chat
- suppress tooltips for macroLinks
- use tooltips for inline rolls
```json
{
  "face edge": 1,
  "face vertex": 0,
  "portrait size": 175,
  "show portrait": true,
  "show stat sheet": true,
  "file sync directory": "",
  "show avatar in chat": true,
  "suppress tooltips for macroLinks": false,
  "use tooltips for inline rolls": true,
  "version": "0.0.1",
  "isFullScreen": 0,
  "timeInMs": 1592519870334,
  "timeDate": "2020-06-18 18:37:50",
  "isoTimeDate": "2020-06-18T18:37:50.33516-04:00",
  "user defined functions": {},
  "client id": "7a024f3b-28db-4a65-8a75-c38765682621"
}
```

#### Added to `getInfo("server")`:
- personal server
```json
{
  "tooltips for default roll format": 1,
  "GM reveals vision for unowned tokens": 0,
  "players can reveal": 0,
  "auto reveal on movement": 0,
  "movement locked": 0,
  "token editor locked": 0,
  "restricted impersonation": 0,
  "individual views": 0,
  "individual fow": 0,
  "strict token management": 0,
  "players receive campaign macros": 0,
  "movement metric": "ONE_TWO_ONE",
  "using ai": 1,
  "vbl blocks movement": 1,
  "timeInMs": 1592519870371,
  "timeDate": "2020-06-18 18:37:50",
  "gm": ["theGM"],
  "hosting server": 0,
  "personal server": 1
}
```
Fixes RPTools/maptool#2032

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2033)
<!-- Reviewable:end -->
