### PR TITLE
Upgrade spotless gradle plugin to 5.14.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 plugins {
     id "application"
     id "org.ajoberstar.grgit" version "4.1.0"
-    id "com.diffplug.spotless" version "5.2.0"
+    id "com.diffplug.spotless" version "5.14.3"
     id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'org.beryx.runtime' version '1.12.5'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,9 @@ developerRelease=-Dev-Release
 sentry_development_dsn=https://loalhost.dont.log.me@sentry.io/1404248
 sentry_staging_dsn=https://18e447713c1249d4abe853266ca4d1e4@sentry.io/1404248
 sentry_production_dsn=https://18e447713c1249d4abe853266ca4d1e4@sentry.io/1404248
+
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/main/java/net/rptools/maptool/client/functions/TokenInitFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenInitFunction.java
@@ -45,7 +45,7 @@ public class TokenInitFunction extends AbstractFunction {
   /** @return singleton instance */
   public static TokenInitFunction getInstance() {
     return singletonInstance;
-  };
+  }
 
   @Override
   public Object childEvaluate(

--- a/src/main/java/net/rptools/maptool/client/functions/TokenInitHoldFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenInitHoldFunction.java
@@ -44,7 +44,7 @@ public class TokenInitHoldFunction extends AbstractFunction {
   /** @return singleton instance */
   public static TokenInitHoldFunction getInstance() {
     return singletonInstance;
-  };
+  }
 
   @Override
   public Object childEvaluate(

--- a/src/main/java/net/rptools/maptool/client/ui/ConnectToServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ConnectToServerDialog.java
@@ -144,7 +144,7 @@ public class ConnectToServerDialog extends AbeillePanel<ConnectToServerDialogPre
                 if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
                   handleOK();
                 }
-              };
+              }
             });
   }
 
@@ -198,7 +198,7 @@ public class ConnectToServerDialog extends AbeillePanel<ConnectToServerDialogPre
                       .setText(rem.getModel().getValueAt(rem.getSelectedRow(), 0).toString());
                   if (e.getClickCount() == 2) handleOK();
                 }
-              };
+              }
             });
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/Tool.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Tool.java
@@ -176,7 +176,7 @@ public abstract class Tool extends JToggleButton implements ActionListener, KeyL
 
   public void keyTyped(KeyEvent e) {}
 
-  public void updateButtonState() {};
+  public void updateButtonState() {}
 
   /**
    * Perform the escape action on a tool.

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
@@ -192,7 +192,8 @@ public class MessagePanel extends JPanel {
                   ; // visible for everyone
                 else if (options.contains("w:" + MapTool.getPlayer().getName().toLowerCase()))
                   ; // visible for this player
-                else if (options.contains("g") && MapTool.getPlayer().isGM()) ; // visible for GMs
+                else if (options.contains("g") && MapTool.getPlayer().isGM())
+                  ; // visible for GMs
                 else if (options.contains("s")
                     && message.getSource().equals(MapTool.getPlayer().getName()))
                   ; // visible to the player who sent it

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -568,7 +568,7 @@ public class InitiativePanel extends JPanel
         @Override
         public void actionPerformed(ActionEvent e) {
           list.nextInitiative();
-        };
+        }
       };
 
   /** This action will reverse initiative to the previous token in the list. */
@@ -577,7 +577,7 @@ public class InitiativePanel extends JPanel
         @Override
         public void actionPerformed(ActionEvent e) {
           list.prevInitiative();
-        };
+        }
       };
 
   /** This action will remove the selected token from the list. */
@@ -589,7 +589,7 @@ public class InitiativePanel extends JPanel
           if (ti == null) return;
           int index = list.indexOf(ti);
           list.removeToken(index);
-        };
+        }
       };
 
   /** This action will turn the selected token's initiative on and off. */
@@ -600,7 +600,7 @@ public class InitiativePanel extends JPanel
           TokenInitiative ti = displayList.getSelectedValue();
           if (ti == null) return;
           ti.setHolding(!ti.isHolding());
-        };
+        }
       };
 
   /** This action will make the selected token the current token. */
@@ -611,7 +611,7 @@ public class InitiativePanel extends JPanel
           TokenInitiative ti = displayList.getSelectedValue();
           if (ti == null) return;
           list.setCurrent(list.indexOf(ti));
-        };
+        }
       };
 
   /** This action toggles the display of token images. */
@@ -624,7 +624,7 @@ public class InitiativePanel extends JPanel
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
           AppPreferences.setInitShowTokens(showTokens);
-        };
+        }
       };
 
   /** This action toggles the display of token images. */
@@ -637,7 +637,7 @@ public class InitiativePanel extends JPanel
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
           AppPreferences.setInitShowTokenStates(showTokenStates);
-        };
+        }
       };
 
   /** This action toggles the display of token images. */
@@ -650,7 +650,7 @@ public class InitiativePanel extends JPanel
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
           AppPreferences.setInitShowInitiative(showInitState);
