### PR TITLE
Improve efficiency and avoid repeated redraws when importing macrosets.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
@@ -20,6 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JFileChooser;
@@ -349,149 +352,127 @@ public class ButtonGroupPopupMenu extends JPopupMenu {
       final File selectedFile = chooser.getSelectedFile();
       EventQueue.invokeLater(
           new Runnable() {
+            /**
+             * Handles imports to a token-based panel (Selected or Impersonated). De-conflicts
+             * within the context of the given token.
+             *
+             * @param newButtonProps the loaded macro buttons to import
+             * @param token the Token receiving the new macros
+             */
+            public void addMacrosToToken(List<MacroButtonProperties> newButtonProps, Token token) {
+              List<MacroButtonProperties> existingMacros = token.getMacroList(true);
+              Map<Integer, MacroButtonProperties> existingForComparison =
+                  existingMacros.stream()
+                      .collect(
+                          Collectors.toMap(
+                              MacroButtonProperties::hashCodeForComparison, Function.identity()));
+              List<MacroButtonProperties> toAdd = new ArrayList<>(newButtonProps.size());
+              int nextIndex = token.getMacroNextIndex();
+              String tokenName = token.getName();
+              if (MapTool.getPlayer().isGM()) {
+                if (token.getGMName() != null) {
+                  if (!token.getGMName().equals("")) {
+                    tokenName = tokenName + "(" + token.getGMName() + ")";
+                  }
+                }
+              }
+              for (MacroButtonProperties nextProps : newButtonProps) {
+                Integer code = nextProps.hashCodeForComparison();
+                boolean shouldAdd = true;
+                if (existingForComparison.containsKey(code)) {
+                  // confirmImport is inverted?
+                  shouldAdd =
+                      !confirmImport(
+                          nextProps, I18N.getText("confirm.macro.tokenLocation", tokenName));
+                }
+                if (shouldAdd) {
+                  MacroButtonProperties theMacro =
+                      new MacroButtonProperties(token, nextIndex++, nextProps, false);
+                  toAdd.add(theMacro);
+                  existingForComparison.put(theMacro.hashCodeForComparison(), theMacro);
+                }
+              }
+              if (!toAdd.isEmpty()) {
+                MapTool.serverCommand()
+                    .updateTokenProperty(token, Token.Update.saveMacroList, toAdd, false);
+              }
+            }
+
+            /**
+             * Handles imports to the Global, Campaign, or GM panels.
+             *
+             * @param newButtonProps the loaded macro buttons to import
+             */
+            public void addMacrosToGeneralPanel(List<MacroButtonProperties> newButtonProps) {
+              List<MacroButtonProperties> existingMacros;
+              String locationText;
+              if ("GlobalPanel".equals(panelClass)) {
+                existingMacros = MacroButtonPrefs.getButtonProperties();
+                locationText =
+                    I18N.getText("confirm.macro.panelLocation", I18N.getText("panel.Global"));
+              } else if ("CampaignPanel".equals(panelClass)) {
+                existingMacros = MapTool.getCampaign().getMacroButtonPropertiesArray();
+                locationText =
+                    I18N.getText("confirm.macro.panelLocation", I18N.getText("panel.Campaign"));
+              } else if ("GmPanel".equals(panelClass)) {
+                existingMacros = MapTool.getCampaign().getGmMacroButtonPropertiesArray();
+                locationText =
+                    I18N.getText("confirm.macro.panelLocation", I18N.getText("panel.Gm"));
+              } else {
+                throw new IllegalStateException("Error importing macros - panelClass changed?");
+              }
+              Map<Integer, MacroButtonProperties> existingForComparison =
+                  existingMacros.stream()
+                      .collect(
+                          Collectors.toMap(
+                              MacroButtonProperties::hashCodeForComparison, Function.identity()));
+              List<MacroButtonProperties> toAdd = new ArrayList<>(newButtonProps.size());
+              for (MacroButtonProperties nextProps : newButtonProps) {
+                Integer code = nextProps.hashCodeForComparison();
+                boolean shouldAdd = true;
+                if (existingForComparison.containsKey(code)) {
+                  // confirmImport is inverted?
+                  shouldAdd = !confirmImport(nextProps, locationText);
+                }
+                if (shouldAdd) {
+                  MacroButtonProperties theMacro =
+                      new MacroButtonProperties(panelClass, 0, nextProps, false);
+                  toAdd.add(theMacro);
+                  existingForComparison.put(theMacro.hashCodeForComparison(), theMacro);
+                }
+              }
+              if ("GlobalPanel".equals(panelClass)) {
+                MacroButtonPrefs.saveMacroButtonsAtNextIndex(toAdd);
+              } else if ("CampaignPanel".equals(panelClass)) {
+                MapTool.getCampaign().addMacroButtonPropertiesAtNextIndex(toAdd, false);
+              } else if ("GmPanel".equals(panelClass)) {
+                MapTool.getCampaign().addMacroButtonPropertiesAtNextIndex(toAdd, true);
+              }
+            }
+
             public void run() {
               try {
                 List<MacroButtonProperties> newButtonProps =
                     PersistenceUtil.loadMacroSet(selectedFile);
                 Boolean alreadyExists;
                 if (newButtonProps != null) {
-                  for (MacroButtonProperties nextProps : newButtonProps) {
-                    alreadyExists = false;
-                    if (panelClass.equals("GlobalPanel")) {
-                      for (MacroButtonProperties nextMacro :
-                          MacroButtonPrefs.getButtonProperties()) {
-                        if (nextProps.hashCodeForComparison()
-                            == nextMacro.hashCodeForComparison()) {
-                          alreadyExists = true;
-                        }
-                      }
-                      if (alreadyExists) {
-                        alreadyExists =
-                            confirmImport(
-                                nextProps,
-                                I18N.getText(
-                                    "confirm.macro.panelLocation", I18N.getText("panel.Global")));
-                      }
-                      if (!alreadyExists) {
-                        new MacroButtonProperties(
-                            panelClass, MacroButtonPrefs.getNextIndex(), nextProps);
-                      }
-                    } else if (panelClass.equals("CampaignPanel")) {
-                      for (MacroButtonProperties nextMacro :
-                          MapTool.getCampaign().getMacroButtonPropertiesArray()) {
-                        if (nextProps.hashCodeForComparison()
-                            == nextMacro.hashCodeForComparison()) {
-                          alreadyExists = true;
-                        }
-                      }
-                      if (alreadyExists) {
-                        alreadyExists =
-                            confirmImport(
-                                nextProps,
-                                I18N.getText(
-                                    "confirm.macro.panelLocation", I18N.getText("panel.Campaign")));
-                      }
-                      if (!alreadyExists) {
-                        new MacroButtonProperties(
-                            panelClass, MapTool.getCampaign().getMacroButtonNextIndex(), nextProps);
-                      }
-                    } else if (panelClass.equals("GmPanel")) {
-                      for (MacroButtonProperties nextMacro :
-                          MapTool.getCampaign().getGmMacroButtonPropertiesArray()) {
-                        if (nextProps.hashCodeForComparison()
-                            == nextMacro.hashCodeForComparison()) {
-                          alreadyExists = true;
-                        }
-                      }
-                      if (alreadyExists) {
-                        alreadyExists =
-                            confirmImport(
-                                nextProps,
-                                I18N.getText(
-                                    "confirm.macro.panelLocation", I18N.getText("panel.Gm")));
-                      }
-                      if (!alreadyExists) {
-                        new MacroButtonProperties(
-                            panelClass,
-                            MapTool.getCampaign().getGmMacroButtonNextIndex(),
-                            nextProps);
-                      }
-                    } else if (panelClass.equals("SelectionPanel")) {
-                      if (areaGroup != null) {
-                        if (areaGroup
+                  if ("GlobalPanel".equals(panelClass)
+                      || "CampaignPanel".equals(panelClass)
+                      || "GmPanel".equals(panelClass)) {
+                    addMacrosToGeneralPanel(newButtonProps);
+                  } else {
+                    if (areaGroup != null
+                        && areaGroup
                             .getGroupLabel()
                             .equals(I18N.getText("component.areaGroup.macro.commonMacros"))) {
-                          for (Token nextToken :
-                              MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokensList()) {
-                            alreadyExists = false;
-                            for (MacroButtonProperties nextMacro : nextToken.getMacroList(true)) {
-                              if (nextProps.hashCodeForComparison()
-                                  == nextMacro.hashCodeForComparison()) {
-                                alreadyExists = true;
-                              }
-                            }
-                            if (alreadyExists) {
-                              alreadyExists =
-                                  confirmImport(
-                                      nextProps,
-                                      I18N.getText("confirm.macro.commonSelectionLocation"));
-                            }
-                            if (!alreadyExists) {
-                              new MacroButtonProperties(
-                                  nextToken, nextToken.getMacroNextIndex(), nextProps);
-                            }
-                          }
-                        } else if (tokenId != null) {
-                          Token token = getToken();
-                          for (MacroButtonProperties nextMacro : token.getMacroList(true)) {
-                            if (nextProps.hashCodeForComparison()
-                                == nextMacro.hashCodeForComparison()) {
-                              alreadyExists = true;
-                            }
-                          }
-                          if (alreadyExists) {
-                            String tokenName = token.getName();
-                            if (MapTool.getPlayer().isGM()) {
-                              if (token.getGMName() != null) {
-                                if (!token.getGMName().equals("")) {
-                                  tokenName = tokenName + "(" + token.getGMName() + ")";
-                                }
-                              }
-                            }
-                            alreadyExists =
-                                confirmImport(
-                                    nextProps,
-                                    I18N.getText("confirm.macro.tokenLocation", tokenName));
-                          }
-                          if (!alreadyExists) {
-                            new MacroButtonProperties(token, token.getMacroNextIndex(), nextProps);
-                          }
-                        }
+                      for (Token nextToken :
+                          MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokensList()) {
+                        addMacrosToToken(newButtonProps, nextToken);
                       }
                     } else if (tokenId != null) {
-                      Token token = getToken();
-                      for (MacroButtonProperties nextMacro : token.getMacroList(true)) {
-                        if (nextProps.hashCodeForComparison()
-                            == nextMacro.hashCodeForComparison()) {
-                          alreadyExists = true;
-                        }
-                      }
-                      if (alreadyExists) {
-                        String tokenName = token.getName();
-                        if (MapTool.getPlayer().isGM()) {
-                          if (token.getGMName() != null) {
-                            if (!token.getGMName().equals("")) {
-                              tokenName = tokenName + "(" + token.getGMName() + ")";
-                            }
-                          }
-                        }
-                        alreadyExists =
-                            confirmImport(
-                                nextProps, I18N.getText("confirm.macro.tokenLocation", tokenName));
-                      }
-                      if (!alreadyExists) {
-                        new MacroButtonProperties(token, token.getMacroNextIndex(), nextProps);
-                      }
+                      addMacrosToToken(newButtonProps, getToken());
+                    } else {
+                      throw new IllegalStateException("Macros import - invalid panel.");
                     }
                   }
                 }

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPrefs.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPrefs.java
@@ -50,7 +50,38 @@ public class MacroButtonPrefs {
 
   public MacroButtonPrefs() {}
 
+  /**
+   * Adds multiple MacroButtonProperties to the Global macro panel, starting at the next appropriate
+   * index.
+   *
+   * @param toSave the list of button properties to add
+   */
+  public static void saveMacroButtonsAtNextIndex(List<MacroButtonProperties> toSave) {
+    for (MacroButtonProperties newProp : toSave) {
+      newProp.setIndex(getNextIndex());
+      savePreferences(newProp, false);
+    }
+    MapTool.getFrame().getGlobalPanel().reset();
+  }
+
+  /**
+   * Adds the given MacroButton to the Global panel, and causes the panel to refresh immediately.
+   *
+   * @param properties the macro to add
+   */
   public static void savePreferences(MacroButtonProperties properties) {
+    savePreferences(properties, true);
+  }
+
+  /**
+   * Adds the given MacroButton to the Global panel, optionally triggering a panel refresh upon
+   * completion. Panel reset should be requested unless multiple macros are being added at once, and
+   * the intention is to reset the panel after the batch.
+   *
+   * @param properties the macro to add
+   * @param resetFrame whether to reset the panel
+   */
+  public static void savePreferences(MacroButtonProperties properties, boolean resetFrame) {
     int index = properties.getIndex();
 
     // use zero padding to ensure proper ordering in the registry (otherwise 10 will come before 2
@@ -95,7 +126,9 @@ public class MacroButtonPrefs {
       prefs.put(PREF_MAX_WIDTH, properties.getMaxWidth());
       prefs.put(PREF_TOOLTIP, properties.getToolTip());
       prefs.flush();
-      MapTool.getFrame().getGlobalPanel().reset();
+      if (resetFrame) {
+        MapTool.getFrame().getGlobalPanel().reset();
+      }
     } catch (BackingStoreException e) {
       MapTool.showError("Problem saving Global macros?!", e);
     }

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -501,6 +501,43 @@ public class Campaign {
   }
 
   /**
+   * Adds multiple MacroButtonProperties to the GM or Campaign macro panel, starting at the next
+   * appropriate index.
+   *
+   * @param toSave the list of button properties to add
+   * @param gmPanel true for the GM panel, false for the Campaign panel.
+   */
+  public void addMacroButtonPropertiesAtNextIndex(
+      List<MacroButtonProperties> toSave, boolean gmPanel) {
+    List<MacroButtonProperties> macroButtonList =
+        gmPanel ? gmMacroButtonProperties : macroButtonProperties;
+    int lastIndex = gmPanel ? gmMacroButtonLastIndex : macroButtonLastIndex;
+    // populate the lookup table and confirm lastIndex
+    for (MacroButtonProperties prop : macroButtonList) {
+      int curIndex = prop.getIndex();
+      if (curIndex > lastIndex) {
+        lastIndex = curIndex;
+      }
+    }
+    // set the indexes and add to list
+    for (MacroButtonProperties newProp : toSave) {
+      newProp.setIndex(++lastIndex);
+    }
+    macroButtonList.addAll(toSave);
+
+    // update the ButtonLastIndex prop as appropriate
+    if (gmPanel) {
+      gmMacroButtonLastIndex = lastIndex;
+    } else {
+      macroButtonLastIndex = lastIndex;
+    }
+
+    AbstractMacroPanel macroPanel =
+        gmPanel ? MapTool.getFrame().getGmPanel() : MapTool.getFrame().getCampaignPanel();
+    macroPanel.reset();
+  }
+
+  /**
    * Saves a button in the Campaign or GM panel.
    *
    * @param properties the properties of the button to save

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -191,8 +191,29 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     save();
   }
 
-  // constructor for creating a new copy of an existing button, auto-saves
+  /**
+   * Creates a copy of an existing button on the designated panel. Auto-saves.
+   *
+   * @param panelClass the panel name where the new button is being created
+   * @param index the next index to use on the panel
+   * @param properties the properties from which to copy
+   */
   public MacroButtonProperties(String panelClass, int index, MacroButtonProperties properties) {
+    this(panelClass, index, properties, true);
+  }
+
+  /**
+   * Creates a copy of an existing button on the designated panel. Optionally auto-saves. Auto-save
+   * should be requested unless multiple buttons are being created at once, and the intention is to
+   * save in bulk.
+   *
+   * @param panelClass the panel name where the new button is being created
+   * @param index the next index to use on the panel
+   * @param properties the properties from which to copy
+   * @param autoSave whether to automatically call {@link #save()}
+   */
+  public MacroButtonProperties(
+      String panelClass, int index, MacroButtonProperties properties, boolean autoSave) {
     this(index);
     setSaveLocation(panelClass);
     setColorKey(properties.getColorKey());
@@ -218,7 +239,9 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setCompareCommand(properties.getCompareCommand());
     String tt = properties.getToolTip();
     setToolTip(tt);
-    save();
+    if (autoSave) {
+      save();
+    }
   }
 
   /**


### PR DESCRIPTION
* Reduces algorithm complexity of de-confliction by building a lookup table to replace repeated scans
* Avoids repeated redraws by adding new macro buttons in batches.

Significant improvements in processing time and memory required when importing large macrosets to the Global, Campaign, GM, Impersonated, and Selection panels.

Fixes RPTools/maptool#2118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2130)
<!-- Reviewable:end -->
