### PR TITLE
Copy token delta to selected 2657

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
@@ -268,7 +268,14 @@ public class TokenCopyDeleteFunctions extends AbstractFunction {
     Grid grid =
         zone.getGrid(); // These won't change for a given execution; this could be more efficient
     if (!useDistance) {
-      CellPoint cp = grid.convert(new ZonePoint(deltX, deltY));
+      CellPoint cp =
+          grid.convert(
+              new ZonePoint(
+                  x, y)); // Accidentally removed these 3 lines earlier, it serves a very important
+      // purpose for when the tokens don't move in a certain direction.
+      x = cp.x;
+      y = cp.y;
+      cp = grid.convert(new ZonePoint(deltX, deltY));
       deltX = cp.x;
       deltY = cp.y;
     }


### PR DESCRIPTION
Man spotless made line 271 look ugly. Anyway, this should fix a bug from #2657 changes present in #2691 where not setting x or y would place the tokens an amount of tiles away equal to the pixel distance. All of the original test cases came up normal. The table is reprinted here with the new test cases to ensure this doesn't pop up if this function is edited again. Also ensured that the Author's macro works still (which it does), but it wouldn't display nicely into the table.


<!--StartFragment-->
As of new commit   (2021-05-31 9:51 AM GMT) this is how the changes should operate. | &nbsp;
-- | --
Input | Output
absolute   position | All create a single copied token at global   coordinates 1,1
[copyToken("Eagle  1",1,"Grasslands","{x:1,y:1}")] | &nbsp;
[copyToken("Eagle  1",1,"Grasslands","{'x':1,'y':1,'delta':0}")] | &nbsp;
[copyToken("Eagle  1",1,"Grasslands",json.set("{}","delta",0,"x",1,"y",1))] | &nbsp;
[copyToken("Eagle  1",1,"Grasslands",json.set("{}","relativeto","map","x",1,"y",1))] | &nbsp;
[copyToken("Eagle 1",1,"Grasslands",json.set("{}","relativeto","MaP","x",1,"y",1))] | &nbsp;
&nbsp; | &nbsp;
relative to copied 'token' | All create a single copied token offset from the original by 1   in both x and y
[copyToken("Eagle  1",1,"Grasslands","{x:1,y:1,delta:1}")] | &nbsp;
[copyToken("Eagle 1",1,"Grasslands","{'x':1,'y':1,'relativeto':'SOURCE'}")] | &nbsp;
[copyToken("Eagle  1",1,"Grasslands",json.set("{}","relativeto","souRCE","x",1,"y",1))] | &nbsp;
[copyToken("Eagle  1",1,"Grasslands",json.set("{}","delta","&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;   ","x",1,"y",1))] | &nbsp;
&nbsp; | &nbsp;
relative to in context 'token' | All create a single copied token offset from in context token by   1 in both x and y
[copyToken("Eagle  1",1,"Grasslands","{x:1,y:1,relativeto:current}")] | &nbsp;
[copyToken("Eagle  1",1,"Grasslands",json.set("{}","relativeto","CURrenT","x",1,"y",1))] | &nbsp;
&nbsp; | &nbsp;
not moving in certain directions with absolute coords | &nbsp;
[copyToken("Eagle 1",1,"Grasslands","{x:0,y:0,relativeto:map}")] | Place at 0,0
[copyToken("Eagle 1",1,"Grasslands","{name:'ERIC'}")] | Edit properties, but not location properties
[copyToken("Eagle 1",1,"Grasslands","{x:0,relativeto:map}")] | Keep original y, but place at absolute 0 x
[copyToken("Eagle 1",1,"Grasslands","{y:0}")] | Keep original x, place at absolute 0 y
[copyToken("Eagle 1",1,"Grasslands","{relativeto:map}")] | Don't move at all
&nbsp; | &nbsp;
earlier tests with moving only in one direction | &nbsp;
[copyToken("Eagle 1",1,"Grasslands",json.set("{}","delta",0,"y",1))] | don't edit x, place at y 1 absolute
[copyToken("Eagle 1",1,"Grasslands",json.set("{}","relativeto","souRCE","x",1))] | don't edit y, place at x + 1 to source
[copyToken("Eagle 1",1,"Grasslands",json.set("{}","relativeto","CURrenT","x",-1))] | don't edit y, place x - 1 to current
&nbsp; | &nbsp;
Non-snapping test | &nbsp;
[copyToken("Eagle 1",1,"Grasslands",json.set("{}","relativeto","CURrenT","useDistance",1,"x",500,"y",200))] | You'll have to calculate expected behavior depending on your grid size.
&nbsp; | &nbsp;
&nbsp; | &nbsp;
error for missing map | No puedo encontrar el mapa "FakeMapName" en la función   "copyToken".\nError trace : (new)@token:Eagle
[copyToken("Eagle  1",1,"FakeMapName","{x:1,y:1,relativeto:current}")] | &nbsp;
&nbsp; | &nbsp;
&nbsp; | &nbsp;
error for conflicting   arguments | In "copyToken": Parameters "delta" and   "relativeto" cant be used  at the same time. ("delta"   parameter is deprecated as of 1.9.0). Visit    https://wiki.rptools.info/index.php/copyToken\nError trace :   (new)@token:Eagle
[copyToken("Eagle  1",1,"Grasslands","{x:1,y:1,relativeto:source,delta:1}")] | &nbsp;
&nbsp; | &nbsp;
&nbsp; | &nbsp;
error for unresolvable   relativeto | In "copyToken": "relativeto" value within   4th parameter (json properties) not recognized. Visit   https://wiki.rptools.info/index.php/copyToken\nError trace :   (new)@token:Eagle
[copyToken("Eagle  1",1,"Grasslands","{x:1,y:1,relativeto:currenty}")] | &nbsp;
&nbsp; | &nbsp;
&nbsp; | &nbsp;
error for no current token | No current token found. Try using switchToken() or impersonate   one. See https://wiki.rptools.info/index.php/Current_Token\nError trace :   chat
[copyToken("Eagle  1",1,"Grasslands",json.set("{}","relativeto","curreNT","x",1,"y",1))] | &nbsp;
&nbsp; | &nbsp;

<!--EndFragment-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2699)
<!-- Reviewable:end -->
