### PR TITLE
Add localization support for token type and role

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2229,14 +2229,14 @@ public class AppActions {
                       dialog.getUsernameTextField().getText(), config, policy, campaign, true);
 
                   // Connect to server
-                  String playerType = dialog.getRoleCombo().getSelectedItem().toString();
-                  if (playerType.equals("GM")) {
+                  Player.Role playerType = (Player.Role) dialog.getRoleCombo().getSelectedItem();
+                  if (playerType == Player.Role.GM) {
                     MapTool.createConnection(
                         "localhost",
                         serverProps.getPort(),
                         new LocalPlayer(
                             dialog.getUsernameTextField().getText(),
-                            serverProps.getRole(),
+                            playerType,
                             serverProps.getGMPassword()));
                   } else {
                     MapTool.createConnection(
@@ -2244,7 +2244,7 @@ public class AppActions {
                         serverProps.getPort(),
                         new LocalPlayer(
                             dialog.getUsernameTextField().getText(),
-                            serverProps.getRole(),
+                            playerType,
                             serverProps.getPlayerPassword()));
                   }
 

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -145,7 +145,7 @@ public class MapToolEventQueue extends EventQueue {
     // Set the user in the current context.
     Sentry.getContext().setUser(user.build());
 
-    Sentry.getContext().addTag("role", player != null ? player.getRole().toString() : null);
+    Sentry.getContext().addTag("role", player != null ? player.getRole().name() : null);
     boolean hostingServer = MapTool.isHostingServer();
     Sentry.getContext().addTag("hosting", String.valueOf(MapTool.isHostingServer()));
 

--- a/src/main/java/net/rptools/maptool/client/ui/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/StartServerDialog.java
@@ -26,6 +26,7 @@ import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.GenericDialog;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.Player;
 import net.rptools.maptool.util.PasswordGenerator;
 import net.rptools.maptool.util.StringUtil;
 import yasb.Binder;
@@ -68,6 +69,9 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
     generatePlayerPassword = (JButton) getComponent("@generatePlayerPassword");
     gmPassword = (JTextField) getComponent("@GMPassword");
     playerPassword = (JTextField) getComponent("@playerPassword");
+
+    getRoleCombo().setModel(new DefaultComboBoxModel<>(Player.Role.values()));
+    getRoleCombo().setSelectedItem(prefs.getRole());
 
     useIndividualFOW.setEnabled(prefs.getUseIndividualViews());
     useIndividualViews.addItemListener(
@@ -146,7 +150,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
   }
 
   public JComboBox getRoleCombo() {
-    return (JComboBox) getComponent("@role");
+    return (JComboBox) getComponent("role");
   }
 
   public JButton getNetworkingHelpButton() {
@@ -197,6 +201,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 return;
               }
               if (commit()) {
+                prefs.setRole((Player.Role) getRoleCombo().getSelectedItem());
                 prefs.setMovementMetric((WalkerMetric) movementMetricCombo.getSelectedItem());
                 prefs.setAutoRevealOnMovement(autoRevealOnMovement.isSelected());
                 accepted = true;

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -209,6 +209,9 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     // ICON
     getTokenIconPanel().setImageId(token.getImageAssetId());
 
+    // TYPE
+    getTypeCombo().setSelectedItem(token.getType());
+
     // SIGHT
     updateSightTypeCombo();
 
@@ -438,14 +441,11 @@ public class EditTokenDialog extends AbeillePanel<Token> {
   // }
 
   public void initTypeCombo() {
-    DefaultComboBoxModel model = new DefaultComboBoxModel();
-    model.addElement(Token.Type.NPC);
-    model.addElement(Token.Type.PC);
-    // getTypeCombo().setModel(model);
+    getTypeCombo().setModel(new DefaultComboBoxModel<>(Token.Type.values()));
   }
 
   public JComboBox getTypeCombo() {
-    return (JComboBox) getComponent("@type");
+    return (JComboBox) getComponent("type");
   }
 
   public void initTokenIconPanel() {
@@ -606,6 +606,9 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     if (!super.commit() || MapTool.getFrame().getCurrentZoneRenderer() == null) {
       return false;
     }
+    // TYPE
+    token.setType((Token.Type) getTypeCombo().getSelectedItem());
+
     // SIZE
     token.setSnapToScale(getSizeCombo().getSelectedIndex() != 0);
     if (getSizeCombo().getSelectedIndex() > 0) {

--- a/src/main/java/net/rptools/maptool/model/Player.java
+++ b/src/main/java/net/rptools/maptool/model/Player.java
@@ -14,12 +14,29 @@
  */
 package net.rptools.maptool.model;
 
+import net.rptools.maptool.language.I18N;
+
 /** @author trevor */
 public class Player {
 
   public enum Role {
-    PLAYER,
-    GM
+    PLAYER(),
+    GM();
+
+    private final String displayName;
+
+    Role() {
+      if (name().equals("GM")) {
+        displayName = I18N.getString("userTerm.GM");
+      } else {
+        displayName = I18N.getString("userTerm.Player");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
   }
 
   private String name; // Primary Key
@@ -89,6 +106,6 @@ public class Player {
 
   @Override
   public String toString() {
-    return name + " " + (getRole() == Role.PLAYER ? "(Player)" : "(GM)");
+    return String.format("%s (%s)", name, getRole().toString());
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -108,8 +108,19 @@ public class Token extends BaseModel implements Cloneable {
 
   /** Type of character: PC or NPC. */
   public enum Type {
-    PC,
-    NPC
+    PC(),
+    NPC();
+
+    private final String displayName;
+
+    Type() {
+      displayName = I18N.getString("Token.Type." + name());
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
   }
 
   /** Type of update for the token. */

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml
@@ -479,7 +479,7 @@
               </at>
              </object>
             </at>
-            <at name="name">@role</at>
+            <at name="name">role</at>
             <at name="width">214</at>
             <at name="items">
              <object classname="com.jeta.forms.store.properties.ItemsProperty">

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
@@ -8651,7 +8651,7 @@
                    </at>
                   </object>
                  </at>
-                 <at name="name">@type</at>
+                 <at name="name">type</at>
                  <at name="width">25</at>
                  <at name="items">
                   <object classname="com.jeta.forms.store.properties.ItemsProperty">

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -851,6 +851,9 @@ Token.TokenShape.CIRCLE   = Circle
 Token.TokenShape.SQUARE   = Square
 Token.TokenShape.FIGURE   = Figure
 
+Token.Type.PC  = PC
+Token.Type.NPC = NPC
+
 # Token sizes, from smallest to largest
 TokenFootprint.name.fine       = Fine
 TokenFootprint.name.diminutive = Diminutive


### PR DESCRIPTION
Part of and probably closes #2583.

This changes the token type (PC or NPC) drop down in the Edit Token dialog and the role drop down in the Start Server dialog to use localized names, and for the localized role names to be used in the Connections frame. The only thing of note here is previously the drop downs were bound and handled that way, but I switched to handling them manually. While strictly speaking changing that isn't entirely necessary for localization, previously the text would be made proper case which was odd for acronyms etc..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2643)
<!-- Reviewable:end -->
