### PR TITLE
Flush overlays when closed.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -192,6 +192,7 @@ public class HTMLOverlayPanel extends JFXPanel {
       root.getChildren().remove(overlay.getWebView());
       overlays.remove(overlay);
       AppMenuBar.removeFromOverlayMenu(overlay.getName());
+      overlay.flush();
       if (overlays.isEmpty()) {
         setVisible(false); // hide overlay panel if all are gone
       }
@@ -207,6 +208,7 @@ public class HTMLOverlayPanel extends JFXPanel {
           for (HTMLOverlayManager overlay : overlays) {
             listChildren.remove(overlay.getWebView());
             AppMenuBar.removeFromOverlayMenu(overlay.getName());
+            overlay.flush();
           }
           overlays.clear();
           setVisible(false);


### PR DESCRIPTION
This brings overlays in line with frames and dialogs, where the page does not remain loaded after being closed.

Fixes #2249

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2586)
<!-- Reviewable:end -->
