### PR TITLE
Updated the CSP

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -136,6 +136,7 @@ public class HTMLWebViewManager {
           + " https://fonts.googleapis.com  https://fonts.gstatic.com " // Google Fonts
           + " 'unsafe-inline' 'unsafe-eval' ; "
           + " font-src https://fonts.gstatic.com 'self'"
+          + " img-src 'self' data: ;"
           + "\">\n";
 
   /** The default rule for the body tag. */


### PR DESCRIPTION
Content Security Policy doesn't seem to be allowing the data: URI to produce PNGs in maptools.
REF. #2256 
If possible, someone please test this out, and let me know if it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2257)
<!-- Reviewable:end -->
