### PR TITLE
Fix log dir always being in user.home/.maptool-rptools

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -44,13 +44,19 @@ import org.apache.logging.log4j.Logger;
 
 /** This class provides utility functions for maptool client. */
 public class AppUtil {
-
   public static final String DEFAULT_DATADIR_NAME = ".maptool";
   public static final String DATADIR_PROPERTY_NAME = "MAPTOOL_DATADIR";
-  private static final Logger log = LogManager.getLogger(AppUtil.class);
+  public static final String LOGDIR_PROPERTY_NAME = "MAPTOOL_LOGDIR";
   private static final String CLIENT_ID_FILE = "client-id";
   private static final String CONFIG_SUB_DIR = "config";
   private static final String APP_HOME_CONFIG_FILENAME = "maptool.cfg";
+
+  static {
+    // Don't move this. This MUST be set before the logger is initialized
+    System.setProperty(LOGDIR_PROPERTY_NAME, getAppHome("logs").getAbsolutePath());
+  }
+
+  private static final Logger log = LogManager.getLogger(AppUtil.class);
 
   /** Returns true if currently running on a Windows based operating system. */
   public static boolean WINDOWS =
@@ -72,15 +78,10 @@ public class AppUtil {
           : "de.muntjak.tinylookandfeel.TinyLookAndFeel";
 
   private static File dataDirPath;
-  private static String packagerCfgFileName;
-
-  static {
-    System.setProperty("appHome", getAppHome("logs").getAbsolutePath());
-    packagerCfgFileName =
-        getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) != null
-            ? getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) + ".cfg"
-            : null;
-  }
+  private static String packagerCfgFileName =
+      getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) != null
+          ? getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) + ".cfg"
+          : null;
 
   /**
    * Returns a File object for USER_HOME if USER_HOME is non-null, otherwise null.

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -32,6 +32,9 @@ public class LaunchInstructions {
 
   public static void main(String[] args) {
     try {
+      // This is to initialize the log4j to set the path for logs. Just calling AppUtil sets the
+      // System.property
+      AppUtil.getAppHome();
 
       long mem = Runtime.getRuntime().maxMemory();
       String msg = String.format(USAGE, mem / (1024 * 1024));

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1529,7 +1529,6 @@ public class MapTool {
     log.info("**                              MapTool Started!                              **");
     log.info("**                                                                            **");
     log.info("********************************************************************************");
-    log.info("AppHome System Property: " + System.getProperty("appHome"));
     log.info("Logging to: " + getLoggerFileName());
 
     String versionImplementation = version;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO" packages="net.rptools.maptool.client.ui.logger">
-    <Properties>
-        <Property name="log-path">log</Property>
-    </Properties>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} (%F:%L) [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
         <RollingFile
                 name="LogFile"
-                fileName="${sys:user.home}/.maptool-rptools/logs/maptool.log"
-                filePattern="${sys:user.home}/.maptool-rptools/logs/archive/maptool_%d{yyyy-MM-dd_HH-mm-ss}.log.zip"
+                fileName="${sys:MAPTOOL_LOGDIR}/maptool.log"
+                filePattern="${sys:MAPTOOL_LOGDIR}/archive/maptool_%d{yyyy-MM-dd_HH-mm-ss}.log.zip"
                 ignoreExceptions="false">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
             <Policies>
@@ -18,7 +15,7 @@
                 <SizeBasedTriggeringPolicy size="10 MB"/>
             </Policies>
             <DefaultRolloverStrategy max="10">
-                <Delete basePath="${sys:user.home}/.maptool-rptools/logs/archive">
+                <Delete basePath="${sys:MAPTOOL_LOGDIR}/archive">
                     <IfFileName glob="maptool_*.log*"/>
                     <IfLastModified age="14d"/>
                 </Delete>


### PR DESCRIPTION
Fixes #2786.

As per the discussion in the issue, the `appHome` property has been replaced with something more appropriately named  (`MAPTOOL_LOGDIR`) and the property is set before the logger is initialized so it can be used to set the logger's path. I also just removed the line that was for logging the value of `appHome` since it didn't seem to be adding much (the log file path is still logged).

One thing I noticed is in `getAppHome()` there is a chance of it attempting to use the logger before it's initialized when it's unable to create the data dir ([here](https://github.com/Irarara/maptool/blob/da0fa49790dc37d7140335c97c3c2267c868b2a1/src/main/java/net/rptools/maptool/client/AppUtil.java#L125)). I didn't touch this in case there's something I'm missing, but if the data dir can't be created there should be nowhere to log to anyway, right? Should that bit just be removed? To note though, that being reached doesn't actually affect anything, because being unable to create the data dir results in a "Failed to launch JVM" error either way (would be nice if it popped a proper error message, but that's a separate matter).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2811)
<!-- Reviewable:end -->
