### PR TITLE
Add optional param to capitalize() that uses only whitespace as word boundaries.

### DIFF
--- a/src/test/java/net/rptools/maptool/client/functions/StringFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/StringFunctionsTest.java
@@ -1,0 +1,62 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import net.rptools.parser.ParserException;
+import org.junit.jupiter.api.Test;
+
+public class StringFunctionsTest {
+  private final StringFunctions funcs = StringFunctions.getInstance();
+  private final String capitalize = "capitalize";
+
+  private Object submitStringFunction(String functionName, Object... params)
+      throws ParserException {
+    return funcs.childEvaluate(null, functionName, Arrays.asList(params));
+  }
+
+  @Test
+  public void testCapitalize() throws ParserException {
+    String string1 = "i'll do it. no you won't. like you'd know. i've seen you 1st.";
+    String cap1WithSymbolBoundaries =
+        "I'Ll Do It. No You Won'T. Like You'D Know. I'Ve Seen You 1St.";
+    String cap1WithWhitespaceBoundaries =
+        "I'll Do It. No You Won't. Like You'd Know. I've Seen You 1st.";
+    String string2 = "but o'shea works";
+    String cap2WithSymbolBoundaries = "But O'Shea Works";
+    String cap2WithWhiteSpaceBoundaries = "But O'shea Works";
+
+    assertEquals(
+        cap1WithSymbolBoundaries, submitStringFunction(capitalize, string1, BigDecimal.ONE));
+    assertEquals(
+        cap1WithWhitespaceBoundaries, submitStringFunction(capitalize, string1, BigDecimal.ZERO));
+    assertEquals(
+        cap1WithSymbolBoundaries,
+        submitStringFunction(capitalize, string1),
+        "use numbers and symbols as boundaries by default");
+
+    assertEquals(
+        cap2WithSymbolBoundaries, submitStringFunction(capitalize, string2, BigDecimal.ONE));
+    assertEquals(
+        cap2WithWhiteSpaceBoundaries, submitStringFunction(capitalize, string2, BigDecimal.ZERO));
+    assertEquals(
+        cap2WithSymbolBoundaries,
+        submitStringFunction(capitalize, string2),
+        "use numbers and symbols as boundaries by default");
+  }
+}


### PR DESCRIPTION
`capitalize()` will still use numbers and symbols as word boundaries (in addition to whitespace) by default, but passing in `0` for the new second parameter will make it use only whitespace.

`capitalize("o'shea, he'll see you 1st")` produces `O'Shea, He'Ll See You 1St`
`capitalize("o'shea, he'll see you 1st", 0)` produces `O'shea, He'll See You 1st`

Added unit test.

Fixes RPTools/maptool#1995

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2036)
<!-- Reviewable:end -->
