### PR TITLE
Properly return numeric values from jsUDFs.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -155,7 +155,7 @@ public class MacroJavaScriptBridge extends AbstractFunction implements DefinesSp
     if (obj instanceof Double d) {
       return BigDecimal.valueOf(d);
     }
-    
+
     if (obj instanceof MapToolJSAPIInterface maptoolWrapper) {
       return maptoolWrapper.serializeToString();
     }

--- a/src/main/java/net/rptools/maptool/client/script/javascript/JSMacro.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/JSMacro.java
@@ -13,7 +13,7 @@
  * text at <http://www.gnu.org/licenses/agpl.html>.
  */
 package net.rptools.maptool.client.script.javascript;
-import org.graalvm.polyglot.*;
+
 import java.util.*;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.*;
@@ -22,6 +22,7 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
+import org.graalvm.polyglot.*;
 
 public class JSMacro extends AbstractFunction {
   private static JSMacro instance = new JSMacro();
@@ -57,7 +58,7 @@ public class JSMacro extends AbstractFunction {
     Object ret = JSScriptEngine.getJSScriptEngine().applyFunction(macro, aargs);
     if (ret != null) {
       if (ret instanceof Value val) {
-	return MacroJavaScriptBridge.getInstance().ValueToMTScriptType(val, new ArrayList());
+        return MacroJavaScriptBridge.getInstance().ValueToMTScriptType(val, new ArrayList());
       }
       return MacroJavaScriptBridge.getInstance().HostObjectToMTScriptType(ret, new ArrayList());
     }


### PR DESCRIPTION


### Identify the Bug or Feature request

#3035


### Description of the Change

Detects `Integer` and `Double` returns from javascript UDFs and converts them to `BigDecimal`

### Possible Drawbacks

None.

### Release Notes

jsUDFs now properly return numeric types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3036)
<!-- Reviewable:end -->
