### PR TITLE
Change compare function to equalsIgnoreCase for functionName

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ChatFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ChatFunction.java
@@ -56,7 +56,7 @@ public class ChatFunction extends AbstractFunction {
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
 
-    if (functionName.equals("broadcast")) {
+    if (functionName.equalsIgnoreCase("broadcast")) {
       return broadcast(resolver, parameters);
     } else {
       throw new ParserException("Unknown function: " + functionName);

--- a/src/main/java/net/rptools/maptool/client/functions/CurrentInitiativeFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/CurrentInitiativeFunction.java
@@ -54,9 +54,9 @@ public class CurrentInitiativeFunction extends AbstractFunction {
         throw new ParserException(I18N.getText("macro.function.initiative.mustBeGM", functionName));
     }
 
-    if (functionName.equals("getCurrentInitiative")) {
+    if (functionName.equalsIgnoreCase("getCurrentInitiative")) {
       return getCurrentInitiative();
-    } else if (functionName.equals("setCurrentInitiative")) {
+    } else if (functionName.equalsIgnoreCase("setCurrentInitiative")) {
       if (args.size() != 1)
         throw new ParserException(I18N.getText("macro.function.initiative.oneParam", functionName));
       setCurrentInitiative(args.get(0));

--- a/src/main/java/net/rptools/maptool/client/functions/DefineMacroFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DefineMacroFunction.java
@@ -45,7 +45,7 @@ public class DefineMacroFunction extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    if (functionName.equals("defineFunction")) {
+    if (functionName.equalsIgnoreCase("defineFunction")) {
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
       }
@@ -91,10 +91,10 @@ public class DefineMacroFunction extends AbstractFunction {
               parser, parameters.get(0).toString(), macro, ignoreOutput, newVariableContext);
       return I18N.getText(
           "macro.function.defineFunction.functionDefined", parameters.get(0).toString());
-    } else if (functionName.equals("oldFunction")) {
+    } else if (functionName.equalsIgnoreCase("oldFunction")) {
       return UserDefinedMacroFunctions.getInstance()
           .executeOldFunction(parser, resolver, parameters);
-    } else if (functionName.equals("getDefinedFunctions")) {
+    } else if (functionName.equalsIgnoreCase("getDefinedFunctions")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : "";
       boolean showFullLocations = false;

--- a/src/main/java/net/rptools/maptool/client/functions/EvalMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/EvalMacroFunctions.java
@@ -57,7 +57,7 @@ public class EvalMacroFunctions extends AbstractFunction {
     Token tokenInContext = ((MapToolVariableResolver) resolver).getTokenInContext();
 
     // execMacro has new variable scope where as evalMacro does not.
-    if (functionName.equals("execMacro")) {
+    if (functionName.equalsIgnoreCase("execMacro")) {
       return execMacro(tokenInContext, parameters.get(0).toString());
     } else if ("evalMacro".equalsIgnoreCase(functionName)) {
       return evalMacro(

--- a/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
@@ -61,7 +61,7 @@ public class ExportDataFunctions extends AbstractFunction {
       throw new ParserException(I18N.getText("macro.function.general.accessDenied", functionName));
 
     // New function to save data to an external file.
-    if (functionName.equals("exportData")) {
+    if (functionName.equalsIgnoreCase("exportData")) {
       if (parameters.size() != 3)
         throw new ParserException(
             I18N.getText(
@@ -96,7 +96,7 @@ public class ExportDataFunctions extends AbstractFunction {
       return BigDecimal.ONE;
     }
 
-    if (functionName.equals("getEnvironmentVariable")) {
+    if (functionName.equalsIgnoreCase("getEnvironmentVariable")) {
       if (parameters.size() != 1)
         throw new ParserException(
             I18N.getText(

--- a/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
@@ -311,14 +311,14 @@ public class FindTokenFunctions extends AbstractFunction {
       throws ParserException {
     boolean nameOnly = false;
 
-    if (!functionName.equals("currentToken")
+    if (!functionName.equalsIgnoreCase("currentToken")
         && !functionName.startsWith("getImpersonated")
         && !functionName.startsWith("getVisible")
         && !functionName.startsWith("getSelected")
         && !MapTool.getParser().isMacroTrusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
-    if (functionName.equals("findToken")) {
+    if (functionName.equalsIgnoreCase("findToken")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       String mapName = parameters.size() > 1 ? parameters.get(1).toString() : null;
       return findTokenId(parameters.get(0).toString(), mapName);
@@ -328,7 +328,7 @@ public class FindTokenFunctions extends AbstractFunction {
     FindType findType;
     String findArgs = null;
     ZoneRenderer zoneRenderer = null;
-    if (functionName.equals("currentToken")) {
+    if (functionName.equalsIgnoreCase("currentToken")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 0);
       findType = FindType.CURRENT;
     } else if (functionName.startsWith("getSelected")) {

--- a/src/main/java/net/rptools/maptool/client/functions/FogOfWarFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FogOfWarFunctions.java
@@ -64,7 +64,7 @@ public class FogOfWarFunctions extends AbstractFunction {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
 
-    int maxParamSize = functionName.equals("exposeFOW") || functionName.equals("exposeFoW") ? 3 : 1;
+    int maxParamSize = functionName.equalsIgnoreCase("exposeFOW") || functionName.equalsIgnoreCase("exposeFoW") ? 3 : 1;
 
     if (parameters.size() > maxParamSize) {
       throw new ParserException(
@@ -90,21 +90,21 @@ public class FogOfWarFunctions extends AbstractFunction {
     /*
      * String empty = exposePCOnlyArea(optional String mapName)
      */
-    if (functionName.equals("exposePCOnlyArea")) {
+    if (functionName.equalsIgnoreCase("exposePCOnlyArea")) {
       FogUtil.exposePCArea(zoneRenderer);
       return "<!---->";
     }
     /*
      * String empty = exposeAllOwnedArea(optional String mapName)
      */
-    if (functionName.equals("exposeAllOwnedArea")) {
+    if (functionName.equalsIgnoreCase("exposeAllOwnedArea")) {
       FogUtil.exposeAllOwnedArea(zoneRenderer);
       return "<!---->";
     }
     /*
      * String empty = exposeFOW(optional String mapName, optional String tokens, optional String delim)
      */
-    if (functionName.equals("exposeFOW") || functionName.equals("exposeFoW")) {
+    if (functionName.equalsIgnoreCase("exposeFOW") || functionName.equalsIgnoreCase("exposeFoW")) {
 
       Set<GUID> tokenSet;
 
@@ -123,14 +123,14 @@ public class FogOfWarFunctions extends AbstractFunction {
     /*
      * String empty = restoreFOW(optional String mapName)
      */
-    if (functionName.equals("restoreFOW") || functionName.equals("restoreFoW")) {
+    if (functionName.equalsIgnoreCase("restoreFOW") || functionName.equalsIgnoreCase("restoreFoW")) {
       FogUtil.restoreFoW(zoneRenderer);
       return "<!---->";
     }
     /*
      * Lee: String empty = toggleFoW()
      */
-    if (functionName.equals("toggleFoW")) {
+    if (functionName.equalsIgnoreCase("toggleFoW")) {
       ((ZoneAdminClientAction) AppActions.TOGGLE_FOG).execute(null);
       return ((ZoneAdminClientAction) AppActions.TOGGLE_FOG).isSelected()
           ? I18N.getText("msg.info.action.enableFoW")
@@ -139,7 +139,7 @@ public class FogOfWarFunctions extends AbstractFunction {
     /*
      * Lee: String empty = exposeFogAtWaypoints()
      */
-    if (functionName.equals("exposeFogAtWaypoints")) {
+    if (functionName.equalsIgnoreCase("exposeFogAtWaypoints")) {
 
       if (((ZoneAdminClientAction) AppActions.TOGGLE_WAYPOINT_FOG_REVEAL).isAvailable()) {
         ((ZoneAdminClientAction) AppActions.TOGGLE_WAYPOINT_FOG_REVEAL).execute(null);

--- a/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
@@ -60,7 +60,7 @@ public class HeroLabFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    if (functionName.equals("herolab.getInfo")) {
+    if (functionName.equalsIgnoreCase("herolab.getInfo")) {
       Token token;
 
       if (!MapTool.getParser().isMacroTrusted())
@@ -91,7 +91,7 @@ public class HeroLabFunctions extends AbstractFunction {
       if (token.getHeroLabData() == null) return BigDecimal.ZERO;
 
       return token.getHeroLabData().getInfo();
-    } else if (functionName.equals("herolab.getStatBlock")) {
+    } else if (functionName.equalsIgnoreCase("herolab.getStatBlock")) {
       if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
@@ -133,7 +133,7 @@ public class HeroLabFunctions extends AbstractFunction {
       String statBlockType = parameters.get(0).toString();
 
       return token.getHeroLabData().getStatBlock_data(statBlockType);
-    } else if (functionName.equals("herolab.hasChanged")) {
+    } else if (functionName.equalsIgnoreCase("herolab.hasChanged")) {
       Token token;
 
       if (!MapTool.getParser().isMacroTrusted())
@@ -165,7 +165,7 @@ public class HeroLabFunctions extends AbstractFunction {
         throw new ParserException(I18N.getText("macro.function.herolab.null", functionName));
 
       return token.getHeroLabData().isDirty() ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else if (functionName.equals("herolab.refresh")) {
+    } else if (functionName.equalsIgnoreCase("herolab.refresh")) {
       Token token;
 
       if (!MapTool.getParser().isMacroTrusted())
@@ -218,7 +218,7 @@ public class HeroLabFunctions extends AbstractFunction {
         return BigDecimal.ZERO;
       }
 
-    } else if (functionName.equals("herolab.XPath")) {
+    } else if (functionName.equalsIgnoreCase("herolab.XPath")) {
       FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
 
@@ -248,7 +248,7 @@ public class HeroLabFunctions extends AbstractFunction {
               I18N.getText("macro.function.herolab.xpath.invalid", xPathExpression), iae);
         }
       }
-    } else if (functionName.equals("herolab.getImage")) {
+    } else if (functionName.equalsIgnoreCase("herolab.getImage")) {
       if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
@@ -295,7 +295,7 @@ public class HeroLabFunctions extends AbstractFunction {
       assetURL.append(assetID.toString());
 
       return assetURL.toString();
-    } else if (functionName.equals("herolab.isMinion")) {
+    } else if (functionName.equalsIgnoreCase("herolab.isMinion")) {
       Token token;
 
       if (!MapTool.getParser().isMacroTrusted())
@@ -327,7 +327,7 @@ public class HeroLabFunctions extends AbstractFunction {
         throw new ParserException(I18N.getText("macro.function.herolab.null", functionName));
 
       return token.getHeroLabData().isMinion() ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else if (functionName.equals("herolab.getMasterName")) {
+    } else if (functionName.equalsIgnoreCase("herolab.getMasterName")) {
       Token token;
 
       if (!MapTool.getParser().isMacroTrusted())

--- a/src/main/java/net/rptools/maptool/client/functions/InitiativeRoundFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InitiativeRoundFunction.java
@@ -48,7 +48,7 @@ public class InitiativeRoundFunction extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> args)
       throws ParserException {
-    if (functionName.equals("getInitiativeRound")) {
+    if (functionName.equalsIgnoreCase("getInitiativeRound")) {
       return getInitiativeRound();
     } else if ("setInitiativeRound".equalsIgnoreCase(functionName)) {
       if (args.size() != 1)

--- a/src/main/java/net/rptools/maptool/client/functions/JSONMacroFunctionsOld.java
+++ b/src/main/java/net/rptools/maptool/client/functions/JSONMacroFunctionsOld.java
@@ -95,7 +95,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
 
-    if (functionName.equals("json.fromList")) {
+    if (functionName.equalsIgnoreCase("json.fromList")) {
       String delim = ",";
       if (parameters.size() > 1) {
         delim = parameters.get(1).toString();
@@ -103,7 +103,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return fromStrList(parameters.get(0).toString(), delim);
     }
 
-    if (functionName.equals("json.path.read")) {
+    if (functionName.equalsIgnoreCase("json.path.read")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
       String jsonStr = parameters.get(0).toString();
       String path = parameters.get(1).toString();
@@ -131,7 +131,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       }
     }
 
-    if (functionName.equals("json.path.add")) {
+    if (functionName.equalsIgnoreCase("json.path.add")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
       String jsonStr = parameters.get(0).toString();
       String path = parameters.get(1).toString();
@@ -147,7 +147,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       }
     }
 
-    if (functionName.equals("json.path.set")) {
+    if (functionName.equalsIgnoreCase("json.path.set")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
       String jsonStr = parameters.get(0).toString();
       String path = parameters.get(1).toString();
@@ -163,7 +163,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       }
     }
 
-    if (functionName.equals("json.path.put")) {
+    if (functionName.equalsIgnoreCase("json.path.put")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 4, 4);
       String jsonStr = parameters.get(0).toString();
       String path = parameters.get(1).toString();
@@ -180,7 +180,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       }
     }
 
-    if (functionName.equals("json.path.delete")) {
+    if (functionName.equalsIgnoreCase("json.path.delete")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
       String jsonStr = parameters.get(0).toString();
       String path = parameters.get(1).toString();
@@ -193,7 +193,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       }
     }
 
-    if (functionName.equals("json.fromStrProp")) {
+    if (functionName.equalsIgnoreCase("json.fromStrProp")) {
       String delim = ";";
       if (parameters.size() > 1) {
         delim = parameters.get(1).toString();
@@ -243,7 +243,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return jsonNames;
     }
 
-    if (functionName.equals("json.set")) {
+    if (functionName.equalsIgnoreCase("json.set")) {
       if (parameters.size() < 3) {
         throw new ParserException(
             I18N.getText(
@@ -252,11 +252,11 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONSet(asJSON(parameters.get(0)), parameters);
     }
 
-    if (functionName.equals("json.length")) {
+    if (functionName.equalsIgnoreCase("json.length")) {
       return JSONLength(asJSON(parameters.get(0)));
     }
 
-    if (functionName.equals("json.fields")) {
+    if (functionName.equalsIgnoreCase("json.fields")) {
       String delim = ",";
       if (parameters.size() > 1) {
         delim = parameters.get(1).toString();
@@ -264,11 +264,11 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONFields(asJSON(parameters.get(0)), delim);
     }
 
-    if (functionName.equals("json.type")) {
+    if (functionName.equalsIgnoreCase("json.type")) {
       return getJSONObjectType(parameters.get(0)).toString();
     }
 
-    if (functionName.equals("json.toList")) {
+    if (functionName.equalsIgnoreCase("json.toList")) {
       String delim = ",";
       if (parameters.size() > 1) {
         delim = parameters.get(1).toString();
@@ -276,7 +276,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONToList(asJSON(parameters.get(0)), delim);
     }
 
-    if (functionName.equals("json.toStrProp")) {
+    if (functionName.equalsIgnoreCase("json.toStrProp")) {
       String delim = ";";
       if (parameters.size() > 1) {
         delim = parameters.get(1).toString();
@@ -284,7 +284,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONToStrProp(asJSON(parameters.get(0)), delim);
     }
 
-    if (functionName.equals("json.get")) {
+    if (functionName.equalsIgnoreCase("json.get")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -293,7 +293,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONGet(asJSON(parameters.get(0)), parameters.subList(1, parameters.size()));
     }
 
-    if (functionName.equals("json.append")) {
+    if (functionName.equalsIgnoreCase("json.append")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -302,7 +302,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONAppend(asJSON(parameters.get(0)), parameters);
     }
 
-    if (functionName.equals("json.remove")) {
+    if (functionName.equalsIgnoreCase("json.remove")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -311,7 +311,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONDelete(asJSON(parameters.get(0)), parameters.get(1).toString());
     }
 
-    if (functionName.equals("json.indent")) {
+    if (functionName.equalsIgnoreCase("json.indent")) {
       int indent = 4;
       if (parameters.size() > 1) {
         try {
@@ -323,7 +323,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONIndent(asJSON(parameters.get(0)), indent);
     }
 
-    if (functionName.equals("json.contains")) {
+    if (functionName.equalsIgnoreCase("json.contains")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -334,7 +334,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
           : BigDecimal.ZERO;
     }
 
-    if (functionName.equals("json.sort")) {
+    if (functionName.equalsIgnoreCase("json.sort")) {
       if (parameters.size() > 2) {
         List<String> fields = new ArrayList<String>(parameters.size() - 2);
         for (Object o : parameters.subList(2, parameters.size())) {
@@ -355,15 +355,15 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       }
     }
 
-    if (functionName.equals("json.shuffle")) {
+    if (functionName.equalsIgnoreCase("json.shuffle")) {
       return JSONShuffle(asJSON(parameters.get(0)));
     }
 
-    if (functionName.equals("json.reverse")) {
+    if (functionName.equalsIgnoreCase("json.reverse")) {
       return JSONReverse(asJSON(parameters.get(0)));
     }
 
-    if (functionName.equals("json.evaluate")) {
+    if (functionName.equalsIgnoreCase("json.evaluate")) {
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
       }
@@ -385,7 +385,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONEvaluate((MapToolVariableResolver) resolver, json);
     }
 
-    if (functionName.equals("json.isEmpty")) {
+    if (functionName.equalsIgnoreCase("json.isEmpty")) {
       Object j = asJSON(parameters.get(0));
       if (j instanceof JSONObject) {
         return ((JSONObject) j).isEmpty() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -399,7 +399,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return BigDecimal.ZERO;
     }
 
-    if (functionName.equals("json.equals")) {
+    if (functionName.equalsIgnoreCase("json.equals")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -452,7 +452,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return BigDecimal.ZERO;
     }
 
-    if (functionName.equals("json.count")) {
+    if (functionName.equalsIgnoreCase("json.count")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -473,7 +473,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONCount(asJSON(parameters.get(0).toString()), parameters.get(1), start);
     }
 
-    if (functionName.equals("json.indexOf")) {
+    if (functionName.equalsIgnoreCase("json.indexOf")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -494,19 +494,19 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONIndexOf(asJSON(parameters.get(0).toString()), parameters.get(1), start);
     }
 
-    if (functionName.equals("json.merge")) {
+    if (functionName.equalsIgnoreCase("json.merge")) {
       return JSONMerge(parameters);
     }
 
-    if (functionName.equals("json.unique")) {
+    if (functionName.equalsIgnoreCase("json.unique")) {
       return JSONUnique(asJSON(parameters.get(0).toString()));
     }
 
-    if (functionName.equals("json.removeAll")) {
+    if (functionName.equalsIgnoreCase("json.removeAll")) {
       return JSONRemoveAll(parameters);
     }
 
-    if (functionName.equals("json.removeFirst")) {
+    if (functionName.equalsIgnoreCase("json.removeFirst")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -515,7 +515,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONRemoveFirst(parameters);
     }
 
-    if (functionName.equals("json.union")) {
+    if (functionName.equalsIgnoreCase("json.union")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -524,7 +524,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONUnion(parameters);
     }
 
-    if (functionName.equals("json.difference")) {
+    if (functionName.equalsIgnoreCase("json.difference")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -533,7 +533,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONDifference(parameters);
     }
 
-    if (functionName.equals("json.intersection")) {
+    if (functionName.equalsIgnoreCase("json.intersection")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -542,7 +542,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONIntersection(parameters);
     }
 
-    if (functionName.equals("json.isSubset")) {
+    if (functionName.equalsIgnoreCase("json.isSubset")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -551,7 +551,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONIsSubset(parameters);
     }
 
-    if (functionName.equals("json.rolls")) {
+    if (functionName.equalsIgnoreCase("json.rolls")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -564,7 +564,7 @@ public class JSONMacroFunctionsOld extends AbstractFunction {
       return JSONRolls(parameters);
     }
 
-    if (functionName.equals("json.objrolls")) {
+    if (functionName.equalsIgnoreCase("json.objrolls")) {
       if (parameters.size() != 3) {
         throw new ParserException(
             I18N.getText(

--- a/src/main/java/net/rptools/maptool/client/functions/MacroArgsFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroArgsFunctions.java
@@ -45,7 +45,7 @@ public class MacroArgsFunctions extends AbstractFunction {
       argCount = ((BigDecimal) numArgs).intValue();
     }
 
-    if (functionName.equals("argCount")) {
+    if (functionName.equalsIgnoreCase("argCount")) {
       return BigDecimal.valueOf(argCount);
     } else if ("arg".equalsIgnoreCase(functionName)) {
 

--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -73,13 +73,13 @@ public class MacroDialogFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    if (functionName.equals("isDialogVisible")) {
+    if (functionName.equalsIgnoreCase("isDialogVisible")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       return HTMLFrameFactory.isVisible(false, parameters.get(0).toString())
           ? BigDecimal.ONE
           : BigDecimal.ZERO;
     }
-    if (functionName.equals("isFrameVisible")) {
+    if (functionName.equalsIgnoreCase("isFrameVisible")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       return HTMLFrameFactory.isVisible(true, parameters.get(0).toString())
           ? BigDecimal.ONE
@@ -90,34 +90,34 @@ public class MacroDialogFunctions extends AbstractFunction {
       String name = parameters.get(0).toString();
       return isOverlayRegistered(name) ? BigDecimal.ONE : BigDecimal.ZERO;
     }
-    if (functionName.equals("closeDialog")) {
+    if (functionName.equalsIgnoreCase("closeDialog")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       HTMLFrameFactory.close(false, parameters.get(0).toString());
       return "";
     }
-    if (functionName.equals("closeFrame")) {
+    if (functionName.equalsIgnoreCase("closeFrame")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       HTMLFrameFactory.close(true, parameters.get(0).toString());
       return "";
     }
-    if (functionName.equals("closeOverlay")) {
+    if (functionName.equalsIgnoreCase("closeOverlay")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       String name = parameters.get(0).toString();
       removeOverlay(name);
       return "";
     }
-    if (functionName.equals("resetFrame")) {
+    if (functionName.equalsIgnoreCase("resetFrame")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       HTMLFrame.center(parameters.get(0).toString());
       return "";
     }
-    if (functionName.equals("getFrameProperties")) {
+    if (functionName.equalsIgnoreCase("getFrameProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       Optional<JsonObject> props = HTMLFrame.getFrameProperties(parameters.get(0).toString());
       if (props.isPresent()) return props.get();
       else return "";
     }
-    if (functionName.equals("getDialogProperties")) {
+    if (functionName.equalsIgnoreCase("getDialogProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       Optional<JsonObject> props = HTMLDialog.getDialogProperties(parameters.get(0).toString());
       if (props.isPresent()) return props.get();

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -59,7 +59,7 @@ public class MapFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    if (functionName.equals("getCurrentMapName")) {
+    if (functionName.equalsIgnoreCase("getCurrentMapName")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 0);
       ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
       if (currentZR == null) {
@@ -67,7 +67,7 @@ public class MapFunctions extends AbstractFunction {
       } else {
         return currentZR.getZone().getName();
       }
-    } else if (functionName.equals("getMapDisplayName")) {
+    } else if (functionName.equalsIgnoreCase("getMapDisplayName")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
       if (parameters.size() == 0) {
         ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
@@ -97,7 +97,7 @@ public class MapFunctions extends AbstractFunction {
           return foundMap;
         }
       }
-    } else if (functionName.equals("setCurrentMap")) {
+    } else if (functionName.equalsIgnoreCase("setCurrentMap")) {
       checkTrusted(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       String mapName = parameters.get(0).toString();

--- a/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MathFunctions.java
@@ -228,73 +228,73 @@ public class MathFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> param)
       throws ParserException {
-    if ("math.abs".equals(functionName)) {
+    if ("math.abs".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.abs(nparam.get(0).doubleValue()));
-    } else if ("math.ceil".equals(functionName)) {
+    } else if ("math.ceil".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.ceil(nparam.get(0).doubleValue()));
-    } else if ("math.floor".equals(functionName)) {
+    } else if ("math.floor".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.floor(nparam.get(0).doubleValue()));
-    } else if ("math.cos".equals(functionName)) {
+    } else if ("math.cos".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.cos(Math.toRadians(nparam.get(0).doubleValue())));
-    } else if ("math.cos_r".equals(functionName)) {
+    } else if ("math.cos_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.cos(nparam.get(0).doubleValue()));
-    } else if ("math.sin".equals(functionName)) {
+    } else if ("math.sin".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.sin(Math.toRadians(nparam.get(0).doubleValue())));
-    } else if ("math.sin_r".equals(functionName)) {
+    } else if ("math.sin_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.sin(nparam.get(0).doubleValue()));
-    } else if ("math.tan".equals(functionName)) {
+    } else if ("math.tan".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.tan(Math.toRadians(nparam.get(0).doubleValue())));
-    } else if ("math.tan_r".equals(functionName)) {
+    } else if ("math.tan_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.tan(nparam.get(0).doubleValue()));
-    } else if ("math.acos".equals(functionName)) {
+    } else if ("math.acos".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toDegrees(Math.acos(nparam.get(0).doubleValue())));
-    } else if ("math.acos_r".equals(functionName)) {
+    } else if ("math.acos_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.acos(nparam.get(0).doubleValue()));
-    } else if ("math.asin".equals(functionName)) {
+    } else if ("math.asin".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toDegrees(Math.asin(nparam.get(0).doubleValue())));
-    } else if ("math.asin_r".equals(functionName)) {
+    } else if ("math.asin_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.asin(nparam.get(0).doubleValue()));
-    } else if ("math.atan".equals(functionName)) {
+    } else if ("math.atan".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toDegrees(Math.atan(nparam.get(0).doubleValue())));
-    } else if ("math.atan_r".equals(functionName)) {
+    } else if ("math.atan_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.atan(nparam.get(0).doubleValue()));
-    } else if ("math.atan2".equals(functionName)) {
+    } else if ("math.atan2".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, 2, functionName);
       return BigDecimal.valueOf(
           Math.toDegrees(Math.atan2(nparam.get(0).doubleValue(), nparam.get(1).doubleValue())));
-    } else if ("math.atan2_r".equals(functionName)) {
+    } else if ("math.atan2_r".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, 2, functionName);
       return BigDecimal.valueOf(
           Math.atan2(nparam.get(0).doubleValue(), nparam.get(1).doubleValue()));
-    } else if ("math.cbrt".equals(functionName) || "math.cuberoot".equals(functionName)) {
+    } else if ("math.cbrt".equalsIgnoreCase(functionName) || "math.cuberoot".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.cbrt(nparam.get(0).doubleValue()));
-    } else if ("math.hypot".equals(functionName) || "math.hypotenuse".equals(functionName)) {
+    } else if ("math.hypot".equalsIgnoreCase(functionName) || "math.hypotenuse".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, 2, functionName);
       return BigDecimal.valueOf(
           Math.hypot(nparam.get(0).doubleValue(), nparam.get(1).doubleValue()));
-    } else if ("math.log".equals(functionName)) {
+    } else if ("math.log".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.log(nparam.get(0).doubleValue()));
-    } else if ("math.log10".equals(functionName)) {
+    } else if ("math.log10".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.log10(nparam.get(0).doubleValue()));
-    } else if ("math.min".equals(functionName)) {
+    } else if ("math.min".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, UNLIMITED_PARAMETERS, functionName);
       double minVal = nparam.get(0).doubleValue();
       for (BigDecimal n : nparam) {
@@ -304,7 +304,7 @@ public class MathFunctions extends AbstractFunction {
         }
       }
       return BigDecimal.valueOf(minVal);
-    } else if ("math.max".equals(functionName)) {
+    } else if ("math.max".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, UNLIMITED_PARAMETERS, functionName);
       double maxVal = nparam.get(0).doubleValue();
       for (BigDecimal n : nparam) {
@@ -314,7 +314,7 @@ public class MathFunctions extends AbstractFunction {
         }
       }
       return BigDecimal.valueOf(maxVal);
-    } else if ("math.mod".equals(functionName)) {
+    } else if ("math.mod".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, 2, functionName);
       if (!isInteger(nparam.get(0))) {
         throw new ParserException(
@@ -327,37 +327,37 @@ public class MathFunctions extends AbstractFunction {
       }
 
       return BigDecimal.valueOf(nparam.get(0).intValue() % nparam.get(1).intValue());
-    } else if ("math.pow".equals(functionName)) {
+    } else if ("math.pow".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 2, 2, functionName);
       return BigDecimal.valueOf(Math.pow(nparam.get(0).doubleValue(), nparam.get(1).doubleValue()));
-    } else if ("math.random".equals(functionName)) {
+    } else if ("math.random".equalsIgnoreCase(functionName)) {
       if (param.size() > 0) {
         throw new ParserException(
             I18N.getText("macro.function.general.wrongNumParam", functionName, 0, param.size()));
       }
       return BigDecimal.valueOf(Math.random());
-    } else if ("math.sqrt".equals(functionName) || "math.squareroot".equals(functionName)) {
+    } else if ("math.sqrt".equalsIgnoreCase(functionName) || "math.squareroot".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.sqrt(nparam.get(0).doubleValue()));
-    } else if ("math.toRadians".equals(functionName)) {
+    } else if ("math.toRadians".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toRadians(nparam.get(0).doubleValue()));
-    } else if ("math.toDegrees".equals(functionName)) {
+    } else if ("math.toDegrees".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return BigDecimal.valueOf(Math.toDegrees(nparam.get(0).doubleValue()));
-    } else if ("math.pi".equals(functionName)) {
+    } else if ("math.pi".equalsIgnoreCase(functionName)) {
       if (param.size() > 0) {
         throw new ParserException(
             I18N.getText("macro.function.general.wrongNumParam", functionName, 0, param.size()));
       }
       return BigDecimal.valueOf(Math.PI);
-    } else if ("math.e".equals(functionName)) {
+    } else if ("math.e".equalsIgnoreCase(functionName)) {
       if (param.size() > 0) {
         throw new ParserException(
             I18N.getText("macro.function.general.wrongNumParam", functionName, 0, param.size()));
       }
       return BigDecimal.valueOf(Math.E);
-    } else if ("math.isEven".equals(functionName)) {
+    } else if ("math.isEven".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       if (!isInteger(nparam.get(0))) {
         throw new ParserException(
@@ -367,7 +367,7 @@ public class MathFunctions extends AbstractFunction {
       return nparam.get(0).remainder(BigDecimal.valueOf(2)).equals(BigDecimal.ZERO)
           ? BigDecimal.ONE
           : BigDecimal.ZERO;
-    } else if ("math.isOdd".equals(functionName)) {
+    } else if ("math.isOdd".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       if (!isInteger(nparam.get(0))) {
         throw new ParserException(
@@ -377,38 +377,38 @@ public class MathFunctions extends AbstractFunction {
       return nparam.get(0).remainder(BigDecimal.valueOf(2)).equals(BigDecimal.ZERO)
           ? BigDecimal.ZERO
           : BigDecimal.ONE;
-    } else if ("math.isInt".equals(functionName)) {
+    } else if ("math.isInt".equalsIgnoreCase(functionName)) {
       List<BigDecimal> nparam = getNumericParams(param, 1, 1, functionName);
       return isInteger(nparam.get(0)) ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else if ("math.arraySum".equals(functionName)) {
+    } else if ("math.arraySum".equalsIgnoreCase(functionName)) {
       return streamSum(getNumericValuesFromArrayParam(functionName, param));
-    } else if ("math.arrayProduct".equals(functionName)) {
+    } else if ("math.arrayProduct".equalsIgnoreCase(functionName)) {
       return streamProduct(getNumericValuesFromArrayParam(functionName, param));
-    } else if ("math.arrayMin".equals(functionName)) {
+    } else if ("math.arrayMin".equalsIgnoreCase(functionName)) {
       return streamMin(getNumericValuesFromArrayParam(functionName, param));
-    } else if ("math.arrayMax".equals(functionName)) {
+    } else if ("math.arrayMax".equalsIgnoreCase(functionName)) {
       return streamMax(getNumericValuesFromArrayParam(functionName, param));
-    } else if ("math.arrayMean".equals(functionName)) {
+    } else if ("math.arrayMean".equalsIgnoreCase(functionName)) {
       List<BigDecimal> theValues =
           getNumericValuesFromArrayParam(functionName, param).collect(Collectors.toList());
       return getMean(theValues);
-    } else if ("math.arrayMedian".equals(functionName)) {
+    } else if ("math.arrayMedian".equalsIgnoreCase(functionName)) {
       List<BigDecimal> theValues =
           getNumericValuesFromArrayParam(functionName, param).collect(Collectors.toList());
       return getMedian(theValues);
-    } else if ("math.listSum".equals(functionName)) {
+    } else if ("math.listSum".equalsIgnoreCase(functionName)) {
       return streamSum(getNumericValuesFromStrListParam(functionName, param));
-    } else if ("math.listProduct".equals(functionName)) {
+    } else if ("math.listProduct".equalsIgnoreCase(functionName)) {
       return streamProduct(getNumericValuesFromStrListParam(functionName, param));
-    } else if ("math.listMin".equals(functionName)) {
+    } else if ("math.listMin".equalsIgnoreCase(functionName)) {
       return streamMin(getNumericValuesFromStrListParam(functionName, param));
-    } else if ("math.listMax".equals(functionName)) {
+    } else if ("math.listMax".equalsIgnoreCase(functionName)) {
       return streamMax(getNumericValuesFromStrListParam(functionName, param));
-    } else if ("math.listMean".equals(functionName)) {
+    } else if ("math.listMean".equalsIgnoreCase(functionName)) {
       List<BigDecimal> theValues =
           getNumericValuesFromStrListParam(functionName, param).collect(Collectors.toList());
       return getMean(theValues);
-    } else if ("math.listMedian".equals(functionName)) {
+    } else if ("math.listMedian".equalsIgnoreCase(functionName)) {
       List<BigDecimal> theValues =
           getNumericValuesFromStrListParam(functionName, param).collect(Collectors.toList());
       return getMedian(theValues);

--- a/src/main/java/net/rptools/maptool/client/functions/MiscInitiativeFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MiscInitiativeFunction.java
@@ -64,7 +64,7 @@ public class MiscInitiativeFunction extends AbstractFunction {
       throws ParserException {
     InitiativeList list = MapTool.getFrame().getCurrentZoneRenderer().getZone().getInitiativeList();
     InitiativePanel ip = MapTool.getFrame().getInitiativePanel();
-    if (functionName.equals("nextInitiative")) {
+    if (functionName.equalsIgnoreCase("nextInitiative")) {
       if (!MapTool.getParser().isMacroTrusted()) {
         if (!ip.hasGMPermission()
             && (list.getCurrent() <= 0
@@ -77,7 +77,7 @@ public class MiscInitiativeFunction extends AbstractFunction {
       }
       list.nextInitiative();
       return new BigDecimal(list.getCurrent());
-    } else if (functionName.equals("prevInitiative")) {
+    } else if (functionName.equalsIgnoreCase("prevInitiative")) {
       if (!MapTool.getParser().isMacroTrusted()) {
         if (!ip.hasGMPermission()
             && (list.getCurrent() <= 0
@@ -90,7 +90,7 @@ public class MiscInitiativeFunction extends AbstractFunction {
       }
       list.prevInitiative();
       return new BigDecimal(list.getCurrent());
-    } else if (functionName.equals("getInitiativeList")) {
+    } else if (functionName.equalsIgnoreCase("getInitiativeList")) {
 
       // Save round and zone name
       JsonObject out = new JsonObject();
@@ -118,14 +118,14 @@ public class MiscInitiativeFunction extends AbstractFunction {
     }
     if (!MapTool.getParser().isMacroTrusted() && !ip.hasGMPermission())
       throw new ParserException(I18N.getText("macro.function.general.onlyGM", functionName));
-    if (functionName.equals("sortInitiative")) {
+    if (functionName.equalsIgnoreCase("sortInitiative")) {
       boolean ascendingOrder = false;
       if (args.size() > 0) {
         ascendingOrder = FunctionUtil.paramAsBoolean(functionName, args, 0, false);
       }
       list.sort(ascendingOrder);
       return new BigDecimal(list.getSize());
-    } else if (functionName.equals("initiativeSize")) {
+    } else if (functionName.equalsIgnoreCase("initiativeSize")) {
       return new BigDecimal(list.getSize());
     } // endif
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));

--- a/src/main/java/net/rptools/maptool/client/functions/ParserPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ParserPropertyFunctions.java
@@ -76,13 +76,13 @@ public class ParserPropertyFunctions extends AbstractFunction {
 
     int returnVal = 0;
 
-    if (functionName.equals("getMaxRecursionDepth")) {
+    if (functionName.equalsIgnoreCase("getMaxRecursionDepth")) {
       returnVal = mtlParser.getMaxRecursionDepth();
     } else if (functionName.equalsIgnoreCase("getMaxLoopIterations")) {
       returnVal = mtlParser.getMaxLoopIterations();
-    } else if (functionName.equals("getRecursionDepth")) {
+    } else if (functionName.equalsIgnoreCase("getRecursionDepth")) {
       returnVal = mtlParser.getRecursionDepth();
-    } else if (functionName.equals("getMacroContext")) {
+    } else if (functionName.equalsIgnoreCase("getMacroContext")) {
       JsonObject mco = new JsonObject();
       MapToolMacroContext mc = mtlParser.getContext();
       mco.addProperty("stackSize", mtlParser.getContextStackSize());
@@ -93,10 +93,10 @@ public class ParserPropertyFunctions extends AbstractFunction {
         mco.addProperty("buttonIndex", mc.getMacroButtonIndex());
       }
       return mco;
-    } else if (functionName.equals("setMaxRecursionDepth")) {
+    } else if (functionName.equalsIgnoreCase("setMaxRecursionDepth")) {
       mtlParser.setMaxRecursionDepth(argVal);
       returnVal = mtlParser.getMaxRecursionDepth();
-    } else if (functionName.equals("setMaxLoopIterations")) {
+    } else if (functionName.equalsIgnoreCase("setMaxLoopIterations")) {
       mtlParser.setMaxLoopIterations(argVal);
       returnVal = mtlParser.getMaxLoopIterations();
     } else {

--- a/src/main/java/net/rptools/maptool/client/functions/PlayerNameFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/PlayerNameFunctions.java
@@ -43,7 +43,7 @@ public class PlayerNameFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    if (functionName.equals("getPlayerName")) {
+    if (functionName.equalsIgnoreCase("getPlayerName")) {
       return MapTool.getPlayer().getName();
     } else if ("getAllPlayerNames".equalsIgnoreCase(functionName)) {
       ObservableList<Player> players = MapTool.getPlayerList();

--- a/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
@@ -174,13 +174,13 @@ public class RESTfulFunctions extends AbstractFunction {
 
     if (headerMap.isEmpty()) {
       // Build without any headers...
-      if (functionName.equals("REST.post")) {
+      if (functionName.equalsIgnoreCase("REST.post")) {
         request = new Request.Builder().url(baseURL).post(requestBody).build();
-      } else if (functionName.equals("REST.put")) {
+      } else if (functionName.equalsIgnoreCase("REST.put")) {
         request = new Request.Builder().url(baseURL).put(requestBody).build();
-      } else if (functionName.equals("REST.patch")) {
+      } else if (functionName.equalsIgnoreCase("REST.patch")) {
         request = new Request.Builder().url(baseURL).patch(requestBody).build();
-      } else if (functionName.equals("REST.delete")) {
+      } else if (functionName.equalsIgnoreCase("REST.delete")) {
         request = new Request.Builder().url(baseURL).delete(requestBody).build();
       } else {
         throw new ParserException(
@@ -188,13 +188,13 @@ public class RESTfulFunctions extends AbstractFunction {
       }
     } else {
       // Now build request with headers
-      if (functionName.equals("REST.post")) {
+      if (functionName.equalsIgnoreCase("REST.post")) {
         request = new Request.Builder().url(baseURL).headers(headers).post(requestBody).build();
-      } else if (functionName.equals("REST.put")) {
+      } else if (functionName.equalsIgnoreCase("REST.put")) {
         request = new Request.Builder().url(baseURL).headers(headers).put(requestBody).build();
-      } else if (functionName.equals("REST.patch")) {
+      } else if (functionName.equalsIgnoreCase("REST.patch")) {
         request = new Request.Builder().url(baseURL).headers(headers).patch(requestBody).build();
-      } else if (functionName.equals("REST.delete")) {
+      } else if (functionName.equalsIgnoreCase("REST.delete")) {
         request = new Request.Builder().url(baseURL).headers(headers).delete(requestBody).build();
       } else {
         throw new ParserException(

--- a/src/main/java/net/rptools/maptool/client/functions/RemoveAllFromInitiativeFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RemoveAllFromInitiativeFunction.java
@@ -63,7 +63,7 @@ public class RemoveAllFromInitiativeFunction extends AbstractFunction {
     if (!MapTool.getParser().isMacroTrusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
-    if (functionName.equals("removeAllFromInitiative")) {
+    if (functionName.equalsIgnoreCase("removeAllFromInitiative")) {
       count = list.getSize();
       list.clearModel();
     } else if ("removeAllNPCsFromInitiative".equalsIgnoreCase(functionName)

--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -78,7 +78,7 @@ public class StringFunctions extends AbstractFunction {
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
     try {
-      if (functionName.equals("replace")) {
+      if (functionName.equalsIgnoreCase("replace")) {
         if (parameters.size() < 3) {
           throw new ParserException(
               I18N.getText(
@@ -105,7 +105,7 @@ public class StringFunctions extends AbstractFunction {
               parameters.get(2).toString());
         }
       }
-      if (functionName.equals("stringToList")) {
+      if (functionName.equalsIgnoreCase("stringToList")) {
         if (parameters.size() < 2) {
           throw new ParserException(
               I18N.getText(
@@ -119,7 +119,7 @@ public class StringFunctions extends AbstractFunction {
         }
         return stringToList(parameters.get(0).toString(), parameters.get(1).toString(), delim);
       }
-      if (functionName.equals("substring")) {
+      if (functionName.equalsIgnoreCase("substring")) {
         if (parameters.size() < 2) {
           throw new ParserException(
               I18N.getText(
@@ -152,10 +152,10 @@ public class StringFunctions extends AbstractFunction {
             .toString()
             .substring(((BigDecimal) parameters.get(1)).intValue(), end);
       }
-      if (functionName.equals("length")) {
+      if (functionName.equalsIgnoreCase("length")) {
         return BigDecimal.valueOf(parameters.get(0).toString().length());
       }
-      if (functionName.equals("upper")) {
+      if (functionName.equalsIgnoreCase("upper")) {
         if (parameters.size() > 1) {
           String str = parameters.get(0).toString();
           try {
@@ -174,7 +174,7 @@ public class StringFunctions extends AbstractFunction {
           return parameters.get(0).toString().toUpperCase();
         }
       }
-      if (functionName.equals("lower")) {
+      if (functionName.equalsIgnoreCase("lower")) {
         if (parameters.size() > 1) {
           String str = parameters.get(0).toString();
           try {
@@ -193,7 +193,7 @@ public class StringFunctions extends AbstractFunction {
           return parameters.get(0).toString().toLowerCase();
         }
       }
-      if (functionName.equals("indexOf")) {
+      if (functionName.equalsIgnoreCase("indexOf")) {
         if (parameters.size() < 2) {
           throw new ParserException(
               I18N.getText(
@@ -216,7 +216,7 @@ public class StringFunctions extends AbstractFunction {
         return BigDecimal.valueOf(
             parameters.get(0).toString().indexOf(parameters.get(1).toString(), from));
       }
-      if (functionName.equals("lastIndexOf")) {
+      if (functionName.equalsIgnoreCase("lastIndexOf")) {
         if (parameters.size() < 2) {
           throw new ParserException(
               I18N.getText(
@@ -225,10 +225,10 @@ public class StringFunctions extends AbstractFunction {
         return BigDecimal.valueOf(
             parameters.get(0).toString().lastIndexOf(parameters.get(1).toString()));
       }
-      if (functionName.equals("trim")) {
+      if (functionName.equalsIgnoreCase("trim")) {
         return parameters.get(0).toString().trim();
       }
-      if (functionName.equals("strformat")) {
+      if (functionName.equalsIgnoreCase("strformat")) {
         int size = parameters.size();
         if (size > 1) {
           return format(parameters.get(0).toString(), resolver, parameters.subList(1, size));
@@ -236,7 +236,7 @@ public class StringFunctions extends AbstractFunction {
           return format(parameters.get(0).toString(), resolver, null);
         }
       }
-      if (functionName.equals("matches")) {
+      if (functionName.equalsIgnoreCase("matches")) {
         if (parameters.size() < 2) {
           throw new ParserException(
               I18N.getText(
@@ -251,10 +251,10 @@ public class StringFunctions extends AbstractFunction {
     } catch (PatternSyntaxException e) {
       throw new ParserException(e.getMessage());
     }
-    if (functionName.equals("string")) {
+    if (functionName.equalsIgnoreCase("string")) {
       return parameters.get(0).toString();
     }
-    if (functionName.equals("number")) {
+    if (functionName.equalsIgnoreCase("number")) {
       if (parameters.get(0).toString().trim().isEmpty()) return BigDecimal.ZERO;
       try {
         return BigDecimal.valueOf(Integer.parseInt(parameters.get(0).toString()));
@@ -272,14 +272,14 @@ public class StringFunctions extends AbstractFunction {
                 parameters.get(0).toString()));
       }
     }
-    if (functionName.equals("isNumber")) {
+    if (functionName.equalsIgnoreCase("isNumber")) {
       if (NumberUtils.isParsable(parameters.get(0).toString())) {
         return BigDecimal.ONE;
       } else {
         return BigDecimal.ZERO;
       }
     }
-    if (functionName.equals("strfind")) {
+    if (functionName.equalsIgnoreCase("strfind")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -287,7 +287,7 @@ public class StringFunctions extends AbstractFunction {
       }
       return stringFind(resolver, parameters.get(0).toString(), parameters.get(1).toString());
     }
-    if (functionName.equals("getGroupCount")) {
+    if (functionName.equalsIgnoreCase("getGroupCount")) {
       if (parameters.size() < 1) {
         throw new ParserException(
             I18N.getText(
@@ -307,14 +307,14 @@ public class StringFunctions extends AbstractFunction {
       sb.append("match.").append(parameters.get(0));
       sb.append(".m").append(parameters.get(1));
       sb.append(".group").append(parameters.get(2));
-      if (functionName.equals("getGroupStart")) {
+      if (functionName.equalsIgnoreCase("getGroupStart")) {
         sb.append(".start");
-      } else if (functionName.equals("getGroupEnd")) {
+      } else if (functionName.equalsIgnoreCase("getGroupEnd")) {
         sb.append(".end");
       }
       return resolver.getVariable(sb.toString());
     }
-    if (functionName.equals("getFindCount")) {
+    if (functionName.equalsIgnoreCase("getFindCount")) {
       if (parameters.size() < 1) {
         throw new ParserException(
             I18N.getText(
@@ -324,7 +324,7 @@ public class StringFunctions extends AbstractFunction {
       sb.append("match.").append(parameters.get(0)).append(".matchCount");
       return resolver.getVariable(sb.toString());
     }
-    if (functionName.equals("encode")) {
+    if (functionName.equalsIgnoreCase("encode")) {
       if (parameters.size() < 1) {
         throw new ParserException(
             I18N.getText(
@@ -337,7 +337,7 @@ public class StringFunctions extends AbstractFunction {
       encoded = URLEncoder.encode(encoded, StandardCharsets.UTF_8);
       return encoded;
     }
-    if (functionName.equals("decode")) {
+    if (functionName.equalsIgnoreCase("decode")) {
       if (parameters.size() < 1) {
         throw new ParserException(
             I18N.getText(
@@ -350,7 +350,7 @@ public class StringFunctions extends AbstractFunction {
       decoded = decoded.replaceAll("&semi;", ";");
       return decoded;
     }
-    if (functionName.equals("startsWith")) {
+    if (functionName.equalsIgnoreCase("startsWith")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -360,7 +360,7 @@ public class StringFunctions extends AbstractFunction {
           ? BigDecimal.ONE
           : BigDecimal.ZERO;
     }
-    if (functionName.equals("endsWith")) {
+    if (functionName.equalsIgnoreCase("endsWith")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -370,7 +370,7 @@ public class StringFunctions extends AbstractFunction {
           ? BigDecimal.ONE
           : BigDecimal.ZERO;
     }
-    if (functionName.equals("capitalize")) {
+    if (functionName.equalsIgnoreCase("capitalize")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       boolean treatNumbersSymbolsAsBoundaries = true;
       if (parameters.size() == 2) {

--- a/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java
@@ -49,15 +49,15 @@ public class TokenBarFunction extends AbstractFunction {
     String bar = (String) parameters.get(0);
     verifyBar(functionName, bar);
 
-    if (functionName.equals("getBar")) {
+    if (functionName.equalsIgnoreCase("getBar")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return getValue(token, bar);
-    } else if (functionName.equals("setBar")) {
+    } else if (functionName.equalsIgnoreCase("setBar")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 4);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
       return setValue(token, bar, parameters.get(1));
-    } else if (functionName.equals("isBarVisible")) {
+    } else if (functionName.equalsIgnoreCase("isBarVisible")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return isVisible(token, bar);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
@@ -61,7 +61,7 @@ public class TokenCopyDeleteFunctions extends AbstractFunction {
     FunctionUtil.blockUntrustedMacro(functionName);
     int psize = parameters.size();
 
-    if (functionName.equals(COPY_FUNC)) {
+    if (functionName.equalsIgnoreCase(COPY_FUNC)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 4);
 
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 2);
@@ -73,7 +73,7 @@ public class TokenCopyDeleteFunctions extends AbstractFunction {
       return copyTokens((MapToolVariableResolver) resolver, token, nCopies, newVals);
     }
 
-    if (functionName.equals(REMOVE_FUNC)) {
+    if (functionName.equalsIgnoreCase(REMOVE_FUNC)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
 

--- a/src/main/java/net/rptools/maptool/client/functions/TokenGMNameFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenGMNameFunction.java
@@ -47,7 +47,7 @@ public class TokenGMNameFunction extends AbstractFunction {
       Parser parser, VariableResolver resolver, String functionName, List<Object> args)
       throws ParserException {
 
-    if (functionName.equals("getGMName")) {
+    if (functionName.equalsIgnoreCase("getGMName")) {
       FunctionUtil.checkNumberParam("getGMName", args, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, args, 0, 1);
       return getGMName(token);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenHaloFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenHaloFunction.java
@@ -50,7 +50,7 @@ public class TokenHaloFunction extends AbstractFunction {
       Parser parser, VariableResolver resolver, String functionName, List<Object> args)
       throws ParserException {
 
-    if (functionName.equals("getHalo")) {
+    if (functionName.equalsIgnoreCase("getHalo")) {
       return getHalo((MapToolVariableResolver) resolver, args);
     } else if ("setHalo".equalsIgnoreCase(functionName)) {
       return setHalo((MapToolVariableResolver) resolver, args);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -89,7 +89,7 @@ public class TokenImage extends AbstractFunction {
       throws ParserException {
     Token token;
 
-    if (functionName.equals("setTokenOpacity")) {
+    if (functionName.equalsIgnoreCase("setTokenOpacity")) {
       if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
@@ -102,7 +102,7 @@ public class TokenImage extends AbstractFunction {
       return token.getTokenOpacity();
     }
 
-    if (functionName.equals("getTokenOpacity")) {
+    if (functionName.equalsIgnoreCase("getTokenOpacity")) {
       if (!MapTool.getParser().isMacroTrusted())
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
@@ -112,7 +112,7 @@ public class TokenImage extends AbstractFunction {
       return token.getTokenOpacity();
     }
 
-    if (functionName.equals("setTokenImage")) {
+    if (functionName.equalsIgnoreCase("setTokenImage")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
 
       String assetName = args.get(0).toString();
@@ -122,7 +122,7 @@ public class TokenImage extends AbstractFunction {
       return "";
     }
 
-    if (functionName.equals("setTokenPortrait")) {
+    if (functionName.equalsIgnoreCase("setTokenPortrait")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
 
       String assetName = args.get(0).toString();
@@ -132,7 +132,7 @@ public class TokenImage extends AbstractFunction {
       return "";
     }
 
-    if (functionName.equals("setTokenHandout")) {
+    if (functionName.equalsIgnoreCase("setTokenHandout")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
 
       String assetName = args.get(0).toString();
@@ -155,7 +155,7 @@ public class TokenImage extends AbstractFunction {
 
     /* getImage, getTokenImage, getTokenPortrait, or getTokenHandout */
     int indexSize = -1; // by default, no size added to asset id
-    if (functionName.equals("getImage")) {
+    if (functionName.equalsIgnoreCase("getImage")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 2);
 
       token = findImageToken(args.get(0).toString(), "getImage");
@@ -178,17 +178,17 @@ public class TokenImage extends AbstractFunction {
     }
 
     StringBuilder assetId = new StringBuilder("asset://");
-    if (functionName.equals("getTokenImage")) {
+    if (functionName.equalsIgnoreCase("getTokenImage")) {
       if (token.getImageAssetId() == null) {
         return "";
       }
       assetId.append(token.getImageAssetId().toString());
-    } else if (functionName.equals("getTokenPortrait")) {
+    } else if (functionName.equalsIgnoreCase("getTokenPortrait")) {
       if (token.getPortraitImage() == null) {
         return "";
       }
       assetId.append(token.getPortraitImage().toString());
-    } else if (functionName.equals("getImage")) {
+    } else if (functionName.equalsIgnoreCase("getImage")) {
       if (token.getImageAssetId() == null) {
         return "";
       }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLabelFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLabelFunction.java
@@ -61,7 +61,7 @@ public class TokenLabelFunction extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> args)
       throws ParserException {
-    if (functionName.equals("getLabel")) {
+    if (functionName.equalsIgnoreCase("getLabel")) {
       return getLabel((MapToolVariableResolver) resolver, args);
     } else if ("setLabel".equalsIgnoreCase(functionName)) {
       return setLabel((MapToolVariableResolver) resolver, args);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -85,7 +85,7 @@ public class TokenLocationFunctions extends AbstractFunction {
       throws ParserException {
     FunctionUtil.blockUntrustedMacro(functionName);
 
-    if (functionName.equals("getTokenX") || functionName.equals("getTokenY")) {
+    if (functionName.equalsIgnoreCase("getTokenX") || functionName.equalsIgnoreCase("getTokenY")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
       boolean useDistancePerCell =
           parameters.size() > 0
@@ -93,14 +93,14 @@ public class TokenLocationFunctions extends AbstractFunction {
               : true;
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       TokenLocation location = getTokenLocation(useDistancePerCell, token);
-      return BigDecimal.valueOf(functionName.equals("getTokenX") ? location.x : location.y);
+      return BigDecimal.valueOf(functionName.equalsIgnoreCase("getTokenX") ? location.x : location.y);
     }
-    if (functionName.equals("getTokenDrawOrder")) {
+    if (functionName.equalsIgnoreCase("getTokenDrawOrder")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return BigDecimal.valueOf(token.getZOrder());
     }
-    if (functionName.equals("setTokenDrawOrder")) {
+    if (functionName.equalsIgnoreCase("setTokenDrawOrder")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       int newZOrder = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
@@ -113,27 +113,27 @@ public class TokenLocationFunctions extends AbstractFunction {
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
       return getTokenMap(identifier, delim);
     }
-    if (functionName.equals("getDistance")) {
+    if (functionName.equalsIgnoreCase("getDistance")) {
       FunctionUtil.checkNumberParam("getDistance", parameters, 1, 4);
       return getDistance(resolver, parameters);
     }
-    if (functionName.equals("getDistanceToXY")) {
+    if (functionName.equalsIgnoreCase("getDistanceToXY")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 6);
       return getDistanceToXY(resolver, parameters);
     }
-    if (functionName.equals("goto")) {
+    if (functionName.equalsIgnoreCase("goto")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       return gotoLoc(resolver, parameters);
     }
-    if (functionName.equals("moveToken")) {
+    if (functionName.equalsIgnoreCase("moveToken")) {
       FunctionUtil.checkNumberParam("moveToken", parameters, 2, 4);
       return moveToken(resolver, parameters);
     }
-    if (functionName.equals("moveTokenToMap")) {
+    if (functionName.equalsIgnoreCase("moveTokenToMap")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 5);
       return tokenMoveMap(true, parameters);
     }
-    if (functionName.equals("moveTokenFromMap")) {
+    if (functionName.equalsIgnoreCase("moveTokenFromMap")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 5);
       return tokenMoveMap(false, parameters);
     }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -90,7 +90,7 @@ public class TokenMoveFunctions extends AbstractFunction {
     boolean useDistancePerCell = true;
     Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
 
-    if (functionName.equals("getLastPath")) {
+    if (functionName.equalsIgnoreCase("getLastPath")) {
       BigDecimal val = null;
       if (parameters.size() == 1) {
         if (!(parameters.get(0) instanceof BigDecimal)) {
@@ -105,7 +105,7 @@ public class TokenMoveFunctions extends AbstractFunction {
       List<Map<String, Integer>> pathPoints = getLastPathList(path, useDistancePerCell);
       return pathPointsToJSONArray(pathPoints);
     }
-    if (functionName.equals("movedOverPoints")) {
+    if (functionName.equalsIgnoreCase("movedOverPoints")) {
       // macro.function.general.noPerm
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
@@ -134,7 +134,7 @@ public class TokenMoveFunctions extends AbstractFunction {
                 "macro.function.general.wrongNumParam", functionName, 2, parameters.size()));
       }
     }
-    if (functionName.equals("getMoveCount")) {
+    if (functionName.equalsIgnoreCase("getMoveCount")) {
       boolean useFractionOnly = false;
       boolean useTerrainModifiers = false;
 
@@ -159,7 +159,7 @@ public class TokenMoveFunctions extends AbstractFunction {
         return getMovement(tokenInContext, useFractionOnly, useTerrainModifiers);
       }
     }
-    if (functionName.equals("movedOverToken")) {
+    if (functionName.equalsIgnoreCase("movedOverToken")) {
       // macro.function.general.noPerm
       if (!MapTool.getParser().isMacroTrusted()) {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -128,7 +128,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String type = getPropertyType(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getPropertyType")) {
+    if (functionName.equalsIgnoreCase("getPropertyType")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getPropertyType();
@@ -137,7 +137,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setPropertyType(String propTypeName, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setPropertyType")) {
+    if (functionName.equalsIgnoreCase("setPropertyType")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       MapTool.serverCommand()
@@ -148,18 +148,18 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String names = getPropertyNames(String delim: ",", String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getPropertyNames") || functionName.equals("getPropertyNamesRaw")) {
+    if (functionName.equalsIgnoreCase("getPropertyNames") || functionName.equalsIgnoreCase("getPropertyNamesRaw")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : ",";
       String pattern = ".*";
-      return getPropertyNames(token, delim, pattern, functionName.equals("getPropertyNamesRaw"));
+      return getPropertyNames(token, delim, pattern, functionName.equalsIgnoreCase("getPropertyNamesRaw"));
     }
 
     /*
      * String names = getMatchingProperties(String pattern, String delim: ",", String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getMatchingProperties")) {
+    if (functionName.equalsIgnoreCase("getMatchingProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 4);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
       String pattern = parameters.get(0).toString();
@@ -170,7 +170,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String names = getAllPropertyNames(String propType: "", String delim: ",")
      */
-    if (functionName.equals("getAllPropertyNames")) {
+    if (functionName.equalsIgnoreCase("getAllPropertyNames")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       if (parameters.size() < 1) {
         return getAllPropertyNames(null, ",");
@@ -184,7 +184,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = hasProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("hasProperty")) {
+    if (functionName.equalsIgnoreCase("hasProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return hasProperty(token, parameters.get(0).toString()) ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -193,7 +193,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isNPC(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isNPC")) {
+    if (functionName.equalsIgnoreCase("isNPC")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getType() == Token.Type.NPC ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -202,7 +202,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isPC(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isPC")) {
+    if (functionName.equalsIgnoreCase("isPC")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getType() == Token.Type.PC ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -211,7 +211,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setPC(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setPC")) {
+    if (functionName.equalsIgnoreCase("setPC")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setPC);
@@ -221,7 +221,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setNPC(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setNPC")) {
+    if (functionName.equalsIgnoreCase("setNPC")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setNPC);
@@ -231,7 +231,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String layer = getLayer(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getLayer")) {
+    if (functionName.equalsIgnoreCase("getLayer")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getLayer().name();
@@ -240,7 +240,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String layer = setLayer(String layer, String tokenId: currentToken(), boolean forceShape: true, string mapName: current map)
      */
-    if (functionName.equals("setLayer")) {
+    if (functionName.equalsIgnoreCase("setLayer")) {
       boolean forceShape = true;
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 4);
       if (parameters.size() > 2) {
@@ -254,7 +254,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String size = getSize(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getSize")) {
+    if (functionName.equalsIgnoreCase("getSize")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return getSize(token);
@@ -263,14 +263,14 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String size = setSize(String size, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setSize")) {
+    if (functionName.equalsIgnoreCase("setSize")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
 
       return setSize(token, parameters.get(0).toString());
     }
 
-    if (functionName.equals("resetSize")) {
+    if (functionName.equalsIgnoreCase("resetSize")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       resetSize(token);
@@ -281,7 +281,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String owners = getOwners(String delim: ",", String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getOwners")) {
+    if (functionName.equalsIgnoreCase("getOwners")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return getOwners(token, parameters.size() > 0 ? parameters.get(0).toString() : ",");
@@ -290,7 +290,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isOwnedByAll(String tokenId: currentToken())
      */
-    if (functionName.equals("isOwnedByAll")) {
+    if (functionName.equalsIgnoreCase("isOwnedByAll")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isOwnedByAll() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -299,7 +299,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isOwner(String player: self, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isOwner")) {
+    if (functionName.equalsIgnoreCase("isOwner")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       if (parameters.size() > 0) {
@@ -323,7 +323,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setProperty(String propName, String value, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setProperty")) {
+    if (functionName.equalsIgnoreCase("setProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 4);
       String property = parameters.get(0).toString();
       String value = parameters.get(1).toString();
@@ -336,7 +336,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * {String|Number} value = getRawProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getRawProperty")) {
+    if (functionName.equalsIgnoreCase("getRawProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Object val = token.getProperty(parameters.get(0).toString());
@@ -359,7 +359,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * {String|Number} value = getProperty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getProperty")) {
+    if (functionName.equalsIgnoreCase("getProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Object val = token.getEvaluatedProperty(parameters.get(0).toString());
@@ -379,7 +379,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isPropertyEmpty(String propName, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isPropertyEmpty")) {
+    if (functionName.equalsIgnoreCase("isPropertyEmpty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       return token.getProperty(parameters.get(0).toString()) == null
@@ -392,7 +392,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Number zeroOne = getPropertyDefault(String propName, String propType: currentToken().getPropertyType())
      */
-    if (functionName.equals("getPropertyDefault")) {
+    if (functionName.equalsIgnoreCase("getPropertyDefault")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       String name = parameters.get(0).toString();
 
@@ -433,7 +433,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String notes = getGMNotes(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getGMNotes")) {
+    if (functionName.equalsIgnoreCase("getGMNotes")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       String notes = token.getGMNotes();
@@ -443,7 +443,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String notes = setGMNotes(String notes, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setGMNotes")) {
+    if (functionName.equalsIgnoreCase("setGMNotes")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       String gmNotes = parameters.get(0).toString();
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
@@ -454,7 +454,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String notes = getNotes(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getNotes")) {
+    if (functionName.equalsIgnoreCase("getNotes")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       String notes = token.getNotes();
@@ -464,7 +464,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String notes = setNotes(String notes, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setNotes")) {
+    if (functionName.equalsIgnoreCase("setNotes")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       String notes = parameters.get(0).toString();
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
@@ -475,7 +475,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = bringToFront(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("bringToFront")) {
+    if (functionName.equalsIgnoreCase("bringToFront")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       Zone zone = token.getZoneRenderer().getZone();
@@ -487,7 +487,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = sendToBack(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("sendToBack")) {
+    if (functionName.equalsIgnoreCase("sendToBack")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       Zone zone = token.getZoneRenderer().getZone();
@@ -499,7 +499,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String value = getLibProperty(String propName, String tokenId: macroSource)
      */
-    if (functionName.equals("getLibProperty")) {
+    if (functionName.equalsIgnoreCase("getLibProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       String location;
       if (parameters.size() > 1) {
@@ -522,7 +522,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setLibProperty(String propName, String value, String tokenId: macroSource)
      */
-    if (functionName.equals("setLibProperty")) {
+    if (functionName.equalsIgnoreCase("setLibProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 3);
       String property = parameters.get(0).toString();
       String value = parameters.get(1).toString();
@@ -541,7 +541,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String names = getLibPropertyNames(String tokenId: {macroSource | "*" | "this"}, String delim: ",")
      */
-    if (functionName.equals("getLibPropertyNames")) {
+    if (functionName.equalsIgnoreCase("getLibPropertyNames")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       String location;
       if (parameters.size() > 0) {
@@ -564,7 +564,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String names = getMatchingLibProperties(String pattern, String tokenId: {macroSource | "*" | "this"}, String delim: ",")
      */
-    if (functionName.equals("getMatchingLibProperties")) {
+    if (functionName.equalsIgnoreCase("getMatchingLibProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       String location;
       String pattern = parameters.get(0).toString();
@@ -588,7 +588,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number facing = getTokenFacing(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getTokenFacing")) {
+    if (functionName.equalsIgnoreCase("getTokenFacing")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       if (token.getFacing() == null) {
@@ -600,7 +600,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number degrees = getTokenRotation(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("getTokenRotation")) {
+    if (functionName.equalsIgnoreCase("getTokenRotation")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
 
@@ -610,7 +610,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setTokenFacing(Number facing, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setTokenFacing")) {
+    if (functionName.equalsIgnoreCase("setTokenFacing")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       BigDecimal facing = getBigDecimalFromParam(functionName, parameters, 0);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
@@ -621,7 +621,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = removeTokenFacing(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("removeTokenFacing")) {
+    if (functionName.equalsIgnoreCase("removeTokenFacing")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setFacing, (Integer) null);
@@ -631,7 +631,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isSnapToGrid(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isSnapToGrid")) {
+    if (functionName.equalsIgnoreCase("isSnapToGrid")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isSnapToGrid() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -640,7 +640,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isFlippedX(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isFlippedX")) {
+    if (functionName.equalsIgnoreCase("isFlippedX")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isFlippedX() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -649,7 +649,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isFlippedY(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isFlippedY")) {
+    if (functionName.equalsIgnoreCase("isFlippedY")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isFlippedY() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -658,7 +658,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * Number zeroOne = isFlippedIso(String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("isFlippedIso")) {
+    if (functionName.equalsIgnoreCase("isFlippedIso")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.isFlippedIso() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -667,7 +667,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setOwner(String playerName | JSONArray playerNames, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setOwner")) {
+    if (functionName.equalsIgnoreCase("setOwner")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
       boolean trusted = MapTool.getParser().isMacroTrusted();
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
@@ -703,7 +703,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     /*
      * String empty = setOwnedByAll(0|1, String tokenId: currentToken(), string mapName: current map)
      */
-    if (functionName.equals("setOwnedByAll")) {
+    if (functionName.equalsIgnoreCase("setOwnedByAll")) {
       // If not trusted, do nothing and return -1 result
       if (!MapTool.getParser().isMacroTrusted()) return -1;
 
@@ -724,7 +724,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * See Token.TokenShape for return values. Currently "TOP_DOWN", "CIRCLE", "SQUARE", and "FIGURE".
      */
-    if (functionName.equals("getTokenShape")) {
+    if (functionName.equalsIgnoreCase("getTokenShape")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       return token.getShape().name();
@@ -735,7 +735,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * See Token.TokenShape for shape values. Currently "top down", "top_down", "circle", "square", and "figure".
      */
-    if (functionName.equals("setTokenShape")) {
+    if (functionName.equalsIgnoreCase("setTokenShape")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
 
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
@@ -753,12 +753,12 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Returns pixel width/height for a given token. Useful for free size tokens.
      */
-    if (functionName.equals("getTokenNativeWidth") || functionName.equals("getTokenNativeHeight")) {
+    if (functionName.equalsIgnoreCase("getTokenNativeWidth") || functionName.equalsIgnoreCase("getTokenNativeHeight")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
 
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
 
-      if (functionName.equals("getTokenNativeWidth")) {
+      if (functionName.equalsIgnoreCase("getTokenNativeWidth")) {
         return BigDecimal.valueOf(token.getWidth());
       } else { // it wasn't 'getTokenWidth' which means functionName equals 'getTokenHeight'
         return BigDecimal.valueOf(token.getHeight());
@@ -772,7 +772,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Returns pixel width/height for a given token. Useful for free size tokens.
      */
-    if (functionName.equals("getTokenWidth") || functionName.equals("getTokenHeight")) {
+    if (functionName.equalsIgnoreCase("getTokenWidth") || functionName.equalsIgnoreCase("getTokenHeight")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
 
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
@@ -782,7 +782,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       // Get the pixel width or height of a given token
       Rectangle tokenBounds = token.getBounds(zone);
 
-      if (functionName.equals("getTokenWidth")) {
+      if (functionName.equalsIgnoreCase("getTokenWidth")) {
         return BigDecimal.valueOf(tokenBounds.width);
       } else { // it wasn't 'getTokenWidth' which means functionName equals 'getTokenHeight'
         return BigDecimal.valueOf(tokenBounds.height);
@@ -796,7 +796,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Sets the width/height for a given token. Useful for free size tokens.
      */
-    if (functionName.equals("setTokenWidth") || functionName.equals("setTokenHeight")) {
+    if (functionName.equalsIgnoreCase("setTokenWidth") || functionName.equalsIgnoreCase("setTokenHeight")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       ZoneRenderer zoneR = token.getZoneRenderer();
@@ -809,7 +809,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       double oldHeight = tokenBounds.height;
       double newScaleX;
       double newScaleY;
-      if (functionName.equals("setTokenWidth")) {
+      if (functionName.equalsIgnoreCase("setTokenWidth")) {
         newScaleX = magnitude / token.getWidth();
         newScaleY = oldHeight / token.getHeight();
       } else { // it wasn't 'setTokenWidth' which means functionName equals 'setTokenHeight'
@@ -826,7 +826,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Sets whether the token should snap to the grid or not
      */
-    if (functionName.equals("setTokenSnapToGrid")) {
+    if (functionName.equalsIgnoreCase("setTokenSnapToGrid")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
       Boolean toGrid = FunctionUtil.getBooleanValue(parameters.get(0));
@@ -839,7 +839,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Toggles Flipped X setting
      */
-    if (functionName.equals("flipTokenX")) {
+    if (functionName.equalsIgnoreCase("flipTokenX")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.flipX);
@@ -851,7 +851,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Toggles Flipped Y setting
      */
-    if (functionName.equals("flipTokenY")) {
+    if (functionName.equalsIgnoreCase("flipTokenY")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.flipY);
@@ -863,7 +863,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      *
      * Toggles Flipped Iso setting
      */
-    if (functionName.equals("flipTokenIso")) {
+    if (functionName.equalsIgnoreCase("flipTokenIso")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.flipIso);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSelectionFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSelectionFunctions.java
@@ -52,9 +52,9 @@ public class TokenSelectionFunctions extends AbstractFunction {
     if (!MapTool.getParser().isMacroTrusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
-    if (functionName.equals("selectTokens")) {
+    if (functionName.equalsIgnoreCase("selectTokens")) {
       selectTokens(parameters);
-    } else if (functionName.equals("deselectTokens")) {
+    } else if (functionName.equalsIgnoreCase("deselectTokens")) {
       deselectTokens(parameters);
     } else {
       throw new ParserException(

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
@@ -66,7 +66,7 @@ public class TokenSightFunctions extends AbstractFunction {
       if (functionName.equalsIgnoreCase("hasSight"))
         return token.getHasSight() ? BigDecimal.ONE : BigDecimal.ZERO;
 
-      // if (functionName.equals("getSightType"))
+      // if (functionName.equalsIgnoreCase("getSightType"))
       // Don't test to remove code warning for always true if statement
       String sightType = token.getSightType();
       if (sightType == null) sightType = "";
@@ -77,19 +77,19 @@ public class TokenSightFunctions extends AbstractFunction {
     FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
     token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
 
-    if (functionName.equals("setHasSight")) {
+    if (functionName.equalsIgnoreCase("setHasSight")) {
       boolean hasSight = !parameters.get(0).equals(BigDecimal.ZERO);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setHasSight, hasSight);
       return token.getHasSight() ? BigDecimal.ONE : BigDecimal.ZERO;
     }
 
-    if (functionName.equals("setSightType")) {
+    if (functionName.equalsIgnoreCase("setSightType")) {
       String sightType = parameters.get(0).toString();
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setSightType, sightType);
       return token.getSightType();
     }
 
-    if (functionName.equals("canSeeToken")) {
+    if (functionName.equalsIgnoreCase("canSeeToken")) {
       if (!token.getHasSight()) {
         return "[]";
       }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSpeechFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSpeechFunctions.java
@@ -47,7 +47,7 @@ public class TokenSpeechFunctions extends AbstractFunction {
           I18N.getText("macro.function.general.noImpersonated", functionName));
     }
 
-    if (functionName.equals("getSpeech")) {
+    if (functionName.equalsIgnoreCase("getSpeech")) {
       if (parameters.size() < 1) {
         throw new ParserException(
             I18N.getText(
@@ -57,7 +57,7 @@ public class TokenSpeechFunctions extends AbstractFunction {
       return speech == null ? "" : speech;
     }
 
-    if (functionName.equals("setSpeech")) {
+    if (functionName.equalsIgnoreCase("setSpeech")) {
       if (parameters.size() < 2) {
         throw new ParserException(
             I18N.getText(
@@ -67,7 +67,7 @@ public class TokenSpeechFunctions extends AbstractFunction {
       return "";
     }
 
-    if (functionName.equals("getSpeechNames")) {
+    if (functionName.equalsIgnoreCase("getSpeechNames")) {
       String[] speech = new String[token.getSpeechNames().size()];
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : ",";
       if ("json".equals(delim)) {

--- a/src/main/java/net/rptools/maptool/client/functions/TokenStateFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenStateFunction.java
@@ -56,24 +56,24 @@ public class TokenStateFunction extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> args)
       throws ParserException {
-    if (functionName.equals("setAllStates")) {
+    if (functionName.equalsIgnoreCase("setAllStates")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
       Boolean val = getBooleanFromValue(args.get(0));
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, args, 1, 2);
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setAllStates, val);
       return val ? BigDecimal.valueOf(1) : BigDecimal.valueOf(0);
-    } else if (functionName.equals("getState")) {
+    } else if (functionName.equalsIgnoreCase("getState")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
       String stateName = args.get(0).toString();
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, args, 1, 2);
       return getState(token, stateName);
-    } else if (functionName.equals("setState")) {
+    } else if (functionName.equalsIgnoreCase("setState")) {
       FunctionUtil.checkNumberParam(functionName, args, 2, 4);
       String stateName = args.get(0).toString();
       Object value = args.get(1);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, args, 2, 3);
       return setState(token, stateName, value);
-    } else if (functionName.equals("getTokenStates")) {
+    } else if (functionName.equalsIgnoreCase("getTokenStates")) {
       FunctionUtil.checkNumberParam(functionName, args, 0, 4);
       String delim = args.size() > 0 ? args.get(0).toString() : ",";
       String group = args.size() > 1 ? args.get(1).toString() : "*";

--- a/src/main/java/net/rptools/maptool/client/functions/TokenTerrainModifierFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenTerrainModifierFunctions.java
@@ -69,9 +69,9 @@ public class TokenTerrainModifierFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> param)
       throws ParserException {
-    if (functionName.equals("getTerrainModifier")) {
+    if (functionName.equalsIgnoreCase("getTerrainModifier")) {
       return getTerrainModifierInfo(resolver, param);
-    } else if (functionName.equals("setTerrainModifier")) {
+    } else if (functionName.equalsIgnoreCase("setTerrainModifier")) {
       return setTerrainModifier(resolver, param);
     } else {
       throw new ParserException(I18N.getText("macro.function.general.unknownFunction"));

--- a/src/main/java/net/rptools/maptool/client/functions/TokenVisibleFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenVisibleFunction.java
@@ -125,17 +125,17 @@ public class TokenVisibleFunction extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> param)
       throws ParserException {
-    if (functionName.equals("getVisible")) {
+    if (functionName.equalsIgnoreCase("getVisible")) {
       return getVisible(resolver, param);
-    } else if (functionName.equals("setOwnerOnlyVisible")) {
+    } else if (functionName.equalsIgnoreCase("setOwnerOnlyVisible")) {
       return setOwnerOnlyVisible(resolver, param);
-    } else if (functionName.equals("getOwnerOnlyVisible")) {
+    } else if (functionName.equalsIgnoreCase("getOwnerOnlyVisible")) {
       return getOwnerOnlyVisible(resolver, param);
-    } else if (functionName.equals("setVisible")) {
+    } else if (functionName.equalsIgnoreCase("setVisible")) {
       return setVisible(resolver, param);
-    } else if (functionName.equals("setAlwaysVisible")) {
+    } else if (functionName.equalsIgnoreCase("setAlwaysVisible")) {
       return setAlwaysVisible(resolver, param);
-    } else if (functionName.equals("getAlwaysVisible")) {
+    } else if (functionName.equalsIgnoreCase("getAlwaysVisible")) {
       return getAlwaysVisible(resolver, param);
     } else {
       throw new ParserException(I18N.getText("macro.function.general.unknownFunction"));

--- a/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
@@ -94,13 +94,13 @@ public class Topology_Functions extends AbstractFunction {
     ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
     int results = -1;
 
-    if (functionName.equals("drawVBL")
-        || functionName.equals("eraseVBL")
-        || functionName.equals("drawMBL")
-        || functionName.equals("eraseMBL")) {
+    if (functionName.equalsIgnoreCase("drawVBL")
+        || functionName.equalsIgnoreCase("eraseVBL")
+        || functionName.equalsIgnoreCase("drawMBL")
+        || functionName.equalsIgnoreCase("eraseMBL")) {
       boolean erase = false;
       Zone.TopologyMode mode =
-          (functionName.equals("drawVBL") || functionName.equals("eraseVBL"))
+          (functionName.equalsIgnoreCase("drawVBL") || functionName.equalsIgnoreCase("eraseVBL"))
               ? Zone.TopologyMode.VBL
               : Zone.TopologyMode.MBL;
 
@@ -114,7 +114,7 @@ public class Topology_Functions extends AbstractFunction {
         throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
       }
 
-      if (functionName.equals("eraseVBL") || functionName.equals("eraseMBL")) {
+      if (functionName.equalsIgnoreCase("eraseVBL") || functionName.equalsIgnoreCase("eraseMBL")) {
         erase = true;
       }
 
@@ -159,9 +159,9 @@ public class Topology_Functions extends AbstractFunction {
             break;
         }
       }
-    } else if (functionName.equals("getVBL") || functionName.equals("getMBL")) {
+    } else if (functionName.equalsIgnoreCase("getVBL") || functionName.equalsIgnoreCase("getMBL")) {
       Zone.TopologyMode mode =
-          functionName.equals("getVBL") ? Zone.TopologyMode.VBL : Zone.TopologyMode.MBL;
+          functionName.equalsIgnoreCase("getVBL") ? Zone.TopologyMode.VBL : Zone.TopologyMode.MBL;
       boolean simpleJSON = false; // If true, send only array of x,y
 
       if (parameters.size() > 2) {
@@ -211,7 +211,7 @@ public class Topology_Functions extends AbstractFunction {
         }
       }
       return getAreaPoints(topologyArea, simpleJSON);
-    } else if (functionName.equals("getTokenVBL")) {
+    } else if (functionName.equalsIgnoreCase("getTokenVBL")) {
       Token token;
 
       if (parameters.size() == 1) {
@@ -242,7 +242,7 @@ public class Topology_Functions extends AbstractFunction {
       } else {
         return "";
       }
-    } else if (functionName.equals("setTokenVBL")) {
+    } else if (functionName.equalsIgnoreCase("setTokenVBL")) {
       Token token = null;
 
       if (parameters.size() > 2) {
@@ -332,7 +332,7 @@ public class Topology_Functions extends AbstractFunction {
       }
       // Replace with new VBL
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setVBL, tokenVBL);
-    } else if (functionName.equals("transferVBL")) {
+    } else if (functionName.equalsIgnoreCase("transferVBL")) {
       Token token = null;
 
       if (parameters.size() > 3) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Use case insensitive compare of function names listed in #3013

Closes #3013

### Description of the Change

Replaces all occurencies of `functionName.equals` to `functionName.equalsIgnoreCase`. All tests are passing.