### PR TITLE
Temporarily disable js eval

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -16,10 +16,7 @@ package net.rptools.maptool.client.functions;
 
 import java.math.BigDecimal;
 import java.util.*;
-import javax.script.ScriptException;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
-import net.rptools.maptool.client.script.javascript.JSScriptEngine;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
 import net.rptools.parser.Parser;
@@ -47,6 +44,11 @@ public class MacroJavaScriptBridge extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> args)
       throws ParserException {
+    throw new ParserException(
+        I18N.getText("macro.function.general.temporarilyUnavailable", functionName));
+
+    /* Temporarily commented out to avoid "unreachable statements" errors while a fix is being developed
+    see https://github.com/RPTools/maptool/issues/2519 for more details.
     variableResolver = (MapToolVariableResolver) resolver;
     if ("js.eval".equals(functionName)) {
       if (!MapTool.getParser().isMacroTrusted()) {
@@ -72,6 +74,7 @@ public class MacroJavaScriptBridge extends AbstractFunction {
     }
 
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
+    */
   }
 
   public Object JavaScriptToMTScriptType(Object val) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1668,6 +1668,8 @@ macro.function.general.unknownToken                = Error executing "{0}":  the
 macro.function.general.unknownTokenOnMap           = Error executing "{0}":  the token name or id "{1}" is unknown on map "{2}".
 macro.function.general.wrongNumParam               = Function "{0}" requires exactly {1} parameters; {2} were provided.
 macro.function.general.listCannotBeEmpty           = {0}: string list at argument {1} cannot be empty
+macro.function.general.temporarilyUnavailable      = {0} has been temporarily removed from the current build due to a problem, it is expected to be fixed in a later version.
+
 # Token Distance functions
 # I.e. ONE_TWO_ONE or ONE_ONE_ONE
 macro.function.getDistance.invalidMetric           = Invalid metric type "{0}".


### PR DESCRIPTION
Temporarily disable js.eval() function so that we can get 1.9 out the door. This is expected to be re-enabled in a future version.


See issues #2519

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2717)
<!-- Reviewable:end -->
