### PR TITLE
Proper closing order when writing assets

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -537,9 +537,11 @@ public class AssetManager {
           () -> {
             assetFile.getParentFile().mkdirs();
 
-            try (var operation = new AssetWriteRenameOperation(assetFile);
-                var temporaryFileStream = new FileOutputStream(operation.temporaryFile)) {
-              temporaryFileStream.write(asset.getImage());
+            try (var operation = new AssetWriteRenameOperation(assetFile)) {
+              try (var temporaryFileStream = new FileOutputStream(operation.temporaryFile)) {
+                temporaryFileStream.write(asset.getImage());
+              }
+
               // Now that the data is in a file, we move it to its final resting place.
               operation.commit();
             } catch (IOException ioe) {


### PR DESCRIPTION
The stream used for writing to temporary asset files was still open at the point of renaming the file. Despite being incorrect, this works fine on some filesystems, but windows requires the stream to be closed before renaming.

Fixes the bug introduced while fixing #2663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2843)
<!-- Reviewable:end -->
