### PR TITLE
Move "Use WebRTC" checkbox to start / connect to server dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2373,7 +2373,9 @@ public class AppActions {
 
           final ConnectToServerDialog dialog = new ConnectToServerDialog();
           dialog.showDialog();
-          if (!dialog.accepted()) return;
+          if (!dialog.accepted()) {
+            return;
+          }
 
           ServerDisconnectHandler.disconnectExpected = true;
           LOAD_MAP.setSeenWarning(false);
@@ -3265,23 +3267,6 @@ public class AppActions {
         protected void executeAction() {
           MapTool.getFrame()
               .setPaintDrawingMeasurement(!MapTool.getFrame().isPaintDrawingMeasurement());
-        }
-      };
-
-  public static final Action TOGGLE_WEBRTC =
-      new AdminClientAction() {
-        {
-          init("action.toggleUseWebRTC");
-        }
-
-        @Override
-        public boolean isSelected() {
-          return AppState.useWebRTC();
-        }
-
-        @Override
-        protected void executeAction() {
-          AppState.setUseWebRTC(!AppState.useWebRTC());
         }
       };
 

--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -395,10 +395,6 @@ public class AppMenuBar extends JMenuBar {
     }
     menu.add(new JMenuItem(AppActions.GATHER_DEBUG_INFO));
 
-    JCheckBoxMenuItem item = new RPCheckBoxMenuItem(AppActions.TOGGLE_WEBRTC, menu);
-    item.setSelected(AppState.useWebRTC());
-    menu.add(item);
-
     if (!AppUtil.MAC_OS_X) {
       menu.addSeparator();
       menu.add(new JMenuItem(AppActions.SHOW_ABOUT));

--- a/src/main/java/net/rptools/maptool/client/ui/ConnectToServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ConnectToServerDialogPreferences.java
@@ -32,6 +32,7 @@ public class ConnectToServerDialogPreferences {
   private static final String KEY_TAB = "tab";
   private static final String KEY_SERVER_NAME = "serverName";
   private static final String USE_PUBLIC_KEY = "usePublicKey";
+  private static final String USE_WEB_RTC = "useWebRTC";
 
   public String getUsername() {
     return prefs.get(KEY_USERNAME, "");
@@ -95,5 +96,13 @@ public class ConnectToServerDialogPreferences {
 
   public void setUsePublicKey(boolean usePublicKey) {
     prefs.putBoolean(USE_PUBLIC_KEY, usePublicKey);
+  }
+
+  public boolean getUseWebRTC() {
+    return prefs.getBoolean(USE_WEB_RTC, false);
+  }
+
+  public void setUseWebRTC(boolean useWebRTC) {
+    prefs.putBoolean(USE_WEB_RTC, useWebRTC);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/StartServerDialog.java
@@ -20,7 +20,10 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.GenericDialog;
@@ -134,7 +137,16 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
         });
 
     getRootPane().setDefaultButton(getOKButton());
+    getUseWebRTCCheckBox().setEnabled(getRPToolsAlias().getText().length() > 0);
     dialog.showDialog();
+  }
+
+  public JCheckBox getUseWebRTCCheckBox() {
+    return (JCheckBox) getComponent("@useWebRTC");
+  }
+
+  public JTextField getRPToolsAlias() {
+    return (JTextField) getComponent("@RPToolsName");
   }
 
   public JButton getGenerateGMPasswordButton() {
@@ -221,8 +233,34 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 prefs.setMovementMetric((WalkerMetric) movementMetricCombo.getSelectedItem());
                 prefs.setAutoRevealOnMovement(autoRevealOnMovement.isSelected());
                 prefs.setUsePasswordFile(usePasswordFile.isSelected());
+                JCheckBox useWebRTCCheckBox = getUseWebRTCCheckBox();
+                AppState.setUseWebRTC(
+                    useWebRTCCheckBox.isEnabled() && useWebRTCCheckBox.isSelected());
                 accepted = true;
                 dialog.closeDialog();
+              }
+            });
+    getRPToolsAlias()
+        .getDocument()
+        .addDocumentListener(
+            new DocumentListener() {
+              private void checkName() {
+                getUseWebRTCCheckBox().setEnabled(getRPToolsAlias().getText().length() > 0);
+              }
+
+              @Override
+              public void insertUpdate(DocumentEvent e) {
+                checkName();
+              }
+
+              @Override
+              public void removeUpdate(DocumentEvent e) {
+                checkName();
+              }
+
+              @Override
+              public void changedUpdate(DocumentEvent e) {
+                checkName();
               }
             });
   }

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/connectToServerDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/connectToServerDialog.xml
@@ -24,10 +24,10 @@
     </at>
     <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
    </super>
-   <at name="id">C:\Development\rptools\maptool\src\main\resources\net\rptools\maptool\client\ui\forms\connectToServerDialog.xml</at>
-   <at name="path">resources\net\rptools\maptool\client\ui\forms\connectToServerDialog.xml</at>
+   <at name="id">/Users/cwisniew/Development/RPTools/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/connectToServerDialog.xml</at>
+   <at name="path">resources/net/rptools/maptool/client/ui/forms/connectToServerDialog.xml</at>
    <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
