### PR TITLE
Fix `isNumber()`, add cases to unit test.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -30,7 +30,7 @@ import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import org.apache.commons.lang.WordUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 public class StringFunctions extends AbstractFunction {
   private int matchNo = 0;
@@ -273,7 +273,7 @@ public class StringFunctions extends AbstractFunction {
       }
     }
     if (functionName.equals("isNumber")) {
-      if (StringUtils.isNumeric(parameters.get(0).toString())) {
+      if (NumberUtils.isParsable(parameters.get(0).toString())) {
         return BigDecimal.ONE;
       } else {
         return BigDecimal.ZERO;

--- a/src/test/java/net/rptools/maptool/client/functions/StringFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/StringFunctionsTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.List;
 import net.rptools.parser.ParserException;
 import org.junit.jupiter.api.Test;
 
@@ -63,8 +64,23 @@ public class StringFunctionsTest {
   @Test
   public void testIsNumber() throws ParserException {
     String isNumber = "isNumber";
-    String emptyString = "";
 
-    assertEquals(BigDecimal.ZERO, submitStringFunction(isNumber, emptyString));
+    List<String> numbers = List.of("4", "4.3", "-4.3", "04");
+    // strings that the parser doesn't consider numeric or doesn't interpret correctly should be
+    // considered NOT numbers
+    List<String> notNumbers = List.of("", "control", "1E3", "1,000");
+
+    for (String s : numbers) {
+      assertEquals(
+          BigDecimal.ONE,
+          submitStringFunction(isNumber, s),
+          "Expection [" + s + "] to be recognized as a number");
+    }
+    for (String s : notNumbers) {
+      assertEquals(
+          BigDecimal.ZERO,
+          submitStringFunction(isNumber, s),
+          "Expecting [" + s + "] to be non-numeric");
+    }
   }
 }


### PR DESCRIPTION
Mostly restores functionality from 1.7, but will return `0` for some additional number formats that are not handled correctly by the parser but that were previously considered numeric by this function.  Specifically:
* `isNumber("2nd")` returned `1` in 1.7, now returns `0`.  Parser interprets as `2`.
* `isNumber("1E3")` returned `1` in 1.7, now returns `0`.  Parser interprets as `1`.

Added cases to unit test.

Fixes RPTools/maptool#2211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2217)
<!-- Reviewable:end -->
