### PR TITLE
Fix for pasted tokens not being placed in the correct cell

### DIFF
--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -293,8 +293,8 @@ public class SquareGrid extends Grid {
     boolean exactCalcX = (zp.x - getOffsetX()) % getSize() == 0;
     boolean exactCalcY = (zp.y - getOffsetY()) % getSize() == 0;
 
-    int newX = (int) (zp.x < 0 && !exactCalcX ? calcX - 1 : calcX);
-    int newY = (int) (zp.y < 0 && !exactCalcY ? calcY - 1 : calcY);
+    int newX = (int) (calcX < 0 && !exactCalcX ? calcX - 1 : calcX);
+    int newY = (int) (calcY < 0 && !exactCalcY ? calcY - 1 : calcY);
 
     // System.out.format("%d / %d => %f, %f => %d, %d\n", zp.x, getSize(), calcX, calcY, newX,
     // newY);


### PR DESCRIPTION
Addresses #2260.

There are two separate problems that together lead to some rather inconsistent behaviour:
1. Converting from `ZonePoint`to `CellPoint` needs to round to the nearest cell, which has slightly different logic for
   positive and negative positions. The choice was being done on the unshifted `ZonePoint` which does not correspond to
   whether the position is logically negative or positive. Thsi resulted in off-by-one errors when x or y is near zero.
2. When copying tokens, their position relative to the "top-left" token is remembered. Upon pasting, it is assumed that
   this relative position can be treated as a `ZonePoint`, including being converted to a `CellPoint`. This fails to
   account for the grid offset (or rather, the grid offset is applied during the conversion when it shouldn't
   be). Essentially, we're treating a vector as a point, and vice-versa.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2959)
<!-- Reviewable:end -->