-   <at name="colspecs">FILL:DEFAULT:NONE,RIGHT:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
+   <at name="colspecs">FILL:DEFAULT:NONE,RIGHT:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
    <at name="components">
     <object classname="java.util.LinkedList">
      <item >
@@ -74,7 +74,7 @@
               </at>
              </object>
             </at>
-            <at name="width">164</at>
+            <at name="width">194</at>
             <at name="name"/>
             <at name="text">ConnectToServerDialog.username</at>
             <at name="fill">
@@ -82,7 +82,7 @@
               <at name="name">fill</at>
              </object>
             </at>
-            <at name="height">14</at>
+            <at name="height">15</at>
            </object>
           </at>
          </object>
@@ -134,15 +134,15 @@
               </at>
              </object>
             </at>
-            <at name="name"></at>
-            <at name="width">163</at>
+            <at name="width">193</at>
+            <at name="name"/>
             <at name="text">ConnectToServerDialog.password</at>
             <at name="fill">
              <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
               <at name="name">fill</at>
              </object>
             </at>
-            <at name="height">14</at>
+            <at name="height">15</at>
            </object>
           </at>
          </object>
@@ -158,7 +158,7 @@
           <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
            <at name="column">4</at>
            <at name="row">2</at>
-           <at name="colspan">2</at>
+           <at name="colspan">5</at>
            <at name="rowspan">1</at>
            <at name="halign">default</at>
            <at name="valign">default</at>
@@ -195,8 +195,8 @@
              </object>
             </at>
             <at name="name">@username</at>
-            <at name="width">1436</at>
-            <at name="height">20</at>
+            <at name="width">1202</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -212,7 +212,7 @@
           <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
            <at name="column">4</at>
            <at name="row">4</at>
-           <at name="colspan">2</at>
+           <at name="colspan">5</at>
            <at name="rowspan">1</at>
            <at name="halign">default</at>
            <at name="valign">default</at>
@@ -249,8 +249,8 @@
              </object>
             </at>
             <at name="name">@password</at>
-            <at name="width">1436</at>
-            <at name="height">20</at>
+            <at name="width">1202</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -266,7 +266,7 @@
           <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
            <at name="column">2</at>
            <at name="row">8</at>
-           <at name="colspan">4</at>
+           <at name="colspan">7</at>
            <at name="rowspan">1</at>
            <at name="halign">fill</at>
            <at name="valign">fill</at>
@@ -337,7 +337,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.969938852</at>
+                     <at name="id">embedded.858886027</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -386,15 +386,15 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="name"></at>
-                              <at name="width">178</at>
+                              <at name="width">209</at>
+                              <at name="name"/>
                               <at name="text">ConnectToServerDialog.server.name</at>
                               <at name="fill">
                                <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
                                 <at name="name">fill</at>
                                </object>
                               </at>
-                              <at name="height">14</at>
+                              <at name="height">15</at>
                              </object>
                             </at>
                            </object>
@@ -448,9 +448,9 @@
                               </at>
                               <at name="actionCommand">Refresh</at>
                               <at name="name">refreshButton</at>
-                              <at name="width">103</at>
+                              <at name="width">113</at>
                               <at name="text">Button.refresh</at>
-                              <at name="height">22</at>
+                              <at name="height">23</at>
                              </object>
                             </at>
                            </object>
@@ -503,8 +503,8 @@
                                </object>
                               </at>
                               <at name="name">@serverName</at>
-                              <at name="width">1236</at>
-                              <at name="height">20</at>
+                              <at name="width">991</at>
+                              <at name="height">21</at>
                              </object>
                             </at>
                            </object>
@@ -557,7 +557,7 @@
                                </object>
                               </at>
                               <at name="name">aliasTable</at>
-                              <at name="width">1555</at>
+                              <at name="width">1351</at>
                               <at name="scollBars">
                                <object classname="com.jeta.forms.store.properties.ScrollBarsProperty">
                                 <at name="name">scollBars</at>
@@ -717,7 +717,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.991799388</at>
+                     <at name="id">embedded.2101283598</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:GROW(1.0),CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -766,7 +766,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="width">1453</at>
+                              <at name="width">1239</at>
                               <at name="name"/>
                               <at name="text">ConnectToServerDialog.server.local</at>
                               <at name="fill">
@@ -774,7 +774,7 @@
                                 <at name="name">fill</at>
                                </object>
                               </at>
-                              <at name="height">14</at>
+                              <at name="height">15</at>
                              </object>
                             </at>
                            </object>
@@ -829,7 +829,7 @@
                               <at name="scrollableTracksViewportHeight">true</at>
                               <at name="scrollableTracksViewportWidth">true</at>
                               <at name="name">localServerList</at>
-                              <at name="width">1555</at>
+                              <at name="width">1351</at>
                               <at name="items">
                                <object classname="com.jeta.forms.store.properties.ItemsProperty">
                                 <at name="name">items</at>
@@ -862,7 +862,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="height">520</at>
+                              <at name="height">583</at>
                              </object>
                             </at>
                            </object>
