### PR TITLE
Fixes #2270

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2151,7 +2151,9 @@ public class AppActions {
                     serverProps.getUseToolTipsForUnformattedRolls());
 
                 // my addition
-                policy.setRestrictedImpersonation(serverProps.getRestrictedImpersonation());
+                // Note: Restricted impersonation setting is the opposite of its label
+                // (Unrestricted when checked and restricted when unchecked)
+                policy.setRestrictedImpersonation(!serverProps.getRestrictedImpersonation());
                 policy.setMovementMetric(serverProps.getMovementMetric());
                 boolean useIF =
                     serverProps.getUseIndividualViews() && serverProps.getUseIndividualFOW();

--- a/src/main/java/net/rptools/maptool/client/macro/impl/ImpersonateMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/ImpersonateMacro.java
@@ -57,7 +57,11 @@ public class ImpersonateMacro implements Macro {
     }
     // Permission
     if (!canImpersonate(token)) {
-      MapTool.addLocalMessage(I18N.getText("impersonate.mustOwn", token.getName()));
+      if (token != null) {
+        MapTool.addLocalMessage(I18N.getText("impersonate.mustOwn", name));
+      } else {
+        MapTool.addLocalMessage(I18N.getText("msg.error.gmRequired"));
+      }
       return;
     }
     // Impersonate

--- a/src/main/java/net/rptools/maptool/client/ui/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/StartServerDialogPreferences.java
@@ -97,7 +97,7 @@ public class StartServerDialogPreferences {
 
   // my addition
   public boolean getRestrictedImpersonation() {
-    return prefs.getBoolean(KEY_RESTRICTED_IMPERSONATION, true);
+    return prefs.getBoolean(KEY_RESTRICTED_IMPERSONATION, false);
   }
 
   public void setRestrictedImpersonation(boolean impersonation) {


### PR DESCRIPTION
Fixes #2270. 
- Restricted impersonation option's internal state now matches the label (true if not selected)
- No longer throws an exception when a player tries to impersonate something that has no token when impersonation is restricted
- Restricted impersonation option defaults to false (restricted)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2303)
<!-- Reviewable:end -->
