### PR TITLE
MapExplorer respects strict token ownership

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/TokenPanelTreeModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/TokenPanelTreeModel.java
@@ -427,10 +427,8 @@ public class TokenPanelTreeModel implements TreeModel, ModelChangeListener {
       if (MapTool.getPlayer().isGM()) {
         return true;
       }
-      if (MapTool.getServerPolicy().isUseIndividualViews() || token.isVisibleOnlyToOwner()) {
-        if (!AppUtil.playerOwns(token)) {
-          return false;
-        }
+      if (!AppUtil.playerOwns(token)) {
+        return false;
       }
       return token.isVisible();
     }


### PR DESCRIPTION
Reverted MapExplorer back to its previous behaviour where it would not display any tokens not owned by the player if strict token ownership is turned on.

If strict token ownership is on it will still show all tokens.

Fixes #2402

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2412)
<!-- Reviewable:end -->