@@ -916,9 +916,9 @@
                               </at>
                               <at name="actionCommand">Rescan</at>
                               <at name="name">rescanButton</at>
-                              <at name="width">100</at>
+                              <at name="width">110</at>
                               <at name="text">Button.rescan</at>
-                              <at name="height">22</at>
+                              <at name="height">23</at>
                              </object>
                             </at>
                            </object>
@@ -1050,7 +1050,7 @@
                       </at>
                       <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
                      </super>
-                     <at name="id">embedded.-1555914762</at>
+                     <at name="id">embedded.769035931</at>
                      <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
                      <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:MAX(48DLU;DEFAULT):NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE</at>
                      <at name="components">
@@ -1099,7 +1099,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="width">190</at>
+                              <at name="width">224</at>
                               <at name="name"/>
                               <at name="text">ConnectToServerDialog.server.address</at>
                               <at name="fill">
@@ -1107,7 +1107,7 @@
                                 <at name="name">fill</at>
                                </object>
                               </at>
-                              <at name="height">14</at>
+                              <at name="height">15</at>
                              </object>
                             </at>
                            </object>
@@ -1159,7 +1159,7 @@
                                 </at>
                                </object>
                               </at>
-                              <at name="width">190</at>
+                              <at name="width">224</at>
                               <at name="name"/>
                               <at name="text">ConnectToServerDialog.server.port</at>
                               <at name="fill">
@@ -1167,7 +1167,7 @@
                                 <at name="name">fill</at>
                                </object>
                               </at>
-                              <at name="height">14</at>
+                              <at name="height">15</at>
                              </object>
                             </at>
                            </object>
@@ -1220,8 +1220,8 @@
                                </object>
                               </at>
                               <at name="name">@host</at>
-                              <at name="width">1347</at>
-                              <at name="height">20</at>
+                              <at name="width">1109</at>
+                              <at name="height">21</at>
                              </object>
                             </at>
                            </object>
@@ -1275,8 +1275,8 @@
                               </at>
                               <at name="columns">5</at>
                               <at name="name">@port</at>
-                              <at name="width">68</at>
-                              <at name="height">20</at>
+                              <at name="width">92</at>
+                              <at name="height">21</at>
                              </object>
                             </at>
                            </object>
@@ -1384,9 +1384,122 @@
               </at>
              </object>
             </at>
-            <at name="width">1620</at>
+            <at name="width">1416</at>
             <at name="tabCount">3</at>
-            <at name="height">672</at>
+            <at name="height">737</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">4</at>
+           <at name="row">6</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">javax.swing.JCheckBox</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">javax.swing.JCheckBox</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="actionCommand">ConnectToServerDialog.usePublicKey</at>
+            <at name="name">@usePublicKey</at>
+            <at name="width">233</at>
+            <at name="text">ConnectToServerDialog.usePublicKey</at>
+            <at name="height">17</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">6</at>
+           <at name="row">6</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">javax.swing.JCheckBox</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">javax.swing.JCheckBox</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="actionCommand">ConnectToServerDialog.usePublicKey</at>
+            <at name="name">@useWebRTC</at>
+            <at name="width">179</at>
+            <at name="text">WebRTC.toggleUseWebRTC</at>
+            <at name="toolTipText">WebRTC.toggleUseWebRTC.tooltip</at>
+            <at name="height">17</at>
            </object>
           </at>
          </object>
@@ -1402,7 +1515,7 @@
           <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
            <at name="column">2</at>
            <at name="row">10</at>
-           <at name="colspan">4</at>
+           <at name="colspan">7</at>
            <at name="rowspan">1</at>
            <at name="halign">right</at>
            <at name="valign">default</at>
@@ -1411,7 +1524,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.-1108400864</at>
+        <at name="id">embedded.477922296</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -1462,9 +1575,9 @@
                  </at>
                  <at name="actionCommand">OK</at>
                  <at name="name">okButton</at>
-                 <at name="width">79</at>
+                 <at name="width">86</at>
                  <at name="text">Button.ok</at>
-                 <at name="height">22</at>
+                 <at name="height">23</at>
                 </object>
                </at>
               </object>
@@ -1518,9 +1631,9 @@
                  </at>
                  <at name="actionCommand">JButton</at>
                  <at name="name">cancelButton</at>
-                 <at name="width">98</at>
+                 <at name="width">108</at>
                  <at name="text">Button.cancel</at>
-                 <at name="height">22</at>
+                 <at name="height">23</at>
                 </object>
                </at>
               </object>
@@ -1610,62 +1723,6 @@
        </object>
       </at>
      </item>
