### PR TITLE
Bug fix for Two Image bars

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
@@ -730,7 +730,7 @@ public class TokenBarController
       model.copyInto(assetIds);
 
       // Create the bars
-      if (overlay.equals("Two Image")) {
+      if (overlay.equals("Two Images")) {
         to = new TwoImageBarTokenOverlay(name, assetIds[1], assetIds[0]);
       } else if (overlay.equals("Single Image")) {
         to = new SingleImageBarTokenOverlay(name, assetIds[0]);


### PR DESCRIPTION
Overlay type string was incorrect for Two Image bar type.

Fix for #2709

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2710)
<!-- Reviewable:end -->
