### PR TITLE
Add workaround for layout persistance issues with macro frames

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.jidesoft.docking.DockContext;
 import com.jidesoft.docking.DockableFrame;
+import com.jidesoft.docking.DockingManager;
 import com.jidesoft.docking.event.DockableFrameAdapter;
 import com.jidesoft.docking.event.DockableFrameEvent;
 import java.awt.*;
@@ -228,7 +229,21 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
     addHTMLPanel(isHTML5);
 
     this.getContext().setInitMode(DockContext.STATE_FLOATING);
-    MapTool.getFrame().getDockingManager().addFrame(this);
+
+    /* Issue #2485
+     * If the frame exists, then it's a placeholder frame that should be removed
+     * Note: There should be no risk of MT frames being removed, as that is checked
+     * for in showFrame() (the only place this constructor is called)
+     */
+    DockingManager dm = MapTool.getFrame().getDockingManager();
+    if (dm.getFrame(name) != null) {
+      // The frame needs to be shown before being removed otherwise the layout gets messed up
+      dm.showFrame(name);
+      dm.removeFrame(name, true);
+    }
+    /* /Issue #2485 */
+
+    dm.addFrame(this);
     this.setVisible(true);
     addDockableFrameListener(
         new DockableFrameAdapter() {


### PR DESCRIPTION
Fixes #2485. As detailed in the discussion around the issue, the layout information for frames that are not added to the `DockingManager` before layout is loaded is not retained. This works around that by saving the names of macro frames to a file (frames.dat, just a `NULL` delimited list of the names) when Maptool exits and then, when launching, using those names to generate placeholder frames before the layout is loaded so that the layout information is retained. Really, I'd consider this more of a "temporary" workaround to be removed if the issue is ever actually addressed within the library.

In my testing, it seems to do the trick, layout seems to restore the same as you'd expect pre-1.8, and I also haven't observed any issue with the encoding of the frame names. I did once observe frames opening incorrectly (they opened docked somewhere I know I hadn't put them, and when opening them in 1.7 they were in the right spot), but I haven't been able to reproduce this so it may have just been due to something I was doing at the time messing with things. Also of note, if the frame is floating its position is not restored, _but_ this is also the case for macro frames in 1.7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2682)
<!-- Reviewable:end -->
