### PR TITLE
Update AppActions.java

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2719,6 +2719,11 @@ public class AppActions {
               // Jamz: Bug fix, would not add extension if map name had a . in it...
               // Lets do a better job and actually check the end of the file name for the extension
               mapFile = getFileWithExtension(mapFile, AppConstants.MAP_FILE_EXTENSION);
+              if (mapFile.exists()) {
+                if (!MapTool.confirm("msg.confirm.fileExists")) {
+                  return;
+                }
+              }
               PersistenceUtil.saveMap(zr.getZone(), mapFile);
               AppPreferences.setSaveMapDir(mapFile.getParentFile());
               MapTool.showInformation("msg.info.mapSaved");


### PR DESCRIPTION
Added a warning if user tries to save a map with a name that already exists. (same warning as with trying to save campaign with existing file name)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2782)
<!-- Reviewable:end -->
