### PR TITLE
Fix rowcount calculation

### DIFF
--- a/src/main/java/net/rptools/lib/swing/ImagePanel.java
+++ b/src/main/java/net/rptools/lib/swing/ImagePanel.java
@@ -392,7 +392,8 @@ public class ImagePanel extends JComponent
     if (width < gridSize + gridPadding.width * 2) {
       rowCount = model.getImageCount();
     } else {
-      rowCount = model.getImageCount() / (width / itemWidth);
+      int itemsPerRow = width / itemWidth;
+      rowCount = (int) Math.ceil(model.getImageCount() / (float)itemsPerRow);
     }
     int height = rowCount * itemHeight;
     return new Dimension(width, height);

--- a/src/main/java/net/rptools/lib/swing/ImagePanel.java
+++ b/src/main/java/net/rptools/lib/swing/ImagePanel.java
@@ -393,7 +393,7 @@ public class ImagePanel extends JComponent
       rowCount = model.getImageCount();
     } else {
       int itemsPerRow = width / itemWidth;
-      rowCount = (int) Math.ceil(model.getImageCount() / (float)itemsPerRow);
+      rowCount = (int) Math.ceil(model.getImageCount() / (float) itemsPerRow);
     }
     int height = rowCount * itemHeight;
     return new Dimension(width, height);


### PR DESCRIPTION
This change will fix issue [#755](https://github.com/RPTools/maptool/issues/755).
When scrolling through the image pane, the last row of images might not be fully displayed, even when the scroll bar is at the bottom (or in the case of the screenshot in the issue, even when the scrollbar does not appear at all).

The problem was a miscalculation of the number of rows in the pane.
E.g. 7 images, 2 images per row -> rowCount should be 4, but it was actually 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2301)
<!-- Reviewable:end -->
