### PR TITLE
Enforcement of MBL

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -442,7 +442,13 @@ public class ZoneRenderer extends JComponent
     }
 
     // Lee: check only matters for snap-to-grid
-    if (stg) {
+    // Phill: and limit players to only complete found paths
+    boolean isValidPath =
+        stg
+            && (MapTool.getPlayer().isGM()
+                || set.getWalker() == null
+                || set.getWalker().getDistance() != 0);
+    if (isValidPath) {
       CodeTimer moveTimer = new CodeTimer("ZoneRenderer.commitMoveSelectionSet");
       moveTimer.setEnabled(AppState.isCollectProfilingData() || log.isDebugEnabled());
       moveTimer.setThreshold(1);
@@ -579,10 +585,6 @@ public class ZoneRenderer extends JComponent
           log.debug(results);
         }
         moveTimer.clear();
-      }
-    } else {
-      for (GUID tokenGUID : selectionSet) {
-        denyMovement(zone.getToken(tokenGUID));
       }
     }
 


### PR DESCRIPTION
Change to prevent players from dropping owned (snap-to-grid) tokens into MBL only areas.  Before, the token's path would fail, show as 0 distance on-screen, then cause the server and clients to all freeze for a moment, but would then be moved to the MBL blocked area.

Now, only the GM will be allowed to drag a token into a MBL area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2845)
<!-- Reviewable:end -->