-     <item >
-      <at name="value">
-       <object classname="com.jeta.forms.store.memento.BeanMemento">
-        <super classname="com.jeta.forms.store.memento.ComponentMemento">
-         <at name="cellconstraints">
-          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-           <at name="column">5</at>
-           <at name="row">6</at>
-           <at name="colspan">1</at>
-           <at name="rowspan">1</at>
-           <at name="halign">default</at>
-           <at name="valign">default</at>
-           <at name="insets" object="insets">0,0,0,0</at>
-          </object>
-         </at>
-         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-        </super>
-        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-        <at name="beanclass">javax.swing.JCheckBox</at>
-        <at name="beanproperties">
-         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-          <at name="classname">javax.swing.JCheckBox</at>
-          <at name="properties">
-           <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="border">
-             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-              <super classname="com.jeta.forms.store.properties.BorderProperty">
-               <at name="name">border</at>
-              </super>
-              <at name="borders">
-               <object classname="java.util.LinkedList">
-                <item >
-                 <at name="value">
-                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                  </object>
-                 </at>
-                </item>
-               </object>
-              </at>
-             </object>
-            </at>
-            <at name="actionCommand">ConnectToServerDialog.usePublicKey</at>
-            <at name="name">@usePublicKey</at>
-            <at name="width">1420</at>
-            <at name="text">ConnectToServerDialog.usePublicKey</at>
-            <at name="height">16</at>
-           </object>
-          </at>
-         </object>
-        </at>
-       </object>
-      </at>
-     </item>
     </object>
    </at>
    <at name="properties">
@@ -1683,7 +1740,7 @@
          </at>
         </object>
        </at>
-       <at name="name"/>
+       <at name="name"></at>
        <at name="fill">
         <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
          <at name="name">fill</at>
@@ -1725,37 +1782,37 @@
      <at name="rows">
       <object classname="[Ljava.lang.Object;" size="11">
        <at name="item" index="0">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="1">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="2">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="3">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="4">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="5">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="6">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="7">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="8">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="9">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
        <at name="item" index="10">
-        <object classname="[Ljava.lang.Object;" size="6"/>
+        <object classname="[Ljava.lang.Object;" size="9"/>
        </at>
       </object>
      </at>

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml
@@ -24,7 +24,7 @@
     </at>
     <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
    </super>
-   <at name="id">/home/cwisniew/Development/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml</at>
+   <at name="id">/Users/cwisniew/Development/RPTools/maptool/src/main/resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml</at>
    <at name="path">resources/net/rptools/maptool/client/ui/forms/startServerDialog.xml</at>
    <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
    <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,LEFT:MIN(125DLU;DEFAULT):NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
@@ -76,8 +76,8 @@
             </at>
             <at name="columns">20</at>
             <at name="name">@username</at>
-            <at name="width">215</at>
-            <at name="height">20</at>
+            <at name="width">227</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -131,8 +131,8 @@
             </at>
             <at name="columns">20</at>
             <at name="name">@GMPassword</at>
-            <at name="width">215</at>
-            <at name="height">20</at>
+            <at name="width">227</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -186,8 +186,8 @@
             </at>
             <at name="columns">20</at>
             <at name="name">@playerPassword</at>
-            <at name="width">215</at>
-            <at name="height">20</at>
+            <at name="width">227</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -240,14 +240,14 @@
              </object>
             </at>
             <at name="name">username</at>
-            <at name="width">195</at>
+            <at name="width">223</at>
             <at name="text">ConnectToServerDialog.username</at>
             <at name="fill">
              <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
               <at name="name">fill</at>
              </object>
             </at>
-            <at name="height">14</at>
+            <at name="height">15</at>
            </object>
           </at>
          </object>
@@ -299,7 +299,7 @@
               </at>
              </object>
             </at>
-            <at name="width">195</at>
+            <at name="width">223</at>
             <at name="name"/>
             <at name="text">ConnectionInfoDialog.port</at>
             <at name="fill">
@@ -307,7 +307,7 @@
               <at name="name">fill</at>
              </object>
             </at>
-            <at name="height">14</at>
+            <at name="height">15</at>
            </object>
           </at>
          </object>
@@ -359,15 +359,15 @@
               </at>
              </object>
             </at>
-            <at name="name"></at>
-            <at name="width">195</at>
+            <at name="width">223</at>
+            <at name="name"/>
             <at name="text">ServerDialog.label.password</at>
             <at name="fill">
              <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
               <at name="name">fill</at>
              </object>
             </at>
-            <at name="height">14</at>
+            <at name="height">15</at>
            </object>
           </at>
          </object>
@@ -420,13 +420,13 @@
              </object>
             </at>
             <at name="name">role</at>
-            <at name="width">216</at>
+            <at name="width">214</at>
             <at name="items">
              <object classname="com.jeta.forms.store.properties.ItemsProperty">
               <at name="name">items</at>
              </object>
             </at>
-            <at name="height">20</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -478,7 +478,7 @@
               </at>
              </object>
             </at>
-            <at name="width">195</at>
+            <at name="width">223</at>
             <at name="name"/>
             <at name="text">ServerDialog.label.alias</at>
             <at name="fill">
@@ -487,7 +487,7 @@
              </object>
             </at>
             <at name="toolTipText">ServerDialog.tooltip.alias</at>
-            <at name="height">14</at>
+            <at name="height">15</at>
            </object>
           </at>
          </object>
@@ -541,9 +541,9 @@
             </at>
             <at name="columns">20</at>
             <at name="name">@RPToolsName</at>
-            <at name="width">215</at>
+            <at name="width">227</at>
             <at name="toolTipText">ServerDialog.tooltip.alias</at>
