### PR TITLE
Localize Campaign Properties dropdowns

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/FormPanelI18N.java
+++ b/src/main/java/net/rptools/maptool/client/swing/FormPanelI18N.java
@@ -21,6 +21,7 @@ import com.jeta.forms.components.panel.FormPanel;
 import com.jeta.forms.gui.form.FormAccessor;
 import com.jeta.forms.gui.form.FormComponent;
 import com.jeta.forms.gui.form.GridView;
+import com.jeta.forms.store.properties.ListItemProperty;
 import java.awt.*;
 import java.util.Iterator;
 import javax.swing.*;
@@ -72,6 +73,10 @@ public class FormPanelI18N extends FormPanel {
       String tooltip = jComboBox.getToolTipText();
       if (tooltip != null) {
         jComboBox.setToolTipText(I18N.getText(tooltip));
+      }
+      for (int i = 0; i < jComboBox.getItemCount(); ++i) {
+        ListItemProperty item = (ListItemProperty) jComboBox.getItemAt(i);
+        item.setLabel(I18N.getText(item.getLabel()));
       }
     } else if (comp instanceof JTextField) {
       JTextField jTextField = (JTextField) comp;

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -428,7 +428,7 @@ public class TokenStatesController
   public void changedUpdate(DocumentEvent e) {
     String text = formPanel.getText(IMAGE);
     boolean hasImage =
-        !((ListItemProperty) formPanel.getSelectedItem(TYPE)).getLabel().contains("Image")
+        !((ListItemProperty) formPanel.getSelectedItem(TYPE)).getName().contains("Image")
             || text != null && (text = text.trim()).length() != 0;
     text = formPanel.getText(NAME);
     boolean hasName = text != null && (text = text.trim()).length() != 0;
@@ -665,7 +665,7 @@ public class TokenStatesController
     String name = formPanel.getText(NAME);
     String group = formPanel.getText(GROUP);
     boolean mouseover = formPanel.isSelected(MOUSEOVER);
-    String overlay = ((ListItemProperty) formPanel.getSelectedItem(TYPE)).getLabel();
+    String overlay = ((ListItemProperty) formPanel.getSelectedItem(TYPE)).getName();
     int opacity = getSpinner(OPACITY, "opacity", formPanel);
     int index = getSpinner(INDEX, "index", formPanel);
     boolean showGM = formPanel.isSelected(SHOW_GM);
@@ -675,8 +675,7 @@ public class TokenStatesController
     // Check for overlays that don't use width
     BooleanTokenOverlay to = null;
     if (overlay.equals("Dot")) {
-      String cornerName =
-          formPanel.getSelectedItem(CORNER).toString().toUpperCase().replace(' ', '_');
+      String cornerName = ((ListItemProperty) formPanel.getSelectedItem(CORNER)).getName();
       to = new ColorDotTokenOverlay(name, color, Quadrant.valueOf(cornerName));
     } else if (overlay.equals("Shaded")) {
       to = new ShadedTokenOverlay(name, color);
@@ -739,8 +738,7 @@ public class TokenStatesController
         if (overlay.equals("Image")) {
           to = new ImageTokenOverlay(name, assetId);
         } else if (overlay.equals("Corner Image")) {
-          String cornerName =
-              formPanel.getSelectedItem(CORNER).toString().toUpperCase().replace(' ', '_');
+          String cornerName = ((ListItemProperty) formPanel.getSelectedItem(CORNER)).getName();
           to = new CornerImageTokenOverlay(name, assetId, Quadrant.valueOf(cornerName));
         } else if (overlay.equals("Grid Image")) {
           to = new FlowImageTokenOverlay(name, assetId, grid);

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/campaignPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/campaignPropertiesDialog.xml
@@ -1432,8 +1432,8 @@
                               </at>
                               <at name="selectedItem">
                                <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                <at name="name">listitem</at>
-                                <at name="label">Image</at>
+                                <at name="name">Image</at>
+                                <at name="label">CampaignPropertiesDialog.combo.states.type.image</at>
                                 <at name="icon">
                                  <object classname="com.jeta.forms.store.properties.IconProperty">
                                   <at name="embedded">false</at>
@@ -1453,8 +1453,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Image</at>
+                                     <at name="name">Image</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.image</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1468,8 +1468,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Corner Image</at>
+                                     <at name="name">Corner Image</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.cornerImage</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1483,8 +1483,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Grid Image</at>
+                                     <at name="name">Grid Image</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.gridImage</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1498,8 +1498,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Dot</at>
+                                     <at name="name">Dot</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.dot</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1513,8 +1513,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Grid Dot</at>
+                                     <at name="name">Grid Dot</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.gridDot</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1528,8 +1528,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Circle</at>
+                                     <at name="name">Circle</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.circle</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1543,8 +1543,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Shaded</at>
+                                     <at name="name">Shaded</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.shaded</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1558,8 +1558,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">X</at>
+                                     <at name="name">X</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.x</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1573,8 +1573,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Cross</at>
+                                     <at name="name">Cross</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.cross</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1588,8 +1588,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Diamond</at>
+                                     <at name="name">Diamond</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.diamond</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1603,8 +1603,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Grid Diamond</at>
+                                     <at name="name">Grid Diamond</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.gridDiamond</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1618,8 +1618,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Yield</at>
+                                     <at name="name">Yield</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.yield</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1633,8 +1633,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Grid Yield</at>
+                                     <at name="name">Grid Yield</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.gridYield</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1648,8 +1648,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Triangle</at>
+                                     <at name="name">Triangle</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.triangle</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1663,8 +1663,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Grid Triangle</at>
+                                     <at name="name">Grid Triangle</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.gridTriangle</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -1678,8 +1678,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">Grid Square</at>
+                                     <at name="name">Grid Square</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.type.gridSquare</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -2201,8 +2201,8 @@
                               </at>
                               <at name="selectedItem">
                                <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                <at name="name">listitem</at>
-                                <at name="label">North East</at>
+                                <at name="name">NORTH_EAST</at>
+                                <at name="label">CampaignPropertiesDialog.combo.states.corner.topRight</at>
                                 <at name="icon">
                                  <object classname="com.jeta.forms.store.properties.IconProperty">
                                   <at name="embedded">false</at>
@@ -2222,8 +2222,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">North East</at>
+                                     <at name="name">NORTH_EAST</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.corner.topRight</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -2237,8 +2237,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">North West</at>
+                                     <at name="name">NORTH_WEST</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.corner.topLeft</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -2252,8 +2252,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">South East</at>
+                                     <at name="name">SOUTH_EAST</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.corner.bottomRight</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -2267,8 +2267,8 @@
                                   <item >
                                    <at name="value">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
-                                     <at name="label">South West</at>
+                                     <at name="name">SOUTH_WEST</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.states.corner.bottomLeft</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -4159,7 +4159,7 @@
                                    <at name="selectedItem">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                      <at name="name">listitem</at>
-                                     <at name="label">Two Image</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.bars.type.twoImages</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -4180,7 +4180,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Two Image</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.twoImages</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4195,7 +4195,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Single Image</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.singleImage</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4210,7 +4210,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Multiple Images</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.multipleImages</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4225,7 +4225,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Solid</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.solid</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4240,7 +4240,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Two Tone</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.twoTone</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4561,7 +4561,7 @@
                                    <at name="selectedItem">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                      <at name="name">listitem</at>
-                                     <at name="label">Top</at>
+                                     <at name="label">CampaignPropertiesDialog.combo.bars.side.top</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
                                        <at name="embedded">false</at>
@@ -4582,7 +4582,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Top</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.side.top</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4597,7 +4597,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Bottom</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.bottom</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4612,7 +4612,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Left</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.left</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>
@@ -4627,7 +4627,7 @@
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
                                           <at name="name">listitem</at>
-                                          <at name="label">Right</at>
+                                          <at name="label">CampaignPropertiesDialog.combo.bars.type.right</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
                                             <at name="embedded">false</at>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -616,6 +616,40 @@ CampaignPropertiesDialog.tab.light     = Light
 CampaignPropertiesDialog.tab.states    = States
 CampaignPropertiesDialog.tab.bars      = Bars
 CampaignPropertiesDialog.button.import = Import predefined
+# Bar type
+CampaignPropertiesDialog.combo.bars.type.twoImages      = Two Images
+CampaignPropertiesDialog.combo.bars.type.singleImage    = Single Image
+CampaignPropertiesDialog.combo.bars.type.multipleImages = Multiple Images
+CampaignPropertiesDialog.combo.bars.type.solid          = Solid
+CampaignPropertiesDialog.combo.bars.type.twoTone        = Two Tone
+# Bar side
+CampaignPropertiesDialog.combo.bars.side.top    = Top
+CampaignPropertiesDialog.combo.bars.type.bottom = Bottom
+CampaignPropertiesDialog.combo.bars.type.left   = Left
+CampaignPropertiesDialog.combo.bars.type.right  = Right
+# State type
+CampaignPropertiesDialog.combo.states.type.image        = Image
+CampaignPropertiesDialog.combo.states.type.cornerImage  = Corner Image
+CampaignPropertiesDialog.combo.states.type.gridImage    = Grid Image
+CampaignPropertiesDialog.combo.states.type.dot          = Dot
+CampaignPropertiesDialog.combo.states.type.gridDot      = Grid Dot
+CampaignPropertiesDialog.combo.states.type.circle       = Circle
+CampaignPropertiesDialog.combo.states.type.shaded       = Shaded
+CampaignPropertiesDialog.combo.states.type.x            = X
+CampaignPropertiesDialog.combo.states.type.cross        = Cross
+CampaignPropertiesDialog.combo.states.type.diamond      = Diamond
+CampaignPropertiesDialog.combo.states.type.gridDiamond  = Grid Diamond
+# "Yield" here refers to the shape of the traffic sign (an inverted triangle)
+CampaignPropertiesDialog.combo.states.type.yield        = Yield
+CampaignPropertiesDialog.combo.states.type.gridYield    = Grid Yield
+CampaignPropertiesDialog.combo.states.type.triangle     = Triangle
+CampaignPropertiesDialog.combo.states.type.gridTriangle = Grid Triangle
+CampaignPropertiesDialog.combo.states.type.gridSquare   = Grid Square
+# State corner
+CampaignPropertiesDialog.combo.states.corner.topLeft     = Top Left
+CampaignPropertiesDialog.combo.states.corner.topRight    = Top Right
+CampaignPropertiesDialog.combo.states.corner.bottomLeft  = Bottom Left
+CampaignPropertiesDialog.combo.states.corner.bottomRight = Bottom Right
 CampaignPropertiesDialog.label.sight   = <html>\
   <b>Format:</b>\
   <pre>Name : options</pre>\


### PR DESCRIPTION
Part of #2583.

This adds strings for the state type, state corner, bar type, and bar side dropdowns to `i18n.properties`.

This feels slightly hacky, or at least, it feels like it could be done in a nicer way, but I'm under the impression a lot of these dialogs are going to be reworked at some point anyway so it didn't seem too worthwhile to mess around with their behavior too much.

With this change,  `JComboBox` items in form XML will be localized by `FormPanelI18N`. With state type, I stuck the original English name in the `name` value, and for state corner I stuck the enum name in the `name` value, because those strings are used in `TokenStatesController` (which previously relied on checking the label instead). Previously, the names were all `listitem`. This wasn't necessary for bar type or bar side, because `TokenBarController` references the selection by index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2618)
<!-- Reviewable:end -->
