### PR TITLE
fix for issue #2779 of mousewheel events not reaching html5 overlay

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -89,9 +89,8 @@ public class HTMLOverlayPanel extends JFXPanel {
           }
         });
 
-
-    //In JavaFX mousewheel events are not included in MouseEvent.ANY but in ScrollEvent.ANY, add a
-    //separate event filter for those to make sure these events reach the Webview
+    // In JavaFX mousewheel events are not included in MouseEvent.ANY but in ScrollEvent.ANY, add a
+    // separate event filter for those to make sure these events reach the Webview
     front.addEventFilter(
         ScrollEvent.ANY,
         event -> {

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -25,6 +25,7 @@ import javafx.embed.swing.JFXPanel;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.Scene;
+import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
@@ -79,6 +80,20 @@ public class HTMLOverlayPanel extends JFXPanel {
     front.setPickOnBounds(true); // catches the clicks
     front.addEventFilter(
         javafx.scene.input.MouseEvent.ANY,
+        event -> {
+          // Passes the mouse event to all overlays
+          for (HTMLOverlayManager overlay : overlays) {
+            if (overlay.isVisible()) {
+              overlay.getWebView().fireEvent(event);
+            }
+          }
+        });
+
+
+    //In JavaFX mousewheel events are not included in MouseEvent.ANY but in ScrollEvent.ANY, add a
+    //separate event filter for those to make sure these events reach the Webview
+    front.addEventFilter(
+        ScrollEvent.ANY,
         event -> {
           // Passes the mouse event to all overlays
           for (HTMLOverlayManager overlay : overlays) {


### PR DESCRIPTION
Added an event filter for Scrollevents in `HTMLOverlayPanel.setupScene()` as in JavaFX mousewheel events are not covered under `MouseEvent.ANY`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2780)
<!-- Reviewable:end -->
