### PR TITLE
Make the asset cache more robust, to avoid broken assets.

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,6 +85,7 @@ public class AssetManager {
   private static AssetLoader assetLoader = new AssetLoader();
 
   private static ExecutorService assetLoaderThreadPool = Executors.newFixedThreadPool(1);
+  private static ExecutorService assetWriterThreadPool = Executors.newFixedThreadPool(1);
 
   static {
     cacheDir = AppUtil.getAppHome("assetcache");
@@ -451,7 +455,9 @@ public class AssetManager {
       Asset asset = new Asset(props.getProperty(NAME), data);
 
       if (!asset.getId().equals(id)) {
-        log.error("MD5 for asset " + asset.getName() + " corrupted");
+        log.error("MD5 for asset " + asset.getName() + " corrupted; purging corrupted file");
+        assetFile.delete();
+        return null;
       }
 
       assetMap.put(id, asset);
@@ -525,23 +531,24 @@ public class AssetManager {
     }
 
     if (!assetIsInPersistentCache(asset)) {
-
       final File assetFile = getAssetCacheFile(asset);
 
-      new Thread(
-              () -> {
-                assetFile.getParentFile().mkdirs();
-                try (OutputStream out = new FileOutputStream(assetFile)) {
-                  out.write(asset.getImage());
-                } catch (IOException ioe) {
-                  log.error("Could not persist asset while writing image data", ioe);
-                  return;
-                } catch (NullPointerException npe) {
-                  // Not an issue, will update once th frame is finished loading...
-                  log.warn("Could not update statusbar while MapTool frame is loading.", npe);
-                }
-              })
-          .start();
+      assetWriterThreadPool.submit(
+          () -> {
+            assetFile.getParentFile().mkdirs();
+
+            try (var operation = new AssetWriteRenameOperation(assetFile);
+                var temporaryFileStream = new FileOutputStream(operation.temporaryFile)) {
+              temporaryFileStream.write(asset.getImage());
+              // Now that the data is in a file, we move it to its final resting place.
+              operation.commit();
+            } catch (IOException ioe) {
+              log.error("Could not persist asset while writing image data", ioe);
+            } catch (NullPointerException npe) {
+              // Not an issue, will update once th frame is finished loading...
+              log.warn("Could not update statusbar while MapTool frame is loading.", npe);
+            }
+          });
     }
     if (!assetInfoIsInPersistentCache(asset)) {
 
@@ -815,5 +822,48 @@ public class AssetManager {
       missing.put(entry.getKey(), entry.getValue());
     }
     return missing;
+  }
+
+  /** Helper type to handle creating and moving temporary files. */
+  private static class AssetWriteRenameOperation implements AutoCloseable {
+    private final File assetFile;
+    private final File temporaryFile;
+
+    public AssetWriteRenameOperation(File assetFile) throws IOException {
+      this.assetFile = assetFile;
+      // Placing the temp file in the cache dir means it will be on the same filesystem in typical
+      // cases.
+      this.temporaryFile =
+          Files.createTempFile(assetFile.getParentFile().toPath(), "tmp.", "").toFile();
+    }
+
+    /**
+     * Move the temporary file to its final location.
+     *
+     * <p>The move will be done atomically if possible, but a non-atomic move may be used as a
+     * fallback.
+     *
+     * @throws IOException If the move fails.
+     */
+    public void commit() throws IOException {
+      try {
+        Files.move(temporaryFile.toPath(), assetFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(temporaryFile.toPath(), assetFile.toPath());
+      }
+    }
+
+    /**
+     * Clean up the temporary file.
+     *
+     * <p>If the operation has been committed, there is no longer a temporary file and this does
+     * nothing.
+     *
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException {
+      Files.deleteIfExists(temporaryFile.toPath());
+    }
   }
 }


### PR DESCRIPTION
When writing to the persistent asset cache, we no longer directly write to the asset file. Instead, we write to a temporary file (`tmp.*`) and then rename it once all data has been written to the file. This reduces the chance that an asset file contains partial results, and makes it easy to determine whether a cache entry is valid and available for reading.

When reading from the persistent asset cache, if the cached asset's MD5 does not match its ID, we do not load it since it does not have valid data. Due to the write-side changes, we can also be confident that the file itself is corrupted rather than simply being partially written. We purge the corrupted file from the cache so that it can be recached in the future if a link to the original file still exists.

A minor change is also made to the writer so that it uses an executor instead of creating a new thread for each asset.

Fixes #2663.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2835)
<!-- Reviewable:end -->
