### PR TITLE
Minor error message key fix introduced in 1263 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2489,7 +2489,7 @@ public class AppActions {
       } catch (Throwable t) {
         if (t.getCause() instanceof AppState.FailedToAcquireLockException)
           MapTool.showError("msg.error.failedLoadCampaignLock");
-        else MapTool.showError("msg.error.failedSaveCampaign", t.getCause());
+        else MapTool.showError("msg.error.failedLoadCampaign", t.getCause());
       }
     }
   }


### PR DESCRIPTION
Maptool is showing save campaign error-text if a load error occurs

I can create an issue if you want to to track this as such.

#1263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2115)
<!-- Reviewable:end -->
