### PR TITLE
Add dialogs, frames, and overlays to getInfo("client") output.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.regex.Pattern;
 import net.rptools.maptool.client.MapTool;
@@ -100,11 +101,15 @@ public class MacroDialogFunctions extends AbstractFunction {
     }
     if (functionName.equals("getFrameProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
-      return HTMLFrame.getFrameProperties(parameters.get(0).toString());
+      Optional<JsonObject> props = HTMLFrame.getFrameProperties(parameters.get(0).toString());
+      if (props.isPresent()) return props.get();
+      else return "";
     }
     if (functionName.equals("getDialogProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
-      return HTMLDialog.getDialogProperties(parameters.get(0).toString());
+      Optional<JsonObject> props = HTMLDialog.getDialogProperties(parameters.get(0).toString());
+      if (props.isPresent()) return props.get();
+      else return "";
     }
     if (functionName.equalsIgnoreCase("getOverlayProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
@@ -144,31 +149,17 @@ public class MacroDialogFunctions extends AbstractFunction {
           MapTool.getFrame().getOverlayPanel().getOverlays();
       JsonArray jarr = new JsonArray();
       for (HTMLOverlayManager overlay : overlays) {
-        jarr.add(getOverlayProperties(overlay));
+        jarr.add(overlay.getProperties());
       }
       return jarr;
     } else {
       HTMLOverlayManager overlay = MapTool.getFrame().getOverlayPanel().getOverlay(name);
       if (overlay != null) {
-        return getOverlayProperties(overlay);
+        return overlay.getProperties();
       } else {
         return "";
       }
     }
-  }
-
-  /**
-   * Returns a JsonObject with the properties of the overlay. Includes name, zorder, and visible.
-   *
-   * @param overlay the overlay to get the properties from.
-   * @return the properties
-   */
-  private JsonObject getOverlayProperties(HTMLOverlayManager overlay) {
-    JsonObject jobj = new JsonObject();
-    jobj.addProperty("name", overlay.getName());
-    jobj.addProperty("zorder", overlay.getZOrder());
-    jobj.addProperty("visible", overlay.isVisible() ? BigDecimal.ONE : BigDecimal.ZERO);
-    return jobj;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLDialog.java
@@ -20,8 +20,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import javax.swing.*;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.MapTool;
@@ -29,6 +28,7 @@ import net.rptools.maptool.client.functions.MacroLinkFunction;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.util.FunctionUtil;
 
 /**
  * Represents a JDialog holding an HTML panel. Can hold either an HTML3.2 (Swing) or a HTML5
@@ -85,6 +85,15 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       return dialogs.get(name).isVisible();
     }
     return false;
+  }
+
+  /**
+   * Gets an unmodifiable set view of the names of all known dialogs.
+   *
+   * @return the dialog names
+   */
+  public static Set<String> getDialogNames() {
+    return Collections.unmodifiableSet(dialogs.keySet());
   }
 
   /**
@@ -246,9 +255,9 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
    * Return a json with the width, height, temporary variable and title of the dialog
    *
    * @param name The name of the frame.
-   * @return A json with the width, height, temporary, title, and value of dialog
+   * @return A json with the width, height, temporary, title, and value of dialog, if one was found
    */
-  public static Object getDialogProperties(String name) {
+  public static Optional<JsonObject> getDialogProperties(String name) {
     if (dialogs.containsKey(name)) {
       HTMLDialog dialog = dialogs.get(name);
       JsonObject dialogProperties = new JsonObject();
@@ -256,8 +265,10 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       dialogProperties.addProperty("width", dialog.getWidth());
       dialogProperties.addProperty("height", dialog.getHeight());
       dialogProperties.addProperty(
-          "temporary", dialog.getTemporary() ? BigDecimal.ONE : BigDecimal.ZERO);
+          "temporary", FunctionUtil.getDecimalForBoolean(dialog.getTemporary()));
       dialogProperties.addProperty("title", dialog.getTitle());
+      dialogProperties.addProperty(
+          "visible", FunctionUtil.getDecimalForBoolean(dialog.isVisible()));
 
       Object dialogValue = dialog.getValue();
       if (dialogValue == null) {
@@ -273,9 +284,9 @@ public class HTMLDialog extends JDialog implements HTMLPanelContainer {
       }
       dialogProperties.add("value", JSONMacroFunctions.getInstance().asJsonElement(dialogValue));
 
-      return dialogProperties;
+      return Optional.of(dialogProperties);
     } else {
-      return "";
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -23,13 +23,13 @@ import com.jidesoft.docking.event.DockableFrameEvent;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import javax.swing.ImageIcon;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.util.FunctionUtil;
 
 /**
  * Represents a dockable frame holding an HTML panel. Can hold either an HTML3.2 (Swing) or a HTML5
@@ -97,6 +97,15 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
     if (frames.containsKey(name)) {
       frames.get(name).closeRequest();
     }
+  }
+
+  /**
+   * Gets an unmodifiable set view of the names of all known frames.
+   *
+   * @return the frame names
+   */
+  public static Set<String> getFrameNames() {
+    return Collections.unmodifiableSet(frames.keySet());
   }
 
   /**
@@ -303,9 +312,10 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
    * Return a json with the width, height, title, temporary, and value of the frame
    *
    * @param name the name of the frame.
-   * @return a json with the width, height, title, temporary, and value of the frame
+   * @return a json with the width, height, title, temporary, and value of the frame, if one was
+   *     found
    */
-  public static Object getFrameProperties(String name) {
+  public static Optional<JsonObject> getFrameProperties(String name) {
     if (frames.containsKey(name)) {
       HTMLFrame frame = frames.get(name);
       JsonObject frameProperties = new JsonObject();
@@ -313,8 +323,10 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       frameProperties.addProperty("width", frame.getWidth());
       frameProperties.addProperty("height", frame.getHeight());
       frameProperties.addProperty(
-          "temporary", frame.getTemporary() ? BigDecimal.ONE : BigDecimal.ZERO);
+          "temporary", FunctionUtil.getDecimalForBoolean(frame.getTemporary()));
       frameProperties.addProperty("title", frame.getTitle());
+      frameProperties.addProperty("visible", FunctionUtil.getDecimalForBoolean(frame.isVisible()));
+      frameProperties.addProperty("docked", FunctionUtil.getDecimalForBoolean(frame.isDocked()));
 
       Object frameValue = frame.getValue();
       if (frameValue == null) {
@@ -333,9 +345,9 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       }
       frameProperties.addProperty("value", frameValue.toString());
 
-      return frameProperties;
+      return Optional.of(frameProperties);
     } else {
-      return "";
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
@@ -14,11 +14,13 @@
  */
 package net.rptools.maptool.client.ui.htmlframe;
 
+import com.google.gson.JsonObject;
 import com.sun.webkit.WebPage;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import javafx.scene.web.WebEngine;
@@ -237,6 +239,18 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
   @Override
   public void remove(Component component) {}
 
+  /**
+   * Returns a JsonObject with the properties of the overlay. Includes name, zorder, and visible.
+   *
+   * @return the properties
+   */
+  public JsonObject getProperties() {
+    JsonObject jobj = new JsonObject();
+    jobj.addProperty("name", getName());
+    jobj.addProperty("zorder", getZOrder());
+    jobj.addProperty("visible", isVisible() ? BigDecimal.ONE : BigDecimal.ZERO);
+    return jobj;
+  }
   /**
    * Act when an action is performed.
    *

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -430,6 +430,15 @@ public class FunctionUtil {
   }
 
   /**
+   * Get our standard BigDecimal representation (1 or 0) of a boolean value.
+   *
+   * @param b the boolean value
+   * @return {@link BigDecimal#ONE} if true, {@link BigDecimal#ZERO} if false
+   */
+  public static BigDecimal getDecimalForBoolean(boolean b) {
+    return b ? BigDecimal.ONE : BigDecimal.ZERO;
+  }
+  /**
    * Throw an exception if the macro isn't trusted.
    *
    * @param functionName the name of the function.


### PR DESCRIPTION
Used the existing `getFrameProperties()` (and corresponding) methods, added `visible` indicator to dialogs & frames output, added `docked` indicator to frames output.

Sample output (these fields only) of `getInfo("client")` from a campaign of mine with a few of these features:
```json
{
  "dialogs": {"Testing":   {
    "width": 390,
    "height": 212,
    "temporary": 0,
    "title": "Testing",
    "visible": 1,
    "value": ""
  }},
  "frames":   {
    "PlayMat - Hammer Bot":     {
      "width": 839,
      "height": 382,
      "temporary": 0,
      "title": "PlayMat - Hammer Bot",
      "visible": 1,
      "docked": 1,
      "value": ""
    },
    "Option Cards - Hammer Bot":     {
      "width": 800,
      "height": 600,
      "temporary": 0,
      "title": "Option Cards - Hammer Bot",
      "visible": 1,
      "docked": 0,
      "value": ""
    }
  },
  "overlays":   {
    "TimingReference":     {
      "name": "TimingReference",
      "zorder": 0,
      "visible": 0
    },
    "partyOverlay":     {
      "name": "partyOverlay",
      "zorder": 0,
      "visible": 1
    }
  },
}
```

Fixes #2230

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2235)
<!-- Reviewable:end -->
