### PR TITLE
Flush DrawableRenderers on DRAWABLE_ADDED and DRAWABLE_REMOVED events

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/DiskBasedPartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/DiskBasedPartitionedDrawableRenderer.java
@@ -47,12 +47,13 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
 
   private final Map<String, BufferedImage> chunkMap = new HashMap<String, BufferedImage>();
 
-  private double lastDrawableCount;
   private double lastScale;
   private Rectangle lastViewport;
 
   private int horizontalChunkCount;
   private int verticalChunkCount;
+
+  private boolean dirty = false;
 
   static {
     try {
@@ -81,16 +82,21 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
       ioe.printStackTrace();
     }
     chunkMap.clear();
+    dirty = false;
+  }
+
+  public void setDirty() {
+    dirty = true;
   }
 
   public void renderDrawables(
       Graphics g, List<DrawnElement> drawableList, Rectangle viewport, double scale) {
     // NOTHING TO DO
     if (drawableList == null || drawableList.size() == 0) {
-      flush();
+      if (dirty) flush();
       return;
     }
-    if (drawableList.size() != lastDrawableCount || lastScale != scale) {
+    if (dirty || lastScale != scale) {
       flush();
     }
     if (lastViewport == null
@@ -159,7 +165,6 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
 
     // REMEMBER
     lastViewport = viewport;
-    lastDrawableCount = drawableList.size();
     lastScale = scale;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/DrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/DrawableRenderer.java
@@ -26,4 +26,6 @@ public interface DrawableRenderer {
       Graphics g, List<DrawnElement> drawableList, Rectangle viewport, double scale);
 
   public void flush();
+
+  public void setDirty();
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
@@ -47,12 +47,13 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
   private final List<Tuple> chunkList = new LinkedList<Tuple>();
   private int maxChunks;
 
-  private double lastDrawableCount;
   private double lastScale;
   private Rectangle lastViewport;
 
   private int horizontalChunkCount;
   private int verticalChunkCount;
+
+  private boolean dirty = false;
 
   private CodeTimer timer;
 
@@ -67,6 +68,11 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
     }
     chunkList.clear();
     noImageSet.clear();
+    dirty = false;
+  }
+
+  public void setDirty() {
+    dirty = true;
   }
 
   public void renderDrawables(
@@ -76,12 +82,12 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
     timer.setEnabled(false);
 
     // NOTHING TO DO
-    if (drawableList == null || drawableList.size() == 0) {
-      flush();
+    if (drawableList == null || drawableList.isEmpty()) {
+      if (dirty) flush();
       return;
     }
     // View changed ?
-    if (drawableList.size() != lastDrawableCount || lastScale != scale) {
+    if (dirty || lastScale != scale) {
       flush();
     }
     if (lastViewport == null
@@ -175,7 +181,6 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
     }
     // REMEMBER
     lastViewport = viewport;
-    lastDrawableCount = drawableList.size();
     lastScale = scale;
 
     if (timer.isEnabled()) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -4865,6 +4865,23 @@ public class ZoneRenderer extends JComponent
       if (evt == Zone.Event.FOG_CHANGED) {
         flushFog = true;
       }
+      if (evt == Zone.Event.DRAWABLE_ADDED || evt == Zone.Event.DRAWABLE_REMOVED) {
+        DrawnElement de = (DrawnElement) event.getArg();
+        switch (de.getDrawable().getLayer()) {
+          case TOKEN:
+            tokenDrawableRenderer.setDirty();
+            break;
+          case GM:
+            gmDrawableRenderer.setDirty();
+            break;
+          case OBJECT:
+            objectDrawableRenderer.setDirty();
+            break;
+          case BACKGROUND:
+            backgroundDrawableRenderer.setDirty();
+            break;
+        }
+      }
       MapTool.getFrame().updateTokenTree(); // for any event
       repaintDebouncer.dispatch();
     }


### PR DESCRIPTION
Fixes #2661. This makes it so `DRAWABLE_ADDED` and `DRAWABLE_REMOVED` events guarantee that the `DrawableRenderer` will be flushed. Previously, the renderers only flushed if the number of drawings on a layer changed, if the zoom level changed, or if `flush()` was manually called elsewhere.

There's a few ways the issue could have been addressed, but I noticed the `DRAWABLE_ADDED` and `DRAWABLE_REMOVED` events already existed* and using them seemed like a natural way of going about this. Rather than flushing every time the events are fired this sets a flag to indicate that the renderer should be flushed the next time `renderDrawables()` is called (to avoid a bunch of redundant flush calls with batch deletions, etc.).

`DiskBasedPartitionedDrawableRenderer` seems to be unused, but since I modified the underlying interface I just made it work the same just in case.

*Note: updating a drawing fires `DRAWABLE_ADDED`. Should there be a `DRAWABLE_UPDATED` event? It didn't seem like there was much point making any changes there right now since they weren't even being put to use, but, just a thought.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2662)
<!-- Reviewable:end -->
