### PR TITLE
Only show save reminder on close if the campaign is dirty

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1900,7 +1900,7 @@ public class MapToolFrame extends DefaultDockableHolder
   }
 
   public void closingMaintenance() {
-    if (AppPreferences.getSaveReminder()) {
+    if (AppPreferences.getSaveReminder() && MapTool.isCampaignDirty()) {
       if (MapTool.getPlayer().isGM()) {
         int result =
             MapTool.confirmImpl(


### PR DESCRIPTION
Fixes #2774.

I did not modify the behaviour for creating new campaigns. The confirmation dialog is currently the only feedback to the user that they really did request a new campaign. Removing it could lead to confusion if trying to create a new campaign when a blank campaign is open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2869)
<!-- Reviewable:end -->
