### PR TITLE
Optimize for performance by only using deterministic parser where needed

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1382,7 +1382,7 @@ public class MapTool {
   }
 
   public static boolean useToolTipsForUnformatedRolls() {
-    if (isPersonalServer()) {
+    if (isPersonalServer() || getServerPolicy() == null) {
       return AppPreferences.getUseToolTipForInlineRoll();
     } else {
       return getServerPolicy().getUseToolTipsForDefaultRollFormat();

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -631,7 +631,7 @@ public class MapToolLineParser {
       Object retval = params[index];
       // No parsing is done if the param isn't a String (e.g. it's already a BigDecimal)
       if (params[index] instanceof String) {
-        Result result = parseExpression(res, tokenInContext, (String) params[index], true);
+        Result result = parseExpression(res, tokenInContext, (String) params[index], false);
         retval = result.getValue();
       }
       return retval;
@@ -737,7 +737,6 @@ public class MapToolLineParser {
   public String parseLine(
       MapToolVariableResolver res, Token tokenInContext, String line, MapToolMacroContext context)
       throws ParserException {
-
     // copy previous rolls and clear out for new rolls.
     if (parserRecurseDepth == 0 && macroRecurseDepth == 0) {
       lastRolled.clear();
@@ -854,7 +853,7 @@ public class MapToolLineParser {
                   outputOpts.add("w");
                   for (int i = 0; i < option.getParamCount(); i++) {
                     String arg =
-                        parseExpression(resolver, tokenInContext, option.getStringParam(i), true)
+                        parseExpression(resolver, tokenInContext, option.getStringParam(i), false)
                             .getValue()
                             .toString();
                     if (arg.trim().startsWith("[")) {
@@ -952,7 +951,7 @@ public class MapToolLineParser {
                     String listDelim = option.getStringParam(3);
                     if (listDelim.trim().startsWith("\"")) {
                       listDelim =
-                          parseExpression(resolver, tokenInContext, listDelim, true)
+                          parseExpression(resolver, tokenInContext, listDelim, false)
                               .getValue()
                               .toString();
                     }
@@ -1147,7 +1146,7 @@ public class MapToolLineParser {
                     (loopCondition == null) ? null : String.format("if(%s, 1, 0)", loopCondition);
                 // Stop loop if the while condition is false
                 try {
-                  Result result = parseExpression(resolver, tokenInContext, hackCondition, true);
+                  Result result = parseExpression(resolver, tokenInContext, hackCondition, false);
                   loopConditionValue = ((Number) result.getValue()).intValue();
                   if (loopConditionValue == 0) {
                     doLoop = false;
@@ -1161,7 +1160,7 @@ public class MapToolLineParser {
             // Output the loop separator
             if (doLoop && iteration != 0 && output != Output.NONE) {
               expressionBuilder.append(
-                  parseExpression(resolver, tokenInContext, loopSep, true).getValue());
+                  parseExpression(resolver, tokenInContext, loopSep, false).getValue());
             }
 
             if (!doLoop) {
@@ -1182,7 +1181,7 @@ public class MapToolLineParser {
               }
               Result result = null;
               try {
-                result = parseExpression(resolver, tokenInContext, hackCondition, true);
+                result = parseExpression(resolver, tokenInContext, hackCondition, false);
               } catch (Exception e) {
                 throw doError(
                     I18N.getText(
@@ -1328,10 +1327,10 @@ public class MapToolLineParser {
                      * TODO: If you're adding a new formatting option, add a new case to build the output
                      */
                   case NONE:
-                    parseExpression(resolver, tokenInContext, rollBranch, true);
+                    parseExpression(resolver, tokenInContext, rollBranch, false);
                     break;
                   case RESULT:
-                    result = parseExpression(resolver, tokenInContext, rollBranch, true);
+                    result = parseExpression(resolver, tokenInContext, rollBranch, false);
                     output_text = result != null ? result.getValue().toString() : "";
                     if (!this.isMacroTrusted()) {
                       output_text =
@@ -1359,7 +1358,7 @@ public class MapToolLineParser {
                       }
                       resolver.setVariable("roll.result", result.getValue());
                       output_text =
-                          parseExpression(resolver, tokenInContext, text, true)
+                          parseExpression(resolver, tokenInContext, text, false)
                               .getValue()
                               .toString();
                     }
@@ -1389,9 +1388,9 @@ public class MapToolLineParser {
                  */
               case MACRO:
                 // [MACRO("macroName@location"): args]
-                result = parseExpression(resolver, tokenInContext, macroName, true);
+                result = parseExpression(resolver, tokenInContext, macroName, false);
                 String callName = result.getValue().toString();
-                result = parseExpression(resolver, tokenInContext, rollBranch, true);
+                result = parseExpression(resolver, tokenInContext, rollBranch, false);
                 String macroArgs = result.getValue().toString();
 
                 try {
@@ -1473,7 +1472,7 @@ public class MapToolLineParser {
           }
         } else if (match.getMatch().startsWith("{")) {
           roll = match.getRoll();
-          Result result = parseExpression(resolver, tokenInContext, roll, true);
+          Result result = parseExpression(resolver, tokenInContext, roll, false);
           if (isMacroTrusted()) {
             builder.append(result != null ? result.getValue().toString() : "");
           } else {
@@ -1511,12 +1510,15 @@ public class MapToolLineParser {
         // This is the top level call, time to clean up
         resolver.flush();
       }
-      // If we have exited the last context let the html frame we have (potentially)
-      // updated a token.
-      if (contextStackEmpty()) {
-        HTMLFrameFactory.tokenChanged(tokenInContext);
+      if (MapTool.getFrame() != null) {
+        // If we have exited the last context let the html frame we have (potentially)
+        // updated a token.
+        if (contextStackEmpty() && tokenInContext != null) {
+          HTMLFrameFactory.tokenChanged(tokenInContext);
+        }
+        // Repaint incase macros changed anything.
+        MapTool.getFrame().refresh();
       }
-      MapTool.getFrame().refresh(); // Repaint incase macros changed anything.
     }
   }
 

--- a/src/test/java/net/rptools/maptool/client/MapToolLineParserTest.java
+++ b/src/test/java/net/rptools/maptool/client/MapToolLineParserTest.java
@@ -1,0 +1,189 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+import net.rptools.common.expression.Result;
+import net.rptools.maptool.model.MacroButtonProperties;
+import net.rptools.maptool.model.Token;
+import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
+import org.junit.jupiter.api.Test;
+
+public class MapToolLineParserTest {
+
+  private static final MapToolLineParser parser = MapTool.getParser();
+
+  private Result parseExpression(
+      String expression, boolean makeDeterministic, Token tokenInContext, VariableResolver resolver)
+      throws ParserException {
+    return parser.parseExpression(
+        resolver == null ? new MapToolVariableResolver(null) : resolver,
+        tokenInContext,
+        expression,
+        makeDeterministic);
+  }
+
+  private void assertEqualsIgnoreSpaces(String expected, String actual) {
+    assertEquals(expected.replaceAll(" ", ""), actual.replaceAll(" ", ""));
+  }
+
+  private void assertMatches(String expected, String actual) {
+    expected = expected.replace("(", "\\(").replace(")", "\\)");
+    assertLinesMatch(Collections.singletonList(expected), Collections.singletonList(actual));
+  }
+
+  private String parseLine(String line, Token tokenInContext, MapToolVariableResolver resolver)
+      throws ParserException {
+    MapToolMacroContext ctx = new MapToolMacroContext("test", line, true);
+    return parser.parseLine(
+        resolver == null ? new MapToolVariableResolver(tokenInContext) : resolver,
+        tokenInContext,
+        line,
+        ctx);
+  }
+
+  @Test
+  public void testMacros() throws ParserException {
+
+    // no branch
+    assertEquals("a var gives 1", parseLine("a var gives [r: a = 1]", null, null));
+
+    // branch type if
+    assertEquals(
+        "a condition leads to 1",
+        parseLine("a condition leads to [r: if(1 == 1, 1, 0)]", null, null));
+    assertEquals(
+        "a d10 roll is always a No Critical Hit",
+        parseLine(
+            "a d10 roll[h: d20roll = 1d10] is always a [r,if(d20roll == 20): output = \"Critical Hit\"; output = \"No Critical Hit\"]",
+            null,
+            null));
+    assertEquals(
+        "a hidden evaluation gives nothing",
+        parseLine("a hidden evaluation gives nothing[h: if(1 == 1, 1, 0)]", null, null));
+    // expanded rolls contain MessagePanel's ASCII control characters that mark of roll information
+    assertMatches(
+        "expanded roll shows ...if(1 == 1, 1, 0) = 1.",
+        parseLine("expanded roll shows [if(1 == 1, 1, 0)]", null, null));
+
+    // branch type count loop
+    assertEquals(
+        "a loop yields hit, hit, hit",
+        parseLine("a loop yields [r, count(3): \"hit\" ]", null, null));
+
+    // branch type switch
+    assertEquals(
+        "switched is 1",
+        parseLine(
+            "switched is [h:a=1][r,switch(a): case 0: 0; case 1: 1; case 2: 2; default: -1]",
+            null,
+            null));
+
+    // eval macro
+    assertEquals("got evaluated", parseLine("got [r: evalMacro('[r:\"evaluated\"]')]", null, null));
+
+    // macro
+    MacroButtonProperties macro = new MacroButtonProperties(0);
+    macro.setLabel("testMacro");
+    macro.setCommand("[r:macro.args]");
+
+    Token token = new Token();
+    token.saveMacro(macro);
+
+    assertEquals(
+        "hello world", parseLine("hello [MACRO(\"testMacro@TOKEN\"): \"world\"]", token, null));
+  }
+
+  @Test
+  public void testConditional() throws ParserException {
+
+    // if , deterministic
+    String ifcondition = "if(1==1,\"match\",\"no match\")";
+    Result result = parseExpression(ifcondition, true, null, null);
+    assertEquals(result.getValue(), "match");
+    assertEquals(result.getDetailExpression(), "match");
+
+    // if, non deterministic
+    ifcondition = "if(1==1,\"match\",\"no match\")";
+    result = parseExpression(ifcondition, false, null, null);
+    assertEquals("match", result.getValue());
+    assertEqualsIgnoreSpaces(ifcondition, result.getDetailExpression());
+
+    // if, deterministic
+    ifcondition = "if(1<2,\"match\",\"no match\")";
+    result = parseExpression(ifcondition, true, null, null);
+    assertEquals("match", result.getValue());
+    assertEquals("match", result.getDetailExpression());
+
+    // if, non deterministic, the result is equal to deterministic but detailed expression is not
+    // resolved to a deterministic value
+    ifcondition = "if(1<2,\"match\",\"no match\")";
+    result = parseExpression(ifcondition, false, null, null);
+    assertEquals("match", result.getValue());
+    assertEqualsIgnoreSpaces(ifcondition, result.getDetailExpression());
+  }
+
+  @Test
+  public void testValue() throws ParserException {
+
+    MapToolVariableResolver resolver = new MapToolVariableResolver(null);
+
+    // "match" + "this", deterministic
+    Result result = parseExpression("\"match\"+\"this\"", true, null, resolver);
+    assertEquals("matchthis", result.getValue());
+    assertEquals("\"match\" + \"this\"", result.getDetailExpression());
+
+    // "match" + "this", non deterministic
+    result = parseExpression("\"match\"+\"this\"", false, null, resolver);
+    assertEquals("matchthis", result.getValue());
+    assertEquals("\"match\" + \"this\"", result.getDetailExpression());
+  }
+
+  @Test
+  public void testExpression() throws ParserException {
+
+    MapToolVariableResolver resolver = new MapToolVariableResolver(null);
+
+    // a = 1, deterministic
+    Result result = parseExpression("a = 1", true, null, resolver);
+    assertEquals(result.getValue(), BigDecimal.ONE);
+    assertEquals(resolver.getVariable("a"), BigDecimal.ONE);
+    assertEquals(result.getDetailExpression(), "a = 1");
+
+    // a = a * 10, deterministic
+    result = parseExpression("a = a * 10", true, null, resolver);
+    assertEquals(result.getValue(), BigDecimal.TEN);
+    assertEquals(resolver.getVariable("a"), BigDecimal.TEN);
+    assertEquals(result.getDetailExpression(), "a = (1 * 10)");
+
+    // a = 1, non-deterministic
+    result = parseExpression("a = 1", false, null, resolver);
+    assertEquals(result.getValue(), BigDecimal.ONE);
+    assertEquals(resolver.getVariable("a"), BigDecimal.ONE);
+    assertEquals(result.getDetailExpression(), "a = 1");
+
+    // a = a * 10
+    result = parseExpression("a = a * 10", false, null, resolver);
+    assertEquals(result.getValue(), BigDecimal.TEN);
+    assertEquals(resolver.getVariable("a"), BigDecimal.TEN);
+    assertEquals(result.getDetailExpression(), "a = (a * 10)");
+  }
+}

--- a/src/test/java/net/rptools/maptool/client/MapToolLineParserTest.java
+++ b/src/test/java/net/rptools/maptool/client/MapToolLineParserTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 import java.math.BigDecimal;
 import java.util.Collections;
-
 import net.rptools.common.expression.Result;
 import net.rptools.maptool.model.MacroButtonProperties;
 import net.rptools.maptool.model.Token;


### PR DESCRIPTION
(TOOLTIP, expandRoll). This makes headless macros (those that work with h and r roll options) faster as no deterministic AST tree is generated within parser.

Added unit tests for macro branch roll options that previously failed.

Unit testing MapToolLineParser is difficult as it's not truly headless. There are calls to static methods that fail, so I hardened a bit where needed.

fixes #1898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2062)
<!-- Reviewable:end -->