-            <at name="height">20</at>
+            <at name="height">21</at>
            </object>
           </at>
          </object>
@@ -595,7 +595,7 @@
               </at>
              </object>
             </at>
-            <at name="width">216</at>
+            <at name="width">214</at>
             <at name="name"/>
             <at name="text">Label.optional</at>
             <at name="fill">
@@ -620,6 +620,292 @@
      </item>
      <item >
       <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">6</at>
+           <at name="row">8</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">javax.swing.JButton</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">javax.swing.JButton</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="actionCommand">ServerDialog.generatePassword</at>
+            <at name="name">@generateGMPassword</at>
+            <at name="width">214</at>
+            <at name="text">ServerDialog.generatePassword</at>
+            <at name="height">23</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">6</at>
+           <at name="row">10</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">javax.swing.JButton</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">javax.swing.JButton</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="actionCommand">ServerDialog.generatePassword</at>
+            <at name="name">@generatePlayerPassword</at>
+            <at name="width">214</at>
+            <at name="text">ServerDialog.generatePassword</at>
+            <at name="height">23</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">2</at>
+           <at name="row">8</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">com.jeta.forms.components.label.JETALabel</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="width">223</at>
+            <at name="name"/>
+            <at name="text">ServerDialog.label.gmpassword</at>
+            <at name="fill">
+             <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
+              <at name="name">fill</at>
+             </object>
+            </at>
+            <at name="height">15</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">2</at>
+           <at name="row">12</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">javax.swing.JCheckBox</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">javax.swing.JCheckBox</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="actionCommand">Use UPnP</at>
+            <at name="name">@usePasswordFile</at>
+            <at name="width">223</at>
+            <at name="text">ServerDialog.label.usePasswordFile</at>
+            <at name="toolTipText">ServerDialog.tooltip.usePasswordFile</at>
+            <at name="height">17</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
+       <object classname="com.jeta.forms.store.memento.BeanMemento">
+        <super classname="com.jeta.forms.store.memento.ComponentMemento">
+         <at name="cellconstraints">
+          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
+           <at name="column">4</at>
+           <at name="row">12</at>
+           <at name="colspan">1</at>
+           <at name="rowspan">1</at>
+           <at name="halign">default</at>
+           <at name="valign">default</at>
+           <at name="insets" object="insets">0,0,0,0</at>
+          </object>
+         </at>
+         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
+        </super>
+        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
+        <at name="beanclass">javax.swing.JCheckBox</at>
+        <at name="beanproperties">
+         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
+          <at name="classname">javax.swing.JCheckBox</at>
+          <at name="properties">
+           <object classname="com.jeta.forms.store.support.PropertyMap">
+            <at name="border">
+             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
+              <super classname="com.jeta.forms.store.properties.BorderProperty">
+               <at name="name">border</at>
+              </super>
+              <at name="borders">
+               <object classname="java.util.LinkedList">
+                <item >
+                 <at name="value">
+                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
+                   <super classname="com.jeta.forms.store.properties.BorderProperty">
+                    <at name="name">border</at>
+                   </super>
+                  </object>
+                 </at>
+                </item>
+               </object>
+              </at>
+             </object>
+            </at>
+            <at name="actionCommand">Use UPnP</at>
+            <at name="name">@useWebRTC</at>
+            <at name="width">179</at>
+            <at name="text">WebRTC.toggleUseWebRTC</at>
+            <at name="toolTipText">WebRTC.toggleUseWebRTC.tooltip</at>
+            <at name="height">17</at>
+           </object>
+          </at>
+         </object>
+        </at>
+       </object>
+      </at>
+     </item>
+     <item >
+      <at name="value">
        <object classname="com.jeta.forms.store.memento.FormMemento">
         <super classname="com.jeta.forms.store.memento.ComponentMemento">
          <at name="cellconstraints">
@@ -635,7 +921,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.408969100</at>
+        <at name="id">embedded.1516568862</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE,CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:33PX:NONE,FILL:154PX:NONE,FILL:DEFAULT:GROW(1.0),FILL:102PX:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -686,10 +972,10 @@
                  </at>
                  <at name="actionCommand">Strict token ownership</at>
                  <at name="name">@useStrictTokenOwnership</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.ownership</at>
                  <at name="toolTipText">ServerDialog.option.ownership.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -743,9 +1029,9 @@
                  </at>
                  <at name="actionCommand">Players can reveal vision</at>
                  <at name="name">@playersCanRevealVision</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.reveal.player</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -799,10 +1085,10 @@
                  </at>
                  <at name="actionCommand">Use Individual Views</at>
                  <at name="name">@useIndividualViews</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.vision.individual</at>
                  <at name="toolTipText">ServerDialog.option.vision.individual.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -856,10 +1142,10 @@
                  </at>
                  <at name="actionCommand">Use Unrestricted Player Impersonation</at>
                  <at name="name">@restrictedImpersonation</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.impersonate</at>
                  <at name="toolTipText">ServerDialog.option.impersonate.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -913,10 +1199,10 @@
                  </at>
                  <at name="actionCommand">Use Unrestricted Player Impersonation</at>
                  <at name="name">@playersReceiveCampaignMacros</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.macros</at>
                  <at name="toolTipText">ServerDialog.option.macros.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -970,10 +1256,10 @@
                  </at>
                  <at name="actionCommand">Use Unrestricted Player Impersonation</at>
                  <at name="name">@useToolTipsForUnformattedRolls</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.rolls</at>
                  <at name="toolTipText">ServerDialog.option.rolls.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -1034,7 +1320,7 @@
                   </object>
                  </at>
                  <at name="toolTipText">ServerDialog.label.metric.tooltip</at>
