### PR TITLE
Replace special (varied) return values with ParserExceptions when fun…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
@@ -112,6 +112,6 @@ public class ExportDataFunctions extends AbstractFunction {
       }
     }
 
-    return BigDecimal.ZERO;
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
@@ -373,6 +373,6 @@ public class HeroLabFunctions extends AbstractFunction {
       return token.getHeroLabData().getMinionMasterName();
     }
 
-    return "<ERROR>";
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -24,6 +24,7 @@ import net.rptools.maptool.client.ui.htmlframe.HTMLDialog;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrame;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrameFactory;
 import net.rptools.maptool.client.ui.htmlframe.HTMLOverlayManager;
+import net.rptools.maptool.language.I18N;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.AbstractFunction;
@@ -96,7 +97,7 @@ public class MacroDialogFunctions extends AbstractFunction {
       return getOverlayProperties(name);
     }
 
-    return null;
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
@@ -340,9 +340,6 @@ public class MathFunctions extends AbstractFunction {
     } else if ("math.toRadians".equals(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toRadians(nparam.get(0).doubleValue()));
-    } else if ("math.toRadians".equals(functionName)) {
-      List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
-      return BigDecimal.valueOf(Math.toRadians(nparam.get(0).doubleValue()));
     } else if ("math.toDegrees".equals(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toDegrees(nparam.get(0).doubleValue()));
@@ -415,7 +412,7 @@ public class MathFunctions extends AbstractFunction {
       return getMedian(theValues);
     }
 
-    return "";
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/ParserPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ParserPropertyFunctions.java
@@ -97,6 +97,9 @@ public class ParserPropertyFunctions extends AbstractFunction {
     } else if (functionName.equals("setMaxLoopIterations")) {
       mtlParser.setMaxLoopIterations(argVal);
       returnVal = mtlParser.getMaxLoopIterations();
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
     }
 
     return BigDecimal.valueOf(returnVal);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -188,7 +188,7 @@ public class TokenMoveFunctions extends AbstractFunction {
                 "macro.function.general.wrongNumParam", functionName, 2, parameters.size()));
       }
     }
-    return null;
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 
   private List<Map<String, Integer>> crossedToken(

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
@@ -22,6 +22,7 @@ import java.util.List;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
@@ -56,10 +57,11 @@ public class TokenSightFunctions extends AbstractFunction {
       throws ParserException {
     Token token;
     // For functions no parameters except option tokenID and mapname
-    if (functionName.equals("hasSight") || functionName.equals("getSightType")) {
+    if (functionName.equalsIgnoreCase("hasSight")
+        || functionName.equalsIgnoreCase("getSightType")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       token = FunctionUtil.getTokenFromParam(parser, functionName, parameters, 0, 1);
-      if (functionName.equals("hasSight"))
+      if (functionName.equalsIgnoreCase("hasSight"))
         return token.getHasSight() ? BigDecimal.ONE : BigDecimal.ZERO;
 
       // if (functionName.equals("getSightType"))
@@ -156,6 +158,6 @@ public class TokenSightFunctions extends AbstractFunction {
       return sb.toString();
     }
 
-    return "";
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSpeechFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSpeechFunctions.java
@@ -77,6 +77,6 @@ public class TokenSpeechFunctions extends AbstractFunction {
         return StringFunctions.getInstance().join(token.getSpeechNames().toArray(speech), delim);
       }
     }
-    return null;
+    throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/VBL_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/VBL_Functions.java
@@ -129,9 +129,7 @@ public class VBL_Functions extends AbstractFunction {
             break;
         }
       }
-    }
-
-    if (functionName.equals("getVBL")) {
+    } else if (functionName.equals("getVBL")) {
       boolean simpleJSON = false; // If true, send only array of x,y
 
       if (parameters.size() > 2) {
@@ -180,9 +178,7 @@ public class VBL_Functions extends AbstractFunction {
         }
       }
       return getAreaPoints(vblArea, simpleJSON);
-    }
-
-    if (functionName.equals("getTokenVBL")) {
+    } else if (functionName.equals("getTokenVBL")) {
       Token token;
 
       if (parameters.size() == 1) {
@@ -213,9 +209,7 @@ public class VBL_Functions extends AbstractFunction {
       } else {
         return "";
       }
-    }
-
-    if (functionName.equals("setTokenVBL")) {
+    } else if (functionName.equals("setTokenVBL")) {
       Token token = null;
 
       if (parameters.size() > 2) {
@@ -301,9 +295,7 @@ public class VBL_Functions extends AbstractFunction {
       }
       // Replace with new VBL
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setVBL, tokenVBL);
-    }
-
-    if (functionName.equals("transferVBL")) {
+    } else if (functionName.equals("transferVBL")) {
       Token token = null;
 
       if (parameters.size() > 3) {
@@ -376,6 +368,9 @@ public class VBL_Functions extends AbstractFunction {
           TokenVBL.renderVBL(renderer, vbl, true);
         }
       }
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.general.unknownFunction", functionName));
     }
 
     if (results >= 0) {


### PR DESCRIPTION
…ctions are called with incorrect case.

The `getSightType()` and `hasSight()` functions are now explicitly case-insensitive as the least disruptive code change to avoid an odd user experience where using the improper case would have produced an error message incorrectly advising the use of additional parameters.

Other functions from the "Return Value" category have been standardized to produce ParserExceptions instead of the special return values.

This takes care of the "Return Value" instances from within the MT project itself - the RollWithBounds class is in dicelib, so another PR will be coming there.

As a side note, I removed a duplicate block that was making a redundant check for the `math.toRadians()` function.

Part of #2041 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2059)
<!-- Reviewable:end -->
