### PR TITLE
Update build file for new library versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,11 +314,11 @@ dependencies {
     implementation 'com.github.jai-imageio:jai-imageio-jpeg2000:1.3.0'					// For pdf image extraction, specifically for jpeg2000 (jpx) support.
 
     // Image processing lib
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.6.2'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.6.2'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.6.4'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.6.4'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.6.4'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.6.4'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.6.4'
 
     implementation 'org.apache.xmlgraphics:batik-transcoder:1.13' // For Twelvemonkey SVG
 

--- a/build.gradle
+++ b/build.gradle
@@ -265,7 +265,7 @@ dependencies {
     implementation 'net.rptools.decktool:decktool:1.0.b1'
     implementation 'com.github.RPTools:maptool-resources:1.6.0'
     implementation 'com.github.RPTools:parser:1.8.3'
-    implementation 'com.github.RPTools:dicelib:1.7.0'
+    implementation 'com.github.RPTools:dicelib:1.7.1'
 
     // Currently hosted on nerps.net/repo
     implementation group: 'com.jidesoft', name: 'jide-common', version: '3.7.9'
@@ -314,11 +314,13 @@ dependencies {
     implementation 'com.github.jai-imageio:jai-imageio-jpeg2000:1.3.0'					// For pdf image extraction, specifically for jpeg2000 (jpx) support.
 
     // Image processing lib
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.4.3'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.4.3'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.4.3'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.6.2'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.6.2'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tga', version: '3.6.2'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-bmp', version: '3.6.2'
 
     implementation 'org.apache.xmlgraphics:batik-transcoder:1.13' // For Twelvemonkey SVG
 

--- a/build.gradle
+++ b/build.gradle
@@ -319,8 +319,6 @@ dependencies {
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.6.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.6.2'
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.6.2'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tga', version: '3.6.2'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-bmp', version: '3.6.2'
 
     implementation 'org.apache.xmlgraphics:batik-transcoder:1.13' // For Twelvemonkey SVG
 

--- a/src/test/java/net/rptools/lib/image/ImageUtilTest.java
+++ b/src/test/java/net/rptools/lib/image/ImageUtilTest.java
@@ -55,8 +55,8 @@ public class ImageUtilTest {
   @Test
   void testReadSvgAsBufferedImage() throws IOException {
     Image img = ImageUtil.getCompatibleImage("net/rptools/maptool/client/image/star.svg");
-    assertEquals(img.getWidth(null), 51);
-    assertEquals(img.getHeight(null), 48);
+    assertEquals(img.getWidth(null), 255);
+    assertEquals(img.getHeight(null), 240);
   }
 
   @Test


### PR DESCRIPTION
Update to DiceLib 1.7.1 for #2444 fix.
Update ImageIO plugins to current version 3.6.4 for #2474 update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2475)
<!-- Reviewable:end -->
