### PR TITLE
Fix and tweak various aspects of the A* walker, especially relating to 1-2-1 movement on square grids.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
@@ -56,18 +56,56 @@ public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoi
     isAStarCanceled = aStarCanceled;
   }
 
+  /**
+   * Create an A* node from a position.
+   *
+   * <p>The node will have no scores or data carried over from a cell point.
+   *
+   * @param x The x cell position of the node.
+   * @param y The y cell position of the node.
+   */
   public AStarCellPoint(int x, int y) {
     super(x, y);
   }
 
+  /**
+   * Create an A* node from a cell point.
+   *
+   * <p>The distance travelled is copied from the cell point, making this useful for creating nodes
+   * that need to carry over data, such as after a waypoint.
+   *
+   * @param p The cell point to associate with the A* node.
+   */
   public AStarCellPoint(CellPoint p) {
     super(p.x, p.y, p.distanceTraveled, p.distanceTraveledWithoutTerrain);
   }
 
+  /**
+   * Create a node with terrain modifiers.
+   *
+   * <p>This is only used to associate terrain modifiers with a position. It is not queued to be
+   * used as part of A* itself.
+   *
+   * @param p The cell at which the node should exist.
+   * @param mod The amount of the terrain modifier.
+   * @param operation Which operation is used to calculate the terrain's effect.
+   */
   public AStarCellPoint(CellPoint p, double mod, TerrainModifierOperation operation) {
     super(p.x, p.y);
     terrainModifier = mod;
     terrainModifierOperation = operation;
+  }
+
+  /**
+   * Check if the path taken to this node has an odd number of diagonal steps.
+   *
+   * <p>The cost of the nth diagonal step under 1-2-1 movement depends on whether n is odd or even.
+   * This method allows that to be easily decided for a given node.
+   *
+   * @return `true` if the path to this number has an odd number of diagonal steps.
+   */
+  public boolean isOddStepOfOneTwoOneMovement() {
+    return (int) this.distanceTraveledWithoutTerrain != this.distanceTraveledWithoutTerrain;
   }
 
   public double fCost() {

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarHexEuclideanWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarHexEuclideanWalker.java
@@ -30,7 +30,7 @@ public abstract class AbstractAStarHexEuclideanWalker extends AbstractAStarWalke
   protected abstract int[][] getNeighborMap(int x, int y);
 
   @Override
-  protected double hScore(CellPoint p1, CellPoint p2) {
+  protected double hScore(AStarCellPoint p1, CellPoint p2) {
     return euclideanDistance(p1, p2);
   }
 

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.walker.astar;
 
 import java.awt.Color;
+import java.awt.EventQueue;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
 import java.text.DecimalFormat;
@@ -178,11 +179,14 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     }
 
     // Erase previous debug labels, this actually erases ALL labels! Use only when debugging!
-    if (!zone.getLabels().isEmpty() && debugCosts) {
-      for (Label label : zone.getLabels()) {
-        zone.removeLabel(label.getId());
-      }
-    }
+    EventQueue.invokeLater(
+        () -> {
+          if (!zone.getLabels().isEmpty() && debugCosts) {
+            for (Label label : zone.getLabels()) {
+              zone.removeLabel(label.getId());
+            }
+          }
+        });
 
     // Timeout quicker for GM cause reasons
     if (MapTool.getPlayer().isGM()) {
@@ -486,6 +490,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     Label gScore = new Label();
     Label hScore = new Label();
     Label fScore = new Label();
+    Label parent = new Label();
 
     gScore.setLabel(f.format(node.gCost()));
     gScore.setX(cellBounds.x + 10);
@@ -500,9 +505,18 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     fScore.setY(cellBounds.y + 25);
     fScore.setForegroundColor(Color.RED);
 
-    zone.putLabel(gScore);
-    zone.putLabel(hScore);
-    zone.putLabel(fScore);
+    parent.setLabel(String.format("(%d, %d)", node.parent.x, node.parent.y));
+    parent.setX(cellBounds.x + 25);
+    parent.setY(cellBounds.y + 35);
+    parent.setForegroundColor(Color.BLUE);
+
+    EventQueue.invokeLater(
+        () -> {
+          zone.putLabel(gScore);
+          zone.putLabel(hScore);
+          zone.putLabel(fScore);
+          zone.putLabel(parent);
+        });
 
     // Track labels to delete later
     // debugLabels.add(gScore.getId());


### PR DESCRIPTION
There are two big changes for correctness:
1. Modified nodes are reinserted into the priority queue. Without this, we weren't getting the node with the lowest f-score, which causes some nodes to be closed prematurely. This is a general fix that applies to all metrics and all grids.
2. The g-score now agrees with the 1-2-1 metric, which is also displayed to the user. Previously the g-score was counted as 1-1.5-1, which caused A* to consider some sub-optimal paths as though they were optimal.

A few minor, technical changes are also in here:
1. The heuristic function (`hScore()`) is now admissible for square grids. It now *rewards* paths that are more in-line with the start-goal direction, rather than *punishing* out-of-line paths.
2. Path aesthetics have been improved in some common cases by making the heuristic function more accurate under 1-2-1 (it now accounts for the number of diagonals already taken in the path). This extra accuracy allows the tie breaker to have an effect in more cases.
3. Concurrency issues with the A* debug labels have been fixed by having them added and removed through the AWT EventQueue.

This fixes most of the errant behaviour in #2696.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2713)
<!-- Reviewable:end -->
