### PR TITLE
Open com.sun.webkit.dom in jpackage section to match run section

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ runtime {
                    "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
                    "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
                    "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
-                   "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",
+                   "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED",
                    "--add-opens=java.desktop/javax.swing=ALL-UNNAMED","--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED"]
 
         imageOptions = []


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #2741

### Description of the Change

The [original PR](https://github.com/RPTools/maptool/pull/2933) added some module opens to the `run` configurations, but the `jpackage` configurations were not updated to match. This PR fixes that so the code works outside of a dev environment.

### Possible Drawbacks

None known.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3008)
<!-- Reviewable:end -->
