### PR TITLE
Add shortcut key F to flip selected tokens horizontally

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1307,6 +1307,7 @@ public class PointerTool extends DefaultTool {
             }
           }
         });
+    actionMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, 0), new FlipTokenActionListener());
   }
 
   /**
@@ -1492,6 +1493,23 @@ public class PointerTool extends DefaultTool {
         }
       }
       isSpaceDown = false;
+    }
+  }
+
+  private class FlipTokenActionListener extends AbstractAction {
+    private static final long serialVersionUID = -6286351028470892136L;
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+      List<Token> selectedTokensList = renderer.getSelectedTokensList();
+      for (Token token : selectedTokensList) {
+        if (token == null) {
+          continue;
+        }
+        token.setFlippedX(!token.isFlippedX());
+        MapTool.serverCommand().putToken(renderer.getZone().getId(), token);
+      }
+      MapTool.getFrame().refresh();
     }
   }
 


### PR DESCRIPTION
Hey!
I added this feature because I've seen many people asking for a faster way to flip tokens horizontally for RP purposes. To use this, just hit the F key while having one or more tokens selected with the pointer tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2304)
<!-- Reviewable:end -->
