### PR TITLE
Fix regression in using user defined functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolExpressionParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolExpressionParser.java
@@ -80,7 +80,6 @@ public class MapToolExpressionParser extends ExpressionParser {
               TokenSpeechFunctions.getInstance(),
               TokenStateFunction.getInstance(),
               TokenVisibleFunction.getInstance(),
-              UserDefinedMacroFunctions.getInstance(),
               isVisibleFunction.getInstance(),
               getInfoFunction.getInstance(),
               TokenMoveFunctions.getInstance(),
@@ -138,6 +137,24 @@ public class MapToolExpressionParser extends ExpressionParser {
         expressionCache.put(expression, exp);
       }
       return exp;
+    }
+
+    /**
+     * Functions are only passed to the parser once, on initial create User defined functions are
+     * injected here if defined in UserDefinedMacroFunctions
+     *
+     * @param functionName the name of the function
+     * @return Either user defined function or function known to parser
+     */
+    @Override
+    public Function getFunction(String functionName) {
+
+      // check user defined functions first
+      UserDefinedMacroFunctions userFunctions = UserDefinedMacroFunctions.getInstance();
+      if (userFunctions.isFunctionDefined(functionName)) return userFunctions;
+
+      // let parser do its thing
+      return super.getFunction(functionName);
     }
   }
 }

--- a/src/test/java/net/rptools/maptool/client/functions/UserDefinedMacroTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/UserDefinedMacroTest.java
@@ -1,0 +1,51 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import net.rptools.maptool.client.*;
+import net.rptools.maptool.model.MacroButtonProperties;
+import net.rptools.maptool.model.Token;
+import net.rptools.parser.ParserException;
+import org.junit.jupiter.api.Test;
+
+public class UserDefinedMacroTest {
+
+  @Test
+  public void testUserDefinedFunction() throws ParserException {
+
+    // create a new macro of name mymacro that returns some text and argument passed in
+    MacroButtonProperties macro = new MacroButtonProperties(0);
+    macro.setLabel("mymacro");
+    macro.setCommand("[r:'got parameter ' + arg(0)]");
+
+    // create a token w/macro
+    Token token = new Token();
+    token.saveMacro(macro);
+
+    // setup evaluation, trusted, on token
+    MapToolVariableResolver resolver = new MapToolVariableResolver(token);
+    MapTool.getParser().enterContext(new MapToolMacroContext("test", "test", true));
+
+    // define myfunction
+    MapToolExpressionParser parser = new MapToolExpressionParser();
+    parser.evaluate("defineFunction('myfunction', 'mymacro@TOKEN')", resolver);
+
+    // evaluate myfunction that should call mymacro on token
+    assertEquals(
+        "got parameter Hello", parser.evaluate("myfunction('Hello')", resolver).getValue());
+  }
+}


### PR DESCRIPTION
They are defined after the caching parser has been instantiated. Previously any additional defineFunction would be fed to a new (non caching) instance of Parser.

Reworked the CachingParser to handle the lookup of those user defined functions instead. Added unittest for user defined functions.

fixes #1898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2100)
<!-- Reviewable:end -->
