### PR TITLE
Fix for size modifier  in getTokenImage()  (caused by asset string url -size modifier no longer working)

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AssetURLStreamHandler.java
+++ b/src/main/java/net/rptools/maptool/client/AssetURLStreamHandler.java
@@ -51,11 +51,11 @@ public class AssetURLStreamHandler extends URLStreamHandler {
 
     @Override
     public InputStream getInputStream() throws IOException {
+
       String id = url.getHost();
-      if (url.getQuery() == null) {
+      if (url.getQuery() == null && id.indexOf('-') == -1) {
         var asset = AssetManager.getAssetAndWait(new MD5Key(id));
-        var stream = new ByteArrayInputStream(asset.getImage());
-        return stream;
+        return new ByteArrayInputStream(asset.getImage());
       }
 
       BufferedImage img = ImageManager.getImageFromUrl(url);


### PR DESCRIPTION

### Identify the Bug or Feature request
Addresses #3037


### Description of the Change
Fixes the problem described in #3037 where using an asset:// URL with the -size modifier was causing it to not be able to render.


### Possible Drawbacks
Raw asset fetching for asset:// will only work where the -size modifier is not used, if it is it will be resized as a static png... This is not going to cause compatibility issues as it wouldn't have been rendering at all so no one could be using it. But it does fix the compatibility issue for static images.


### Release Notes
Fixes Issue where `getTokenImage()` function with a size parameter was not usable in html/html5 dialogs and frames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3042)
<!-- Reviewable:end -->
