### PR TITLE
Change UberJar to use Zip64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -381,6 +381,7 @@ task configSentryRelease(type: Copy) {
 
 task uberJar(type: Jar) {
     group = 'distribution'
+    zip64 = true
     description = 'Create uber jar for native installers'
 
     baseName project.name + '-' + tagVersion


### PR DESCRIPTION
Too many files now to use the wimpy 32-bit zip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2606)
<!-- Reviewable:end -->
