### PR TITLE
Give a proper name to each bar side option 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
@@ -714,7 +714,8 @@ public class TokenBarController
     boolean showOthers = formPanel.isSelected(SHOW_OTHERS);
     int thickness = TokenStatesController.getSpinner(THICKNESS, "thickness", formPanel);
     int increments = TokenStatesController.getSpinner(INCREMENTS, "increments", formPanel);
-    Side side = Side.valueOf(formPanel.getSelectedItem(SIDE).toString().toUpperCase());
+    Side side =
+        Side.valueOf(((ListItemProperty) formPanel.getSelectedItem(SIDE)).getName().toUpperCase());
 
     BarTokenOverlay to = null;
     if (overlay.equals("Solid")) {

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/campaignPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/campaignPropertiesDialog.xml
@@ -4560,7 +4560,7 @@
                                    </at>
                                    <at name="selectedItem">
                                     <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                     <at name="name">listitem</at>
+                                     <at name="name">Top</at>
                                      <at name="label">CampaignPropertiesDialog.combo.bars.side.top</at>
                                      <at name="icon">
                                       <object classname="com.jeta.forms.store.properties.IconProperty">
@@ -4581,7 +4581,7 @@
                                        <item >
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                          <at name="name">listitem</at>
+                                          <at name="name">Top</at>
                                           <at name="label">CampaignPropertiesDialog.combo.bars.side.top</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
@@ -4596,7 +4596,7 @@
                                        <item >
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                          <at name="name">listitem</at>
+                                          <at name="name">Bottom</at>
                                           <at name="label">CampaignPropertiesDialog.combo.bars.type.bottom</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
@@ -4611,7 +4611,7 @@
                                        <item >
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                          <at name="name">listitem</at>
+                                          <at name="name">Left</at>
                                           <at name="label">CampaignPropertiesDialog.combo.bars.type.left</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">
@@ -4626,7 +4626,7 @@
                                        <item >
                                         <at name="value">
                                          <object classname="com.jeta.forms.store.properties.ListItemProperty">
-                                          <at name="name">listitem</at>
+                                          <at name="name">Right</at>
                                           <at name="label">CampaignPropertiesDialog.combo.bars.type.right</at>
                                           <at name="icon">
                                            <object classname="com.jeta.forms.store.properties.IconProperty">


### PR DESCRIPTION
It's not correct top use translated text when resolving enum values using `valueOf()`. This change gives an untranslated name to each option for `tokenBarSide`, and that name is used when calling `Side.valueOf()`.

Fixes #2861

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2862)
<!-- Reviewable:end -->
