### PR TITLE
get/setMapVisible: return BigDecimal instead of String 0/1

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -16,6 +16,8 @@ package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonPrimitive;
+
+import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
@@ -72,14 +74,14 @@ public class MapFunctions extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
       if (parameters.size() > 0) {
         String mapName = parameters.get(0).toString();
-        return getNamedMap(functionName, mapName).getZone().isVisible() ? "1" : "0";
+        return getNamedMap(functionName, mapName).getZone().isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
       } else {
         // Return the visibility of the current map/zone
         ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
         if (currentZR == null) {
           throw new ParserException(I18N.getText("macro.function.map.none", functionName));
         } else {
-          return currentZR.getZone().isVisible() ? "1" : "0";
+          return currentZR.getZone().isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
         }
       }
     } else if ("setMapVisible".equalsIgnoreCase(functionName)) {
@@ -103,7 +105,7 @@ public class MapFunctions extends AbstractFunction {
       MapTool.serverCommand().setZoneVisibility(zone.getId(), zone.isVisible());
       MapTool.getFrame().getZoneMiniMapPanel().flush();
       MapTool.getFrame().repaint();
-      return zone.isVisible() ? "1" : "0";
+      return zone.isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
 
     } else if ("setMapName".equalsIgnoreCase(functionName)) {
       checkTrusted(functionName);

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -16,7 +16,6 @@ package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonPrimitive;
-
 import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
@@ -74,7 +73,9 @@ public class MapFunctions extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
       if (parameters.size() > 0) {
         String mapName = parameters.get(0).toString();
-        return getNamedMap(functionName, mapName).getZone().isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
+        return getNamedMap(functionName, mapName).getZone().isVisible()
+            ? BigDecimal.ONE
+            : BigDecimal.ZERO;
       } else {
         // Return the visibility of the current map/zone
         ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();


### PR DESCRIPTION
The functions returned a string, which caused `assert()` and similar logic checks to not work as expected (string "0" treated as true).
Changed to an explicit BigDecimal, which seems to be the most common format for this kind of situation.
I checked these for comparison:
[isVisibleFunction](https://github.com/RPTools/maptool/blob/da4c630ae0f4c344f06c23e2eead12db3bde9cfb/src/main/java/net/rptools/maptool/client/functions/isVisibleFunction.java#L85-L104)
[isDialogVisible / isFrameVisible](https://github.com/RPTools/maptool/blob/da4c630ae0f4c344f06c23e2eead12db3bde9cfb/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java#L64-L74)
[isBarVisible](https://github.com/RPTools/maptool/blob/da4c630ae0f4c344f06c23e2eead12db3bde9cfb/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java#L97-L116)
[getAlwaysVisible](https://github.com/RPTools/maptool/blob/da4c630ae0f4c344f06c23e2eead12db3bde9cfb/src/main/java/net/rptools/maptool/client/functions/TokenVisibleFunction.java#L341-L350)

Corresponding issue: #2652

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2653)
<!-- Reviewable:end -->
