### PR TITLE
Improve performance of token property evaluation

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -334,8 +334,12 @@ public class MapToolVariableResolver implements VariableResolver {
   }
 
   protected void updateTokenProperty(Token token, String varname, String value) {
-    MapTool.serverCommand()
-        .updateTokenProperty(tokenInContext, Token.Update.setProperty, varname, value);
+    // this logic allows unit tests to execute MT script that changes token properties
+    // there should be no other context where we have no server of any kind
+    if (MapTool.serverCommand() != null)
+      MapTool.serverCommand()
+          .updateTokenProperty(tokenInContext, Token.Update.setProperty, varname, value);
+    else token.setProperty(varname, value);
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -33,6 +33,7 @@ import java.util.*;
 import java.util.List;
 import java.util.Map.Entry;
 import javax.swing.*;
+import net.rptools.lib.CodeTimer;
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.lib.swing.SwingUtil;
@@ -50,6 +51,7 @@ import net.rptools.maptool.util.GraphicsUtil;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool.util.StringUtil;
 import net.rptools.maptool.util.TokenUtil;
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1619,6 +1621,10 @@ public class PointerTool extends DefaultTool {
         Map<String, Integer> propertyLineCount = new LinkedHashMap<String, Integer>();
         LinkedList<TextLayout> lineLayouts = new LinkedList<TextLayout>();
         if (AppPreferences.getShowStatSheet()) {
+          CodeTimer timer = new CodeTimer("statSheet");
+          timer.setEnabled(AppState.isCollectProfilingData() || log.isDebugEnabled());
+          timer.setThreshold(5);
+          timer.start("allProps");
           for (TokenProperty property :
               MapTool.getCampaign().getTokenPropertyList(tokenUnderMouse.getPropertyType())) {
             if (property.isShowOnStatSheet()) {
@@ -1628,28 +1634,26 @@ public class PointerTool extends DefaultTool {
               if (property.isOwnerOnly() && !AppUtil.playerOwns(tokenUnderMouse)) {
                 continue;
               }
+              timer.start(property.getName());
               MapToolVariableResolver resolver = new MapToolVariableResolver(tokenUnderMouse);
-              // TODO: is the double resolution of properties necessary here. I kept
-              // it, but it
-              // seems wasteful and I can't figure out any reason that the first
-              // resolution can't be
-              // used
-              // below.
               resolver.initialize();
               resolver.setAutoPrompt(false);
               Object propertyValue =
                   tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
               resolver.flush();
               if (propertyValue != null && propertyValue.toString().length() > 0) {
-                String propName = property.getName();
-                if (property.getShortName() != null) {
-                  propName = property.getShortName();
-                }
-                Object value = tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
-                resolver.flush();
-                propertyMap.put(propName, value != null ? value.toString() : "");
+                String propName = property.getShortName();
+                if (StringUtils.isEmpty(propName)) propName = property.getName();
+                propertyMap.put(propName, propertyValue.toString());
               }
+              timer.stop(property.getName());
             }
+          }
+          timer.stop("allProps");
+          if (AppState.isCollectProfilingData() || log.isDebugEnabled()) {
+            String results = timer.toString();
+            MapTool.getProfilingNoteFrame().addText(results);
+            if (log.isDebugEnabled()) log.debug(results);
           }
         }
         if (tokenUnderMouse.getPortraitImage() != null || !propertyMap.isEmpty()) {

--- a/src/test/java/net/rptools/maptool/model/TokenPropertiesTest.java
+++ b/src/test/java/net/rptools/maptool/model/TokenPropertiesTest.java
@@ -1,0 +1,122 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
+import net.rptools.maptool.client.MapTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TokenPropertiesTest {
+
+  List<TokenProperty> propsList;
+  Token testToken;
+
+  @BeforeEach
+  public void setUp() {
+    propsList = new ArrayList<>();
+    propsList.add(new TokenProperty("prop1", null, true, false, false, "10"));
+    propsList.add(new TokenProperty("prop2", null, true, false, false, "{prop2=prop1}"));
+    propsList.add(
+        new TokenProperty(
+            "jsonObj1",
+            null,
+            true,
+            false,
+            false,
+            "{\"sampleKey\": 5, \"otherKey\": \"theValue\"}"));
+    propsList.add(new TokenProperty("jsonObj2", null, true, false, false, "{prop3=other}"));
+    propsList.add(new TokenProperty("jsonArr1", null, true, false, false, "[4, 3]"));
+    propsList.add(new TokenProperty("plainStr1", null, true, false, false, "justAString"));
+    propsList.add(new TokenProperty("badJson", null, true, false, false, "{\"a\": 1}{\"b\": 2}"));
+    MapTool.getCampaign().putTokenType("testType", propsList);
+
+    testToken = new Token();
+    testToken.setPropertyType("testType");
+
+    MapTool.getParser().enterContext("test", "testToken", true);
+  }
+
+  /**
+   * Tests evaluation of a properly formed JSON object. This should be a much faster test than the
+   * {@link #testJSONObjectLenient()} counterpart, since the initial strict evaluation should avoid
+   * the need to try MT parsing.
+   */
+  @Test
+  public void testJSONObjectStrict() {
+    Object val = testToken.getEvaluatedProperty("jsonObj1");
+    JsonObject json = (JsonObject) val;
+    assertAll(
+        () -> assertTrue(json.isJsonObject()),
+        () -> assertEquals(5, json.get("sampleKey").getAsInt()),
+        () -> assertEquals("theValue", json.get("otherKey").getAsString()));
+  }
+
+  /**
+   * Tests evaluation of a malformed, but unfortunately acceptable to Gson JSON object. This is
+   * expected to be slower than {@link #testJSONObjectStrict()}, because the initial strict check
+   * should NOT identify this as a JSON object. The full MT parser needs to be applied first, before
+   * we begrudgingly allow the lenient Gson evaluator to call this a JSON object.
+   */
+  @Test
+  public void testJSONObjectLenient() {
+    Object val = testToken.getEvaluatedProperty("jsonObj2");
+    JsonObject json = (JsonObject) val;
+    assertTrue(json.isJsonObject());
+    assertEquals(json.get("prop3").getAsString(), "other");
+  }
+
+  /**
+   * Tests that the <code>{prop2=prop1}</code> assignment syntax is properly supported. This means
+   * it should NOT be evaluated (leniently) as a JSON object, but instead executed as MTScript.
+   */
+  @Test
+  public void testAssignmentInDefaultValue() {
+    assertEquals("10", testToken.getEvaluatedProperty("prop2"));
+
+    // the point of the assignment is that after the first access, prop2 should no longer be
+    // dependent on prop1
+    testToken.setProperty("prop1", "newValue");
+    assertEquals("10", testToken.getEvaluatedProperty("prop2"));
+  }
+
+  @Test
+  public void testJsonArray() {
+    JsonElement elem = (JsonElement) testToken.getEvaluatedProperty("jsonArr1");
+    assertTrue(elem.isJsonArray());
+  }
+
+  @Test
+  public void testPlainStr() {
+    Object val = testToken.getEvaluatedProperty("plainStr1");
+    assertTrue(val instanceof String);
+    assertEquals("justAString", val);
+  }
+
+  @Test
+  public void testUnknownProperty() {
+    assertEquals("", testToken.getEvaluatedProperty("unknownProp"));
+  }
+
+  @Test
+  public void testBadJsonReturnsAsString() {
+    assertEquals("{\"a\": 1}{\"b\": 2}", testToken.getEvaluatedProperty("badJson"));
+  }
+}


### PR DESCRIPTION
- Improves performance evaluating JSON object properties by detecting properly formed JSON before attempting to parse as MTScript.  Using strict evaluation for this initial check maintains the improvement of #1560 without incurring the performance cost of trying to parse JSON objects as MTScript first.
- Collect performance data while preparing the statSheet popup.
- Removes unnecessary double evaluation of properties on the statSheet popup (pre-dated `getEvaluatedProperty()`)
- Add unit test to confirm proper evaluation of Token properties, including the malformed JSON that Gson shouldn't really be supporting but is, and that we'll continue to support to maintain backwards-compatibility.

~~Planning to add another change, converting default value lookup to use a Map instead of iterative comparisons across an entire list of definitions.~~  This planned follow-on has been moved to its own issue, so this PR is now ready.

RPTools/maptool#2396

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2483)
<!-- Reviewable:end -->
