### PR TITLE
Remove redundant PathIterator segments to avoid self-intersections

### DIFF
--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -49,6 +49,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
+import org.locationtech.jts.operation.valid.IsValidOp;
 
 public abstract class AbstractAStarWalker extends AbstractZoneWalker {
   private record TerrainModifier(Token.TerrainModifierOperation operation, double value) {}
@@ -195,16 +196,16 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
       } else {
         try {
           var vblGeometry =
-              shapeReader
-                  .read(new ReverseShapePathIterator(vbl.getPathIterator(null)))
-                  .buffer(1); // .buffer helps creating valid geometry and prevent self-intersecting
+              shapeReader.read(new ReverseShapePathIterator(vbl.getPathIterator(null)));
 
           // polygons
           if (!vblGeometry.isValid()) {
             log.info(
                 "vblGeometry is invalid! May cause issues. Check for self-intersecting polygons.");
+            log.debug("Invalid vblGeometry: " + new IsValidOp(vblGeometry).getValidationError());
           }
 
+          vblGeometry = vblGeometry.buffer(1); // .buffer always creates valid geometry.
           this.vblGeometry = PreparedGeometryFactory.prepare(vblGeometry);
         } catch (Exception e) {
           log.info("vblGeometry oh oh: ", e);

--- a/src/main/java/net/rptools/maptool/client/walker/astar/ReverseShapePathIterator.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/ReverseShapePathIterator.java
@@ -17,7 +17,11 @@ package net.rptools.maptool.client.walker.astar;
 import java.awt.geom.PathIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Reverses the order of rings returned by a PathIterator so that it works better with JST's
@@ -31,13 +35,130 @@ public class ReverseShapePathIterator implements PathIterator {
    * Represents a segment as returned by PathIterator::currentSegment(). I.e., a segment type and a
    * list of coordinates.
    */
-  private static class Segment {
-    public int segmentType;
-    public double[] coords;
+  private record Segment(int segmentType, double[] coords) {}
 
-    Segment(int segmentType, double[] coords) {
-      this.segmentType = segmentType;
-      this.coords = coords;
+  /**
+   * Builds valid rings (closed shapes) from segments returned by a <code>PathIterator</code>.
+   *
+   * <p>There are some weaknesses in AWT's <code>PathIterator</code>. In particular, it can
+   * sometimes return points that differ by only a minute amount. This causes issues downstream, as
+   * it looks like a self-intersecting polygon.
+   *
+   * <p>The RingBuilder enforces the following rules:
+   *
+   * <ol>
+   *   <li>All rings start with <code>SEG_MOVETO</code>.
+   *   <li>All rings end with <code>SEG_CLOSE</code>.
+   *   <li>All rings contain at least one <code>SEG_LINETO</code>.
+   *   <li>All <code>SEG_LINETO</code> segments are distinct from their predecessor.
+   * </ol>
+   *
+   * <p>Violation of rules (1)-(3) results in a ring being dropped entirely. Violation of rule (4)
+   * results in the redundant segment being dropped from the ring.
+   */
+  private static final class RingBuilder {
+    private static final Logger log = LogManager.getLogger(RingBuilder.class);
+
+    private final List<List<Segment>> rings = new ArrayList<>();
+    /** Includes only those segments that are not indistinguishable from their neighbours. */
+    private List<Segment> currentRing = new ArrayList<>();
+    /** Includes all segments added to the current ring. Used for logging. */
+    private List<Segment> currentFullRing = new ArrayList<>();
+    /** Determines which segment types are permitted for the next segment. */
+    private final Set<Integer> allowedSegmentTypes;
+
+    public RingBuilder() {
+      this.allowedSegmentTypes = new HashSet<>();
+      this.allowedSegmentTypes.add(PathIterator.SEG_MOVETO);
+    }
+
+    public List<List<Segment>> build() {
+      return rings;
+    }
+
+    public void add(Segment segment) {
+      final var epsilon = 1e-9;
+
+      if (!this.allowedSegmentTypes.contains(segment.segmentType)) {
+        log.debug(
+            "Eliding ring due to unexpected segment. Unexpected segment type "
+                + segment.segmentType
+                + ". Expected one of "
+                + this.allowedSegmentTypes);
+        // Return to a new ring state.
+        currentRing = new ArrayList<>();
+        currentFullRing = new ArrayList<>();
+        setAllowedSegmentTypes(PathIterator.SEG_MOVETO);
+        return;
+      }
+
+      switch (segment.segmentType) {
+        case PathIterator.SEG_MOVETO:
+          assert currentRing.isEmpty() : "SEG_MOVETO must be the first segment in a ring";
+
+          currentRing.add(segment);
+          currentFullRing.add(segment);
+
+          setAllowedSegmentTypes(PathIterator.SEG_LINETO); // Not allowed to immediately close.
+          break;
+
+        case PathIterator.SEG_CLOSE:
+          assert currentRing.size() >= 1 : "SEG_CLOSE must at least come after SEG_MOVETO";
+          assert currentRing.get(0).segmentType == PathIterator.SEG_MOVETO
+              : "SEG_MOVETO must be the first segment in a ring";
+
+          // Explicit end to the ring. This segment is considered part of the ring.
+          currentRing.add(segment);
+          currentFullRing.add(segment);
+
+          // Note that SEG_CLOSE coordinates are not necessarily meaningful, so we don't do
+          // elision on them.
+
+          // If any SEG_LINETO segments have been elided from this ring, it may have become
+          // degenerate.
+          if (currentRing.size() == 2) {
+            log.debug("Eliding degenerate ring: " + currentFullRing);
+          } else {
+            rings.add(currentRing);
+          }
+
+          currentRing = new ArrayList<>();
+          currentFullRing = new ArrayList<>();
+          setAllowedSegmentTypes(PathIterator.SEG_MOVETO);
+          break;
+
+        case PathIterator.SEG_LINETO:
+          assert currentRing.size() >= 1 : "SEG_LINETO must at least come after SEG_MOVETO";
+          assert currentRing.get(0).segmentType == PathIterator.SEG_MOVETO
+              : "SEG_MOVETO must be the first segment in a ring";
+
+          // Simple case of adding a segment.
+          currentFullRing.add(segment);
+          // Check whether we need to keep or elide the segment.
+          if (distance(segment, currentRing.get(currentRing.size() - 1)) >= epsilon) {
+            currentRing.add(segment);
+          }
+          setAllowedSegmentTypes(PathIterator.SEG_LINETO, PathIterator.SEG_CLOSE);
+          break;
+
+        default:
+          throw new RuntimeException(
+              String.format("Unable to handle segment type %d", segment.segmentType));
+      }
+    }
+
+    private void setAllowedSegmentTypes(int... types) {
+      this.allowedSegmentTypes.clear();
+      for (var type : types) {
+        this.allowedSegmentTypes.add(type);
+      }
+    }
+
+    private double distance(Segment lhs, Segment rhs) {
+      var diffX = rhs.coords[0] - lhs.coords[0];
+      var diffY = rhs.coords[1] - lhs.coords[1];
+
+      return Math.sqrt(diffX * diffX + diffY * diffY);
     }
   }
 
@@ -60,45 +181,17 @@ public class ReverseShapePathIterator implements PathIterator {
    */
   public ReverseShapePathIterator(PathIterator forwardPathIterator) {
     windingRule = forwardPathIterator.getWindingRule();
-    rings = new ArrayList<>();
 
-    // PathIterator::currentSegment() reqiures a 6-element array, in case of SEG_QUADTO.
+    // PathIterator::currentSegment() requires a 6-element array, in case of SEG_QUADTO.
     final double[] coords = new double[6];
-    // Assume all rings are started with SEG_MOVETO and may be explicitly ended with SEG_CLOSE.
-    List<Segment> currentRing = new ArrayList<>();
+    final var ringBuilder = new RingBuilder();
     for (; !forwardPathIterator.isDone(); forwardPathIterator.next()) {
       int segmentType = forwardPathIterator.currentSegment(coords);
-      final Segment segment = new Segment(segmentType, Arrays.copyOf(coords, coords.length));
-
-      switch (segmentType) {
-        case PathIterator.SEG_MOVETO:
-          // May be the first segment we see, in which case it starts the first ring. Otherwise it
-          // implicitly ends the previous ring, to which this segment does not belong.
-          if (!currentRing.isEmpty()) {
-            rings.add(currentRing);
-            currentRing = new ArrayList<>();
-          }
-          currentRing.add(segment);
-          break;
-
-        case PathIterator.SEG_CLOSE:
-          // Explicit end to the ring. This segment is considered part of the ring.
-          currentRing.add(segment);
-          rings.add(currentRing);
-          currentRing = new ArrayList<>();
-          break;
-
-        case PathIterator.SEG_LINETO:
-          // Simple case of adding a segment.
-          currentRing.add(segment);
-          break;
-
-        default:
-          throw new RuntimeException(
-              String.format("Unable to handle segment type %d", segmentType));
-      }
+      final var segment = new Segment(segmentType, Arrays.copyOf(coords, coords.length));
+      ringBuilder.add(segment);
     }
 
+    rings = ringBuilder.build();
     ringIndex = rings.size() - 1;
   }
 


### PR DESCRIPTION
A weakness in AWT's `PathIterator` is that it sometimes yields miniscule segments that are essentially zero-length. When processed by JTS, these segments are interpreted as a self-intersection, which it tries to handle intelligently. Unfortunately, doing so is difficult especially when shapes are nested.

This changes removes these near-zero-length `SEG_LINETO` segments. Doing so also the possibility that a given ring no longer contains any `SEG_LINETO`. These degenerate rings are also removed.

In order to more easily discover broken geometry in the future. the `Geometry::buffer()` call is now done after the logging for invalid geometry. Since `Geometry::buffer()` always creates valid geometry, the logging was not being triggered even when tested with broken geometry.

Fixes #2783.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2784)
<!-- Reviewable:end -->
