### PR TITLE
Localize Preferences dialog drop downs

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -879,7 +879,7 @@ public class AppPreferences {
   }
 
   public static void setMovementMetric(WalkerMetric metric) {
-    prefs.put(KEY_MOVEMENT_METRIC, metric.toString());
+    prefs.put(KEY_MOVEMENT_METRIC, metric.name());
   }
 
   public static void setFrameRateCap(int cap) {
@@ -933,8 +933,7 @@ public class AppPreferences {
   public static WalkerMetric getMovementMetric() {
     WalkerMetric metric;
     try {
-      metric =
-          WalkerMetric.valueOf(prefs.get(KEY_MOVEMENT_METRIC, DEFAULT_MOVEMENT_METRIC.toString()));
+      metric = WalkerMetric.valueOf(prefs.get(KEY_MOVEMENT_METRIC, DEFAULT_MOVEMENT_METRIC.name()));
     } catch (Exception exc) {
       metric = DEFAULT_MOVEMENT_METRIC;
     }

--- a/src/main/java/net/rptools/maptool/client/MapToolUtil.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolUtil.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.rptools.maptool.client.utilities.RandomSuffixFactory;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Token;
@@ -137,7 +138,7 @@ public class MapToolUtil {
     Integer newNum = null;
 
     if (isToken && AppPreferences.getNewTokenNaming().equals(Token.NAME_USE_CREATURE)) {
-      newName = "Creature";
+      newName = I18N.getString("Token.name.creature");
     } else if (!force) {
       return baseName;
     } else if (baseName == null) {

--- a/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
@@ -72,10 +72,10 @@ public class PreferencesDialog extends JDialog {
   private final JCheckBox stampsStartFreeSizeCheckBox;
   private final JCheckBox backgroundsStartSnapToGridCheckBox;
   private final JCheckBox backgroundsStartFreeSizeCheckBox;
-  private final JComboBox duplicateTokenCombo;
-  private final JComboBox tokenNamingCombo;
-  private final JComboBox showNumberingCombo;
-  private final JComboBox movementMetricCombo;
+  private final JComboBox<LocalizedComboItem> duplicateTokenCombo;
+  private final JComboBox<LocalizedComboItem> tokenNamingCombo;
+  private final JComboBox<LocalizedComboItem> showNumberingCombo;
+  private final JComboBox<WalkerMetric> movementMetricCombo;
   private final JComboBox<Zone.VisionType> visionTypeCombo;
   private final JCheckBox showStatSheetCheckBox;
   private final JCheckBox showPortraitCheckBox;
@@ -104,12 +104,12 @@ public class PreferencesDialog extends JDialog {
   private final JSpinner chatAutosaveTime;
   private final JTextField chatFilenameFormat;
   private final JSpinner typingNotificationDuration;
-  private final JComboBox macroEditorThemeCombo;
+  private final JComboBox<String> macroEditorThemeCombo;
   // Chat Notification
   private final JETAColorWell chatNotificationColor;
   private final JCheckBox chatNotificationShowBackground;
   // Defaults
-  private final JComboBox defaultGridTypeCombo;
+  private final JComboBox<LocalizedComboItem> defaultGridTypeCombo;
   private final JTextField defaultGridSizeTextField;
   private final JTextField defaultUnitsPerCellTextField;
   private final JTextField defaultVisionDistanceTextField;
@@ -145,6 +145,34 @@ public class PreferencesDialog extends JDialog {
   private final JComboBox<String> jamLanguageOverrideComboBox;
   private final JLabel startupInfoLabel;
   private boolean jvmValuesChanged = false;
+  private static final LocalizedComboItem[] defaultGridTypeComboItems = {
+    new LocalizedComboItem(GridFactory.SQUARE, "Preferences.combo.maps.grid.square"),
+    new LocalizedComboItem(GridFactory.HEX_HORI, "Preferences.combo.maps.grid.hexHori"),
+    new LocalizedComboItem(GridFactory.HEX_VERT, "Preferences.combo.maps.grid.hexVert"),
+    new LocalizedComboItem(GridFactory.ISOMETRIC, "Preferences.combo.maps.grid.isometric")
+  };
+  private static final LocalizedComboItem[] duplicateTokenComboItems = {
+    new LocalizedComboItem(Token.NUM_INCREMENT, "Preferences.combo.tokens.duplicate.increment"),
+    new LocalizedComboItem(Token.NUM_RANDOM, "Preferences.combo.tokens.duplicate.random"),
+  };
+  private static final LocalizedComboItem[] showNumberingComboItems = {
+    new LocalizedComboItem(Token.NUM_ON_NAME, "Preferences.combo.tokens.numbering.name"),
+    new LocalizedComboItem(Token.NUM_ON_GM, "Preferences.combo.tokens.numbering.gm"),
+    new LocalizedComboItem(Token.NUM_ON_BOTH, "Preferences.combo.tokens.numbering.both")
+  };
+  private static final LocalizedComboItem[] tokenNamingComboItems = {
+    new LocalizedComboItem(Token.NAME_USE_FILENAME, "Preferences.combo.tokens.naming.filename"),
+    new LocalizedComboItem(
+        Token.NAME_USE_CREATURE,
+        "Preferences.combo.tokens.naming.creature",
+        I18N.getString("Token.name.creature"))
+  };
+  private static final WalkerMetric[] movementMetricComboItems = {
+    WalkerMetric.ONE_TWO_ONE,
+    WalkerMetric.ONE_ONE_ONE,
+    WalkerMetric.MANHATTAN,
+    WalkerMetric.NO_DIAGONALS
+  };
 
   public PreferencesDialog() {
     super(MapTool.getFrame(), I18N.getString("Label.preferences"), true);
@@ -760,89 +788,65 @@ public class PreferencesDialog extends JDialog {
             AppPreferences.setChatNotificationShowBackground(
                 chatNotificationShowBackground.isSelected()));
 
-    DefaultComboBoxModel gridTypeModel = new DefaultComboBoxModel();
-    gridTypeModel.addElement(GridFactory.SQUARE);
-    gridTypeModel.addElement(GridFactory.HEX_HORI);
-    gridTypeModel.addElement(GridFactory.HEX_VERT);
-    gridTypeModel.addElement(GridFactory.ISOMETRIC);
-    gridTypeModel.setSelectedItem(AppPreferences.getDefaultGridType());
-    defaultGridTypeCombo.setModel(gridTypeModel);
+    defaultGridTypeCombo.setModel(
+        getLocalizedModel(defaultGridTypeComboItems, AppPreferences.getDefaultGridType()));
     defaultGridTypeCombo.addItemListener(
-        e -> AppPreferences.setDefaultGridType((String) defaultGridTypeCombo.getSelectedItem()));
+        e ->
+            AppPreferences.setDefaultGridType(
+                ((LocalizedComboItem) (defaultGridTypeCombo.getSelectedItem())).getValue()));
 
-    DefaultComboBoxModel tokenNumModel = new DefaultComboBoxModel();
-    tokenNumModel.addElement(Token.NUM_INCREMENT);
-    tokenNumModel.addElement(Token.NUM_RANDOM);
-    tokenNumModel.setSelectedItem(AppPreferences.getDuplicateTokenNumber());
-    duplicateTokenCombo.setModel(tokenNumModel);
+    duplicateTokenCombo.setModel(
+        getLocalizedModel(duplicateTokenComboItems, AppPreferences.getDuplicateTokenNumber()));
     duplicateTokenCombo.addItemListener(
         e ->
-            AppPreferences.setDuplicateTokenNumber((String) duplicateTokenCombo.getSelectedItem()));
+            AppPreferences.setDuplicateTokenNumber(
+                ((LocalizedComboItem) (duplicateTokenCombo.getSelectedItem())).getValue()));
 
-    DefaultComboBoxModel tokenNameModel = new DefaultComboBoxModel();
-    tokenNameModel.addElement(Token.NAME_USE_FILENAME);
-    tokenNameModel.addElement(Token.NAME_USE_CREATURE);
-    tokenNameModel.setSelectedItem(AppPreferences.getNewTokenNaming());
-    tokenNamingCombo.setModel(tokenNameModel);
-    tokenNamingCombo.addItemListener(
-        e -> AppPreferences.setNewTokenNaming((String) tokenNamingCombo.getSelectedItem()));
-
-    DefaultComboBoxModel showNumModel = new DefaultComboBoxModel();
-    showNumModel.addElement(Token.NUM_ON_NAME);
-    showNumModel.addElement(Token.NUM_ON_GM);
-    showNumModel.addElement(Token.NUM_ON_BOTH);
-    showNumModel.setSelectedItem(AppPreferences.getTokenNumberDisplay());
-    showNumberingCombo.setModel(showNumModel);
+    showNumberingCombo.setModel(
+        getLocalizedModel(showNumberingComboItems, AppPreferences.getTokenNumberDisplay()));
     showNumberingCombo.addItemListener(
-        e -> AppPreferences.setTokenNumberDisplay((String) showNumberingCombo.getSelectedItem()));
+        e ->
+            AppPreferences.setTokenNumberDisplay(
+                ((LocalizedComboItem) showNumberingCombo.getSelectedItem()).getValue()));
 
-    DefaultComboBoxModel movementMetricModel = new DefaultComboBoxModel();
-    movementMetricModel.addElement(WalkerMetric.ONE_TWO_ONE);
-    movementMetricModel.addElement(WalkerMetric.ONE_ONE_ONE);
-    movementMetricModel.addElement(WalkerMetric.MANHATTAN);
-    movementMetricModel.addElement(WalkerMetric.NO_DIAGONALS);
-    movementMetricModel.setSelectedItem(AppPreferences.getMovementMetric());
+    tokenNamingCombo.setModel(
+        getLocalizedModel(tokenNamingComboItems, AppPreferences.getNewTokenNaming()));
+    tokenNamingCombo.addItemListener(
+        e ->
+            AppPreferences.setNewTokenNaming(
+                ((LocalizedComboItem) (tokenNamingCombo.getSelectedItem())).getValue()));
 
-    movementMetricCombo.setModel(movementMetricModel);
+    movementMetricCombo.setModel(new DefaultComboBoxModel<>(movementMetricComboItems));
+    movementMetricCombo.setSelectedItem(AppPreferences.getMovementMetric());
     movementMetricCombo.addItemListener(
         e ->
             AppPreferences.setMovementMetric((WalkerMetric) movementMetricCombo.getSelectedItem()));
 
-    DefaultComboBoxModel<Zone.VisionType> visionTypeModel = new DefaultComboBoxModel<>();
-    for (Zone.VisionType vt : Zone.VisionType.values()) {
-      visionTypeModel.addElement(vt);
-    }
-    visionTypeModel.setSelectedItem(AppPreferences.getDefaultVisionType());
-
-    visionTypeCombo.setModel(visionTypeModel);
+    visionTypeCombo.setModel(new DefaultComboBoxModel<>(Zone.VisionType.values()));
+    visionTypeCombo.setSelectedItem(AppPreferences.getDefaultVisionType());
     visionTypeCombo.addItemListener(
         e ->
             AppPreferences.setDefaultVisionType(
                 (Zone.VisionType) visionTypeCombo.getSelectedItem()));
 
-    DefaultComboBoxModel macroEditorThemeModel = new DefaultComboBoxModel();
-
+    macroEditorThemeCombo.setModel(new DefaultComboBoxModel<>());
     try (Stream<Path> paths = Files.list(AppConstants.THEMES_DIR.toPath())) {
       paths
           .filter(Files::isRegularFile)
           .filter(p -> p.toString().toLowerCase().endsWith(".xml"))
           .forEach(
               p ->
-                  macroEditorThemeModel.addElement(
+                  macroEditorThemeCombo.addItem(
                       FilenameUtils.removeExtension(p.getFileName().toString())));
-
-      macroEditorThemeModel.setSelectedItem(AppPreferences.getDefaultMacroEditorTheme());
+      macroEditorThemeCombo.setSelectedItem(AppPreferences.getDefaultMacroEditorTheme());
     } catch (IOException ioe) {
       log.warn("Unable to list macro editor themes.", ioe);
-      macroEditorThemeModel.addElement("default");
+      macroEditorThemeCombo.addItem("Default");
     }
-
-    macroEditorThemeCombo.setModel(macroEditorThemeModel);
-
     macroEditorThemeCombo.addItemListener(
         e ->
             AppPreferences.setDefaultMacroEditorTheme(
-                (String) macroEditorThemeModel.getSelectedItem()));
+                (String) macroEditorThemeCombo.getSelectedItem()));
 
     add(panel);
     pack();
@@ -998,6 +1002,15 @@ public class PreferencesDialog extends JDialog {
     chatNotificationShowBackground.setSelected(AppPreferences.getChatNotificationShowBackground());
   }
 
+  /** Utility method to create and set the selected item for LocalizedComboItem combo box models. */
+  private ComboBoxModel<LocalizedComboItem> getLocalizedModel(
+      LocalizedComboItem[] items, String currPref) {
+    DefaultComboBoxModel<LocalizedComboItem> model = new DefaultComboBoxModel<>(items);
+    model.setSelectedItem(
+        Stream.of(items).filter(i -> i.getValue().equals(currPref)).findFirst().orElse(items[0]));
+    return model;
+  }
+
   /** @author frank */
   private abstract static class DocumentListenerProxy<T> implements DocumentListener {
 
@@ -1046,5 +1059,32 @@ public class PreferencesDialog extends JDialog {
     }
 
     protected abstract void storeSpinnerValue(int value);
+  }
+
+  /**
+   * Stores the localized display name and preference value String for menu items that don't have a
+   * corresponding enum.
+   */
+  private static class LocalizedComboItem {
+    private final String displayName;
+    private final String prefValue;
+
+    LocalizedComboItem(String prefValue, String i18nKey) {
+      this.prefValue = prefValue;
+      displayName = I18N.getText(i18nKey);
+    }
+
+    LocalizedComboItem(String prefValue, String i18nKey, Object... args) {
+      this.prefValue = prefValue;
+      displayName = I18N.getText(i18nKey, args);
+    }
+
+    public String getValue() {
+      return prefValue;
+    }
+
+    public String toString() {
+      return displayName;
+    }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/walker/WalkerMetric.java
+++ b/src/main/java/net/rptools/maptool/client/walker/WalkerMetric.java
@@ -14,9 +14,22 @@
  */
 package net.rptools.maptool.client.walker;
 
+import net.rptools.maptool.language.I18N;
+
 public enum WalkerMetric {
-  NO_DIAGONALS,
-  MANHATTAN,
-  ONE_TWO_ONE,
-  ONE_ONE_ONE;
+  NO_DIAGONALS(),
+  MANHATTAN(),
+  ONE_TWO_ONE(),
+  ONE_ONE_ONE();
+
+  private final String displayName;
+
+  WalkerMetric() {
+    displayName = I18N.getString("WalkerMetric." + name());
+  }
+
+  @Override
+  public String toString() {
+    return displayName;
+  }
 }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -414,6 +414,10 @@ Preferences.label.maps.visible                   = New maps visible to players
 Preferences.label.maps.visible.tooltip           = Individual maps may or may not be visible to players.
 Preferences.label.maps.grid                      = New Map Grid Type
 Preferences.label.maps.grid.tooltip              = The grid type for new maps.  Cannot be changed once the map has been created.
+Preferences.combo.maps.grid.square               = Square
+Preferences.combo.maps.grid.hexHori              = Horizontal Hex
+Preferences.combo.maps.grid.hexVert              = Vertical Hex
+Preferences.combo.maps.grid.isometric            = Isometric
 Preferences.label.maps.grid.new                  = New Map Grid Size
 Preferences.label.maps.grid.new.tooltip          = Number of map pixels that represents one unit of distance.
 Preferences.label.maps.units                     = New Map Units Per Cell
@@ -438,9 +442,17 @@ Preferences.label.tokens.delete                  = Warn when tokens are deleted
 Preferences.label.tokens.delete.tooltip          = There is no "undo" for token deletion. You probably want this enabled.
 Preferences.label.tokens.duplicate               = Duplicate Token Numbering
 Preferences.label.tokens.duplicate.tooltip       = When a token is pasted or dropped onto a map, how should duplicate names be resolved.
+Preferences.combo.tokens.duplicate.increment     = Increment
+Preferences.combo.tokens.duplicate.random        = Random
 Preferences.label.tokens.numbering               = Show Numbering on
+Preferences.combo.tokens.numbering.name          = Name
+Preferences.combo.tokens.numbering.gm            = GM Name
+Preferences.combo.tokens.numbering.both          = Both
 Preferences.label.tokens.naming                  = New Token Naming
 Preferences.label.tokens.naming.tooltip          = Determines how new tokens are initially named.
+Preferences.combo.tokens.naming.filename         = Use Filename
+# {0} is the localized version of "Creature" (See: Token.name.creature)
+Preferences.combo.tokens.naming.creature         = Use "{0}"
 Preferences.label.tokens.dialog                  = Show Dialog on New Token
 Preferences.label.tokens.dialog.tooltip          = Determines whether the New Token dialog appears when a token is dropped onto the map.
 Preferences.label.tokens.statsheet               = Statsheet Portrait Size
@@ -819,6 +831,9 @@ SquareGrid.error.pathhighlightingNotLoaded = Could not load path highlighting im
 SquareGrid.error.squareGridNotLoaded       = Could not load square grid footprints.
 
 Token.dropped.byPlayer = Tokens dropped onto map "{0}" by player {1}
+# This is the name given to new tokens if the New Token Naming preference
+# is set to "Use "Creature""
+Token.name.creature = Creature
 Token.error.unableToPaste = Failed to paste token(s) with duplicate name(s): {0}
 Token.error.unableToRename = <html>Cannot rename token to "{0}" as there is already another token with this name on the map.<br>Only the GM can create multiple tokens with the same name!
 

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -837,6 +837,13 @@ VisionDialog.error.numericDistanceOnly = Distance must be numeric.
 # currently not accessible by the user.
 VisionDialog.msg.title                 = Vision
 
+# Movement metrics
+WalkerMetric.NO_DIAGONALS = No Diagonals
+# "Manhattan" refers to Manhattan Distance (See: https://en.wikipedia.org/wiki/Taxicab_geometry)
+WalkerMetric.MANHATTAN    = Manhattan
+WalkerMetric.ONE_TWO_ONE  = One-Two-One
+WalkerMetric.ONE_ONE_ONE  = One-One-One
+
 # AI cell rounding options
 Zone.AStarRoundingOptions.NONE      = None
 Zone.AStarRoundingOptions.CELL_UNIT = Cell Unit


### PR DESCRIPTION
Part of #2583.

This adds localization support for the remaining drop downs in the preferences dialog (new map grid type, movement metric, duplicate token numbering, show numbering on, and new token naming). For the combos where the items were just strings, I added a little class (`LocalizedComboItem`) that stores the localized name and the the preference option values (ie, the old labels).

 I also added localization support for the New Token Naming "Use "Creature"" option, since it made sense to do that at the same time.