### PR TITLE
Fix typo in getMacroProps

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -172,7 +172,7 @@ public class MacroFunctions extends AbstractFunction {
       props.addProperty("minWidth", mbp.getMinWidth());
       props.addProperty("playerEditable", mbp.getAllowPlayerEdits());
       props.addProperty("command", mbp.getCommand());
-      props.addProperty("maxWith", mbp.getMaxWidth());
+      props.addProperty("maxWidth", mbp.getMaxWidth());
       props.addProperty("tooltip", mbp.getToolTip() == null ? "" : mbp.getToolTip());
       props.addProperty("applyToSelected", mbp.getApplyToTokens());
 


### PR DESCRIPTION
RPTools/maptool#2470

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2472)
<!-- Reviewable:end -->
