### PR TITLE
Fix JVM cfg file loading

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -17,6 +17,16 @@ on:
       - feature*
       - release*
 jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "14"
+      - uses: axel-op/googlejavaformat-action@v3
+        with:
+          args: "--dry-run --skip-sorting-imports --replace"
   build:
     name: ${{ matrix.os }} w/JDK ${{ matrix.java }}
     runs-on:  ${{ matrix.os }}

--- a/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
-import java.util.ServiceConfigurationError;
 import java.util.stream.Stream;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
@@ -943,8 +942,12 @@ public class PreferencesDialog extends JDialog {
     fileSyncPath.setText(AppPreferences.getFileSyncPath());
 
     // get JVM User Defaults/User override preferences
+    loadUserCfg:
     try {
-      UserJvmOptions.loadAppCfg();
+      if (!UserJvmOptions.loadAppCfg()) {
+        tabbedPane.setEnabledAt(tabbedPane.indexOfTab("Startup"), false);
+        break loadUserCfg;
+      }
 
       jvmXmxTextField.setText(UserJvmOptions.getJvmOption(JVM_OPTION.MAX_MEM));
       jvmXmsTextField.setText(UserJvmOptions.getJvmOption(JVM_OPTION.MIN_MEM));
@@ -958,15 +961,8 @@ public class PreferencesDialog extends JDialog {
 
       jamLanguageOverrideComboBox.setSelectedItem(
           UserJvmOptions.getJvmOption(JVM_OPTION.LOCALE_LANGUAGE));
-    } catch (UnsatisfiedLinkError | NoClassDefFoundError | ServiceConfigurationError e) {
-      log.warn(
-          "Warning, unable to get JVM options from preferences. Most likely cause, manual launch of JAR.");
-      tabbedPane.setEnabledAt(tabbedPane.indexOfTab("Startup"), false);
     } catch (Exception e) {
-      log.error(
-          "Error getting JVM options from preferences. Most likely cause, manual launch of JAR.",
-          e);
-      tabbedPane.setEnabledAt(tabbedPane.indexOfTab("Startup"), false);
+      log.error("Unable to retrieve JVM user options!", e);
     }
 
     Integer rawVal = AppPreferences.getTypingNotificationDuration();

--- a/src/main/java/net/rptools/maptool/util/UserJvmOptions.java
+++ b/src/main/java/net/rptools/maptool/util/UserJvmOptions.java
@@ -72,7 +72,7 @@ public class UserJvmOptions {
     INIConfiguration iniConfiguration;
 
     File cfgFile = AppUtil.getAppCfgFile();
-    if(!cfgFile.exists()) {
+    if (!cfgFile.exists()) {
       return false;
     }
 
@@ -129,14 +129,25 @@ public class UserJvmOptions {
                 String newKey = key + jvmNodeConfiguration.getString(key);
                 jvmNodeConfiguration.setProperty(newKey, value);
                 jvmNodeConfiguration.clearProperty(key);
-                log.debug("Updating {}={} to {}={}", key, jvmNodeConfiguration.getString(key), newKey, value);
+                log.debug(
+                    "Updating {}={} to {}={}",
+                    key,
+                    jvmNodeConfiguration.getString(key),
+                    newKey,
+                    value);
               } else if (key.startsWith("-XX")) {
                 String value = "";
-                String newKey = key + ":" + jvmNodeConfiguration.getString(key).replaceAll("\\=","");
+                String newKey =
+                    key + ":" + jvmNodeConfiguration.getString(key).replaceAll("\\=", "");
                 jvmNodeConfiguration.setProperty(newKey, value);
                 jvmNodeConfiguration.clearProperty(key);
 
-                log.debug("Updating {}={} to {}={}", key, jvmNodeConfiguration.getString(key), newKey, value);
+                log.debug(
+                    "Updating {}={} to {}={}",
+                    key,
+                    jvmNodeConfiguration.getString(key),
+                    newKey,
+                    value);
               }
             });
 


### PR DESCRIPTION
Update JVM user preferences so it can load cfg file with dynamic filename based on release type.
Add special logic handling for -XX: type jvm parameters.
Updated error logging

Continued work against #1981

FYI: the cfg file reader/writer uses an apache config for INI files which is closest match to the jpackager cfg file. It can't handle parameters that do not match the normal `key=value` notations so special logic has to be added for any JVM parameters like `XX:+ShowCodeDetailsInExceptionMessages`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2035)
<!-- Reviewable:end -->
