### PR TITLE
Fix issues where incorrectly cased function name resulted in the wron…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/AddAllToInitiativeFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/AddAllToInitiativeFunction.java
@@ -68,8 +68,8 @@ public class AddAllToInitiativeFunction extends AbstractFunction {
 
     // Handle the All functions
     List<Token> tokens = new ArrayList<Token>();
-    boolean all = functionName.equals("addAllToInitiative");
-    boolean pcs = functionName.equals("addAllPCsToInitiative");
+    boolean all = functionName.equalsIgnoreCase("addAllToInitiative");
+    boolean pcs = functionName.equalsIgnoreCase("addAllPCsToInitiative");
     for (Token token : list.getZone().getTokens())
       if ((all || token.getType() == Type.PC && pcs || token.getType() == Type.NPC && !pcs)
           && (allowDuplicates || list.indexOf(token).isEmpty())) {

--- a/src/main/java/net/rptools/maptool/client/functions/CurrentInitiativeFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/CurrentInitiativeFunction.java
@@ -62,9 +62,10 @@ public class CurrentInitiativeFunction extends AbstractFunction {
         throw new ParserException(I18N.getText("macro.function.initiative.oneParam", functionName));
       setCurrentInitiative(args.get(0));
       return args.get(0);
-    } else {
+    } else if (functionName.equalsIgnoreCase("getInitiativeToken")) {
       return getInitiativeToken();
     } // endif
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/DefineMacroFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DefineMacroFunction.java
@@ -99,7 +99,7 @@ public class DefineMacroFunction extends AbstractFunction {
         showFullLocations = FunctionUtil.paramAsBoolean(functionName, parameters, 1, false);
       }
       return UserDefinedMacroFunctions.getInstance().getDefinedFunctions(delim, showFullLocations);
-    } else { // isFunctionDefined
+    } else if ("isFunctionDefined".equalsIgnoreCase(functionName)) {
 
       if (UserDefinedMacroFunctions.getInstance().isFunctionDefined(parameters.get(0).toString())) {
         return BigDecimal.ONE;
@@ -111,5 +111,6 @@ public class DefineMacroFunction extends AbstractFunction {
 
       return BigDecimal.ZERO;
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/EvalMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/EvalMacroFunctions.java
@@ -58,9 +58,10 @@ public class EvalMacroFunctions extends AbstractFunction {
     // execMacro has new variable scope where as evalMacro does not.
     if (functionName.equals("execMacro")) {
       return execMacro(tokenInContext, parameters.get(0).toString());
-    } else {
+    } else if ("evalMacro".equalsIgnoreCase(functionName)) {
       return evalMacro(resolver, tokenInContext, parameters.get(0).toString());
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/InitiativeRoundFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InitiativeRoundFunction.java
@@ -48,7 +48,7 @@ public class InitiativeRoundFunction extends AbstractFunction {
       throws ParserException {
     if (functionName.equals("getInitiativeRound")) {
       return getInitiativeRound();
-    } else {
+    } else if ("setInitiativeRound".equalsIgnoreCase(functionName)) {
       if (args.size() != 1)
         throw new ParserException(I18N.getText("macro.function.setinitiativeRound.oneParam"));
       if (MapTool.getParser().isMacroTrusted()
@@ -59,6 +59,7 @@ public class InitiativeRoundFunction extends AbstractFunction {
         throw new ParserException(I18N.getText("macro.function.initiative.mustBeGM", functionName));
       } // endif
     } // endif
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/IsTrustedFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/IsTrustedFunction.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Player;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -43,8 +44,7 @@ public class IsTrustedFunction extends AbstractFunction {
       return MapTool.getParser().isMacroTrusted() ? BigDecimal.ONE : BigDecimal.ZERO;
     } else if (functionName.equalsIgnoreCase("isExternalMacroAccessAllowed")) {
       return AppPreferences.getAllowExternalMacroAccess() ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else {
-      // functionName is isGM
+    } else if ("isGM".equalsIgnoreCase(functionName)) {
       if (parameters.isEmpty())
         return MapTool.getPlayer().isGM() ? BigDecimal.ONE : BigDecimal.ZERO;
       else {
@@ -52,6 +52,7 @@ public class IsTrustedFunction extends AbstractFunction {
         return getGMs().contains(parameters.get(0)) ? BigDecimal.ONE : BigDecimal.ZERO;
       }
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/LastRolledFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LastRolledFunction.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonPrimitive;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.language.I18N;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
@@ -43,8 +44,11 @@ public class LastRolledFunction extends AbstractFunction {
       MapTool.getParser().getRolled().forEach(r -> jarr.add(new JsonPrimitive(r)));
     } else if (functionName.equalsIgnoreCase("clearRolls")) {
       MapTool.getParser().clearRolls();
-    } else {
+    } else if ("getNewRolls".equalsIgnoreCase(functionName)) {
       MapTool.getParser().getNewRolls().forEach(r -> jarr.add(new JsonPrimitive(r)));
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
     }
 
     return jarr;

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -403,7 +403,9 @@ public class LookupTableFunction extends AbstractFunction {
         } catch (NumberFormatException nfe) {
           return val;
         }
-      } else { // We want the image URI through tblImage or tableImage
+      } else if ("tableImage".equalsIgnoreCase(function)
+          || "tblImage"
+              .equalsIgnoreCase(function)) { // We want the image URI through tblImage or tableImage
 
         if (result.getImageId() == null) {
           return ""; // empty string if no image is found (#538)
@@ -427,6 +429,8 @@ public class LookupTableFunction extends AbstractFunction {
           assetId.append(i);
         }
         return assetId.toString();
+      } else {
+        throw new ParserException(I18N.getText("macro.function.general.unknownFunction", function));
       }
     }
   }

--- a/src/main/java/net/rptools/maptool/client/functions/MacroArgsFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroArgsFunctions.java
@@ -45,23 +45,25 @@ public class MacroArgsFunctions extends AbstractFunction {
 
     if (functionName.equals("argCount")) {
       return BigDecimal.valueOf(argCount);
+    } else if ("arg".equalsIgnoreCase(functionName)) {
+
+      if (parameters.size() != 1 || !(parameters.get(0) instanceof BigDecimal)) {
+        throw new ParserException(I18N.getText("macro.function.args.incorrectParam", "arg"));
+      }
+
+      int argNo = ((BigDecimal) parameters.get(0)).intValue();
+
+      if (argCount == 0 && argNo == 0) {
+        return parser.getVariable("macro.args");
+      }
+
+      if (argNo < 0 || argNo >= argCount) {
+        throw new ParserException(
+            I18N.getText("macro.function.args.outOfRange", "arg", argNo, argCount - 1));
+      }
+
+      return parser.getVariable("macro.args." + argNo);
     }
-
-    if (parameters.size() != 1 || !(parameters.get(0) instanceof BigDecimal)) {
-      throw new ParserException(I18N.getText("macro.function.args.incorrectParam", "arg"));
-    }
-
-    int argNo = ((BigDecimal) parameters.get(0)).intValue();
-
-    if (argCount == 0 && argNo == 0) {
-      return parser.getVariable("macro.args");
-    }
-
-    if (argNo < 0 || argNo >= argCount) {
-      throw new ParserException(
-          I18N.getText("macro.function.args.outOfRange", "arg", argNo, argCount - 1));
-    }
-
-    return parser.getVariable("macro.args." + argNo);
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
@@ -116,7 +116,7 @@ public class MacroLinkFunction extends AbstractFunction {
       linkArgs = args.size() > 2 ? args.get(2).toString() : "";
       linkTarget = args.size() > 3 ? args.get(3).toString() : "Impersonated";
 
-    } else { // execLink
+    } else if ("execLink".equalsIgnoreCase(functionName)) {
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
       }
@@ -145,6 +145,9 @@ public class MacroLinkFunction extends AbstractFunction {
       }
       sendExecLink(link, defer, targets);
       return "";
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
     }
 
     StringBuilder sb = new StringBuilder();

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -111,9 +111,10 @@ public class MapFunctions extends AbstractFunction {
       MapTool.serverCommand().putZone(newMap);
       return newMap.getName();
 
-    } else {
+    } else if ("getVisibleMapNames".equalsIgnoreCase(functionName)
+        || "getAllMapNames".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
-      boolean allMaps = functionName.equals("getAllMapNames");
+      boolean allMaps = functionName.equalsIgnoreCase("getAllMapNames");
 
       if (allMaps) checkTrusted(functionName);
 
@@ -132,6 +133,7 @@ public class MapFunctions extends AbstractFunction {
         return StringFunctions.getInstance().join(mapNames, delim);
       }
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/PlayerFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/PlayerFunctions.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.ObservableList;
 import net.rptools.maptool.model.Player;
 import net.rptools.parser.Parser;
@@ -42,7 +43,7 @@ public class PlayerFunctions extends AbstractFunction {
       throws ParserException {
     if (functionName.equals("getPlayerName")) {
       return MapTool.getPlayer().getName();
-    } else {
+    } else if ("getAllPlayerNames".equalsIgnoreCase(functionName)) {
       ObservableList<Player> players = MapTool.getPlayerList();
       String[] playerArray = new String[players.size()];
       Iterator<Player> iter = players.iterator();
@@ -61,5 +62,6 @@ public class PlayerFunctions extends AbstractFunction {
         return StringFunctions.getInstance().join(playerArray, delim);
       }
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/RemoveAllFromInitiativeFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RemoveAllFromInitiativeFunction.java
@@ -67,9 +67,10 @@ public class RemoveAllFromInitiativeFunction extends AbstractFunction {
     if (functionName.equals("removeAllFromInitiative")) {
       count = list.getSize();
       list.clearModel();
-    } else {
+    } else if ("removeAllNPCsFromInitiative".equalsIgnoreCase(functionName)
+        || "removeAllPCsFromInitiative".equalsIgnoreCase(functionName)) {
       list.startUnitOfWork();
-      boolean pcs = functionName.equals("removeAllPCsFromInitiative");
+      boolean pcs = functionName.equalsIgnoreCase("removeAllPCsFromInitiative");
       for (int i = list.getSize() - 1; i >= 0; i--) {
         Token token = list.getTokenInitiative(i).getToken();
         if (token.getType() == Type.PC && pcs || token.getType() == Type.NPC && !pcs) {
@@ -80,7 +81,10 @@ public class RemoveAllFromInitiativeFunction extends AbstractFunction {
       list.setRound(-1);
       list.setCurrent(-1);
       list.finishUnitOfWork();
-    } // endif
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
+    }
     return new BigDecimal(count);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java
@@ -62,12 +62,13 @@ public class TokenBarFunction extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, parameters, 1, 2);
       return isVisible(token, bar);
-    } else { // setBarVisible
+    } else if ("setBarVisible".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 4);
       boolean visible = FunctionUtil.paramAsBoolean(functionName, parameters, 1, true);
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, parameters, 2, 3);
       return setVisible(token, bar, visible);
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenGMNameFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenGMNameFunction.java
@@ -49,12 +49,13 @@ public class TokenGMNameFunction extends AbstractFunction {
       FunctionUtil.checkNumberParam("getGMName", args, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 0, 1);
       return getGMName(token);
-    } else {
+    } else if ("setGMName".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam("setGMName", args, 1, 3);
       String gmName = args.get(0).toString();
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 1, 2);
       return setGMName(token, gmName);
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenHaloFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenHaloFunction.java
@@ -50,9 +50,10 @@ public class TokenHaloFunction extends AbstractFunction {
 
     if (functionName.equals("getHalo")) {
       return getHalo(parser, args);
-    } else {
+    } else if ("setHalo".equalsIgnoreCase(functionName)) {
       return setHalo(parser, args);
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -192,11 +192,15 @@ public class TokenImage extends AbstractFunction {
         return "";
       }
       assetId.append(token.getImageAssetId().toString());
-    } else { // getTokenHandout, or different capitalization
+    } else if ("getTokenHandout"
+        .equalsIgnoreCase(functionName)) { // getTokenHandout, or different capitalization
       if (token.getCharsheetImage() == null) {
         return "";
       }
       assetId.append(token.getCharsheetImage().toString());
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
     }
 
     if (indexSize >= 0

--- a/src/main/java/net/rptools/maptool/client/functions/TokenInitFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenInitFunction.java
@@ -60,12 +60,13 @@ public class TokenInitFunction extends AbstractFunction {
       String state = args.size() > 1 && !"".equals(args.get(1)) ? args.get(1).toString() : null;
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 2, 3);
       return addToInitiative(allowDuplicates, state, token);
-    } else { // setInitiative
+    } else if ("setInitiative".equalsIgnoreCase(functionName)) { // setInitiative
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
       String value = args.get(0).toString();
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 1, 2);
       return setInitiative(token, value);
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenInitHoldFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenInitHoldFunction.java
@@ -52,12 +52,13 @@ public class TokenInitHoldFunction extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, args, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 0, 1);
       return getInitiativeHold(token);
-    } else {
+    } else if ("setInitiativeHold".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
       boolean set = FunctionUtil.paramAsBoolean(functionName, args, 0, true);
       Token token = FunctionUtil.getTokenFromParam(parser, functionName, args, 1, 2);
       return setInitiativeHold(token, set);
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLabelFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLabelFunction.java
@@ -61,9 +61,10 @@ public class TokenLabelFunction extends AbstractFunction {
       throws ParserException {
     if (functionName.equals("getLabel")) {
       return getLabel(parser, args);
-    } else {
+    } else if ("setLabel".equalsIgnoreCase(functionName)) {
       return setLabel(parser, args);
     }
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenNameFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenNameFunction.java
@@ -48,7 +48,7 @@ public class TokenNameFunction extends AbstractFunction {
     if (functionName.equalsIgnoreCase("getName")) {
       FunctionUtil.checkNumberParam(functionName, args, 0, 2);
       token = FunctionUtil.getTokenFromParam(parser, functionName, args, 0, 1);
-    } else {
+    } else if ("setName".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
       String name = args.get(0).toString();
       token = FunctionUtil.getTokenFromParam(parser, functionName, args, 1, 2);
@@ -58,6 +58,9 @@ public class TokenNameFunction extends AbstractFunction {
             I18N.getText("macro.function.tokenName.emptyTokenNameForbidden", "setName"));
       }
       setName(token, name);
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
     }
     return token.getName();
   }


### PR DESCRIPTION
…g function being called, and make explicit some functions that were case-insensitive by virtue of being the default execution branch.

This handles 32 identified "Wrong Function" cases, and makes explicit 23 functions that were "accidental" case-insensitive via default executions.  The remaining instance of each of those is in dicelib, so there will be a separate PR there.

Part of RPTools/maptool#2041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2051)
<!-- Reviewable:end -->
