### PR TITLE
Make path costs well-defined by distinguishing paths with even/odd diagonals.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -83,7 +83,6 @@ import net.rptools.maptool.client.ui.token.AbstractTokenOverlay;
 import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.client.ui.token.NewTokenDialog;
 import net.rptools.maptool.client.walker.ZoneWalker;
-import net.rptools.maptool.client.walker.astar.AStarCellPoint;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.AbstractPoint;
 import net.rptools.maptool.model.Asset;
@@ -2262,13 +2261,14 @@ public class ZoneRenderer extends JComponent
 
         // Show current Blocked Movement directions for A*
         if (walker != null && (log.isDebugEnabled() || showAstarDebugging)) {
-          Collection<AStarCellPoint> checkPoints = walker.getCheckedPoints();
+          Map<CellPoint, Set<CellPoint>> blockedMovesByTarget = walker.getBlockedMoves();
           // Color currentColor = g.getColor();
-          for (AStarCellPoint acp : checkPoints) {
-            Set<Point2D> validMoves = acp.getValidMoves();
+          for (var entry : blockedMovesByTarget.entrySet()) {
+            var position = entry.getKey();
+            var blockedMoves = entry.getValue();
 
-            for (Point2D point : validMoves) {
-              ZonePoint zp = acp.offsetZonePoint(getZone().getGrid(), point.getX(), point.getY());
+            for (CellPoint point : blockedMoves) {
+              ZonePoint zp = point.midZonePoint(getZone().getGrid(), position);
               double r = (zp.x - 1) * 45;
               showBlockedMoves(g, zp, r, AppStyle.blockMoveImage, 1.0f);
             }

--- a/src/main/java/net/rptools/maptool/client/walker/NaiveWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/NaiveWalker.java
@@ -16,8 +16,8 @@ package net.rptools.maptool.client.walker;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import net.rptools.maptool.client.walker.astar.AStarCellPoint;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.TokenFootprint;
 import net.rptools.maptool.model.Zone;
@@ -65,7 +65,7 @@ public class NaiveWalker extends AbstractZoneWalker {
   }
 
   @Override
-  public Set<AStarCellPoint> getCheckedPoints() {
+  public Map<CellPoint, Set<CellPoint>> getBlockedMoves() {
     return null;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
@@ -15,10 +15,9 @@
 package net.rptools.maptool.client.walker;
 
 import java.awt.geom.Area;
-import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
-import net.rptools.maptool.client.walker.astar.AStarCellPoint;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
 import net.rptools.maptool.model.Token.TerrainModifierOperation;
@@ -68,7 +67,7 @@ public interface ZoneWalker {
 
   public void setFootprint(TokenFootprint footprint);
 
-  public default Collection<AStarCellPoint> getCheckedPoints() {
+  public default Map<CellPoint, Set<CellPoint>> getBlockedMoves() {
     return null;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
@@ -14,86 +14,43 @@
  */
 package net.rptools.maptool.client.walker.astar;
 
-import java.awt.Rectangle;
-import java.awt.Shape;
-import java.awt.geom.Path2D;
-import java.awt.geom.Point2D;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
+import java.util.Objects;
 import net.rptools.maptool.model.CellPoint;
-import net.rptools.maptool.model.Token.TerrainModifierOperation;
-import net.rptools.maptool.model.Zone;
 
-public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoint> {
+class AStarCellPoint {
+  final CellPoint position;
+  final boolean isOddStepOfOneTwoOneMovement;
+
   AStarCellPoint parent;
+  double g;
   double h;
-  double f;
-  double terrainModifier;
-  boolean isAStarCanceled = false;
-  TerrainModifierOperation terrainModifierOperation;
-
-  // Store if it's valid to move from Point2D to this cell.
-  Map<Point2D, Boolean> validMoves = new HashMap<Point2D, Boolean>();
-
-  public AStarCellPoint() {
-    super(0, 0);
-  }
-
-  @Override
-  public boolean isAStarCanceled() {
-    return isAStarCanceled;
-  }
 
   /**
-   * Sets the A* cancellation status to the cell.
+   * Create an A* node from coordinates.
    *
-   * @param aStarCanceled whether A* couldn't find a path to the cell
-   */
-  public void setAStarCanceled(boolean aStarCanceled) {
-    isAStarCanceled = aStarCanceled;
-  }
-
-  /**
-   * Create an A* node from a position.
-   *
-   * <p>The node will have no scores or data carried over from a cell point.
+   * <p>The node will have no scores or data carried over from a cell point. This is useful for
+   * creating brand new nodes, such as for neighbors of existing cells.
    *
    * @param x The x cell position of the node.
    * @param y The y cell position of the node.
+   * @param isOddStepOfOneTwoOneMovement If the movement is 1-2-1 and an odd path was taken so far.
    */
-  public AStarCellPoint(int x, int y) {
-    super(x, y);
+  public AStarCellPoint(int x, int y, boolean isOddStepOfOneTwoOneMovement) {
+    this(new CellPoint(x, y), isOddStepOfOneTwoOneMovement);
   }
 
   /**
    * Create an A* node from a cell point.
    *
-   * <p>The distance travelled is copied from the cell point, making this useful for creating nodes
+   * <p>The distance travelled is copied from the cell point. This is usefull for creating nodes
    * that need to carry over data, such as after a waypoint.
    *
    * @param p The cell point to associate with the A* node.
+   * @param isOddStepOfOneTwoOneMovement If the movement is 1-2-1 and an odd path was taken so far.
    */
-  public AStarCellPoint(CellPoint p) {
-    super(p.x, p.y, p.distanceTraveled, p.distanceTraveledWithoutTerrain);
-  }
-
-  /**
-   * Create a node with terrain modifiers.
-   *
-   * <p>This is only used to associate terrain modifiers with a position. It is not queued to be
-   * used as part of A* itself.
-   *
-   * @param p The cell at which the node should exist.
-   * @param mod The amount of the terrain modifier.
-   * @param operation Which operation is used to calculate the terrain's effect.
-   */
-  public AStarCellPoint(CellPoint p, double mod, TerrainModifierOperation operation) {
-    super(p.x, p.y);
-    terrainModifier = mod;
-    terrainModifierOperation = operation;
+  public AStarCellPoint(CellPoint p, boolean isOddStepOfOneTwoOneMovement) {
+    this.position = new CellPoint(p.x, p.y, p.distanceTraveled, p.distanceTraveledWithoutTerrain);
+    this.isOddStepOfOneTwoOneMovement = isOddStepOfOneTwoOneMovement;
   }
 
   /**
@@ -105,80 +62,31 @@ public class AStarCellPoint extends CellPoint implements Comparable<AStarCellPoi
    * @return `true` if the path to this number has an odd number of diagonal steps.
    */
   public boolean isOddStepOfOneTwoOneMovement() {
-    return (int) this.distanceTraveledWithoutTerrain != this.distanceTraveledWithoutTerrain;
+    return this.isOddStepOfOneTwoOneMovement;
+  }
+
+  public void replaceG(AStarCellPoint previousNode) {
+    g = previousNode.g;
+    position.distanceTraveled = previousNode.position.distanceTraveled;
+    position.distanceTraveledWithoutTerrain = previousNode.position.distanceTraveledWithoutTerrain;
   }
 
   public double fCost() {
-    return h + gCost();
-  }
-
-  public Point2D toPoint() {
-    return new Point2D.Double(x, y);
-  }
-
-  public Point2D toCenterPoint(Zone zone) {
-    Rectangle bounds = zone.getGrid().getBounds(this);
-    return new Point2D.Double(bounds.getCenterX(), bounds.getCenterY());
-  }
-
-  // To store as a map of valid moves, true if you can move into this cellpoint from another
-  // cellpoint
-  public void setValidMove(Point2D key, boolean value) {
-    validMoves.put(key, value);
-  }
-
-  public Boolean isValidMove(Point2D key) {
-    return validMoves.get(key);
-  }
-
-  public void setValidMove(AStarCellPoint key, boolean value) {
-    validMoves.put(key.toPoint(), value);
-  }
-
-  public Boolean isValidMove(AStarCellPoint key) {
-    return validMoves.get(key.toPoint());
-  }
-
-  public Set<Point2D> getValidMoves() {
-    Set<Point2D> validMovePoints = new HashSet<Point2D>();
-
-    for (Entry<Point2D, Boolean> entry : validMoves.entrySet()) {
-      if (entry.getValue()) {
-        validMovePoints.add(
-            new Point2D.Double(entry.getKey().getX() - x, entry.getKey().getY() - y));
-      }
-    }
-
-    return validMovePoints;
-  }
-
-  // Draws a shape for display of all valid moves
-  public Shape getValidMoveShape(Zone zone) {
-    Path2D validMoveShape = new Path2D.Double();
-
-    Rectangle cellBounds = zone.getGrid().getBounds(this);
-    double x1 = cellBounds.getCenterX();
-    double y1 = cellBounds.getCenterY();
-
-    for (Entry<Point2D, Boolean> entry : validMoves.entrySet()) {
-      validMoveShape.moveTo(x1, y1);
-
-      if (entry.getValue()) {
-        CellPoint cp = new CellPoint((int) entry.getKey().getX(), (int) entry.getKey().getY());
-        Rectangle entryBounds = zone.getGrid().getBounds(cp);
-        double x2 = entryBounds.getCenterX();
-        double y2 = entryBounds.getCenterY();
-        validMoveShape.lineTo(x2, y2);
-      }
-    }
-
-    validMoveShape.closePath();
-
-    return validMoveShape;
+    return h + g;
   }
 
   @Override
-  public int compareTo(AStarCellPoint other) {
-    return Double.compare(fCost(), other.fCost());
+  public boolean equals(Object o) {
+    if (!(o instanceof AStarCellPoint)) {
+      return false;
+    }
+    var that = (AStarCellPoint) o;
+    return this.position.equals(that.position)
+        && this.isOddStepOfOneTwoOneMovement == that.isOddStepOfOneTwoOneMovement;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(position, this.isOddStepOfOneTwoOneMovement);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarSquareEuclideanWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarSquareEuclideanWalker.java
@@ -80,8 +80,8 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
   }
 
   private double metricDistance(AStarCellPoint current, CellPoint goal) {
-    int xDist = current.x - goal.x;
-    int yDist = current.y - goal.y;
+    int xDist = current.position.x - goal.x;
+    int yDist = current.position.y - goal.y;
 
     double distance;
     int crossProductTieBreaker;
@@ -94,8 +94,8 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
       default:
       case ONE_ONE_ONE:
       case ONE_TWO_ONE:
-        xDist = Math.abs(current.x - goal.x);
-        yDist = Math.abs(current.y - goal.y);
+        xDist = Math.abs(current.position.x - goal.x);
+        yDist = Math.abs(current.position.y - goal.y);
 
         final int remainingDiagonals = Math.min(xDist, yDist);
         final int remainingStraights = Math.abs(xDist - yDist);
@@ -113,7 +113,8 @@ public class AStarSquareEuclideanWalker extends AbstractAStarWalker {
 
     // break ties to prefer better looking paths that are along the straight line from the
     // starting point to the goal
-    if ((goal.x > current.x && goal.y > current.y) || (goal.x < current.x && goal.y < current.y)) {
+    if ((goal.x > current.position.x && goal.y > current.position.y)
+        || (goal.x < current.position.x && goal.y < current.position.y)) {
       crossProductTieBreaker = Math.abs(xDist * crossY - crossX * yDist);
     } else {
       crossProductTieBreaker = Math.abs(xDist * crossY + crossX * yDist);

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarHexEuclideanWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarHexEuclideanWalker.java
@@ -31,7 +31,7 @@ public abstract class AbstractAStarHexEuclideanWalker extends AbstractAStarWalke
 
   @Override
   protected double hScore(AStarCellPoint p1, CellPoint p2) {
-    return euclideanDistance(p1, p2);
+    return euclideanDistance(p1.position, p2);
   }
 
   // Adjusted math per: https://www.redblobgames.com/grids/hexagons/#distances

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -49,8 +49,7 @@ import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 
 public abstract class AbstractAStarWalker extends AbstractZoneWalker {
-  private record TerrainModifier(Token.TerrainModifierOperation operation, double value) {
-  }
+  private record TerrainModifier(Token.TerrainModifierOperation operation, double value) {}
 
   private static boolean isInteger(double d) {
     return (int) d == d;
@@ -83,8 +82,11 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
       // log.info("Token: " + token.getName() + ", " + token.getTerrainModifier());
       Set<CellPoint> cells = token.getOccupiedCells(zone.getGrid());
       for (CellPoint cell : cells) {
-        terrainCells.computeIfAbsent(cell, ignored -> new ArrayList<>())
-                    .add(new TerrainModifier(token.getTerrainModifierOperation(), token.getTerrainModifier()));
+        terrainCells
+            .computeIfAbsent(cell, ignored -> new ArrayList<>())
+            .add(
+                new TerrainModifier(
+                    token.getTerrainModifierOperation(), token.getTerrainModifier()));
       }
     }
   }
@@ -340,7 +342,8 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
         }
 
         // Check for terrain modifiers
-        for (TerrainModifier terrainModifier : terrainCells.getOrDefault(neighbor.position, Collections.emptyList())) {
+        for (TerrainModifier terrainModifier :
+            terrainCells.getOrDefault(neighbor.position, Collections.emptyList())) {
           if (!terrainModifiersIgnored.contains(terrainModifier.operation)) {
             switch (terrainModifier.operation) {
               case MULTIPLY:
@@ -388,11 +391,15 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
         if (neighbor.isOddStepOfOneTwoOneMovement()) {
           neighbor.g = node.g + terrainAdder + terrainMultiplier;
 
-          neighbor.position.distanceTraveled = node.position.distanceTraveled + terrainAdder + terrainMultiplier;
+          neighbor.position.distanceTraveled =
+              node.position.distanceTraveled + terrainAdder + terrainMultiplier;
         } else {
           neighbor.g = node.g + terrainAdder + terrainMultiplier * Math.ceil(diagonalMultiplier);
 
-          neighbor.position.distanceTraveled = node.position.distanceTraveled + terrainAdder + terrainMultiplier * Math.ceil(diagonalMultiplier);
+          neighbor.position.distanceTraveled =
+              node.position.distanceTraveled
+                  + terrainAdder
+                  + terrainMultiplier * Math.ceil(diagonalMultiplier);
         }
       }
 

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -330,8 +330,6 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
         for (CellPoint cellPoint : occupiedCells) {
           // VBL Check
           if (vblBlocksMovement(cellPoint, neighbor.position)) {
-            closedSet.add(new AStarCellPoint(cellPoint, false));
-            closedSet.add(new AStarCellPoint(cellPoint, true));
             blockNode = true;
             break;
           }

--- a/src/main/java/net/rptools/maptool/model/CellPoint.java
+++ b/src/main/java/net/rptools/maptool/model/CellPoint.java
@@ -28,10 +28,10 @@ import net.rptools.maptool.client.ui.zone.ZoneRenderer;
  */
 public class CellPoint extends AbstractPoint {
 
-  public double g; // Only populated by AStarWalker classes to be used upstream
   public double distanceTraveled; // Only populated by AStarWalker classes to be used upstream
   public double
       distanceTraveledWithoutTerrain; // Only populated by AStarWalker classes to be used upstream
+  private boolean isAStarCanceled = false;
 
   public CellPoint(int x, int y) {
     super(x, y);
@@ -46,6 +46,14 @@ public class CellPoint extends AbstractPoint {
   @Override
   public String toString() {
     return "CellPoint" + super.toString();
+  }
+
+  public boolean isAStarCanceled() {
+    return isAStarCanceled;
+  }
+
+  public void setAStarCanceled(boolean aStarCanceled) {
+    this.isAStarCanceled = aStarCanceled;
   }
 
   /**
@@ -85,6 +93,10 @@ public class CellPoint extends AbstractPoint {
     return zp;
   }
 
+  public ZonePoint midZonePoint(Grid grid, CellPoint other) {
+    return this.offsetZonePoint(grid, other.x - this.x, other.y - this.y);
+  }
+
   /**
    * Return distance in grid units for current map.
    *
@@ -114,15 +126,5 @@ public class CellPoint extends AbstractPoint {
       double result = Math.floor((num + unitsPerCell / 2) / unitsPerCell) * unitsPerCell;
       return Math.max(result, unitsPerCell);
     }
-  }
-
-  public double gCost() {
-    return g;
-  }
-
-  public void replaceG(CellPoint previousCell) {
-    g = previousCell.g;
-    distanceTraveled = previousCell.distanceTraveled;
-    distanceTraveledWithoutTerrain = previousCell.distanceTraveledWithoutTerrain;
   }
 }


### PR DESCRIPTION
Finishes #2696.

The core of this change is to augment A* nodes with a flag that indicates whether the node was arrived at via a path with an odd number of diagonals, specifically under 1-2-1 movement. This flag is also now part of the equality of the node. The effect is that each cell can have up to two nodes associated with it, one for an odd number of diagonals and one for an even number.

Most of the work in this change was in refactoring `AStarCellPoint`. This class served a few distinct purposes:
1. To be queued for use in A*, with path costs and estimates.
2. To associate terrain modifiers with cells.
3. To cache whether moves into a cell are allowed or are blocked by MBL/VBL.

(1) is the aspect we want to modify, while (2) and (3) are incidental uses of `AStarCellPoint` that rely on its equality being the same as for `CellPoint`. Since we seek to change the equality, it was necessary to break (2) and (3) into their own things. This is how things stand now:
1. Retained as `AStarCellPoint`, but no longer inheriting from `CellPoint` and only containing information needed for A* itself (parent node, cost estimates, ...). I would have like it to be renamed to `AStarNode`, but that resulted serialization issues, so for now the name is kept the same.
2. Now represented as a mapping from `CellPoint` to a new record `TerrainModifier`. This has a small perk of no longer needing to iterate over the entire set of terrain modifiers for each cell.
3. Now represented as a nested mapping, first from target cells, then from source cells, and maps to whether the move from the source to the target is valid. This is actually the same structure as before, just without needing to go through an `AStarCellPoint` anymore. Debug rendering was modified to use the new representation.

Now that each cell has two nodes, the debug labels have been updated to display in two columns per cell. The left cell is for when the path has an even number of diagonals, and the right cell for when the path has an odd number. Only one column will be used when not using 1-2-1 movement.

There is also a small bugfix here. Previously, a cell in the token's footprint would be closed if a move from that cell to *any* of the current node's neighbors would be blocked by VBL. This is despite the fact that other valid moves could be made from that cell, and that A* may still expect the cell to be open. This caused issues, for example, when running a large token along the inside top edge of a hollow rectangle of MBL. It did not really affect medium or smaller tokens since the only footprint cell is the current cell, which would end up closed anyways as part of A*. But now that two nodes are associated with each cell, this bug became a more obvious problem since both nodes for the *current cell* ended up closed even though better paths could still be found through the cell. This is now been fixed so that nodes are only closed by being processed by A*, or by determining that the cell is completely blocked thanks to terrain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2721)
<!-- Reviewable:end -->
