### PR TITLE
Handle macro frame name conflicts and return a more meaningful error when they happen

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -24,12 +24,16 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.stream.Stream;
 import javax.swing.ImageIcon;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
+import net.rptools.maptool.client.ui.MapToolFrame;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.util.FunctionUtil;
+import net.rptools.parser.ParserException;
 
 /**
  * Represents a dockable frame holding an HTML panel. Can hold either an HTML3.2 (Swing) or a HTML5
@@ -135,7 +139,8 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
       boolean scrollReset,
       boolean isHTML5,
       Object val,
-      String html) {
+      String html)
+      throws ParserException {
     HTMLFrame frame;
 
     if (frames.containsKey(name)) {
@@ -145,6 +150,18 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
         frame.getDockingManager().showFrame(name);
       }
     } else {
+      // Make sure there isn't a name conflict with the normal MT frames
+      boolean isMtframeName =
+          Stream.of(MapToolFrame.MTFrame.values())
+                  .filter(e -> e.name().equals(name))
+                  .findFirst()
+                  .orElse(null)
+              != null;
+      if (isMtframeName) {
+        String opt = isHTML5 ? "frame5" : "frame";
+        throw new ParserException(I18N.getText("lineParser.optReservedName", opt, name));
+      }
+
       // Only set size on creation so we don't override players resizing.
       frame = new HTMLFrame(name, width, height, isHTML5);
       frames.put(name, frame);

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1551,6 +1551,7 @@ lineParser.onlyGMCanGet             = Only GM can get "{0}".
 lineParser.onlyGMCanSet             = Only GM can set "{0}".
 lineParser.optBadParam              = Roll option "{0}": bad option parameters {1}.
 lineParser.optRequiresParam         = Roll option "{0}" requires a list of no more than {1} parameters in parentheses.
+lineParser.optReservedName          = Roll option "{0}": "{1}" is a reserved name.
 lineParser.optWrongParam            = Roll option "{0}" must have between {1} and {2} parameters; found {3}: parameter list = "{4}"
 lineParser.rollOptionComma          = Roll option list can't end with a comma.
 lineParser.switchError              = Error in roll for SWITCH option.


### PR DESCRIPTION
Fixes #2675. Just checks to make sure the name of a macro frame doesn't match the name of any `MTFrame` and throws a `ParserException` if it does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2677)
<!-- Reviewable:end -->
