### PR TITLE
Handle exceptions thrown when trying to get the logs directory at launch

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -51,12 +51,7 @@ public class AppUtil {
   private static final String CONFIG_SUB_DIR = "config";
   private static final String APP_HOME_CONFIG_FILENAME = "maptool.cfg";
 
-  static {
-    // Don't move this. This MUST be set before the logger is initialized
-    System.setProperty(LOGDIR_PROPERTY_NAME, getAppHome("logs").getAbsolutePath());
-  }
-
-  private static final Logger log = LogManager.getLogger(AppUtil.class);
+  private static Logger log;
 
   /** Returns true if currently running on a Windows based operating system. */
   public static boolean WINDOWS =
@@ -82,6 +77,15 @@ public class AppUtil {
       getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) != null
           ? getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) + ".cfg"
           : null;
+
+  /** Sets the MAPTOOL_LOGDIR system property and initializes the first logger. */
+  public static void initLogging() {
+    if (log == null) {
+      // Note: This property MUST be set before the logger is initialized
+      System.setProperty(LOGDIR_PROPERTY_NAME, getAppHome("logs").getAbsolutePath());
+      log = LogManager.getLogger(AppUtil.class);
+    }
+  }
 
   /**
    * Returns a File object for USER_HOME if USER_HOME is non-null, otherwise null.
@@ -122,7 +126,7 @@ public class AppUtil {
         RuntimeException re =
             new RuntimeException(
                 I18N.getText("msg.error.unableToCreateDataDir", path.getAbsolutePath()));
-        if (log.isInfoEnabled()) {
+        if (log != null && log.isInfoEnabled()) {
           log.info("msg.error.unableToCreateDataDir", re);
         }
         throw re;

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -32,9 +32,10 @@ public class LaunchInstructions {
 
   public static void main(String[] args) {
     try {
-      // This is to initialize the log4j to set the path for logs. Just calling AppUtil sets the
-      // System.property
+      // This is called just to make sure there's a valid data dir
       AppUtil.getAppHome();
+      // Initialize the first logger with the correct log path
+      AppUtil.initLogging();
 
       long mem = Runtime.getRuntime().maxMemory();
       String msg = String.format(USAGE, mem / (1024 * 1024));
@@ -53,6 +54,7 @@ public class LaunchInstructions {
     } catch (Exception e) {
       // Shows a proper error message if MapTool can't initialize. Fix #1678.
       JOptionPane.showMessageDialog(new JFrame(), e.getMessage());
+      System.exit(1);
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1651,13 +1651,6 @@ public class MapTool {
       System.setProperty("com.apple.mrj.application.apple.menu.about.name", "About MapTool...");
       System.setProperty("apple.awt.brushMetalLook", "true");
     }
-    // Before anything else, create a place to store all the data
-    try {
-      AppUtil.getAppHome();
-    } catch (Throwable t) {
-      MapTool.showError("Error creating data directory", t);
-      System.exit(1);
-    }
 
     // System properties
     System.setProperty("swing.aatext", "true");


### PR DESCRIPTION
Fixes #2812.

Moved setting the `MAPTOOL_LOGDIR` property and initializing the logger into a method (`initLogging()`) that is called at launch so any exceptions that might get thrown can actually be handled. `getAppHome()` is still called first in `LaunchInstructions.main()`, and while it may look superfluous (and it kind of is), it's there so that if the data dir itself can't be created the error shown will reflect that (as opposed to being about the logs dir specifically), it just seems clearer that way.

Additionally, `exit()` is now called when an exception is caught so that it exits properly, and I removed a redundant check for the data dir in `MapTool.main()`.