### PR TITLE
Fix onChangeToken firing on mouseover

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1511,12 +1511,7 @@ public class MapToolLineParser {
         resolver.flush();
       }
       if (MapTool.getFrame() != null) {
-        // If we have exited the last context let the html frame we have (potentially)
-        // updated a token.
-        if (contextStackEmpty() && tokenInContext != null) {
-          HTMLFrameFactory.tokenChanged(tokenInContext);
-        }
-        // Repaint incase macros changed anything.
+        // Repaint in case macros changed anything.
         MapTool.getFrame().refresh();
       }
     }


### PR DESCRIPTION
- Fix onChangeToken incorrectly firing after parsing MTScript that doesn't change any token, including evaluating the stat sheet variables
- Close #2078

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2079)
<!-- Reviewable:end -->
