### PR TITLE
Restore PaintChooser dialog's title

### DIFF
--- a/src/main/java/net/rptools/lib/swing/PaintChooser.java
+++ b/src/main/java/net/rptools/lib/swing/PaintChooser.java
@@ -204,7 +204,7 @@ public class PaintChooser extends JPanel {
   }
 
   public Paint choosePaint(Frame owner, Paint paint) {
-    return choosePaint(owner, paint, I18N.getString("dialog.colorChooser.title"));
+    return choosePaint(owner, paint, I18N.getString("PaintChooser.title"));
   }
 
   public Paint choosePaint(Frame owner, Paint paint, String title) {

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
@@ -3246,8 +3246,7 @@
                                    <at name="actionCommand">Use tooltips for inline rolls</at>
                                    <at name="name">toolTipInlineRolls</at>
                                    <at name="width">42</at>
-                                   <at name="toolTipText">&lt;html&gt;Enabled: &lt;b&gt;[ ]&lt;/b&gt; acts like &lt;b&gt;[t: ]&lt;/b&gt;&amp;nbsp;&lt;br&gt;
-Disabled: &lt;b&gt;[ ]&lt;/b&gt; acts like &lt;b&gt;[h: ]&lt;/b&gt;&amp;nbsp;</at>
+                                   <at name="toolTipText">Preferences.checkbox.chat.rolls.tooltip</at>
                                    <at name="height">17</at>
                                   </object>
                                  </at>
@@ -3858,8 +3857,7 @@ Disabled: &lt;b&gt;[ ]&lt;/b&gt; acts like &lt;b&gt;[h: ]&lt;/b&gt;&amp;nbsp;</a
                                    <at name="actionCommand">Use tooltips for inline rolls</at>
                                    <at name="name">suppressToolTipsMacroLinks</at>
                                    <at name="width">42</at>
-                                   <at name="toolTipText">&lt;html&gt;Enabled: do not show tooltips for macroLinks&lt;br&gt;
-Disabled (default): show tooltips for macroLinks</at>
+                                   <at name="toolTipText">Preference.checkbox.chat.macrolinks.tooltip</at>
                                    <at name="height">17</at>
                                   </object>
                                  </at>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -429,6 +429,8 @@ MapToolEventQueue.warning.title       = Warning
 
 MemoryStatusBar.tooltip = Used Memory: {0}M, Total Memory: {1}M, Maximum Memory:{2}M
 
+PaintChooser.title = Choose Paint
+
 PersistenceUtil.error.campaignPropertiesLegacy               = This campaign properties file is not a legacy format file readable by this version of MapTool.
 PersistenceUtil.error.campaignPropertiesVersion              = This campaign properties file is not readable by this version of MapTool.
 PersistenceUtil.error.campaignPropertiesRead                 = Error while reading campaign properties data from file.
@@ -520,6 +522,7 @@ Preferences.label.chat.smilies                   = Insert Smilies
 Preferences.label.chat.smilies.tooltip           = Certain strings of text are treated as smilies and replaced with images. A popup panel of smilies appears to the right of the chat input box.
 Preferences.label.chat.rolls                     = Use ToolTips for Inline Rolls
 Preferences.label.chat.rolls.tooltip             = Die rolls are normally expanded and included in the chat window output.  This options changes them into tooltips, although the result is still shown normally.
+Preferences.checkbox.chat.rolls.tooltip          = <html>Enabled: <b>[ ]</b> acts like <b>[t: ]</b><br>Disabled: <b>[ ]</b> acts like <b>[h: ]</b>
 Preferences.label.chat.type.duration             = Typing Notification Duration Seconds
 Preferences.label.chat.type.duration.tooltip     = Time before typing notifications disappear, in seconds.
 Preferences.label.chat.type.color                = Typing Notification Color
@@ -615,6 +618,7 @@ Preferences.label.macros.permissions              = Enable External Macro Access
 Preferences.label.macros.permissions.tooltip      = Enable macros to call functions that can access your drive and http services. The following functions will be enabled: getRequest, postRequest, exportData, getEnvironmentVariable.
 Preferences.label.chat.macrolinks                 = Suppress ToolTips for MacroLinks
 Preferences.label.chat.macrolinks.tooltip         = MacroLinks show normally tooltips that state informations about the link target. This is a anti cheating device. This options let you disable this tooltips for aesthetic reasons.
+Preference.checkbox.chat.macrolinks.tooltip       = <html>Enabled: do not show tooltips for macroLink<br>Disabled (default): show tooltips for macroLinks 
 
 ServerDialog.error.port                = You must enter a numeric port.
 ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.


### PR DESCRIPTION
Correction for #2583. The title should be different from regular color pickers because it's used to select colors or textures.

And as a bonus, two tooltips that weren't caught (checkboxes in Preferences for "Use ToolTips for Inline Rolls" and  "Suppress ToolTips for MacroLinks").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2648)
<!-- Reviewable:end -->
