### PR TITLE
Add hot keys to menu bar.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1986,15 +1986,7 @@ public class MapToolFrame extends DefaultDockableHolder
   }
 
   public void updateKeyStrokes() {
-    /*
-     * Lee: This causes input map conflicts in Java 7. Going over the code, this line does nothing as key mapping here does not conflict with hotkeys set aside for macros; unless someone modifies
-     * the accelerators in the i18n file. Commenting it out.
-     */
-    // updateKeyStrokes(menuBar);
-
-    for (DockableFrame frame : frameMap.values()) {
-      updateKeyStrokes(frame);
-    }
+    updateKeyStrokes(menuBar);
   }
 
   public Timer getChatTimer() {


### PR DESCRIPTION
This way hot keys work no matter which frame are open and not collapsed. As a result, we don't bother adding the hot
keys to each frame anymore.

Addresses #446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2920)
<!-- Reviewable:end -->
