### PR TITLE
align URI/URL terminology between new functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -174,7 +174,7 @@ public class MacroDialogFunctions extends AbstractFunction {
       Optional<Library> library = new LibraryManager().getLibrary(url).get();
       if (library.isEmpty()) {
         throw new ParserException(
-            I18N.getText("macro.function.html5.invalidURL", url.toExternalForm()));
+            I18N.getText("macro.function.html5.invalidURI", url.toExternalForm()));
       }
 
       htmlString = library.get().readAsString(url).get();

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -112,8 +112,8 @@ public class TokenPropertyFunctions extends AbstractFunction {
         "getTokenLayoutProps",
         "setTokenLayoutProps",
         "setTokenSnapToGrid",
-        "getAllowsURLAccess",
-        "setAllowsURLAccess");
+        "getAllowsURIAccess",
+        "setAllowsURIAccess");
   }
 
   public static TokenPropertyFunctions getInstance() {
@@ -926,22 +926,22 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * getAllowsURLAccess(token: currentToken(), mapName = current map)
      */
-    if (functionName.equalsIgnoreCase("getAllowsURLAccess")) {
+    if (functionName.equalsIgnoreCase("getAllowsURIAccess")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       FunctionUtil.blockUntrustedMacro(functionName);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      return token.getAllowURLAccess() ? BigDecimal.ONE : BigDecimal.ZERO;
+      return token.getAllowURIAccess() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
     /*
      * setAllowsURLAccess(token: currentToken(), mapName = current map)
      */
-    if (functionName.equalsIgnoreCase("setAllowsURLAccess")) {
+    if (functionName.equalsIgnoreCase("setAllowsURIAccess")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       FunctionUtil.blockUntrustedMacro(functionName);
-      BigDecimal allowURLAccess = getBigDecimalFromParam(functionName, parameters, 0);
+      BigDecimal allowURIAccess = getBigDecimalFromParam(functionName, parameters, 0);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      token.setAllowURLAccess(!allowURLAccess.equals(BigDecimal.ZERO));
+      token.setAllowURIAccess(!allowURIAccess.equals(BigDecimal.ZERO));
       return "";
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/EditTokenDialog.java
@@ -337,7 +337,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     setLibTokenPaneEnabled(token.isLibToken());
 
-    getAllowURLAccess().setSelected(token.getAllowURLAccess());
+    getAllowURLAccess().setSelected(token.getAllowURIAccess());
 
     // Jamz: Init the Hero Lab tab...
     heroLabData = token.getHeroLabData();
@@ -1034,7 +1034,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
   }
 
   public JCheckBox getAllowURLAccess() {
-    return (JCheckBox) getComponent("@allowURLAccess");
+    return (JCheckBox) getComponent("@allowURIAccess");
   }
 
   public void initSpeechPanel() {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -90,18 +90,18 @@ public class Token extends BaseModel implements Cloneable {
   private static final TypeAdapter<JsonObject> strictGsonObjectAdapter =
       new Gson().getAdapter(JsonObject.class);
 
-  public boolean getAllowURLAccess() {
-    if (allowURLAccess && !isLibToken()) {
-      allowURLAccess = false;
+  public boolean getAllowURIAccess() {
+    if (allowURIAccess && !isLibToken()) {
+      allowURIAccess = false;
     }
-    return allowURLAccess;
+    return allowURIAccess;
   }
 
-  public void setAllowURLAccess(boolean allowURLAccess) {
+  public void setAllowURIAccess(boolean allowURIAccess) {
     if (isLibToken()) {
-      this.allowURLAccess = allowURLAccess;
+      this.allowURIAccess = allowURIAccess;
     } else {
-      this.allowURLAccess = false;
+      this.allowURIAccess = false;
     }
   }
 
@@ -354,7 +354,7 @@ public class Token extends BaseModel implements Cloneable {
 
   private HeroLabData heroLabData;
 
-  private boolean allowURLAccess = false;
+  private boolean allowURIAccess = false;
 
   /**
    * Constructor from another token, with the option to keep the token id

--- a/src/main/java/net/rptools/maptool/model/framework/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/framework/LibraryToken.java
@@ -157,7 +157,7 @@ class LibraryToken implements Library {
     for (var zone : MapTool.getCampaign().getZones()) {
       List<Token> tokensFiltered =
           zone.getTokensFiltered(t -> name.equalsIgnoreCase(t.getName())).stream()
-              .filter(Token::getAllowURLAccess)
+              .filter(Token::getAllowURIAccess)
               .collect(Collectors.toList());
       if (tokensFiltered.size() > 0) {
         return new LibraryToken(tokensFiltered.get(0).getId());

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
@@ -7056,7 +7056,7 @@
                               </at>
                               <at name="name"></at>
                               <at name="width">125</at>
-                              <at name="text">Label.allowURLAccess</at>
+                              <at name="text">Label.allowURIAccess</at>
                               <at name="fill">
                                <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                 <at name="name">fill</at>
@@ -7114,7 +7114,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="name">@allowURLAccess</at>
+                              <at name="name">@allowURIAccess</at>
                               <at name="width">17</at>
                               <at name="height">17</at>
                              </object>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -190,7 +190,7 @@ Label.view          = View:
 Label.board         = Board
 Label.visibility    = Visibility
 Label.pathfilename  = Path/Filename:
-Label.allowURLAccess = Allow URL Access
+Label.allowURIAccess = Allow URI Access
 
 CampaignPropertyDialog.error.parenthesis              = Missing right parenthesis ")" in the following property: {0}
 

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1808,7 +1808,7 @@ macro.function.varsFromstrProp.wrongArgs           = varsFromStrProp called with
 
 macro.function.markdown.unknownType                = Unknown Markdown type {0}.
 
-macro.function.html5.invalidURL                    = Invalid URL {0}.
+macro.function.html5.invalidURI                    = Invalid URI {0}.
 macro.function.html5.unknownType                   = Unknown HTML5 Container specified.
 
 # Macro Link


### PR DESCRIPTION
Small fix to rename URL to URI for #2964 and #2963 to be consistent with the other new function that uses this `js.evalURI`.

I have updated the comments in the above two issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2979)
<!-- Reviewable:end -->
