### PR TITLE
Setting program name on macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ run {
     // Add  -Djavax.net.debug=all to debug networking issues
 
     if (osdetector.os.is('osx')) {
-        applicationDefaultJvmArgs += [ "-Xdock:name=MapTool" ]
+        applicationDefaultJvmArgs += [ '-Xdock:name=' + project.name + developerRelease ]
     }
 
     if (System.getProperty("exec.args") != null) {
@@ -204,7 +204,7 @@ runtime {
             ]
             targetPlatform('mac') {
                 jdkHome = jdkDownload('https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_mac_hotspot_16_36.tar.gz');
-                jvmArgs += [ "-Xdock:name=MapTool" ]
+                jvmArgs += [ '-Xdock:name=' + project.name + developerRelease ]
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,9 +117,13 @@ javafx {
 
 run {
     args = ['-v=' + appSemVer]
-    applicationDefaultJvmArgs = ["-Xss8M", "-Xdock:name=MapTool", "-Dsentry.environment=Development", "-Dfile.encoding=UTF-8", "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages", "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED", "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=java.desktop/javax.swing=ALL-UNNAMED"]
+    applicationDefaultJvmArgs = ["-Xss8M", "-Dsentry.environment=Development", "-Dfile.encoding=UTF-8", "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages", "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED", "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=java.desktop/javax.swing=ALL-UNNAMED"]
     // Add -Dlog4j2.debug to see log4j2 details
     // Add  -Djavax.net.debug=all to debug networking issues
+
+    if (osdetector.os.is('osx')) {
+        applicationDefaultJvmArgs += [ "-Xdock:name=MapTool" ]
+    }
 
     if (System.getProperty("exec.args") != null) {
         args System.getProperty("exec.args").split()
@@ -200,6 +204,7 @@ runtime {
             ]
             targetPlatform('mac') {
                 jdkHome = jdkDownload('https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_mac_hotspot_16_36.tar.gz');
+                jvmArgs += [ "-Xdock:name=MapTool" ]
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ javafx {
 
 run {
     args = ['-v=' + appSemVer]
-    applicationDefaultJvmArgs = ["-Xss8M", "-Dsentry.environment=Development", "-Dfile.encoding=UTF-8", "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages", "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED", "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=java.desktop/javax.swing=ALL-UNNAMED"]
+    applicationDefaultJvmArgs = ["-Xss8M", "-Xdock:name=MapTool", "-Dsentry.environment=Development", "-Dfile.encoding=UTF-8", "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages", "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED", "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=java.desktop/javax.swing=ALL-UNNAMED"]
     // Add -Dlog4j2.debug to see log4j2 details
     // Add  -Djavax.net.debug=all to debug networking issues
 


### PR DESCRIPTION
On macOS, the name shown in the "MapTool" menu of the menubar is the name of the default class "LaunchInstructions" used to start MapTool. This is less than ideal and this fix sets the name of the application to display "MapTool" rather than the default.

This fix has only been tested and verified on macOS but should work on other platforms as well since it uses an JVM -X argument, which are typically ignored unless supported by the particular platform JVM implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2738)
<!-- Reviewable:end -->
