### PR TITLE
Add various missing strings to i18n.properties

### DIFF
--- a/src/main/java/net/rptools/lib/swing/ColorPicker.java
+++ b/src/main/java/net/rptools/lib/swing/ColorPicker.java
@@ -33,6 +33,7 @@ import javax.swing.JSpinner;
 import javax.swing.JToggleButton;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.border.BevelBorder;
+import net.rptools.maptool.client.swing.FormPanelI18N;
 
 public class ColorPicker extends JPanel {
   private final JFrame owner;
@@ -90,7 +91,7 @@ public class ColorPicker extends JPanel {
     paintChooser = new PaintChooser();
     paintChooser.setPreferredSize(new Dimension(450, 400));
 
-    FormPanel panel = new FormPanel("net/rptools/lib/swing/forms/colorPanel.xml");
+    FormPanel panel = new FormPanelI18N("net/rptools/lib/swing/forms/colorPanel.xml");
 
     ColorWellListener listener = new ColorWellListener(1);
 
@@ -130,7 +131,7 @@ public class ColorPicker extends JPanel {
     snapToggle.setIcon(freeDrawIcon);
     snapToggle.setSelectedIcon(snapToIcon);
 
-    squareCapToggle = (JToggleButton) panel.getButton("toggelSquareCap");
+    squareCapToggle = (JToggleButton) panel.getButton("toggleSquareCap");
     squareCapToggle.setIcon(roundCapIcon);
     squareCapToggle.setSelectedIcon(squareCapIcon);
 

--- a/src/main/java/net/rptools/lib/swing/PaintChooser.java
+++ b/src/main/java/net/rptools/lib/swing/PaintChooser.java
@@ -204,7 +204,7 @@ public class PaintChooser extends JPanel {
   }
 
   public Paint choosePaint(Frame owner, Paint paint) {
-    return choosePaint(owner, paint, "Choose Paint");
+    return choosePaint(owner, paint, I18N.getString("dialog.colorChooser.title"));
   }
 
   public Paint choosePaint(Frame owner, Paint paint, String title) {

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1482,7 +1482,9 @@ public class AppActions {
           // XXX Perhaps ask the user if the copied map should have its GEA and/or TEA cleared? An
           // imported map would ask...
           String zoneName =
-              JOptionPane.showInputDialog("New map name:", "Copy of " + zone.getName());
+              JOptionPane.showInputDialog(
+                  I18N.getText("dialog.copyZone.msg"),
+                  I18N.getText("dialog.copyZone.initial", zone.getName()));
           if (zoneName != null) {
             Zone zoneCopy = new Zone(zone);
             zoneCopy.setName(zoneName);

--- a/src/main/java/net/rptools/maptool/client/macro/impl/WhisperReplyMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/WhisperReplyMacro.java
@@ -32,7 +32,8 @@ public class WhisperReplyMacro extends AbstractMacro {
     if (playerName == null) {
       MapTool.addMessage(
           TextMessage.me(
-              context.getTransformationHistory(), "<b>You have no one to which to reply.</b>"));
+              context.getTransformationHistory(), I18N.getString("whisperreply.noTarget")));
+      return;
     }
     // Validate
     if (!MapTool.isPlayerConnected(playerName)) {

--- a/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MemoryStatusBar.java
@@ -19,6 +19,7 @@ import java.awt.FontMetrics;
 import java.awt.event.MouseAdapter;
 import java.text.DecimalFormat;
 import javax.swing.JProgressBar;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.util.FileUtil;
 
 /** */
@@ -115,12 +116,10 @@ public class MemoryStatusBar extends JProgressBar {
             + FileUtil.byteCountToDisplaySize(totalMemory));
 
     setToolTipText(
-        "Used Memory: "
-            + format.format((totalMemory - freeMemory) / (1024 * 1024))
-            + "M, Total Memory: "
-            + format.format(totalMemory / (1024 * 1024))
-            + "M, Maximum Memory: "
-            + format.format(maxMemory / (1024 * 1024))
-            + "M");
+        I18N.getText(
+            "MemoryStatusBar.tooltip",
+            format.format((totalMemory - freeMemory) / (1024 * 1024)),
+            format.format(totalMemory / (1024 * 1024)),
+            format.format(maxMemory / (1024 * 1024))));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/swing/ZoomStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/ZoomStatusBar.java
@@ -22,6 +22,7 @@ import javax.swing.JTextField;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.util.StringUtil;
 
 /**
@@ -34,7 +35,7 @@ public class ZoomStatusBar extends JTextField implements ActionListener {
 
   public ZoomStatusBar() {
     super("", RIGHT);
-    setToolTipText("Zoom Level");
+    setToolTipText(I18N.getString("ZoomStatusBar.tooltip"));
     addActionListener(this);
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/AutoResizeStampDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AutoResizeStampDialog.java
@@ -78,7 +78,7 @@ public class AutoResizeStampDialog extends JDialog {
     setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
     setAlwaysOnTop(true);
     setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
-    setTitle("Automatically Resize Stamp");
+    setTitle(I18N.getString("dialog.resizeStamp.title"));
     //    setBounds(100, 100, 450, 200);
     getContentPane().setLayout(new BorderLayout());
     contentPanel.setBorder(new EmptyBorder(5, 5, 5, 5));

--- a/src/main/java/net/rptools/maptool/client/ui/TextureChooserPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/TextureChooserPanel.java
@@ -22,6 +22,7 @@ import net.rptools.lib.swing.ImagePanel;
 import net.rptools.lib.swing.PaintChooser;
 import net.rptools.maptool.client.ui.assetpanel.AssetPanel;
 import net.rptools.maptool.client.ui.assetpanel.AssetPanelModel;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
 
 public class TextureChooserPanel extends AbstractPaintChooserPanel {
@@ -66,6 +67,6 @@ public class TextureChooserPanel extends AbstractPaintChooserPanel {
 
   @Override
   public String getDisplayName() {
-    return "Texture";
+    return I18N.getString("TextureChooserPanel.title");
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -733,11 +733,14 @@ public class CommandPanel extends JPanel
 
     // Detect whether the person is attempting to fake rolls.
     if (CHEATER_PATTERN.matcher(command).find()) {
-      MapTool.addServerMessage(TextMessage.me(null, "Cheater. You have been reported."));
+      MapTool.addServerMessage(
+          TextMessage.me(null, I18N.getString("msg.commandPanel.cheater.self")));
       MapTool.serverCommand()
           .message(
               TextMessage.gm(
-                  null, MapTool.getPlayer().getName() + " was caught <i>cheating</i>: " + command));
+                  null,
+                  I18N.getText(
+                      "msg.commandPanel.cheater.gm", MapTool.getPlayer().getName(), command)));
       return;
     }
     // Make sure they aren't trying to break out of the div
@@ -749,8 +752,7 @@ public class CommandPanel extends JPanel
       closeDivCount++;
     }
     if (closeDivCount > divCount) {
-      MapTool.addServerMessage(
-          TextMessage.me(null, "Unexpected &lt;/div&gt; tag without matching &lt;div&gt;."));
+      MapTool.addServerMessage(TextMessage.me(null, I18N.getString("msg.commandPanel.div")));
       return;
     }
     if (command.charAt(0) != '/') {
@@ -870,7 +872,9 @@ public class CommandPanel extends JPanel
           new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-              Color newColor = JColorChooser.showDialog(TextColorWell.this, "Text Color", color);
+              Color newColor =
+                  JColorChooser.showDialog(
+                      TextColorWell.this, I18N.getString("dialog.colorChooser.title"), color);
               if (newColor != null) {
                 setColor(newColor);
               }

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -38,6 +38,7 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.macro.MacroContext;
 import net.rptools.maptool.client.ui.AssetPaint;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.TextMessage;
 import net.rptools.maptool.model.Zone;
@@ -141,11 +142,11 @@ public class DrawPanelPopupMenu extends JPopupMenu {
   public static class DeleteDrawingAction extends AbstractAction {
 
     public DeleteDrawingAction() {
-      super("Delete");
+      super(I18N.getString("token.popup.menu.delete"));
     }
 
     public DeleteDrawingAction(Set<GUID> selectedDrawings) {
-      super("Delete");
+      super(I18N.getString("token.popup.menu.delete"));
       this.selectedDrawings = selectedDrawings;
     }
 
@@ -177,7 +178,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
   private class GetDrawingId extends AbstractAction {
     public GetDrawingId() {
-      super("Get Drawing Id");
+      super(I18N.getString("DrawPanelPopupMenu.menu.getId"));
     }
 
     public void actionPerformed(ActionEvent e) {
@@ -189,7 +190,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
   private class GetPropertiesAction extends AbstractAction {
     public GetPropertiesAction() {
-      super("Get Properties");
+      super(I18N.getString("DrawPanelPopupMenu.menu.getProperties"));
     }
 
     public void actionPerformed(ActionEvent e) {
@@ -211,7 +212,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
   private class GroupDrawingsAction extends AbstractAction {
     public GroupDrawingsAction() {
-      super("Group Drawings");
+      super(I18N.getString("DrawPanelPopupMenu.menu.group"));
       enabled = selectedDrawSet.size() > 1;
       if (enabled) {
         List<DrawnElement> zoneList =
@@ -260,7 +261,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
   private class MergeDrawingsAction extends AbstractAction {
     public MergeDrawingsAction() {
-      super("Merge Drawings");
+      super(I18N.getString("DrawPanelPopupMenu.menu.merge"));
       enabled = selectedDrawSet.size() > 1;
       if (enabled) {
         List<DrawnElement> zoneList =
@@ -332,31 +333,38 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
   private class SetDrawingName extends AbstractAction {
     public SetDrawingName() {
-      super("Set Name");
+      super(I18N.getString("DrawPanelPopupMenu.menu.setName"));
     }
 
     public void actionPerformed(ActionEvent e) {
-      String drawType = "Drawing";
-      if (elementUnderMouse.getDrawable() instanceof DrawnElement) drawType = "Group";
+      String drawType;
+      if (elementUnderMouse.getDrawable() instanceof DrawablesGroup) {
+        drawType = I18N.getString("drawing.type.group");
+      } else {
+        drawType = I18N.getString("drawing.type.drawing");
+      }
       AbstractDrawing group = (AbstractDrawing) elementUnderMouse.getDrawable();
       String groupName =
           (String)
               JOptionPane.showInputDialog(
                   MapTool.getFrame(),
-                  "Enter a name for the " + drawType,
-                  drawType + " Name",
+                  I18N.getText("DrawPanelPopupMenu.dialog.name.msg", drawType),
+                  I18N.getText("DrawPanelPopupMenu.dialog.name.title", drawType),
                   JOptionPane.QUESTION_MESSAGE,
                   null,
                   null,
                   group.getName());
-      group.setName(groupName.isEmpty() ? null : groupName);
+      if (groupName == null) {
+        return;
+      }
+      group.setName(groupName.isBlank() ? null : groupName.trim());
       MapTool.getFrame().updateDrawTree();
     }
   }
 
   private class SetPropertiesAction extends AbstractAction {
     public SetPropertiesAction() {
-      super("Set Properties");
+      super(I18N.getString("DrawPanelPopupMenu.menu.setProperties"));
     }
 
     public void actionPerformed(ActionEvent e) {
@@ -388,7 +396,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
   private class UngroupDrawingsAction extends AbstractAction {
     public UngroupDrawingsAction() {
-      super("Ungroup");
+      super(I18N.getString("DrawPanelPopupMenu.menu.ungroup"));
       enabled = selectedDrawSet.size() == 1 && isDrawnElementGroup(elementUnderMouse);
     }
 
@@ -411,7 +419,10 @@ public class DrawPanelPopupMenu extends JPopupMenu {
      * @param isEraser - boolean, erase VBL if true.
      */
     public VblAction(boolean pathOnly, boolean isEraser) {
-      super((isEraser ? "Remove from " : "Add to ") + "VBL");
+      super(
+          isEraser
+              ? I18N.getString("DrawPanelPopupMenu.menu.vbl.remove")
+              : I18N.getString("DrawPanelPopupMenu.menu.vbl.add"));
       enabled = hasPath(elementUnderMouse);
       this.isEraser = isEraser;
       this.pathOnly = pathOnly;
@@ -460,12 +471,12 @@ public class DrawPanelPopupMenu extends JPopupMenu {
   }
 
   private JMenu createArrangeMenu() {
-    JMenu arrangeMenu = new JMenu("Arrange");
+    JMenu arrangeMenu = new JMenu(I18N.getString("token.popup.menu.arrange"));
     arrangeMenu.setEnabled(topLevelOnly);
-    JMenuItem bringToFrontMenuItem = new JMenuItem("Bring to Front");
+    JMenuItem bringToFrontMenuItem = new JMenuItem(I18N.getString("token.popup.menu.zorder.front"));
     bringToFrontMenuItem.addActionListener(new BringToFrontAction());
 
-    JMenuItem sendToBackMenuItem = new JMenuItem("Send to Back");
+    JMenuItem sendToBackMenuItem = new JMenuItem(I18N.getString("token.popup.menu.zorder.back"));
     sendToBackMenuItem.addActionListener(new SendToBackAction());
 
     arrangeMenu.add(bringToFrontMenuItem);
@@ -475,7 +486,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
   }
 
   private JMenu createChangeToMenu(Zone.Layer... types) {
-    JMenu changeTypeMenu = new JMenu("Change to");
+    JMenu changeTypeMenu = new JMenu(I18N.getString("token.popup.menu.change"));
     changeTypeMenu.setEnabled(topLevelOnly);
     for (Zone.Layer layer : types) {
       changeTypeMenu.add(new JMenuItem(new ChangeTypeAction(layer)));
@@ -484,7 +495,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
   }
 
   private JMenu createPathVblMenu() {
-    JMenu pathVblMenu = new JMenu("Path to VBL");
+    JMenu pathVblMenu = new JMenu(I18N.getString("DrawPanelPopupMenu.menu.pathVbl"));
     pathVblMenu.setEnabled(hasPath(selectedDrawSet));
     pathVblMenu.add(new JMenuItem(new VblAction(true, false)));
     pathVblMenu.add(new JMenuItem(new VblAction(true, true)));
@@ -492,7 +503,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
   }
 
   private JMenu createShapeVblMenu() {
-    JMenu shapeVblMenu = new JMenu("Shape to VBL");
+    JMenu shapeVblMenu = new JMenu(I18N.getString("DrawPanelPopupMenu.menu.shapeVbl"));
     shapeVblMenu.setEnabled(hasPath(selectedDrawSet));
     shapeVblMenu.add(new JMenuItem(new VblAction(false, false)));
     shapeVblMenu.add(new JMenuItem(new VblAction(false, true)));

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
@@ -57,7 +57,7 @@ public class DrawPanelTreeCellRenderer extends DefaultTreeCellRenderer {
       DrawnElement de = (DrawnElement) value;
       text = de.getDrawable().toString();
       if (de.getDrawable() instanceof DrawablesGroup) {
-        text = "Group";
+        text = I18N.getString("drawing.type.group");
       } else if (de.getDrawable() instanceof ShapeDrawable) {
         ShapeDrawable sd = (ShapeDrawable) de.getDrawable();
         key =
@@ -97,10 +97,10 @@ public class DrawPanelTreeCellRenderer extends DefaultTreeCellRenderer {
   private String addText(Pen pen, String text, Drawable drawing) {
     if (pen == null) return text;
     String result = text;
-    if (pen.isEraser()) result = "CUT: " + result;
+    if (pen.isEraser()) result = I18N.getText("panel.DrawExplorer.eraser", result);
     if (pen.getOpacity() < 1) {
       int perc = (int) (pen.getOpacity() * 100);
-      result = result + String.format(" opacity %s%%", perc);
+      result += " " + I18N.getText("panel.DrawExplorer.opacity", perc);
     }
     if (drawing instanceof AbstractDrawing) {
       String dName = ((AbstractDrawing) drawing).getName();

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -331,6 +331,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     // Jamz: Init the Hero Lab tab...
     heroLabData = token.getHeroLabData();
+    String heroLabTitle = I18N.getString("EditTokenDialog.tab.hero");
 
     if (heroLabData != null) {
       boolean isDirty = heroLabData.isDirty() && heroLabData.getPortfolioFile().exists();
@@ -339,14 +340,14 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       if (isDirty && refreshDataButton.getIcon() != REFRESH_ICON_ON) {
         refreshDataButton.setIcon(REFRESH_ICON_ON);
         refreshDataButton.setToolTipText(
-            "<html>Refresh data from Hero Lab<br/><b><i>Changes detected!</i></b></html>");
+            I18N.getString("EditTokenDialog.button.hero.refresh.tooltip.on"));
       } else if (!isDirty && refreshDataButton.getIcon() != REFRESH_ICON_OFF) {
         refreshDataButton.setIcon(REFRESH_ICON_OFF);
         refreshDataButton.setToolTipText(
-            "<html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>");
+            I18N.getString("EditTokenDialog.button.hero.refresh.tooltip.off"));
       }
 
-      tabbedPane.setEnabledAt(tabbedPane.indexOfTab("Hero Lab"), true);
+      tabbedPane.setEnabledAt(tabbedPane.indexOfTab(heroLabTitle), true);
       getHtmlStatblockEditor().setText(heroLabData.getStatBlock_html());
       getHtmlStatblockEditor().setCaretPosition(0);
 
@@ -375,8 +376,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
       // loadHeroLabImageList();
     } else {
-      tabbedPane.setEnabledAt(tabbedPane.indexOfTab("Hero Lab"), false);
-      if (tabbedPane.getSelectedIndex() == tabbedPane.indexOfTab("Hero Lab")) {
+      tabbedPane.setEnabledAt(tabbedPane.indexOfTab(heroLabTitle), false);
+      if (tabbedPane.getSelectedIndex() == tabbedPane.indexOfTab(heroLabTitle)) {
         tabbedPane.setSelectedIndex(6);
       }
     }
@@ -849,7 +850,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
             new JLabel(bar.getName() + ":"),
             new CellConstraints(1, 1, CellConstraints.RIGHT, CellConstraints.TOP));
         JSlider slider = new JSlider(0, 100);
-        JCheckBox hide = new JCheckBox("Hide");
+        JCheckBox hide = new JCheckBox(I18N.getString("EditTokenDialog.checkbox.state.hide"));
         hide.putClientProperty("JSlider", slider);
         hide.addChangeListener(
             e -> {
@@ -1365,7 +1366,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
             if (heroLabData != null) {
               refreshDataButton.setIcon(REFRESH_ICON_OFF);
               refreshDataButton.setToolTipText(
-                  "<html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>");
+                  I18N.getString("EditTokenDialog.button.hero.refresh.tooltip.off"));
 
               ((JLabel) getComponent("portfolioLocation"))
                   .setToolTipText(heroLabData.getPortfolioPath());
@@ -1820,7 +1821,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     public void mouseClicked(MouseEvent e) {
       if (SwingUtilities.isRightMouseButton(e)) {
         JPopupMenu menu = new JPopupMenu();
-        JMenuItem sendToChatItem = new JMenuItem("Send to Chat");
+        JMenuItem sendToChatItem =
+            new JMenuItem(I18N.getString("EditTokenDialog.menu.notes.sendChat"));
         sendToChatItem.addActionListener(
             e12 -> {
               String selectedText = source.getSelectedText();
@@ -1836,7 +1838,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
             });
         menu.add(sendToChatItem);
 
-        JMenuItem sendAsEmoteItem = new JMenuItem("Send as Emit");
+        JMenuItem sendAsEmoteItem =
+            new JMenuItem(I18N.getString("EditTokenDialog.menu.notes.sendEmit"));
         sendAsEmoteItem.addActionListener(
             e1 -> {
               String selectedText = source.getSelectedText();

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
@@ -32,6 +32,7 @@ import net.rptools.lib.MD5Key;
 import net.rptools.lib.swing.SwingUtil;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Token.TokenShape;
 import net.rptools.maptool.model.Zone;
@@ -95,7 +96,7 @@ public class TokenLayoutPanel extends JPanel {
           public void mouseEntered(MouseEvent e) {
             old = MapTool.getFrame().getStatusMessage();
             MapTool.getFrame()
-                .setStatusMessage("Mouse Wheel to zoom; double-LClick to reset position and zoom");
+                .setStatusMessage(I18N.getString("EditTokenDialog.status.layout.instructions"));
           }
 
           @Override

--- a/src/main/resources/net/rptools/lib/swing/forms/colorPanel.xml
+++ b/src/main/resources/net/rptools/lib/swing/forms/colorPanel.xml
@@ -904,7 +904,7 @@
                  </at>
                  <at name="name">toggleSnapToGrid</at>
                  <at name="width">21</at>
-                 <at name="toolTipText">Snap to grid</at>
+                 <at name="toolTipText">ColorPicker.tooltip.gridSnap</at>
                  <at name="height">24</at>
                 </object>
                </at>
@@ -966,9 +966,9 @@
                    <at name="height">16</at>
                   </object>
                  </at>
-                 <at name="name">toggelSquareCap</at>
+                 <at name="name">toggleSquareCap</at>
                  <at name="width">21</at>
-                 <at name="toolTipText">Line Type</at>
+                 <at name="toolTipText">ColorPicker.tooltip.lineType</at>
                  <at name="height">24</at>
                 </object>
                </at>
@@ -1032,7 +1032,7 @@
                  </at>
                  <at name="name">toggleErase</at>
                  <at name="width">21</at>
-                 <at name="toolTipText">Eraser</at>
+                 <at name="toolTipText">ColorPicker.tooltip.eraser</at>
                  <at name="height">24</at>
                 </object>
                </at>
@@ -1273,7 +1273,7 @@
                    <at name="name">fill</at>
                   </object>
                  </at>
-                 <at name="toolTipText">Pen Width</at>
+                 <at name="toolTipText">ColorPicker.tooltip.penWidth</at>
                  <at name="height">16</at>
                 </object>
                </at>
@@ -1342,7 +1342,7 @@
                    <at name="name">fill</at>
                   </object>
                  </at>
-                 <at name="toolTipText">Opacity</at>
+                 <at name="toolTipText">ColorPicker.tooltip.opacity</at>
                  <at name="height">16</at>
                 </object>
                </at>

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/connectToServerDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/connectToServerDialog.xml
@@ -693,7 +693,7 @@
                  <at name="value">
                   <object classname="com.jeta.forms.store.properties.TabProperty">
                    <at name="name">tab</at>
-                   <at name="title">LAN</at>
+                   <at name="title">ConnectToServerDialog.tab.lan</at>
                    <at name="icon">
                     <object classname="com.jeta.forms.store.properties.IconProperty">
                      <at name="embedded">false</at>
@@ -1026,7 +1026,7 @@
                  <at name="value">
                   <object classname="com.jeta.forms.store.properties.TabProperty">
                    <at name="name">tab</at>
-                   <at name="title">Direct</at>
+                   <at name="title">ConnectToServerDialog.tab.direct</at>
                    <at name="icon">
                     <object classname="com.jeta.forms.store.properties.IconProperty">
                      <at name="embedded">false</at>

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/exportDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/exportDialog.xml
@@ -1342,7 +1342,7 @@
                             <at name="classname">javax.swing.JRadioButton</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Image Writer</at>
+                              <at name="text">ExportScreenshot.method.iw</at>
                               <at name="height">17</at>
                               <at name="buttonGroup">
                                <object classname="com.jeta.forms.store.properties.ButtonGroupProperty">
@@ -1353,7 +1353,7 @@
                               <at name="width">83</at>
                               <at name="name">METHOD_IMAGE_WRITER</at>
                               <at name="actionCommand">Image Writer</at>
-                              <at name="toolTipText">Renders the image incrementally as it is needed by the file output formatting code. Uses less memory. Extremely large files can take a long time. The UI will not update during the file output, so the program may be unresponsive for several minutes while the file is saved.</at>
+                              <at name="toolTipText">ExportScreenshot.method.iw.tooltip</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1405,7 +1405,7 @@
                             <at name="classname">javax.swing.JRadioButton</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Background Thread</at>
+                              <at name="text">ExportScreenshot.method.bg</at>
                               <at name="height">17</at>
                               <at name="buttonGroup">
                                <object classname="com.jeta.forms.store.properties.ButtonGroupProperty">
@@ -1416,7 +1416,7 @@
                               <at name="width">113</at>
                               <at name="name">METHOD_BACKGROUND</at>
                               <at name="actionCommand">Background Thread</at>
-                              <at name="toolTipText">NOT IMPLEMENTED! Uses a the Image Writer technique in a background thread so that the UI can be updated with the progress.</at>
+                              <at name="toolTipText">ExportScreenshot.method.bg.tooltip</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">
@@ -1468,7 +1468,7 @@
                             <at name="classname">com.jeta.forms.components.label.JETALabel</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Rendering Method:</at>
+                              <at name="text">ExportScreenshot.method.label</at>
                               <at name="height">14</at>
                               <at name="width">92</at>
                               <at name="name">METHOD_LABEL</at>
@@ -1528,7 +1528,7 @@
                             <at name="classname">javax.swing.JRadioButton</at>
                             <at name="properties">
                              <object classname="com.jeta.forms.store.support.PropertyMap">
-                              <at name="text">Buffered Image</at>
+                              <at name="text">ExportScreenshot.method.buffered</at>
                               <at name="selected">true</at>
                               <at name="height">17</at>
                               <at name="buttonGroup">
@@ -1540,7 +1540,7 @@
                               <at name="width">95</at>
                               <at name="name">METHOD_BUFFERED_IMAGE</at>
                               <at name="actionCommand">Buffered Image</at>
-                              <at name="toolTipText">Renders the image into a single bitmap then saves that to the chosen location. Can use a lot of memory, and may fail if the image is too large.</at>
+                              <at name="toolTipText">ExportScreenshot.method.buffered.tooltip</at>
                               <at name="border">
                                <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
                                 <super classname="com.jeta.forms.store.properties.BorderProperty">

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
@@ -1276,7 +1276,7 @@
                                      <super classname="com.jeta.forms.store.properties.BorderProperty">
                                       <at name="name">border</at>
                                       <at name="includetitle">true</at>
-                                      <at name="title">VBL Preview</at>
+                                      <at name="title">EditTokenDialog.border.title.vbl.preview</at>
                                      </super>
                                      <at name="thickness">1</at>
                                      <at name="color">
@@ -5475,7 +5475,7 @@
                                           <super classname="com.jeta.forms.store.properties.BorderProperty">
                                            <at name="name">border</at>
                                            <at name="includetitle">true</at>
-                                           <at name="title">Handout</at>
+                                           <at name="title">EditTokenDialog.border.title.handout</at>
                                           </super>
                                           <at name="thickness">1</at>
                                           <at name="color">
@@ -5660,7 +5660,7 @@
                                           <super classname="com.jeta.forms.store.properties.BorderProperty">
                                            <at name="name">border</at>
                                            <at name="includetitle">true</at>
-                                           <at name="title">Layout</at>
+                                           <at name="title">EditTokenDialog.border.title.layout</at>
                                           </super>
                                           <at name="thickness">1</at>
                                           <at name="color">
@@ -5845,7 +5845,7 @@
                                           <super classname="com.jeta.forms.store.properties.BorderProperty">
                                            <at name="name">border</at>
                                            <at name="includetitle">true</at>
-                                           <at name="title">Portrait</at>
+                                           <at name="title">EditTokenDialog.border.title.portrait</at>
                                           </super>
                                           <at name="thickness">1</at>
                                           <at name="color">
@@ -6107,7 +6107,7 @@
                  <at name="value">
                   <object classname="com.jeta.forms.store.properties.TabProperty">
                    <at name="name">tab</at>
-                   <at name="title">Hero Lab</at>
+                   <at name="title">EditTokenDialog.tab.hero</at>
                    <at name="icon">
                     <object classname="com.jeta.forms.store.properties.IconProperty">
                      <at name="embedded">false</at>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -191,6 +191,12 @@ Label.pathfilename  = Path/Filename:
 
 CampaignPropertyDialog.error.parenthesis              = Missing right parenthesis ")" in the following property: {0}
 
+ColorPicker.tooltip.gridSnap = Snap to Grid
+ColorPicker.tooltip.lineType = Line Type
+ColorPicker.tooltip.eraser   = Eraser
+ColorPicker.tooltip.penWidth = Pen Width
+ColorPicker.tooltip.opacity  = Opacity
+
 ConnectToServerDialog.msg.headingServer               = Server Name
 ConnectToServerDialog.msg.headingVersion              = Version
 ConnectToServerDialog.msg.title                       = Connect to Server
@@ -203,6 +209,8 @@ ConnectToServerDialog.server.name                     = Server Name:
 ConnectToServerDialog.server.local                    = Local Servers:
 ConnectToServerDialog.server.address                  = Address:
 ConnectToServerDialog.server.port                     = Port:
+ConnectToServerDialog.tab.lan                         = LAN
+ConnectToServerDialog.tab.direct                      = Direct
 
 ConnectionInfoDialog.title                            = Server Info
 ConnectionInfoDialog.address.local                    = Local Address:
@@ -215,6 +223,21 @@ ConnectionStatusPanel.runningServer   = Running a Server
 ConnectionStatusPanel.serverConnected = Connected to Server
 
 CoordinateStatusBar.mapCoordinates = Map Coordinates
+
+DrawPanelPopupMenu.menu.group         = Group Drawings
+DrawPanelPopupMenu.menu.ungroup       = Ungroup
+DrawPanelPopupMenu.menu.merge         = Merge Drawings
+DrawPanelPopupMenu.menu.getProperties = Get Properties
+DrawPanelPopupMenu.menu.setProperties = Set Properties
+DrawPanelPopupMenu.menu.setName       = Set Name
+DrawPanelPopupMenu.menu.getId         = Get Drawing ID
+DrawPanelPopupMenu.menu.pathVbl       = Path to VBL
+DrawPanelPopupMenu.menu.shapeVbl      = Shape to VBL
+DrawPanelPopupMenu.menu.vbl.add       = Add to VBL
+DrawPanelPopupMenu.menu.vbl.remove    = Remove from VBL
+# {0} is the drawing type (Drawing or Group)
+DrawPanelPopupMenu.dialog.name.title  = {0} Name
+DrawPanelPopupMenu.dialog.name.msg    = Enter a name for the {0}
 
 EditLookupTablePanel.error.badRange      = Table "{0}" contains bad range "{1}" on row {2,number}.
 EditLookupTablePanel.error.invalidSize   = Table "{0}" must have at least one row.
@@ -232,6 +255,8 @@ EditLookupTablePanel.lookup              = Allow Lookup by Players
 EditTokenDialog.label.label              = Label:
 EditTokenDialog.tab.notes                = Notes
 EditTokenDialog.label.gmnotes            = GM Notes
+EditTokenDialog.menu.notes.sendChat      = Send to Chat
+EditTokenDialog.menu.notes.sendEmit      = Send as Emit
 EditTokenDialog.label.shape              = Shape:
 EditTokenDialog.label.snaptogrid         = Snap To Grid:
 EditTokenDialog.label.size               = Size:
@@ -247,6 +272,10 @@ EditTokenDialog.label.opacity.tooltip    = Change the opacity of the token.
 EditTokenDialog.label.terrain.ignore     = Ignore Terrain:
 EditTokenDialog.label.terrain.ignore.tooltip= Select any terrain modifier types this token should ignore.
 EditTokenDialog.combo.terrain.mod        = Set whether the cell cost should be added or multiplied. Use negative numbers to subtract and decimal values to divide costs.
+EditTokenDialog.border.title.layout      = Layout
+EditTokenDialog.border.title.portrait    = Portrait
+EditTokenDialog.border.title.handout     = Handout
+EditTokenDialog.status.layout.instructions = Mouse Wheel to zoom; double-LClick to reset position and zoom
 EditTokenDialog.label.allplayers         = All Players
 EditTokenDialog.tab.properties           = Properties
 EditTokenDialog.tab.vbl                  = VBL
@@ -254,6 +283,7 @@ EditTokenDialog.tab.state                = State
 EditTokenDialog.tab.speech               = Speech
 EditTokenDialog.tab.ownership            = Ownership
 EditTokenDialog.tab.config               = Config
+EditTokenDialog.tab.hero                 = Hero Lab
 EditTokenDialog.button.vbl               = Generate Token VBL
 EditTokenDialog.button.vbl.tooltip       = This will create VBL based on non-transparent pixels.
 EditTokenDialog.button.vbl.clear         = Clear Token VBL
@@ -278,6 +308,7 @@ EditTokenDialog.label.vbl.over.tooltip   = Always show this token over FoW when 
 EditTokenDialog.label.vbl.color          = Color Selection
 EditTokenDialog.label.vbl.toggle         = Pick a color from the image to match against when generating token VBL.
 EditTokenDialog.label.vbl.well           = Manually pick a color to match against when generating token VBL.
+EditTokenDialog.border.title.vbl.preview = VBL Preview
 EditTokenDialog.status.vbl.instructions  = Mouse Wheel to zoom; double-LClick to reset position and zoom
 EditTokenDialog.label.hero.summary       = Summary:
 EditTokenDialog.label.hero.portfolio     = Portfolio:
@@ -299,6 +330,10 @@ EditTokenDialog.msg.wrap                 = Wrap
 EditTokenDialog.vbl.label.originalPointCount    = Original Point Count
 EditTokenDialog.vbl.label.optimizedPointCount   = Optimized Point Count
 EditTokenDialog.vbl.label.working               = Working...
+EditTokenDialog.checkbox.state.hide             = Hide
+EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero Lab<br/><b><i>Changes detected!</i></b></html>
+EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
+
 
 MapPropertiesDialog.label.cell.type      = Cell Type:
 MapPropertiesDialog.label.cell.dist      = Distance per cell:
@@ -363,6 +398,14 @@ ExportScreenshot.ftp.path.note           = NOTE: path must already exist
 ExportScreenshot.ftp.host.example        = (ex: myhost.com)
 ExportScreenshot.ftp.username.example    = (ex: pbpuser)
 ExportScreenshot.ftp.path.example        = (ex: path/to/my/images/map.png)
+ExportScreenshot.method.label            = Rendering Method:
+ExportScreenshot.method.buffered         = Buffered Image
+ExportScreenshot.method.buffered.tooltip = Renders the image into a single bitmap then saves that to the chosen location. Can use a lot of memory, and may fail if the image is too large.
+ExportScreenshot.method.iw               = Image Writer
+ExportScreenshot.method.iw.tooltip       = Renders the image incrementally as it is needed by the file output formatting code. Uses less memory. Extremely large files can take a long time. The UI will not update during the file output, so the program may be unresponsive for several minutes while the file is saved.
+ExportScreenshot.method.bg               = Background Thread
+ExportScreenshot.method.bg.tooltip       = NOT IMPLEMENTED! Uses the Image Writer technique in a background thread so that the UI can be updated with the progress.
+
 
 ImageCacheStatusBar.toolTip = Current size of Image thumbs cache directory, Double-Click to clear this cache.
 
@@ -383,6 +426,8 @@ MapToolEventQueue.stackOverflow       = <html>A stack overflow has occurred.<p>T
 MapToolEventQueue.stackOverflow.title = Error: Stack Overflow
 MapToolEventQueue.unexpectedError     = An unexpected error has occurred.
 MapToolEventQueue.warning.title       = Warning
+
+MemoryStatusBar.tooltip = Used Memory: {0}M, Total Memory: {1}M, Maximum Memory:{2}M
 
 PersistenceUtil.error.campaignPropertiesLegacy               = This campaign properties file is not a legacy format file readable by this version of MapTool.
 PersistenceUtil.error.campaignPropertiesVersion              = This campaign properties file is not readable by this version of MapTool.
@@ -787,6 +832,8 @@ CampaignPropertiesDialog.label.order.tooltip = Position in the list of states, c
 CampaignPropertiesDialog.label.else    = Everybody Else
 CampaginPropertiesDialog.label.owner   = Owner
 
+TextureChooserPanel.title = Texture
+
 TokenPropertiesPanel.label.list        = List the token properties for this token type below, one property per line:
 TokenPropertiesPanel.label.type        = Token Type
 TokenPropertiesPanel.format            = <html><body> Format:<p> #*@PropertyName(ShortName):default <p> <p>Key:<br> * - Show property on the statsheet<br> @ - Owner visible only<br># - GM view only<br> ( ) - Short name of the property (e.g. Movement(Mv) )<br>: - Default value</body></html>
@@ -868,6 +915,8 @@ Zone.AStarRoundingOptions.INTEGER   = Integer
 # the maps and optimizing their memory footprint by collapsing
 # drawables, if possible.
 Zone.status.optimizing = Optimizing map: "{0}"
+
+ZoomStatusBar.tooltip = Zoom level
 
 action.addDefaultTables                       = Add Default Tables...
 action.addDefaultTables.description           = Adds several dice image and card tables to the campaign.
@@ -1315,6 +1364,11 @@ dialog.campaignExport.notes.version.1.4.0.1          = Exporting to this version
 dialog.campaignExport.notes.version.1.4.1..1.5.0     = Exporting to this version will make sure the former format of the content.xml inside the campaign file is kept and the unitsPerCell value for zones/maps is an integer (vs. double in the newer versions).
 dialog.campaignExport.notes.version.1.5.1            = Exporting to this version will make sure the former format of the content.xml inside the campaign file is kept.
 dialog.campaignexport.error.invalidversion           = Unable to export, an invalid version number was detected.
+dialog.colorChooser.title                            = Choose Color
+dialog.copyZone.msg                                  = New map name:
+# {0} is the current map name
+dialog.copyZone.initial                              = Copy of {0}
+dialog.resizeStamp.title                             = Automatically Resize Stamp
 dialog.resizeStamp.checkbox.horizontal.anchor        = Adjust Horizontal Anchor?
 dialog.resizeStamp.checkbox.vertical.anchor          = Adjust Vertical Anchor?
 dialog.resizeStamp.label.height                      = Height:
@@ -1340,6 +1394,9 @@ dialog.stampTool.error.badSelection                  = Please create a larger se
 dialog.stampTool.error.noSelection                   = Please select an area that starts and stops over the token.
 dialog.mapProperties.title                           = Map Properties
 dialog.importedMapProperties.title                   = Imported Map Properties
+
+drawing.type.drawing = Drawing
+drawing.type.group   = Group
 
 dungeondraft.import.unknownVersion                   = Unrecognized version number in Dungeondraft VTT file {0}.
 dungeondraft.import.ioError                          = IO Error importing map.
@@ -1743,6 +1800,10 @@ msg.button.close                              = Close
 msg.commandPanel.hasEnteredText               = {0} has entered text.
 # Command Panel; {0} is the player name
 msg.commandPanel.liveTyping                   = {0} is typing...
+msg.commandPanel.cheater.self                 = Cheater. You have been reported.
+# {0} is the player name, {1} is their input
+msg.commandPanel.cheater.gm                   = {0} was caught <i>cheating</i>: {1}
+msg.commandPanel.div                          = Unexpected &lt;/div&gt; tag without matching &lt;div&gt;.
 msg.confirm.aboutToBeginFTP                   = About to begin FTP process of {0,number} file(s)...
 msg.confirm.bootPlayer                        = Are you sure you want to boot {0}?
 msg.confirm.campaignExported                  = Campaign exported.
@@ -1997,6 +2058,9 @@ panel.DrawExplorer.Template.LineCellTemplate  = Line ({0})
 panel.DrawExplorer.Template.RadiusTemplate    = Radius ({0})
 panel.DrawExplorer.Template.RadiusCellTemplate = Radius ({0})
 panel.DrawExplorer.Template.WallTemplate      = Wall ({0})
+panel.DrawExplorer.opacity                    = opacity({0}%)
+# Prefix added when a drawing was done with the eraser
+panel.DrawExplorer.eraser                     = CUT: {0}
 # DrawExplorer panel
 panel.DrawExplorer.Unknown.Shape              = Unknown Shape
 panel.Global                                  = Global
@@ -2361,6 +2425,7 @@ whisper.toSelf           = Talking to yourself again?
 whisper.you.string       = You whisper to {0}: {1}
 
 whisperreply.description = Reply to the last player to whisper to you.
+whisperreply.noTarget    = You do not have anyone to reply to.
 
 zone.player_view         = Player View
 zone.map_not_visible     = Map not visible to players


### PR DESCRIPTION
Part of #2583. Just adds a bunch of previously hardcoded strings to i18n.properties.

Strings moved:
- ColorPicker/drawing options panel tooltips
- Connect to server LAN and Direct tabs
- Edit Token dialog notes/gm notes context menu items
- Various Edit token dialog border titles (Layout, Portrait, Handout, VBL Preview)
- `Hero Lab` tab in the Edit Token dialog (I dunno if this necessarily needs to be localized, but feels like it may as well be included)
- Refresh button tooltips in Hero Lab tab (I can't actually check this, but I just saw it in the code, so seemed like might as well?)
- Hide checkbox label in the state tab of the Edit Token dialog
- Text in the advanced tab of the Export Screenshot dialog
- Memory status bar tooltip
- Texture picker tab name (when setting map background or fog)
- Zoom status bar tooltip
- Copy map input dialog text
- Resize Stamp dialog title
- Messages sent due to "cheat" detection
- Message sent when there are mismatched divs
- Message sent when there's no target for `/reply` (Fixes #2325)
- Drawing context menu
- Command panel and drawing color color picker title (these are technically different dialogs that had different titles, but it feels like it makes sense to have a single title for color pickers rather than a bunch of different ones)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2632)
<!-- Reviewable:end -->
