### PR TITLE
Included possible change to map loading as highlighted in #2656.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -170,6 +170,7 @@ public class MapToolFrame extends DefaultDockableHolder
   private long chatNotifyDuration;
   private final ChatNotificationTimers chatTyperTimers;
   private final ChatTyperObserver chatTyperObserver;
+  private GUID PreRemoveRenderGUID = null;
 
   private final GlassPane glassPane;
   /** Model for the token tree panel of the map explorer. */
@@ -1446,6 +1447,16 @@ public class MapToolFrame extends DefaultDockableHolder
 
   public void addZoneRenderer(ZoneRenderer renderer) {
     zoneRendererList.add(renderer);
+    if (renderer.getZone().getId().equals(this.PreRemoveRenderGUID)) {
+      if (MapTool.getPlayer().isGM() || renderer.getZone().isVisible()) {
+        this.PreRemoveRenderGUID = null;
+        setCurrentZoneRenderer(renderer);
+      } else {
+        this.PreRemoveRenderGUID = null;
+      }
+    } else {
+      this.PreRemoveRenderGUID = null;
+    }
   }
 
   /**
@@ -1456,6 +1467,7 @@ public class MapToolFrame extends DefaultDockableHolder
    */
   public void removeZoneRenderer(ZoneRenderer renderer) {
     boolean isCurrent = renderer == getCurrentZoneRenderer();
+    this.PreRemoveRenderGUID = getCurrentZoneRenderer().getZone().getId();
     zoneRendererList.remove(renderer);
     if (isCurrent) {
       boolean rendererSet = false;


### PR DESCRIPTION
It's a little gross but reimplements expected behavior.

Implemented changes:
*Tracks GUID when a ZoneRenderer is removed. If a map exists with that GUID when the next ZoneRenderer is added, switches to that map.

I might have my Tuesday group use this branch for our game to see if I can get any weird errors to pop up. At one point Malwarebytes got mad at me with my two client test setup, but I couldn't reproduce that. LMK if I need to make any edits to conform to contributor rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2659)
<!-- Reviewable:end -->
