### PR TITLE
Handle invalid XPaths on EditTokenDialog.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -1428,7 +1428,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
             return;
           }
 
-          xmlStatblockRSyntaxTextArea.setText(heroLabData.parseXML(searchText, ", "));
+          String results;
+          try {
+            results = heroLabData.parseXML(searchText, ", ");
+          } catch (IllegalArgumentException exception) {
+            results = I18N.getText("macro.function.herolab.xpath.invalid", searchText);
+          }
+          xmlStatblockRSyntaxTextArea.setText(results);
           xmlStatblockRSyntaxTextArea.setCaretPosition(0);
         });
 


### PR DESCRIPTION
Catches the error and displays the I18N message in the text area.

Fixes RPTools/maptool#1562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2246)
<!-- Reviewable:end -->
