### PR TITLE
Localize Map Properties dropdowns

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -688,13 +688,13 @@ public class AppPreferences {
   }
 
   public static void setDefaultVisionType(Zone.VisionType visionType) {
-    prefs.put(KEY_DEFAULT_VISION_TYPE, visionType.toString());
+    prefs.put(KEY_DEFAULT_VISION_TYPE, visionType.name());
   }
 
   public static Zone.VisionType getDefaultVisionType() {
     try {
       return Zone.VisionType.valueOf(
-          prefs.get(KEY_DEFAULT_VISION_TYPE, DEFAULT_VISION_TYPE.toString()));
+          prefs.get(KEY_DEFAULT_VISION_TYPE, DEFAULT_VISION_TYPE.name()));
     } catch (Exception e) {
       return DEFAULT_VISION_TYPE;
     }

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -125,18 +125,7 @@ public class getInfoFunction extends AbstractFunction {
       minfo.addProperty("largest Z order", zone.getLargestZOrder());
     }
 
-    String visionType = "off";
-    switch (zone.getVisionType()) {
-      case DAY:
-        visionType = "day";
-        break;
-      case NIGHT:
-        visionType = "night";
-        break;
-      case OFF:
-        visionType = "off";
-        break;
-    }
+    String visionType = zone.getVisionType().name();
     minfo.addProperty("vision type", visionType);
 
     JsonObject ginfo = new JsonObject();

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -132,9 +132,20 @@ public class Zone extends BaseModel {
 
   /** Control how A* Pathfinding distances is rounded off due to terrain costs */
   public enum AStarRoundingOptions {
-    NONE,
-    CELL_UNIT,
-    INTEGER
+    NONE(),
+    CELL_UNIT(),
+    INTEGER();
+
+    private final String displayName;
+
+    AStarRoundingOptions() {
+      displayName = I18N.getString("Zone.AStarRoundingOptions." + name());
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
   }
 
   // Control what topology layer(s) to add/get drawing to/from

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -55,9 +55,20 @@ public class Zone extends BaseModel {
 
   /** The vision type (OFF, DAY, NIGHT). */
   public enum VisionType {
-    OFF,
-    DAY,
-    NIGHT
+    OFF(),
+    DAY(),
+    NIGHT();
+
+    private final String displayName;
+
+    VisionType() {
+      displayName = I18N.getString("visionType." + name());
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
   }
 
   /** Event types for the listeners. */

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -803,6 +803,11 @@ VisionDialog.error.numericDistanceOnly = Distance must be numeric.
 # currently not accessible by the user.
 VisionDialog.msg.title                 = Vision
 
+# AI cell rounding options
+Zone.AStarRoundingOptions.NONE      = None
+Zone.AStarRoundingOptions.CELL_UNIT = Cell Unit
+Zone.AStarRoundingOptions.INTEGER   = Integer
+
 # This message appears when a campaign is loaded and MapTool is scanning
 # the maps and optimizing their memory footprint by collapsing
 # drawables, if possible.


### PR DESCRIPTION
Part of #2583.

Localizes the AI Cell Rounding and Lights drop downs (and consequentially, the New Map Light drop down in Preferences).

Macro changes:
* `vision type` property in `getInfo("map")` now uses the enum name (was previously the enum name in lower case?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2619)
<!-- Reviewable:end -->
