### PR TITLE
Showing player map alias in the loading screen. #2802

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -2004,7 +2004,7 @@ public class ZoneRenderer extends JComponent
     loadingProgress =
         String.format(
             " Loading Map '%s' - %d/%d Loaded %d/%d Cached",
-            zone.getName(), downloadCount, assetSet.size(), cacheCount, assetSet.size());
+            zone.getPlayerAlias(), downloadCount, assetSet.size(), cacheCount, assetSet.size());
     isLoaded = loaded;
     if (isLoaded) {
       // Notify the token tree that it should update


### PR DESCRIPTION
Real quick one to stop the loading screen from giving spoilers to players. Never even thought about it since my testing was done on a local computer where the screen was there for a millisecond. #2802 

I made a map with the GM name "GM" and the Display name "DISPLAY".

Connecting on develop confirmed the issue as the following was shown.
![image](https://user-images.githubusercontent.com/33206261/123534930-3716df00-d6e6-11eb-85b2-17f986957568.png)

With this fix, the following was shown.
![image](https://user-images.githubusercontent.com/33206261/123534936-3f6f1a00-d6e6-11eb-8589-d7e44ecc2661.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2804)
<!-- Reviewable:end -->
