### PR TITLE
Fixed bad usage of Set<String>.contains(MD5Key)

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -768,9 +768,11 @@ public class AssetManager {
     }
 
     // Now create the aggregate of all repositories.
-    Set<String> aggregate = new HashSet<String>(size);
+    Set<MD5Key> aggregate = new HashSet<>(size);
     for (String repo : repos) {
-      aggregate.addAll(assetLoader.getRepositoryMap(repo).keySet());
+      for (String key : assetLoader.getRepositoryMap(repo).keySet()) {
+        aggregate.add(new MD5Key(key));
+      }
     }
 
     /*
@@ -782,6 +784,7 @@ public class AssetManager {
      */
     Map<MD5Key, Asset> missing =
         new HashMap<MD5Key, Asset>(Math.min(assetMap.size(), aggregate.size()));
+
     for (MD5Key key : assetMap.keySet()) {
       if (aggregate.contains(key) == false) // Not in any repository so add it.
       missing.put(key, assetMap.get(key));


### PR DESCRIPTION
contains(Object) was being called on Set<String>, with an instance of MD5Key as the parameter, leading to the check always returning false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2134)
<!-- Reviewable:end -->
