### PR TITLE
Fix for issues occurring on first time password additions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/players/PlayerDatabaseDialogController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/players/PlayerDatabaseDialogController.java
@@ -212,7 +212,7 @@ public class PlayerDatabaseDialogController implements SwingJavaFXDialogControll
         | InvalidKeySpecException
         | PasswordDatabaseException
         | InvalidKeyException e) {
-      MapTool.showError("playerDB.dialog.error.undoingChanges", e);
+      MapTool.showError("playerDB.dialog.error.savingChanges", e);
     }
     ;
     Players.removePropertyChangeListener(changeListener);

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2546,8 +2546,7 @@ playerDB.dialog.error.passwordTooShort = Password is too short
 playerDB.dialog.error.invalidPublicKey = Invalid Public Key
 playerDB.dialog.error.emptyBlockReason = Blocked reason can not be empty
 playerDB.dialog.error.playerExists = Player already exists
-playerDB.dialog.error.undoingChanges = Error Unding database changes
-
+playerDB.dialog.error.savingChanges = Error saving database changes
 # Text to display instead of the password
 playerDB.dialog.encodedPassword = -- Encoded Password --
 


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #2915


### Description of the Change
1. Fixes error where first public key you add fails if directory doesn't exist
2. Fixes issue where first player you add doesn't get saved if there is no existing password file and you only add a single player.
3. Fixes error message when reading an invalid password file
4. Fixes error message when failing to write to password file



### Possible Drawbacks
None?

### Documentation Notes
This is a bug fix to get it to perform the way it should.

### Release Notes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3000)
<!-- Reviewable:end -->
