### PR TITLE
Fix slow start up times when the asset cache is large.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/AssetCacheStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/AssetCacheStatusBar.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.swing;
 import java.awt.event.MouseAdapter;
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -25,10 +26,6 @@ import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.AssetManager;
-import org.apache.commons.io.monitor.FileAlterationListener;
-import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
-import org.apache.commons.io.monitor.FileAlterationMonitor;
-import org.apache.commons.io.monitor.FileAlterationObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,7 +34,6 @@ public class AssetCacheStatusBar extends JLabel {
   private static final Logger log = LogManager.getLogger(AssetCacheStatusBar.class);
   private static final File CACHE_DIR = AppUtil.getAppHome("assetcache");
   private static final long POLLING_INTERVAL = 60000;
-  private static long lastChecked = 0;
   private static Icon assetCacheIcon;
 
   static {
@@ -67,30 +63,8 @@ public class AssetCacheStatusBar extends JLabel {
           }
         });
 
-    try {
-      FileAlterationObserver observer = new FileAlterationObserver(CACHE_DIR);
-      FileAlterationMonitor monitor = new FileAlterationMonitor(POLLING_INTERVAL);
-      FileAlterationListener listener =
-          new FileAlterationListenerAdaptor() {
-            // Is triggered when a file is created in the monitored folder
-            @Override
-            public void onFileCreate(File file) {
-              update();
-            }
-
-            // Is triggered when a file is deleted from the monitored folder
-            @Override
-            public void onFileDelete(File file) {
-              update();
-            }
-          };
-
-      observer.addListener(listener);
-      monitor.addObserver(observer);
-      monitor.start();
-    } catch (Exception e) {
-      log.warn("Unable to register file change listener for " + CACHE_DIR.getAbsolutePath());
-    }
+    AppUtil.fileCheckExecutor.scheduleWithFixedDelay(
+        this::update, POLLING_INTERVAL, POLLING_INTERVAL, TimeUnit.MILLISECONDS);
   }
 
   public void clear() {
@@ -98,12 +72,7 @@ public class AssetCacheStatusBar extends JLabel {
   }
 
   public void update() {
-    // Only update once per polling interval as event will fire for every file created/deleted since
-    // last interval
-    if (System.currentTimeMillis() - lastChecked >= POLLING_INTERVAL) {
-      setText(AppUtil.getDiskSpaceUsed(CACHE_DIR));
-      lastChecked = System.currentTimeMillis();
-      log.debug("AssetCacheStatusBar updated...");
-    }
+    setText(AppUtil.getDiskSpaceUsed(CACHE_DIR));
+    log.debug("AssetCacheStatusBar updated...");
   }
 }


### PR DESCRIPTION
Addresses #2887.

When the asset cache has many files in it, the main bottleneck during startup  is `FileAlterationMonitor::start()`, called from
`AppHomeDiskSpaceStatusBar`, `AssetCacheStatusBar` and `ImageCacheStatusBar`. They use this utility to recursively watch for filesystem updates so they can update accordingly.

This change avoids the use of a filesystem watcher of any sort, and instead polls the filesystem at regular intervals (1 minute currently). This is enabled by a performance improvement to `AppUtil.getDiskSpaceUsed()` that avoids the use of `FileUtils.sizeOfDirectory()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/2987)
<!-- Reviewable:end -->