-        };
+        }
       };
 
   /** This action toggles the display of token images. */
@@ -663,7 +663,7 @@ public class InitiativePanel extends JPanel
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
           AppPreferences.setInitShow2ndLine(initStateSecondLine);
-        };
+        }
       };
 
   /** This action sorts the tokens in the list. */
@@ -672,7 +672,7 @@ public class InitiativePanel extends JPanel
         @Override
         public void actionPerformed(ActionEvent e) {
           list.sort(initUseReverseSort);
-        };
+        }
       };
 
   /** Toggle the Use Reverse Sort Order preference */
@@ -683,7 +683,7 @@ public class InitiativePanel extends JPanel
           initUseReverseSort = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           MapTool.getCampaign().setInitiativeUseReverseSort(initUseReverseSort);
           MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
-        };
+        }
       };
 
   /** Enable/Disable the Next & Previous buttons on the Panel */
@@ -695,7 +695,7 @@ public class InitiativePanel extends JPanel
           setInitPanelButtonsDisabled(((JCheckBoxMenuItem) e.getSource()).isSelected());
           MapTool.getCampaign().setInitiativePanelButtonsDisabled(isInitPanelButtonsDisabled());
           MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
-        };
+        }
       };
 
   /** This action will set the initiative state of the currently selected token. */
@@ -716,7 +716,7 @@ public class InitiativePanel extends JPanel
           String input = JOptionPane.showInputDialog(s, ti.getState());
           if (input == null) return;
           ti.setState(input.trim());
-        };
+        }
       };
 
   /** This action will clear the initiative state of the currently selected token. */
@@ -727,7 +727,7 @@ public class InitiativePanel extends JPanel
           TokenInitiative ti = displayList.getSelectedValue();
           if (ti == null) return;
           ti.setState(null);
-        };
+        }
       };
 
   /** This action will remove all tokens from the initiative panel. */
@@ -736,7 +736,7 @@ public class InitiativePanel extends JPanel
         @Override
         public void actionPerformed(ActionEvent e) {
           clearTokens();
-        };
+        }
       };
 
   /** This action will add all tokens in the zone to this initiative panel. */
@@ -745,7 +745,7 @@ public class InitiativePanel extends JPanel
         @Override
         public void actionPerformed(ActionEvent e) {
           list.insertTokens(list.getZone().getTokens());
-        };
+        }
       };
 
   /** This action will add all PC tokens in the zone to this initiative panel. */
@@ -758,7 +758,7 @@ public class InitiativePanel extends JPanel
             if (token.getType() == Type.PC) tokens.add(token);
           } // endfor
           list.insertTokens(tokens);
-        };
+        }
       };
 
   /** This action will hide all initiative items with NPC tokens from players */
@@ -769,7 +769,7 @@ public class InitiativePanel extends JPanel
           list.setHideNPC(!list.isHideNPC());
           if (list.isHideNPC() != hideNPCMenuItem.isSelected())
             hideNPCMenuItem.setSelected(list.isHideNPC());
-        };
+        }
       };
 
   /**
@@ -783,7 +783,7 @@ public class InitiativePanel extends JPanel
           if (ownerPermissionsMenuItem != null) ownerPermissionsMenuItem.setSelected(op);
           MapTool.getCampaign().setInitiativeOwnerPermissions(op);
           MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
-        };
+        }
       };
 
   /**
@@ -797,7 +797,7 @@ public class InitiativePanel extends JPanel
           if (movementLockMenuItem != null) movementLockMenuItem.setSelected(mvLock);
           MapTool.getCampaign().setInitiativeMovementLock(mvLock);
           MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
-        };
+        }
       };
 
   /** This action will reset the round counter for the initiative panel. */
@@ -813,7 +813,7 @@ public class InitiativePanel extends JPanel
           list.setRound(-1);
           list.setCurrent(-1);
           list.finishUnitOfWork();
-        };
+        }
       };
 
   /*---------------------------------------------------------------------------------------------

--- a/src/main/java/net/rptools/maptool/webapi/MTWebClientManager.java
+++ b/src/main/java/net/rptools/maptool/webapi/MTWebClientManager.java
@@ -29,7 +29,7 @@ public class MTWebClientManager {
   private Set<MTWebSocket> clientSockets = Collections.synchronizedSet(new HashSet<MTWebSocket>());
 
   /** Create a new MTWebClientManager. */
-  private MTWebClientManager() {};
+  private MTWebClientManager() {}
 
   /**
    * Returns the singleton instance of MTWebClientManager.


### PR DESCRIPTION
Addresses #2931

As explained in the [spotless issue tracker](https://github.com/diffplug/spotless/issues/834), there is an outstanding issue with the google formatter depending on JDK internals. We add the flags listed there to avoid module errors when running spotless.

After upgrading and rerunning `spotlessApply`, several stray semicolons became apparent and have now been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2932)
<!-- Reviewable:end -->
