### PR TITLE
Allow direct execution of chat commands

### DIFF
--- a/src/main/java/net/rptools/maptool/client/macro/impl/RunTokenSpeechMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/RunTokenSpeechMacro.java
@@ -48,11 +48,7 @@ public class RunTokenSpeechMacro implements Macro {
       if (tmacro == null) {
         continue;
       }
-      MapTool.getFrame()
-          .getCommandPanel()
-          .getCommandTextArea()
-          .setText("/im " + token.getId() + ": " + tmacro);
-      MapTool.getFrame().getCommandPanel().commitCommand();
+      MapTool.getFrame().getCommandPanel().commitCommand("/im " + token.getId() + ": " + tmacro);
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -43,7 +43,6 @@ import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import javax.swing.text.JTextComponent;
 import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppUtil;
@@ -927,14 +926,11 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
     }
 
     public void actionPerformed(ActionEvent e) {
-      JTextComponent commandArea = MapTool.getFrame().getCommandPanel().getCommandTextArea();
-
       if (!AppUtil.playerOwns(tokenUnderMouse)) {
         return;
       }
-      commandArea.setText("/im " + tokenUnderMouse.getId());
-      MapTool.getFrame().getCommandPanel().commitCommand();
-      commandArea.requestFocusInWindow();
+      MapTool.getFrame().getCommandPanel().commitCommand("/im " + tokenUnderMouse.getId());
+      MapTool.getFrame().getCommandPanel().getCommandTextArea().requestFocusInWindow();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/TokenPopupMenu.java
@@ -43,7 +43,6 @@ import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.JSlider;
 import javax.swing.KeyStroke;
-import javax.swing.text.JTextComponent;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
@@ -1046,10 +1045,7 @@ public class TokenPopupMenu extends AbstractTokenPopupMenu {
     @Override
     public void actionPerformed(ActionEvent e) {
       String identity = getTokenUnderMouse().getName();
-      String command = "/im " + identity + ":" + speech;
-      JTextComponent commandArea = MapTool.getFrame().getCommandPanel().getCommandTextArea();
-      commandArea.setText(command);
-      MapTool.getFrame().getCommandPanel().commitCommand();
+      MapTool.getFrame().getCommandPanel().commitCommand("/im " + identity + ":" + speech);
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/lookuptable/LookupTablePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/lookuptable/LookupTablePanel.java
@@ -85,9 +85,7 @@ public class LookupTablePanel extends AbeillePanel<LookupTableImagePanelModel> {
               }
               MapTool.getFrame()
                   .getCommandPanel()
-                  .getCommandTextArea()
-                  .setText("/tbl \"" + lookupTable.getName() + "\"");
-              MapTool.getFrame().getCommandPanel().commitCommand();
+                  .commitCommand("/tbl \"" + lookupTable.getName() + "\"");
             }
           }
         });

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AbstractButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AbstractButtonGroup.java
@@ -301,9 +301,9 @@ public abstract class AbstractButtonGroup extends JPanel
           } else if (SwingUtilities.isLeftMouseButton(event) && SwingUtil.isShiftDown(event)) {
             // impersonate token toggle
             if (token.isBeingImpersonated()) {
-              MapTool.getFrame().getCommandPanel().quickCommit("/im");
+              MapTool.getFrame().getCommandPanel().commitCommand("/im");
             } else {
-              MapTool.getFrame().getCommandPanel().quickCommit("/im " + tokenId, false);
+              MapTool.getFrame().getCommandPanel().commitCommand("/im " + tokenId);
             }
           }
         }

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
@@ -80,7 +80,7 @@ public class ImpersonatePanel extends AbstractMacroPanel {
               new MouseAdapter() {
                 @Override
                 public void mouseClicked(MouseEvent event) {
-                  MapTool.getFrame().getCommandPanel().quickCommit("/im " + t.getId(), false);
+                  MapTool.getFrame().getCommandPanel().commitCommand("/im " + t.getId());
                 }
               });
           button.setBackground(null);
@@ -201,7 +201,7 @@ public class ImpersonatePanel extends AbstractMacroPanel {
         new MouseAdapter() {
           @Override
           public void mouseClicked(MouseEvent event) {
-            MapTool.getFrame().getCommandPanel().quickCommit("/im");
+            MapTool.getFrame().getCommandPanel().commitCommand("/im");
           }
         });
     button.setBackground(null);

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -1834,12 +1834,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                 selectedText = source.getText();
               }
               // TODO: Combine this with the code in MacroButton
-              JTextComponent commandArea =
-                  MapTool.getFrame().getCommandPanel().getCommandTextArea();
-
-              commandArea.setText("/emit " + selectedText);
-              commandArea.requestFocusInWindow();
-              MapTool.getFrame().getCommandPanel().commitCommand();
+              MapTool.getFrame().getCommandPanel().commitCommand("/emit " + selectedText);
+              MapTool.getFrame().getCommandPanel().getCommandTextArea().requestFocusInWindow();
             });
         menu.add(sendAsEmoteItem);
         menu.show((JComponent) e.getSource(), e.getX(), e.getY());

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -449,10 +449,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
       String oldText = commandArea.getText();
 
       if (getIncludeLabel()) {
-        String commandToExecute = getLabel();
-        commandArea.setText(impersonatePrefix + commandToExecute);
-
-        MapTool.getFrame().getCommandPanel().commitCommand();
+        MapTool.getFrame().getCommandPanel().commitCommand(impersonatePrefix + getLabel());
       }
 
       String commandsToExecute[] = parseMultiLineCommand(getCommand());
@@ -463,7 +460,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
       String loc;
       for (String command : commandsToExecute) {
         // If we aren't auto execute, then append the text instead of replace it
-        commandArea.setText(impersonatePrefix + (!getAutoExecute() ? oldText + " " : "") + command);
+        command = impersonatePrefix + (!getAutoExecute() ? oldText + " " : "") + command;
         if (getAutoExecute()) {
           boolean trusted = false;
           if (allowPlayerEdits == null) {
@@ -494,7 +491,9 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
             loc = MapToolLineParser.CHAT_INPUT;
           }
           MapToolMacroContext newMacroContext = new MapToolMacroContext(label, loc, trusted, index);
-          MapTool.getFrame().getCommandPanel().commitCommand(newMacroContext);
+          MapTool.getFrame().getCommandPanel().commitCommand(command, newMacroContext);
+        } else {
+          commandArea.setText(command);
         }
       }
       commandArea.requestFocusInWindow();


### PR DESCRIPTION
This changes `commitCommand()` so that commands can be passed into it directly, avoiding manipulating the chat's text area. This makes it so when executing commands internally the current content of the text area will not be overwritten and the command will not be added to command history. This also makes `quickCommit()` redundant, so I removed it.

This should close #2550 and close #2551.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2553)
<!-- Reviewable:end -->