-                 <at name="height">14</at>
+                 <at name="height">15</at>
                 </object>
                </at>
               </object>
@@ -1088,10 +1374,10 @@
                  </at>
                  <at name="actionCommand">Use Individual Views</at>
                  <at name="name">@useIndividualFOW</at>
-                 <at name="width">586</at>
+                 <at name="width">643</at>
                  <at name="text">ServerDialog.option.fow.individual</at>
                  <at name="toolTipText">ServerDialog.option.fow.individual.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -1144,14 +1430,14 @@
                   </object>
                  </at>
                  <at name="name">movementMetric</at>
-                 <at name="width">432</at>
+                 <at name="width">489</at>
                  <at name="items">
                   <object classname="com.jeta.forms.store.properties.ItemsProperty">
                    <at name="name">items</at>
                   </object>
                  </at>
                  <at name="toolTipText">Determines how MapTool handles movement on the selected grid type.	</at>
-                 <at name="height">20</at>
+                 <at name="height">21</at>
                 </object>
                </at>
               </object>
@@ -1205,10 +1491,10 @@
                  </at>
                  <at name="actionCommand">Auto Reveal On Movement</at>
                  <at name="name">@autoRevealOnMovement</at>
-                 <at name="width">586</at>
+                 <at name="width">643</at>
                  <at name="text">ServerDialog.option.reveal.move</at>
                  <at name="toolTipText">ServerDialog.option.reveal.move.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -1262,10 +1548,10 @@
                  </at>
                  <at name="actionCommand">Players can reveal vision</at>
                  <at name="name">@gmRevealsVisionForUnownedTokens</at>
-                 <at name="width">619</at>
+                 <at name="width">676</at>
                  <at name="text">ServerDialog.option.reveal.gm</at>
                  <at name="toolTipText">ServerDialog.option.reveal.gm.tooltip</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -1441,7 +1727,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.619464141</at>
+        <at name="id">embedded.726109287</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:GROW(1.0),FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE,FILL:DEFAULT:NONE</at>
         <at name="components">
@@ -1492,9 +1778,9 @@
                  </at>
                  <at name="actionCommand">Test Connection</at>
                  <at name="name">networkingHelpButton</at>
-                 <at name="width">235</at>
+                 <at name="width">237</at>
                  <at name="text">ServerDialog.button.networkinghelp</at>
-                 <at name="height">22</at>
+                 <at name="height">23</at>
                 </object>
                </at>
               </object>
@@ -1550,7 +1836,7 @@
                  <at name="name">okButton</at>
                  <at name="width">86</at>
                  <at name="text">Button.ok</at>
-                 <at name="height">22</at>
+                 <at name="height">23</at>
                 </object>
                </at>
               </object>
@@ -1604,9 +1890,9 @@
                  </at>
                  <at name="actionCommand">Cancel</at>
                  <at name="name">cancelButton</at>
-                 <at name="width">109</at>
+                 <at name="width">108</at>
                  <at name="text">Button.cancel</at>
-                 <at name="height">22</at>
+                 <at name="height">23</at>
                 </object>
                </at>
               </object>
@@ -1713,7 +1999,7 @@
          </at>
          <at name="componentclass">com.jeta.forms.gui.form.FormComponent</at>
         </super>
-        <at name="id">embedded.1610544385</at>
+        <at name="id">embedded.2127336432</at>
         <at name="rowspecs">CENTER:DEFAULT:NONE</at>
         <at name="colspecs">FILL:DEFAULT:NONE,FILL:39PX:NONE,FILL:DEFAULT:GROW(1.0)</at>
         <at name="components">
@@ -1764,8 +2050,8 @@
                  </at>
                  <at name="columns">5</at>
                  <at name="name">@port</at>
-                 <at name="width">47</at>
-                 <at name="height">20</at>
+                 <at name="width">53</at>
+                 <at name="height">21</at>
                 </object>
                </at>
               </object>
@@ -1819,10 +2105,10 @@
                  </at>
                  <at name="actionCommand">Use UPnP</at>
                  <at name="name">@useUPnP</at>
-                 <at name="width">120</at>
+                 <at name="width">145</at>
                  <at name="text">ServerDialog.label.usepnp</at>
                  <at name="toolTipText">ServerDialog.tooltip.useupnp</at>
-                 <at name="height">16</at>
+                 <at name="height">17</at>
                 </object>
                </at>
               </object>
@@ -1906,235 +2192,6 @@
          <object classname="com.jeta.forms.store.memento.FormGroupSet">
           <at name="groups">
            <object classname="java.util.HashMap"/>
