### PR TITLE
Update the text of the drawing name change dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -337,19 +337,13 @@ public class DrawPanelPopupMenu extends JPopupMenu {
     }
 
     public void actionPerformed(ActionEvent e) {
-      String drawType;
-      if (elementUnderMouse.getDrawable() instanceof DrawablesGroup) {
-        drawType = I18N.getString("drawing.type.group");
-      } else {
-        drawType = I18N.getString("drawing.type.drawing");
-      }
       AbstractDrawing group = (AbstractDrawing) elementUnderMouse.getDrawable();
       String groupName =
           (String)
               JOptionPane.showInputDialog(
                   MapTool.getFrame(),
-                  I18N.getText("DrawPanelPopupMenu.dialog.name.msg", drawType),
-                  I18N.getText("DrawPanelPopupMenu.dialog.name.title", drawType),
+                  I18N.getString("DrawPanelPopupMenu.dialog.name.msg"),
+                  I18N.getString("DrawPanelPopupMenu.dialog.name.title"),
                   JOptionPane.QUESTION_MESSAGE,
                   null,
                   null,

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
@@ -57,7 +57,7 @@ public class DrawPanelTreeCellRenderer extends DefaultTreeCellRenderer {
       DrawnElement de = (DrawnElement) value;
       text = de.getDrawable().toString();
       if (de.getDrawable() instanceof DrawablesGroup) {
-        text = I18N.getString("drawing.type.group");
+        text = I18N.getString("panel.DrawExplorer.group");
       } else if (de.getDrawable() instanceof ShapeDrawable) {
         ShapeDrawable sd = (ShapeDrawable) de.getDrawable();
         key =

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -235,9 +235,8 @@ DrawPanelPopupMenu.menu.pathVbl       = Path to VBL
 DrawPanelPopupMenu.menu.shapeVbl      = Shape to VBL
 DrawPanelPopupMenu.menu.vbl.add       = Add to VBL
 DrawPanelPopupMenu.menu.vbl.remove    = Remove from VBL
-# {0} is the drawing type (Drawing or Group)
-DrawPanelPopupMenu.dialog.name.title  = {0} Name
-DrawPanelPopupMenu.dialog.name.msg    = Enter a name for the {0}
+DrawPanelPopupMenu.dialog.name.title  = Set Name
+DrawPanelPopupMenu.dialog.name.msg    = Enter a name:
 
 EditLookupTablePanel.error.badRange      = Table "{0}" contains bad range "{1}" on row {2,number}.
 EditLookupTablePanel.error.invalidSize   = Table "{0}" must have at least one row.
@@ -1402,9 +1401,6 @@ dialog.stampTool.error.noSelection                   = Please select an area tha
 dialog.mapProperties.title                           = Map Properties
 dialog.importedMapProperties.title                   = Imported Map Properties
 
-drawing.type.drawing = Drawing
-drawing.type.group   = Group
-
 dungeondraft.import.unknownVersion                   = Unrecognized version number in Dungeondraft VTT file {0}.
 dungeondraft.import.ioError                          = IO Error importing map.
 dungeondraft.import.missingResolution                = Resolution field missing in import file.
@@ -2065,6 +2061,8 @@ panel.DrawExplorer.Template.LineCellTemplate  = Line ({0})
 panel.DrawExplorer.Template.RadiusTemplate    = Radius ({0})
 panel.DrawExplorer.Template.RadiusCellTemplate = Radius ({0})
 panel.DrawExplorer.Template.WallTemplate      = Wall ({0})
+# "Group" is a noun
+panel.DrawExplorer.group                      = Group
 panel.DrawExplorer.opacity                    = opacity({0}%)
 # Prefix added when a drawing was done with the eraser
 panel.DrawExplorer.eraser                     = CUT: {0}


### PR DESCRIPTION
Sort of part of #2583. This changes the text in the "Set Name" dialog for drawings to something more generic to avoid localization issues, as brought up on Crowdin ("Set Name" for the title and "Enter a name:" for the text). I ended up making the title "Set Name" because it felt weird for it to be close to but different from the menu item, but I'm erring on the side of caution and making it its own string just in case for some reason a translation would want them to be different due to the different contexts that they appear in.

I also moved the "Group" string to a more logical place, since it's on its own now and only being used as a label in the Draw Explorer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2664)
<!-- Reviewable:end -->
