### PR TITLE
Removes the check for common macros to be non empty before showing it

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
@@ -90,9 +90,7 @@ public class SelectionPanel extends AbstractMacroPanel {
       // draw common group only when there is more than one token selected
       if (selectedTokenList.size() > 1) {
         populateCommonButtons(selectedTokenList);
-        if (!commonMacros.isEmpty()) {
-          addArea(commonMacros, I18N.getText("component.areaGroup.macro.commonMacros"));
-        }
+        addArea(commonMacros, I18N.getText("component.areaGroup.macro.commonMacros"));
         // add(new ButtonGroup(selectedTokenList, commonMacros, this));
       }
       for (Token token : selectedTokenList) {


### PR DESCRIPTION
This forces the Common Macros panel to be always shown when you have two or more tokens selected. 

No unit test for the moment, I will see how I can add them in another pull request.

* fixes #1496

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2569)
<!-- Reviewable:end -->
