### PR TITLE
Automatically reset picks.

### DIFF
--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -323,12 +323,13 @@ public class LookupTable {
   }
 
   /**
-   * Set whether a table as Pick Once (true/false).
+   * Set whether a table as Pick Once (true/false). Automatically resets the pick once status of entries.
    *
    * @param pickOnce - Boolean
    */
   public void setPickOnce(Boolean pickOnce) {
     this.pickOnce = pickOnce;
+    this.reset();
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -323,7 +323,8 @@ public class LookupTable {
   }
 
   /**
-   * Set whether a table as Pick Once (true/false). Automatically resets the pick once status of entries.
+   * Set whether a table as Pick Once (true/false). Automatically resets the pick once status of
+   * entries.
    *
    * @param pickOnce - Boolean
    */


### PR DESCRIPTION
When `setPickOnce()` is called automatically reset the picked status for all entries.

Fix for issue #2511.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2530)
<!-- Reviewable:end -->
