### PR TITLE
Only update token type if the type has actually changed when editing a token

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -607,7 +607,10 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       return false;
     }
     // TYPE
-    token.setType((Token.Type) getTypeCombo().getSelectedItem());
+    // Only update this if it actually changed
+    if(getTypeCombo().getSelectedItem() != token.getType()) {
+      token.setType((Token.Type) getTypeCombo().getSelectedItem());
+    }
 
     // SIZE
     token.setSnapToScale(getSizeCombo().getSelectedIndex() != 0);

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -608,7 +608,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     }
     // TYPE
     // Only update this if it actually changed
-    if(getTypeCombo().getSelectedItem() != token.getType()) {
+    if (getTypeCombo().getSelectedItem() != token.getType()) {
       token.setType((Token.Type) getTypeCombo().getSelectedItem());
     }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -785,6 +785,11 @@ public class Token extends BaseModel implements Cloneable {
     }
   }
 
+  /**
+   * Sets the token's type. Sets hasSight to true if the new type is PC.
+   *
+   * @param type The new type
+   */
   public void setType(Type type) {
     tokenType = type.name();
     if (type == Type.PC) {


### PR DESCRIPTION
Fixes #2849. 

As the title says, this changes it so token type will only be updated if the token type actually changes to avoid `hasSight` getting set to `true` each time a PC token is edited. Also added a comment to document that side effect in `setType()`. Thanks for pointing me to the source of the issue, @Phergus!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2856)
<!-- Reviewable:end -->
