### PR TITLE
Fix Draw Explorer tree

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
@@ -130,7 +130,7 @@ public class DrawPanelTreeModel implements TreeModel, ModelChangeListener {
   @Override
   public boolean isLeaf(Object node) {
     return node instanceof DrawnElement
-        && ((DrawnElement) node).getDrawable() instanceof DrawablesGroup;
+        && !(((DrawnElement) node).getDrawable() instanceof DrawablesGroup);
   }
 
   @Override


### PR DESCRIPTION
This corrects the logic in `isLeaf()` in `DrawPanelTreeModel`. It was returning `true` _only_ if the `Drawable` was a group instead of the other way around.

Fixes #2637

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2638)
<!-- Reviewable:end -->