-          </at>
-         </object>
-        </at>
-       </object>
-      </at>
-     </item>
-     <item >
-      <at name="value">
-       <object classname="com.jeta.forms.store.memento.BeanMemento">
-        <super classname="com.jeta.forms.store.memento.ComponentMemento">
-         <at name="cellconstraints">
-          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-           <at name="column">6</at>
-           <at name="row">8</at>
-           <at name="colspan">1</at>
-           <at name="rowspan">1</at>
-           <at name="halign">default</at>
-           <at name="valign">default</at>
-           <at name="insets" object="insets">0,0,0,0</at>
-          </object>
-         </at>
-         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-        </super>
-        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-        <at name="beanclass">javax.swing.JButton</at>
-        <at name="beanproperties">
-         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-          <at name="classname">javax.swing.JButton</at>
-          <at name="properties">
-           <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="border">
-             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-              <super classname="com.jeta.forms.store.properties.BorderProperty">
-               <at name="name">border</at>
-              </super>
-              <at name="borders">
-               <object classname="java.util.LinkedList">
-                <item >
-                 <at name="value">
-                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                  </object>
-                 </at>
-                </item>
-               </object>
-              </at>
-             </object>
-            </at>
-            <at name="actionCommand">ServerDialog.generatePassword</at>
-            <at name="name">@generateGMPassword</at>
-            <at name="width">216</at>
-            <at name="text">ServerDialog.generatePassword</at>
-            <at name="height">22</at>
-           </object>
-          </at>
-         </object>
-        </at>
-       </object>
-      </at>
-     </item>
-     <item >
-      <at name="value">
-       <object classname="com.jeta.forms.store.memento.BeanMemento">
-        <super classname="com.jeta.forms.store.memento.ComponentMemento">
-         <at name="cellconstraints">
-          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-           <at name="column">6</at>
-           <at name="row">10</at>
-           <at name="colspan">1</at>
-           <at name="rowspan">1</at>
-           <at name="halign">default</at>
-           <at name="valign">default</at>
-           <at name="insets" object="insets">0,0,0,0</at>
-          </object>
-         </at>
-         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-        </super>
-        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-        <at name="beanclass">javax.swing.JButton</at>
-        <at name="beanproperties">
-         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-          <at name="classname">javax.swing.JButton</at>
-          <at name="properties">
-           <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="border">
-             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-              <super classname="com.jeta.forms.store.properties.BorderProperty">
-               <at name="name">border</at>
-              </super>
-              <at name="borders">
-               <object classname="java.util.LinkedList">
-                <item >
-                 <at name="value">
-                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                  </object>
-                 </at>
-                </item>
-               </object>
-              </at>
-             </object>
-            </at>
-            <at name="actionCommand">ServerDialog.generatePassword</at>
-            <at name="name">@generatePlayerPassword</at>
-            <at name="width">216</at>
-            <at name="text">ServerDialog.generatePassword</at>
-            <at name="height">22</at>
-           </object>
-          </at>
-         </object>
-        </at>
-       </object>
-      </at>
-     </item>
-     <item >
-      <at name="value">
-       <object classname="com.jeta.forms.store.memento.BeanMemento">
-        <super classname="com.jeta.forms.store.memento.ComponentMemento">
-         <at name="cellconstraints">
-          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-           <at name="column">2</at>
-           <at name="row">8</at>
-           <at name="colspan">1</at>
-           <at name="rowspan">1</at>
-           <at name="halign">default</at>
-           <at name="valign">default</at>
-           <at name="insets" object="insets">0,0,0,0</at>
-          </object>
-         </at>
-         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-        </super>
-        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-        <at name="beanclass">com.jeta.forms.components.label.JETALabel</at>
-        <at name="beanproperties">
-         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-          <at name="classname">com.jeta.forms.components.label.JETALabel</at>
-          <at name="properties">
-           <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="border">
-             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-              <super classname="com.jeta.forms.store.properties.BorderProperty">
-               <at name="name">border</at>
-              </super>
-              <at name="borders">
-               <object classname="java.util.LinkedList">
-                <item >
-                 <at name="value">
-                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                  </object>
-                 </at>
-                </item>
-               </object>
-              </at>
-             </object>
-            </at>
-            <at name="name"></at>
-            <at name="width">195</at>
-            <at name="text">ServerDialog.label.gmpassword</at>
-            <at name="fill">
-             <object classname="com.jeta.forms.store.properties.effects.PaintProperty">
-              <at name="name">fill</at>
-             </object>
-            </at>
-            <at name="height">14</at>
-           </object>
-          </at>
-         </object>
-        </at>
-       </object>
-      </at>
-     </item>
-     <item >
-      <at name="value">
-       <object classname="com.jeta.forms.store.memento.BeanMemento">
-        <super classname="com.jeta.forms.store.memento.ComponentMemento">
-         <at name="cellconstraints">
-          <object classname="com.jeta.forms.store.memento.CellConstraintsMemento">
-           <at name="column">4</at>
-           <at name="row">12</at>
-           <at name="colspan">1</at>
-           <at name="rowspan">1</at>
-           <at name="halign">default</at>
-           <at name="valign">default</at>
-           <at name="insets" object="insets">0,0,0,0</at>
-          </object>
-         </at>
-         <at name="componentclass">com.jeta.forms.gui.form.StandardComponent</at>
-        </super>
-        <at name="jetabeanclass">com.jeta.forms.gui.beans.JETABean</at>
-        <at name="beanclass">javax.swing.JCheckBox</at>
-        <at name="beanproperties">
-         <object classname="com.jeta.forms.store.memento.PropertiesMemento">
-          <at name="classname">javax.swing.JCheckBox</at>
-          <at name="properties">
-           <object classname="com.jeta.forms.store.support.PropertyMap">
-            <at name="border">
-             <object classname="com.jeta.forms.store.properties.CompoundBorderProperty">
-              <super classname="com.jeta.forms.store.properties.BorderProperty">
-               <at name="name">border</at>
-              </super>
-              <at name="borders">
-               <object classname="java.util.LinkedList">
-                <item >
-                 <at name="value">
-                  <object classname="com.jeta.forms.store.properties.DefaultBorderProperty">
-                   <super classname="com.jeta.forms.store.properties.BorderProperty">
-                    <at name="name">border</at>
-                   </super>
-                  </object>
-                 </at>
-                </item>
-               </object>
-              </at>
-             </object>
-            </at>
-            <at name="actionCommand">Use UPnP</at>
-            <at name="name">@usePasswordFile</at>
-            <at name="width">215</at>
-            <at name="text">ServerDialog.label.usePasswordFile</at>
-            <at name="toolTipText">ServerDialog.tooltip.usePasswordFile</at>
-            <at name="height">16</at>
-           </object>
           </at>
          </object>
         </at>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -675,7 +675,9 @@ ServerDialog.tooltip.usePasswordFile   = Use MapTool Password file for player an
 ServerDialog.label.usepnp              = Use UPnP
 ServerDialog.tooltip.useupnp           = Attempt to map ports automatically.  Most people should try this option first, and forward ports manually only if UPnP does not work.  If you have set up port forwarding, leave this option unchecked.
 ServerDialog.label.alias               = RPTools.net Alias:
