### PR TITLE
Fix error when clicking Move Up/Down with no bar selected

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/LayerSelectionDialog.java
+++ b/src/main/java/net/rptools/maptool/client/tool/LayerSelectionDialog.java
@@ -21,8 +21,6 @@ import javax.swing.DefaultListModel;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.FormPanelI18N;
 import net.rptools.maptool.model.Zone;
@@ -30,7 +28,7 @@ import net.rptools.maptool.model.Zone;
 public class LayerSelectionDialog extends JPanel {
 
   private final FormPanel panel;
-  private JList list;
+  private JList<Zone.Layer> list;
   private final LayerSelectionListener listener;
   private final Zone.Layer[] layerList;
 
@@ -50,7 +48,7 @@ public class LayerSelectionDialog extends JPanel {
 
     int index = list.getSelectedIndex();
     if (index >= 0 && listener != null) {
-      listener.layerSelected((Zone.Layer) list.getModel().getElementAt(index));
+      listener.layerSelected(list.getModel().getElementAt(index));
     }
   }
 
@@ -59,12 +57,12 @@ public class LayerSelectionDialog extends JPanel {
         .setSelectedValue(MapTool.getFrame().getCurrentZoneRenderer().getActiveLayer(), true);
   }
 
-  private JList getLayerList() {
+  private JList<Zone.Layer> getLayerList() {
 
     if (list == null) {
       list = panel.getList("layerList");
 
-      DefaultListModel model = new DefaultListModel();
+      DefaultListModel<Zone.Layer> model = new DefaultListModel<>();
       for (Zone.Layer layer : layerList) {
         model.addElement(layer);
       }
@@ -72,15 +70,12 @@ public class LayerSelectionDialog extends JPanel {
       list.setModel(model);
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       list.addListSelectionListener(
-          new ListSelectionListener() {
-
-            public void valueChanged(ListSelectionEvent e) {
-              if (e.getValueIsAdjusting()) {
-                return;
-              }
-
-              fireViewSelectionChange();
+          e -> {
+            if (e.getValueIsAdjusting()) {
+              return;
             }
+
+            fireViewSelectionChange();
           });
       list.setSelectedIndex(0);
     }
@@ -92,7 +87,7 @@ public class LayerSelectionDialog extends JPanel {
     list.setSelectedValue(layer, true);
   }
 
-  public static interface LayerSelectionListener {
+  public interface LayerSelectionListener {
     public void layerSelected(Zone.Layer layer);
   }
 }


### PR DESCRIPTION
- Fix Move Up and Move Down bar buttons in Campaign Properties -> Bars being enabled when they shouldn't, causing an ArrayIndexOutOfBoundsException if they are clicked
- Fix Update, Delete, Move Up and Move Down image buttons in Campaign Properties -> Bars being enabled when they shouldn't
- Change raw types to appropriate generics in TokenBarController and LayerSelectionDialog
- Close #2037

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2038)
<!-- Reviewable:end -->
