### PR TITLE
Fix some places where Zone.Layer enum names should be used

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -286,7 +286,7 @@ public class DrawingFunctions extends AbstractFunction {
     JsonObject dinfo = new JsonObject();
     dinfo.addProperty("id", el.getDrawable().getId().toString());
     dinfo.addProperty("name", d.getName());
-    dinfo.addProperty("layer", el.getDrawable().getLayer().toString());
+    dinfo.addProperty("layer", el.getDrawable().getLayer().name());
     dinfo.addProperty("type", getDrawbleType(d));
     dinfo.add("bounds", boundsToJSON(d));
     dinfo.addProperty("penColor", paintToString(el.getPen().getPaint()));

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingGetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingGetterFunctions.java
@@ -64,7 +64,7 @@ public class DrawingGetterFunctions extends DrawingFunctions {
     Zone map = getNamedMap(functionName, mapName).getZone();
     GUID guid = getGUID(functionName, id);
     if ("getDrawingLayer".equalsIgnoreCase(functionName)) {
-      return getDrawable(functionName, map, guid).getLayer();
+      return getDrawable(functionName, map, guid).getLayer().name();
     } else if ("getDrawingOpacity".equalsIgnoreCase(functionName)) {
       return getPen(functionName, map, guid).getOpacity();
     } else if ("getDrawingProperties".equalsIgnoreCase(functionName)) {

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
@@ -57,7 +57,7 @@ public class DrawingSetterFunctions extends DrawingFunctions {
     GUID guid = getGUID(functionName, id);
     if ("setDrawingLayer".equalsIgnoreCase(functionName)) {
       Layer layer = getLayer(parameters.get(2).toString());
-      return changeLayer(map, layer, guid);
+      return changeLayer(map, layer, guid).name();
     } else if ("setDrawingOpacity".equalsIgnoreCase(functionName)) {
       String opacity = parameters.get(2).toString();
       float op = getFloatPercent(functionName, opacity);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -985,7 +985,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     } else {
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setLayer, layer);
     }
-    return layerName;
+    return layer.name();
   }
 
   /**


### PR DESCRIPTION
I missed these when doing #2560, but technically also related to #2595. 

* `getDrawingLayer()`, `setDrawingLayer()`, and `setLayer()` now all return the enum names (`setLayer()` previously returned whatever was passed to the function).
* The `layer` property in the data returned by `getDrawingInfo()` is now the enum name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2614)
<!-- Reviewable:end -->