-ServerDialog.tooltip.alias             = Allows players to find this server by name.  If not provided, players will need your external address to use Direct Connect.
+ServerDialog.tooltip.alias             = <html>Allows players to find this server by name. If not provided, <br/>\
+                                               players will need your external address to use Direct Connect.<br/>\
+                                               must be specified if using WebRTC.</html>
 ServerDialog.label.gmpassword          = GM Password:
 ServerDialog.label.password            = Player Password:
 ServerDialog.label.metric              = Movement metric
@@ -1220,7 +1222,6 @@ action.toggleTokenEditorLock                  = Lock Player Token Editor
 action.toggleTokenEditorLock.description      = Locks access to the Token Editor.
 action.toggleNewZonesHaveFOW                  = New Maps have Fog of War
 action.toggleTokensStartSnapToGrid            = Tokens Start Snap to Grid
-action.toggleUseWebRTC                        = Use WebRTC for communication (experimental)    
 # Edit Menu
 action.undoDrawing                            = Undo Drawing
 action.undoDrawing.accel                      = Z
@@ -2550,6 +2551,13 @@ playerDB.dialog.error.playerExists = Player already exists
 playerDB.dialog.error.savingChanges = Error saving database changes
 # Text to display instead of the password
 playerDB.dialog.encodedPassword = -- Encoded Password --
+
+WebRTC.toggleUseWebRTC           = Use WebRTC (experimental)    
+WebRTC.toggleUseWebRTC.tooltip   = <html>Use WebRTC as connection method, this may help <br/>\
+                                         with connection issues where portforwarding doesn't work<br/>\
+                                         both client and server <strong>must</strong> have the same setting.<br/>\
+                                         This functionality is still experimental.<br/>\
+                                         Requires an RPTools net Alias to be set</html>
 
 dialog.button.ok                = Ok
 dialog.button.cancel            = Cancel


### PR DESCRIPTION



### Identify the Bug or Feature request
Resolves #3006



### Description of the Change

The experimental WebRTC functionality is currently exposed as a check menu item under the help menu. This should be moved to the connect to server / start server dialog boxes.

Describe the solution you'd like

1. Removal of use WebRTC check menu item from the help menu
2. Addition of use WebRTC check box to the Start Server Dialog
3. Addition of use WebRTC check box to the Connect to Server Dialog
4. The WebRTC box checkbox should not be selectable if there is no RPTools Alias in the server in the Start Server Dialog, likewise if no Server Name is specified in the connect to server dialog it should not be selectable.
5. If connecting to local host with a server alias and the Use WebRTC is selected in the connect to server dialog there is no need to warn user they may not be able to connect as WebRTC should be able to handle this.


### Possible Drawbacks
More people will be aware of the functionality so I will need to monitor the number of connections to the server registry more closely.

### Documentation Notes
The start server / connect to server dialogs will not allow you to check the Use WebRTC checkbox if the server name is empty. Also using WebRTC will make it possible to connect to local host using server alias.

### Release Notes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3007)
<!-- Reviewable:end -->
