### PR TITLE
Add optional delim parameter to herolab.XPath

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -1428,7 +1428,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
             return;
           }
 
-          xmlStatblockRSyntaxTextArea.setText(heroLabData.parseXML(searchText));
+          xmlStatblockRSyntaxTextArea.setText(heroLabData.parseXML(searchText, ", "));
           xmlStatblockRSyntaxTextArea.setCaretPosition(0);
         });
 

--- a/src/main/java/net/rptools/maptool/model/HeroLabData.java
+++ b/src/main/java/net/rptools/maptool/model/HeroLabData.java
@@ -116,17 +116,47 @@ public class HeroLabData {
     heroImageAssets.put(DefaultAssetKey.PORTRAIT_KEY, DEFAULT_HERO_LAB_PORTRAIT_ASSET.getId());
   }
 
-  /*
-   * Evaluate the HeroLab XML statBlock against the supplied xPath expression Sample expression: /document/public/character/race/@racetext
+  /**
+   * Evaluate the HeroLab XML statBlock against the supplied xPath expression, returning the results
+   * as a String List with the requested delimiter.
+   *
+   * <p>Sample expression: /document/public/character/race/@racetext
+   *
+   * @param xPathExpression the expression
+   * @param delim the delimiter to use for the returned list
+   * @return the String list (which may contain only a single element)
+   * @throws IllegalArgumentException if xPathExpression is empty, invalid, or does not point to
+   *     text or attribute nodes.
    */
-  public String parseXML(String xPathExpression) {
-    if (xPathExpression.isEmpty()) return "Error: No XPath expression given.";
+  public String parseXML(String xPathExpression, String delim) {
+    if (xPathExpression.isEmpty()) throw new IllegalArgumentException("Empty XPath expression");
 
     String results;
     XML xmlObj = new XMLDocument(getStatBlock_xml());
-    results = String.join(", ", xmlObj.xpath(xPathExpression));
+    results = String.join(delim, xmlObj.xpath(xPathExpression));
 
     // System.out.println("HeroLabData parseXML(" + xPathExpression + ") :: '" + results + "'");
+
+    return results;
+  }
+
+  /**
+   * Evaluate the HeroLab XML statBlock against the supplied xPath expression, returning the results
+   * as a JsonArray.
+   *
+   * @param xPathExpression the expression
+   * @return a JsonArray of results
+   * @throws IllegalArgumentException if xPathExpression is empty, invalid, or does not point to
+   *     text or attribute nodes.
+   */
+  public JsonArray parseXmlToJson(String xPathExpression) {
+    if (xPathExpression.isEmpty()) throw new IllegalArgumentException("Empty XPath expression");
+
+    JsonArray results = new JsonArray();
+    XML xmlObj = new XMLDocument(getStatBlock_xml());
+    for (String r : xmlObj.xpath(xPathExpression)) {
+      results.add(r);
+    }
 
     return results;
   }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1497,6 +1497,7 @@ macro.function.execFunction.incorrectName          = Error executing "{0}": the 
 # Token Halo functions {0} is the color
 macro.function.haloFunctions.invalidColor          = Invalid halo color "{0}".
 macro.function.herolab.null                        = HeroLab data does not exist for this token.
+macro.function.herolab.xpath.invalid               = Provided XPath expression "{0}" was invalid or did not point to a text or attribute node.
 # Initiative functions general errors
 macro.function.initiative.gmOnly                   = Only the GM can perform "{0}".
 macro.function.initiative.gmOrOwner                = Only the GM or owner can perform "{0}".


### PR DESCRIPTION
Allows proper handling of results including commas.  
Provide friendlier error message when invalid xpath is provided.

Fixes #2229, #1562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2236)
<!-- Reviewable:end -->
