### PR TITLE
Fix issues with moving and copying macros for #2785

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
@@ -131,7 +131,8 @@ public class ButtonGroup extends AbstractButtonGroup {
       if (!MapTool.getPlayer().isGM()
           && (panelClass.equals("CampaignPanel")
               || panelClass.equals("GmPanel")
-              || data.panelClass.equals("CampaignPanel")
+              || (data.panelClass.equals("CampaignPanel")
+                  && !MapTool.getServerPolicy().playersReceiveCampaignMacros())
               || data.panelClass.equals("GmPanel"))) {
         MapTool.showError(
             I18N.getText(
@@ -306,9 +307,13 @@ public class ButtonGroup extends AbstractButtonGroup {
     if (data.panelClass.equals("GlobalPanel")) {
       MacroButtonPrefs.delete(properties);
     } else if (data.panelClass.equals("CampaignPanel")) {
-      MapTool.getCampaign().deleteMacroButton(properties);
+      if (MapTool.getPlayer().isGM()) {
+        MapTool.getCampaign().deleteMacroButton(properties);
+      }
     } else if (data.panelClass.equals("GmPanel")) {
-      MapTool.getCampaign().deleteGmMacroButton(properties);
+      if (MapTool.getPlayer().isGM()) {
+        MapTool.getCampaign().deleteGmMacroButton(properties);
+      }
     } else if ((data.panelClass.equals("SelectionPanel")
             || data.panelClass.equals("ImpersonatePanel"))
         && (data.tokenID != null)) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
@@ -128,8 +128,8 @@ public class ButtonGroup extends AbstractButtonGroup {
       MacroButtonProperties oldMacroProps = new MacroButtonProperties(tempProperties);
 
       // stops players from moving macros into/from the Campaign/GM panels
-      if (!MapTool.getPlayer().isGM() &&
-          (panelClass.equals("CampaignPanel")
+      if (!MapTool.getPlayer().isGM()
+          && (panelClass.equals("CampaignPanel")
               || panelClass.equals("GmPanel")
               || data.panelClass.equals("CampaignPanel")
               || data.panelClass.equals("GmPanel"))) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
@@ -127,17 +127,12 @@ public class ButtonGroup extends AbstractButtonGroup {
       // if a reference is needed when moving instead of copying
       MacroButtonProperties oldMacroProps = new MacroButtonProperties(tempProperties);
 
-      if (!MapTool.getPlayer().isGM()
-          && (
-          // stops players from moving non-player-editable macros into another panel
-          (!tempProperties.getAllowPlayerEdits()
-                  && data.panelHashcode != System.identityHashCode(getPanel()))
-              ||
-              // or into/from the Campaign/GM panels
-              (panelClass.equals("CampaignPanel")
-                  || panelClass.equals("GmPanel")
-                  || data.panelClass.equals("CampaignPanel")
-                  || data.panelClass.equals("GmPanel")))) {
+      // stops players from moving macros into/from the Campaign/GM panels
+      if (!MapTool.getPlayer().isGM() &&
+          (panelClass.equals("CampaignPanel")
+              || panelClass.equals("GmPanel")
+              || data.panelClass.equals("CampaignPanel")
+              || data.panelClass.equals("GmPanel"))) {
         MapTool.showError(
             I18N.getText(
                 "macro.function.MacroFunctions.noPermMove",

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPrefs.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPrefs.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import net.rptools.maptool.client.AppConstants;
+import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.MacroButtonHotKeyManager;
 import net.rptools.maptool.model.MacroButtonProperties;
@@ -43,6 +44,7 @@ public class MacroButtonPrefs {
   private static final String PREF_FONT_SIZE = "fontSize";
   private static final String PREF_MIN_WIDTH = "minWidth";
   private static final String PREF_MAX_WIDTH = "maxWidth";
+  private static final String PREF_ALLOW_PLAYER_EDITS = "allowPlayerEdits";
   private static final String PREF_TOOLTIP = "toolTip";
   private static final String PREF_DISPLAY_HOT_KEY = "displayHotKey";
 
@@ -124,6 +126,7 @@ public class MacroButtonPrefs {
       prefs.put(PREF_FONT_SIZE, properties.getFontSize());
       prefs.put(PREF_MIN_WIDTH, properties.getMinWidth());
       prefs.put(PREF_MAX_WIDTH, properties.getMaxWidth());
+      prefs.putBoolean(PREF_ALLOW_PLAYER_EDITS, properties.getAllowPlayerEdits());
       prefs.put(PREF_TOOLTIP, properties.getToolTip());
       prefs.flush();
       if (resetFrame) {
@@ -181,6 +184,8 @@ public class MacroButtonPrefs {
               newPrefs.put(PREF_FONT_SIZE, buttonPref.get(PREF_FONT_SIZE, ""));
               newPrefs.put(PREF_MIN_WIDTH, buttonPref.get(PREF_MIN_WIDTH, ""));
               newPrefs.put(PREF_MAX_WIDTH, buttonPref.get(PREF_MAX_WIDTH, ""));
+              newPrefs.putBoolean(
+                  PREF_ALLOW_PLAYER_EDITS, buttonPref.getBoolean(PREF_ALLOW_PLAYER_EDITS, true));
 
               String colorKey = buttonPref.get(PREF_COLOR_KEY, "");
               String label = buttonPref.get(PREF_LABEL_KEY, Integer.toString(index));
@@ -195,6 +200,9 @@ public class MacroButtonPrefs {
               String fontSize = buttonPref.get(PREF_FONT_SIZE, "");
               String minWidth = buttonPref.get(PREF_MIN_WIDTH, "");
               String maxWidth = buttonPref.get(PREF_MAX_WIDTH, "");
+              boolean allowPlayerEdits =
+                  buttonPref.getBoolean(
+                      PREF_ALLOW_PLAYER_EDITS, AppPreferences.getAllowPlayerMacroEditsDefault());
               String toolTip = buttonPref.get(PREF_TOOLTIP, "");
               boolean displayHotKey = buttonPref.getBoolean(PREF_DISPLAY_HOT_KEY, true);
 
@@ -214,6 +222,7 @@ public class MacroButtonPrefs {
                       fontSize,
                       minWidth,
                       maxWidth,
+                      allowPlayerEdits,
                       toolTip,
                       displayHotKey));
             }
@@ -234,6 +243,9 @@ public class MacroButtonPrefs {
         String fontSize = buttonPref.get(PREF_FONT_SIZE, "");
         String minWidth = buttonPref.get(PREF_MIN_WIDTH, "");
         String maxWidth = buttonPref.get(PREF_MAX_WIDTH, "");
+        boolean allowPlayerEdits =
+            buttonPref.getBoolean(
+                PREF_ALLOW_PLAYER_EDITS, AppPreferences.getAllowPlayerMacroEditsDefault());
         String hotKey = buttonPref.get(PREF_HOTKEY_KEY, MacroButtonHotKeyManager.HOTKEYS[0]);
         String toolTip = buttonPref.get(PREF_TOOLTIP, "");
         boolean displayHotKey = buttonPref.getBoolean(PREF_DISPLAY_HOT_KEY, true);
@@ -254,6 +266,7 @@ public class MacroButtonPrefs {
                 fontSize,
                 minWidth,
                 maxWidth,
+                allowPlayerEdits,
                 toolTip,
                 displayHotKey));
       }

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/TransferData.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/TransferData.java
@@ -30,6 +30,7 @@ public class TransferData implements Serializable {
   public boolean autoExecute = true;
   public boolean includeLabel = false;
   public boolean applyToTokens = true;
+  public boolean allowPlayerEdits = false;
   public String fontColorKey = "";
   public String fontSize = "";
   public String minWidth = "";
@@ -53,6 +54,7 @@ public class TransferData implements Serializable {
     this.autoExecute = prop.getAutoExecute();
     this.includeLabel = prop.getIncludeLabel();
     this.applyToTokens = prop.getApplyToTokens();
+    this.allowPlayerEdits = prop.getAllowPlayerEdits();
     this.panelClass = button.getPanelClass();
     this.fontColorKey = prop.getFontColorKey();
     this.fontSize = prop.getFontSize();

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -74,7 +74,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
   private String fontSize;
   private String minWidth;
   private String maxWidth;
-  private Boolean allowPlayerEdits = true;
+  private Boolean allowPlayerEdits = AppPreferences.getAllowPlayerMacroEditsDefault();
   private String toolTip;
   private Boolean displayHotKey = true;
 
@@ -94,6 +94,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
       String fontSize,
       String minWidth,
       String maxWidth,
+      boolean allowPlayerEdits,
       String toolTip,
       boolean displayHotKey) {
     setIndex(index);
@@ -113,7 +114,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setButton(null);
     setTokenId((GUID) null);
     setSaveLocation("");
-    setAllowPlayerEdits(AppPreferences.getAllowPlayerMacroEditsDefault());
+    setAllowPlayerEdits(allowPlayerEdits);
     setDisplayHotKey(displayHotKey);
     setCompareGroup(true);
     setCompareSortPrefix(true);
@@ -145,7 +146,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setButton(other.button);
     setTokenId(other.tokenId);
     setSaveLocation(other.saveLocation);
-    setAllowPlayerEdits(AppPreferences.getAllowPlayerMacroEditsDefault());
+    setAllowPlayerEdits(other.allowPlayerEdits);
     setDisplayHotKey(other.displayHotKey);
     setCompareGroup(other.compareGroup);
     setCompareSortPrefix(other.compareSortPrefix);
@@ -831,6 +832,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     fontSize = "";
     minWidth = "";
     maxWidth = "";
+    allowPlayerEdits = AppPreferences.getAllowPlayerMacroEditsDefault();
     toolTip = "";
   }
 
@@ -1098,7 +1100,8 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     if (compareIncludeLabel == null) compareIncludeLabel = true;
     if (compareAutoExecute == null) compareAutoExecute = true;
     if (compareApplyToSelectedTokens == null) compareApplyToSelectedTokens = true;
-    if (allowPlayerEdits == null) allowPlayerEdits = true;
+    if (allowPlayerEdits == null)
+      allowPlayerEdits = AppPreferences.getAllowPlayerMacroEditsDefault();
     return this;
   }
 }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1604,6 +1604,7 @@ macro.function.MacroFunctions.missingCommand       = "{0}": Missing command.
 macro.function.MacroFunctions.missingLabel         = "{0}": Missing label.
 macro.function.MacroFunctions.noPerm               = "{0}": You do not have permissions to edit macro button at index {1} on token {2}.
 macro.function.MacroFunctions.noPermOther          = "{0}": You do not have permissions to edit macro button {1} at index {2} on token {3}.
+macro.function.MacroFunctions.noPermMove           = "{0}": You do not have permissions to move macro button {1} at index {2}.
 macro.function.MacroFunctions.noPermCommand        = "{0}": You do not have permissions to change the command of macro button at index {1} on token {2}.
 macro.function.MacroFunctions.noPermEditable       = "{0}": You do not have permissions to change the player editable status of macro button at index {1} on token {2}.
 macro.function.MacroFunctions.outOfRange           = "{0}": Macro at index {1} does not exist for token {2}.


### PR DESCRIPTION
The bug where non-player-editable macros could be moved and suddenly become player-editable is fixed. More importantly though, players can no longer move macros into or out of the Campaign or GM panels. There is definitely reason to allow players to copy macros _out_ of the Campaign panel, but usually a GM might want to keep those macros to themselves. These changes (should) remove any need to restrict the moving/copying of non-player-editable macros in a more general fashion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2787)
<!-- Reviewable:end -->
