### PR TITLE
Updates for lib:token js.evalURI

### DIFF
--- a/src/main/java/net/rptools/maptool/model/framework/LibraryNotValidException.java
+++ b/src/main/java/net/rptools/maptool/model/framework/LibraryNotValidException.java
@@ -14,5 +14,24 @@
  */
 package net.rptools.maptool.model.framework;
 
-/** Exception that is thrown if the library is no longer valid (it has been removed for example). */
-public class LibraryNotValidException extends RuntimeException {}
+/**
+ * Exception that is thrown if the library is not valid Some of the reasons that a library may not
+ * be valid are * It has been removed. * It does not have the permission required
+ */
+public class LibraryNotValidException extends RuntimeException {
+  public enum Reason {
+    MISSING_LIBRARY,
+    MISSING_PERMISSIONS
+  };
+
+  private final Reason reason;
+
+  LibraryNotValidException(Reason reason, String message) {
+    super(message);
+    this.reason = reason;
+  }
+
+  public Reason getReason() {
+    return reason;
+  }
+}

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2561,3 +2561,6 @@ WebRTC.toggleUseWebRTC.tooltip   = <html>Use WebRTC as connection method, this m
 
 dialog.button.ok                = Ok
 dialog.button.cancel            = Cancel
+
+library.error.libtoken.no.access = Allow URI Access is not allowed for {0}.
+library.error.libtoken.missing   = Lib:Token can no longer be found.


### PR DESCRIPTION

### Identify the Bug or Feature request
Addresses #3010 
Addresses #3011 


### Description of the Change
If a user attempts to use js.evalURI() to access a lib:token that exists but does not have the 'Allow URI Access' flag set they will get an error message informing them that that flag is not set.

Also updated 
* code to fix the bug (#3011) where using lowercase produces unexpected results.
* Cleaned up error messages that are returned when trying to execute from a lib:// URI so that they only display error message and not exception where it makes sense.


### Documentation Notes
No additional documentation required this is just displaying a more informative error message for something that was already displaying an error and aligning macro case with what users already expect.

### Release Notes
N/A
