### PR TITLE
Work around missing JavaFX symbols on linux.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ run {
                                  "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
                                  "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
                                  "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
-                                 "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",
+                                 "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED",
                                  "--add-opens=java.desktop/javax.swing=ALL-UNNAMED","--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED"]
     // Add -Dlog4j2.debug to see log4j2 details
     // Add  -Djavax.net.debug=all to debug networking issues

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui.htmlframe;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.sun.webkit.dom.HTMLSelectElementImpl;
 import java.awt.*;
 import java.awt.event.ActionListener;
 import java.math.BigDecimal;
@@ -615,13 +616,18 @@ public class HTMLWebViewManager {
         if (element.getMultiple()) {
           // If multiple selection enabled, returns a JSON array of selected values
           JsonArray selected = new JsonArray();
-          HTMLCollection options = element.getOptions();
-          for (int o = 0; o < options.getLength(); o++) {
-            HTMLOptionElement option = (HTMLOptionElement) options.item(o);
-            if (option.getSelected()) {
+          // We avoid iterating over the result of `element.getOptions()` in order to workaround a
+          // missing symbol for `HTMLOptionsCollectionImpl::itemImpl()` on linux. Ideally we would
+          // go back to using `element.getOptions()` in the future so we don't keep a dependency on
+          // `HTMLSelectElementImpl`.
+          for (int o = 0; o < element.getLength(); o++) {
+            var node = ((HTMLSelectElementImpl) element).item(o);
+            // instanceof check always seems to be true, but we'll keep it to be safe.
+            if (node instanceof HTMLOptionElement option && option.getSelected()) {
               selected.add(option.getValue());
             }
           }
+
           value = selected.toString();
         } else {
           value = element.getValue();


### PR DESCRIPTION
Works around #2741.

On linux, the JavaFX native webkit libraries are missing the necessary symbol that provies the implementation of `HTMLOptionsCollectionImpl::itemImpl`. As a result, we are unable to access the items returned by `HTMLSelectElement::getOptions()`, and thus can't use it to determine which options of a `<select>` are selected.
    
To workaround this, we take a dependency on the `HTMLSelectElementImpl`, the JavaFX implementation of `HTMLSelectElement`. It has a method `item()` that is not exposed in the `HTMLSelectElement` interface, but which provides access to the associated options. Ideally we'll remove this once JavaFX is fixed, so we don't keep a dependency on internals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2933)
<!-- Reviewable:end -->
