### PR TITLE
Fix for currentTime being stuck at end

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
@@ -80,8 +80,10 @@ public class MediaPlayerAdapter {
         () -> {
           int curCount = player.getCurrentCount();
           int cycCount = player.getCycleCount();
-          if (cycCount != MediaPlayer.INDEFINITE && curCount >= cycCount)
+          if (cycCount != MediaPlayer.INDEFINITE && curCount >= cycCount) {
             player.stop(); // otherwise, status stuck on "PLAYING" at end
+            player.seek(Duration.millis(start)); // fixes the problem with getStreamProperties()/currentTime #2658
+          }
         });
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
@@ -82,7 +82,9 @@ public class MediaPlayerAdapter {
           int cycCount = player.getCycleCount();
           if (cycCount != MediaPlayer.INDEFINITE && curCount >= cycCount) {
             player.stop(); // otherwise, status stuck on "PLAYING" at end
-            player.seek(Duration.millis(start)); // fixes the problem with getStreamProperties()/currentTime #2658
+            player.seek(
+                Duration.millis(
+                    start)); // fixes the problem with getStreamProperties()/currentTime #2658
           }
         });
   }


### PR DESCRIPTION
After a stream has stopped and then restarted, getStreamProperties() would always return the stop time value instead of the current time.  

This change forces a seek to the start time after a stream has ended or is stopped so that the MediaPlayer clears the `isEOS` flag.

Issue #2658

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2765)
<!-- Reviewable:end -->
