### PR TITLE
Switch to Graalvm js and update JSAPI - closes #2519

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ runtime {
                'jdk.dynalink',
                'jdk.jfr',
                'jdk.jsobject',
-               'jdk.scripting.nashorn',
+               'org.graalvm.js',
                'jdk.unsupported',
                'jdk.unsupported.desktop',
                'jdk.xml.dom',
@@ -303,6 +303,8 @@ dependencies {
     implementation 'com.thoughtworks.xstream:xstream:1.4.11.1'
     implementation 'yasb:yasb:0.2-21012007'
     implementation 'de.muntjak.tinylookandfeel:tinylaf-nocp:1.4.0'
+    implementation group: 'org.graalvm.js', name: 'js', version: '21.0.0.2'
+    implementation group: 'org.graalvm.js', name: 'js-scriptengine', version: '21.0.0.2'
 
     implementation 'com.jayway.jsonpath:json-path:2.4.0'
 

--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -14,14 +14,11 @@
  */
 package net.rptools.maptool.client.functions;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.*;
 import javax.script.ScriptException;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
-import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.script.javascript.JSScriptEngine;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;

--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -19,7 +19,6 @@ import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.*;
 import javax.script.ScriptException;
-import jdk.nashorn.api.scripting.JSObject;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
@@ -88,21 +87,6 @@ public class MacroJavaScriptBridge extends AbstractFunction {
       return BigDecimal.valueOf((Long) val);
     } else if (val instanceof Double) {
       return BigDecimal.valueOf((Double) val);
-    } else if (val instanceof JSObject) {
-      JSObject jsObject = (JSObject) val;
-      if (jsObject.isArray()) {
-        JsonArray arr = new JsonArray();
-        for (Object o : jsObject.values()) {
-          arr.add(0);
-        }
-        return arr;
-      } else {
-        JsonObject obj = new JsonObject();
-        for (String key : jsObject.keySet()) {
-          obj.add(key, JSONMacroFunctions.getInstance().asJsonElement(jsObject.getMember(key)));
-        }
-        return obj;
-      }
     } else {
       return val;
     }

--- a/src/main/java/net/rptools/maptool/client/script/javascript/JSScriptEngine.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/JSScriptEngine.java
@@ -16,8 +16,6 @@ package net.rptools.maptool.client.script.javascript;
 
 import java.util.Set;
 import javax.script.*;
-import jdk.nashorn.api.scripting.ClassFilter;
-import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
 import net.rptools.maptool.client.script.javascript.api.MapToolJSAPIDefinition;
 import net.rptools.maptool.client.script.javascript.api.MapToolJSAPIInterface;
 import org.apache.logging.log4j.LogManager;
@@ -32,84 +30,6 @@ public class JSScriptEngine {
   private ScriptEngine engine;
   private ScriptContext anonymousContext;
 
-  public static class JSClassFilter implements ClassFilter {
-
-    @Override
-    public boolean exposeToScripts(String jclass) {
-      if (jclass.equals("java.lang.Math")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Boolean")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Byte")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Character")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Double")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Float")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Long")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Number")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.Short")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.StrictMath")) {
-        return true;
-      }
-      if (jclass.equals("java.lang.String")) {
-        return true;
-      }
-      if (jclass.startsWith("java.lang.")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.Timer")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.concurrent")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.concurrent.atomic")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.concurrent.locks")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.function")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.jar")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.logging")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.spi")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.zip")) {
-        return false;
-      }
-      if (jclass.startsWith("java.util.")) {
-        return true;
-      }
-      if (jclass.startsWith("net.rptools.maptool.client.script.javascript.api.")) {
-        return true;
-      }
-
-      return false;
-    }
-  }
-
   private void registerAPIObject(ScriptContext context, MapToolJSAPIInterface apiObj) {
     MapToolJSAPIDefinition def = apiObj.getClass().getAnnotation(MapToolJSAPIDefinition.class);
     Bindings bindings = context.getBindings(ScriptContext.ENGINE_SCOPE);
@@ -117,7 +37,8 @@ public class JSScriptEngine {
   }
 
   private JSScriptEngine() {
-    engine = new NashornScriptEngineFactory().getScriptEngine(new JSClassFilter());
+    engine = new ScriptEngineManager().getEngineByName("graal.js");
+
     anonymousContext = new SimpleScriptContext();
     anonymousContext.setBindings(engine.createBindings(), ScriptContext.ENGINE_SCOPE);
     Reflections reflections = new Reflections("net.rptools.maptool.client.script.javascript.api");

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIChat.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIChat.java
@@ -1,0 +1,39 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.rptools.maptool.client.MapTool;
+import org.graalvm.polyglot.HostAccess;
+
+public class JSAPIChat {
+  @HostAccess.Export
+  public void broadcast(String message) {
+    MapTool.addGlobalMessage(message);
+  }
+
+  @HostAccess.Export
+  public void broadcastTo(List<String> who, String message) {
+    MapTool.addGlobalMessage(message, who);
+  }
+
+  @HostAccess.Export
+  public void broadcastToGM(String message) {
+    List<String> who = new ArrayList<>();
+    who.add("gm");
+    MapTool.addGlobalMessage(message, who);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIClientInfo.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIClientInfo.java
@@ -1,0 +1,89 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.*;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.functions.UserDefinedMacroFunctions;
+import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Zone;
+import org.graalvm.polyglot.HostAccess;
+
+public class JSAPIClientInfo {
+  public boolean faceEdge() {
+    return AppPreferences.getFaceEdge();
+  }
+
+  public boolean faceVertex() {
+    return AppPreferences.getFaceVertex();
+  }
+
+  public int portraitSize() {
+    return AppPreferences.getPortraitSize();
+  }
+
+  public boolean showStatSheet() {
+    return AppPreferences.getShowStatSheet();
+  }
+
+  @HostAccess.Export
+  public String version() {
+    return MapTool.getVersion();
+  }
+
+  @HostAccess.Export
+  public boolean fullScreen() {
+    return MapTool.getFrame().isFullScreen();
+  }
+
+  @HostAccess.Export
+  public long timeInMs() {
+    return System.currentTimeMillis();
+  }
+
+  @HostAccess.Export
+  public Date timeDate() {
+    return Calendar.getInstance().getTime();
+  }
+
+  @HostAccess.Export
+  public JSMap libraryTokens() {
+    Map<String, Object> libInfo = new HashMap<>();
+    for (ZoneRenderer zr : MapTool.getFrame().getZoneRenderers()) {
+      Zone zone = zr.getZone();
+      for (Token token : zone.getTokens()) {
+        if (token.getName().toLowerCase().startsWith("lib:")) {
+          if (token.getProperty("libversion") != null) {
+            libInfo.put(token.getName(), token.getProperty("libversion").toString());
+          } else {
+            libInfo.put(token.getName(), "unknown");
+          }
+        }
+      }
+    }
+    return new JSMap(libInfo);
+  }
+
+  @HostAccess.Export
+  public JSList userDefinedFunctions() {
+    return JSList.fromArray(UserDefinedMacroFunctions.getInstance().getAliases());
+  }
+
+  public String clientId() {
+    return MapTool.getClientId();
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIDrawing.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIDrawing.java
@@ -1,0 +1,77 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.ArrayList;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.drawing.AbstractDrawing;
+import net.rptools.maptool.model.drawing.DrawnElement;
+import org.graalvm.polyglot.*;
+
+public class JSAPIDrawing {
+  @HostAccess.Export public final AbstractDrawing drawing;
+
+  @HostAccess.Export public final GUID guid;
+  private boolean dead = false;
+
+  @HostAccess.Export
+  public JSAPIDrawing(String gid) {
+    guid = new GUID(gid);
+    AbstractDrawing target = null;
+    for (DrawnElement e :
+        MapTool.getFrame().getCurrentZoneRenderer().getZone().getAllDrawnElements()) {
+      if (e.getDrawable().getId().equals(guid)) {
+        target = (AbstractDrawing) e.getDrawable();
+        break;
+      }
+    }
+    drawing = target;
+    if (drawing == null) {
+      dead = true;
+    }
+  }
+
+  public JSAPIDrawing(AbstractDrawing d) {
+    drawing = d;
+    guid = d.getId();
+  }
+
+  @HostAccess.Export
+  public void removeDrawable() {
+    if (!dead) {
+      //            AbstractDrawing target = null;
+      //            for (DrawnElement e:
+      // MapTool.getFrame().getCurrentZoneRenderer().getZone().getAllDrawnElements()) {
+      //                if (e.getDrawable().getId().equals(guid)) {
+      //                    target = (AbstractDrawing) e.getDrawable();
+      //                    break;
+      //                }
+      //            }
+      MapTool.getFrame().getCurrentZoneRenderer().getZone().removeDrawable(guid);
+    }
+    dead = true;
+  }
+
+  @HostAccess.Export
+  public static JSList getAllDrawings() {
+    ArrayList<Object> out = new ArrayList<>();
+    for (DrawnElement e :
+        MapTool.getFrame().getCurrentZoneRenderer().getZone().getAllDrawnElements()) {
+      out.add(new JSAPIDrawing((AbstractDrawing) e.getDrawable()));
+    }
+    return new JSList(out);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIMTScript.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIMTScript.java
@@ -1,0 +1,77 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import net.rptools.maptool.client.functions.AbortFunction;
+import net.rptools.maptool.client.functions.AssertFunction;
+import net.rptools.maptool.client.functions.EvalMacroFunctions;
+import net.rptools.maptool.client.functions.MacroJavaScriptBridge;
+import net.rptools.maptool.language.I18N;
+import net.rptools.parser.ParserException;
+import org.graalvm.polyglot.*;
+
+@MapToolJSAPIDefinition(javaScriptVariableName = "MTScript")
+/** Class used to provide an API to interact with MapTool custom scripting language. */
+public class JSAPIMTScript implements MapToolJSAPIInterface {
+
+  @HostAccess.Export
+  public Object getVariable(String name) throws ParserException {
+    return MacroJavaScriptBridge.getInstance().getMTScriptVariable(name);
+  }
+
+  @HostAccess.Export
+  public void setVariable(String name, Object value) throws ParserException {
+    MacroJavaScriptBridge.getInstance().setMTScriptVariable(name, value);
+  }
+
+  @HostAccess.Export
+  public void raiseError(String msg) throws ParserException {
+    throw new ParserException(msg);
+  }
+
+  @HostAccess.Export
+  public void abort() throws ParserException {
+    throw new AbortFunction.AbortFunctionException(
+        I18N.getText("macro.function.abortFunction.message", "MTScript.abort()"));
+  }
+
+  @HostAccess.Export
+  public void mtsAssert(boolean check, String message)
+      throws AssertFunction.AssertFunctionException {
+    if (!check) {
+      throw new AssertFunction.AssertFunctionException(message);
+    }
+  }
+
+  @HostAccess.Export
+  public Object execMacro(String macro) throws ParserException {
+    return EvalMacroFunctions.getInstance()
+        .execMacro(MacroJavaScriptBridge.getInstance().getTokenInContext(), macro);
+  }
+
+  @HostAccess.Export
+  public Object evalMacro(String macro) throws ParserException {
+    return EvalMacroFunctions.getInstance()
+        .evalMacro(
+            MacroJavaScriptBridge.getInstance().getVariableResolver(),
+            MacroJavaScriptBridge.getInstance().getTokenInContext(),
+            macro);
+  }
+
+  @HostAccess.Export
+  public JSList getMTScriptCallingArgs() {
+    return new JSList(MacroJavaScriptBridge.getInstance().getCallingArgs());
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIMapTool.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIMapTool.java
@@ -1,0 +1,55 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.model.Token;
+import org.graalvm.polyglot.*;
+
+@MapToolJSAPIDefinition(javaScriptVariableName = "MapTool")
+public class JSAPIMapTool implements MapToolJSAPIInterface {
+
+  @HostAccess.Export public final JSAPIClientInfo clientInfo = new JSAPIClientInfo();
+
+  @HostAccess.Export public final JSAPIChat chat = new JSAPIChat();
+
+  @HostAccess.Export public final JSAPITokens tokens = new JSAPITokens();
+
+  @HostAccess.Export
+  public List<JSAPIToken> getSelectedTokens() {
+    List<Token> tokens = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokensList();
+    List<JSAPIToken> out_tokens = new ArrayList<JSAPIToken>();
+    for (Token token : tokens) {
+      out_tokens.add(new JSAPIToken(token));
+    }
+    return out_tokens;
+  }
+
+  @HostAccess.Export
+  public JSAPIToken getSelected() {
+    List<Token> tokens = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokensList();
+    if (tokens.size() > 0) {
+      return new JSAPIToken(tokens.get(0));
+    }
+    return null;
+  }
+
+  @HostAccess.Export
+  public JSAPIToken getTokenByID(String uuid) {
+    return new JSAPIToken(uuid);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -1,0 +1,107 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.Iterator;
+import java.util.Set;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Token;
+import org.graalvm.polyglot.HostAccess;
+
+public class JSAPIToken {
+
+  private final Token token;
+  private Set<String> names;
+  private Iterator<String> names_iter;
+
+  public JSAPIToken(Token token) {
+    this.token = token;
+  }
+
+  public JSAPIToken(String tid) {
+    this(MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(tid)));
+  }
+
+  @HostAccess.Export
+  public String getNotes() {
+    return token.getNotes();
+  }
+
+  @HostAccess.Export
+  public void setNotes(String notes) {
+    token.setNotes(notes);
+  }
+
+  @HostAccess.Export
+  public String getName() {
+    return token.getName();
+  }
+
+  @HostAccess.Export
+  public void setName(String name) {
+    token.setName(name);
+  }
+
+  @HostAccess.Export
+  public boolean hasSight() {
+    return token.getHasSight();
+  }
+
+  @HostAccess.Export
+  public void setSight(boolean sight) {
+    token.setHasSight(sight);
+  }
+
+  @HostAccess.Export
+  public String toString() {
+    return "Token(id=" + token.getId() + ")";
+  }
+
+  @HostAccess.Export
+  public String getId() {
+    return "" + token.getId();
+  }
+
+  @HostAccess.Export
+  public String getProperty(String name) {
+    return "" + this.token.getProperty(name);
+  }
+
+  @HostAccess.Export
+  public void setProperty(String name, String value) {
+    this.token.setProperty(name, value);
+  }
+
+  @HostAccess.Export
+  public int getX() {
+    return this.token.getX();
+  }
+
+  @HostAccess.Export
+  public int getY() {
+    return this.token.getY();
+  }
+
+  @HostAccess.Export
+  public void setX(int x) {
+    this.token.setX(x);
+  }
+
+  @HostAccess.Export
+  public void setY(int y) {
+    this.token.setY(y);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
@@ -1,0 +1,35 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.rptools.maptool.client.MapTool;
+import org.graalvm.polyglot.HostAccess;
+
+public class JSAPITokens {
+
+  @HostAccess.Export
+  public JSList getMapTokens() {
+    final List<Object> tokens = new ArrayList<>();
+
+    MapTool.getFrame()
+        .getCurrentZoneRenderer()
+        .getZone()
+        .getTokens()
+        .forEach(t -> tokens.add(new JSAPIToken(t)));
+    return new JSList(tokens);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSList.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSList.java
@@ -1,0 +1,57 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.*;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyArray;
+
+public class JSList implements ProxyArray {
+
+  private List<Object> values;
+
+  public JSList(List<Object> values) {
+    this.values = values;
+  }
+
+  public static JSList fromArray(Object[] values) {
+    return new JSList(Arrays.asList(values));
+  }
+
+  public static JSList fromList(List<Object> values) {
+    return new JSList(new ArrayList(values));
+  }
+
+  @Override
+  public long getSize() {
+    return values.size();
+  }
+
+  @Override
+  public Value get(long index) {
+    return (Value) values.get((int) index);
+  }
+
+  @Override
+  public boolean remove(long index) {
+    values.remove((int) index);
+    return true;
+  }
+
+  @Override
+  public void set(long index, Value value) {
+    values.set((int) index, value);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSMap.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSMap.java
@@ -1,0 +1,52 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.script.javascript.api;
+
+import java.util.*;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyObject;
+
+public class JSMap implements ProxyObject {
+
+  private Map<String, Object> values;
+
+  public JSMap(Map<String, Object> values) {
+    this.values = values;
+  }
+
+  public static JSMap fromMap(Map<String, Object> values) {
+    return new JSMap(values);
+  }
+
+  @Override
+  public List<String> getMemberKeys() {
+    return new ArrayList(values.keySet());
+  }
+
+  @Override
+  public Value getMember(String key) {
+    return (Value) values.get(key);
+  }
+
+  @Override
+  public boolean hasMember(String key) {
+    return values.containsKey(key);
+  }
+
+  @Override
+  public void putMember(String key, Value value) {
+    values.put(key, value);
+  }
+}


### PR DESCRIPTION
As explained in #2519, this switches to GraalVM-JS for the javascript implementation, and re-adds the broken/missing JSAPI classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2520)
<!-- Reviewable:end -->
