### PR TITLE
additional getMapName changes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -161,10 +161,16 @@ public class MapFunctions extends AbstractFunction {
       String mapName = parameters.get(0).toString();
       String newMapDisplayName = parameters.get(1).toString();
       Zone zone = getNamedMap(functionName, mapName).getZone();
+      String oldName;
+      oldName = zone.getPlayerAlias();
       zone.setPlayerAlias(newMapDisplayName);
+      if (oldName.equals(newMapDisplayName)) return zone.getPlayerAlias();
       MapTool.serverCommand().changeZoneDispName(zone.getId(), newMapDisplayName);
       if (zone == MapTool.getFrame().getCurrentZoneRenderer().getZone())
         MapTool.getFrame().setCurrentZoneRenderer(MapTool.getFrame().getCurrentZoneRenderer());
+      if (oldName.equals(zone.getPlayerAlias()))
+        throw new ParserException(
+            I18N.getText("macro.function.map.duplicateDisplay", functionName));
       return zone.getPlayerAlias();
 
     } else if ("copyMap".equalsIgnoreCase(functionName)) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Cell Type:
 MapPropertiesDialog.label.cell.dist      = Distance per cell:
@@ -1726,6 +1726,8 @@ macro.function.macroLink.unknown                   = Unknown
 macro.function.map.none                            = {0}: function requires a current map, but none is present.
 # {0} is the function name
 macro.function.map.notFound                        = {0}: indicated map in first parameter not found.
+# {0} is the function name
+macro.function.map.duplicateDisplay                = {0}: display name is already in use.
 # {0} is the function name
 macro.function.moveTokenMap.alreadyThere           = Can not use "{0}" to move tokens to a map that they are already on!
 # {0} is the token name/id, {1} is the map it's moved to.

--- a/src/main/resources/net/rptools/maptool/language/i18n_da.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_da.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Celletype\:
 MapPropertiesDialog.label.cell.dist      = Afstand pr. celle\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_es.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_es.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Cell Type\:
 MapPropertiesDialog.label.cell.dist      = Distance per cell\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Type de cellule \:
 MapPropertiesDialog.label.cell.dist      = Distance par cellule \:

--- a/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Type cel\:
 MapPropertiesDialog.label.cell.dist      = Afstand per cel\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Cell Type\:
 MapPropertiesDialog.label.cell.dist      = Distance per cell\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Cell Type\:
 MapPropertiesDialog.label.cell.dist      = Distance per cell\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Typ av cell\:
 MapPropertiesDialog.label.cell.dist      = Avstånd per cell\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Оновити дані 
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Оновити дані з лабораторії героїв<br/><b><i>Змін немає\!</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = Тип клітинки\:
 MapPropertiesDialog.label.cell.dist      = Відстань на клітинку\:

--- a/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
@@ -334,7 +334,7 @@ EditTokenDialog.button.hero.refresh.tooltip.on  = <html>Refresh data from Hero L
 EditTokenDialog.button.hero.refresh.tooltip.off = <html>Refresh data from Hero Lab<br/><b><i>No changes detected...</i></b></html>
 
 MapPropertiesDialog.label.playerMapAlias = Display Name\:
-MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified.
+MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.cell.type      = 单元格类型：
 MapPropertiesDialog.label.cell.dist      = 每单元格距离：


### PR DESCRIPTION
#2775

(old) Swapped out the name of the function to getMapNames instead of getMapByDisp

(old) Swapped to getMapName since display names are now unique.

2021-08-15 Error now provided if a display name is selected that is a duplicate. Tooltip updated to alert the player to this behavior within Map Properties Dialog. I'm unsure if it would've updated across the other languages that don't have translations yet so I manually dropped it there as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2890)
<!-- Reviewable:end -->
