### PR TITLE
Fix for failure of jpackage task for dev builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ runtime {
 
         imageOptions = []
         imageName = project.name + developerRelease
-        installerName = project.name + developerRelease
+        installerName = project.name
         installerOptions = [
                 //'--temp', 'releases/temp-files',
                 '--verbose',


### PR DESCRIPTION
The jpackage task gets confused if the "Dev-Release" is appended to the installer name (it doesn't like it at all). I have removed this and it works successfully on Linux and Mac (should do for windows too as now it will be same logic/dir as the automated builds, but I am unable to test at the moment)...

This will mean that the installer file(s) for jpackage will be created as Maptool-0.0.1.*, but when installing it will still have the name MapTool-Dev-Release. Might have to document this somewhere.  

#fixes #2372

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2373)
<!-- Reviewable:end -->
