### PR TITLE
Fix invalid I18N key in the js.evalURI() function

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -105,7 +105,8 @@ public class MacroJavaScriptBridge extends AbstractFunction implements DefinesSp
         if (library.isPresent()) {
           script = library.get().readAsString(url).get();
         } else {
-          throw new ParserException(I18N.getText("libUIr.invalidLibToken", args.get(0).toString()));
+          throw new ParserException(
+              I18N.getText("macro.function.jsevalURI.invalidURI", args.get(0).toString()));
         }
       } catch (ExecutionException | InterruptedException | IOException e) {
         throw new ParserException(e);

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1815,6 +1815,7 @@ macro.function.markdown.unknownType                = Unknown Markdown type {0}.
 
 macro.function.html5.invalidURI                    = Invalid URI {0}.
 macro.function.html5.unknownType                   = Unknown HTML5 Container specified.
+macro.function.jsevalURI.invalidURI                = Can not access JavaScript from URI {0}.
 
 macro.setAllowsURIAccess.notLibToken               = {0} is not a valid lib:token name, URI access can only be set on lib:tokens.
 macro.setAllowsURIAccess.reservedPrefix             = Can not set URI access on lib:tokens starting with {0}


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #3001


### Description of the Change
The error displayed when the lib:// URI is invalid in this function didn't exist. Renamed key for a bit more consistency and created the key in the I18N property file


### Possible Drawbacks

None


### Documentation Notes
No Further documentation required because of this fix

### Release Notes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3002)
<!-- Reviewable:end -->
