### PR TITLE
The raw asset change breaks several existing functions for webp

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AssetURLStreamHandler.java
+++ b/src/main/java/net/rptools/maptool/client/AssetURLStreamHandler.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.util.Arrays;
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.maptool.model.AssetManager;
@@ -52,10 +53,12 @@ public class AssetURLStreamHandler extends URLStreamHandler {
     @Override
     public InputStream getInputStream() throws IOException {
 
-      String id = url.getHost();
-      if (url.getQuery() == null && id.indexOf('-') == -1) {
-        var asset = AssetManager.getAssetAndWait(new MD5Key(id));
-        return new ByteArrayInputStream(asset.getImage());
+      if (url.getQuery() != null) {
+        if (Arrays.stream(url.getQuery().split("&"))
+            .anyMatch(q -> q.equalsIgnoreCase("raw=true"))) {
+          var asset = AssetManager.getAssetAndWait(new MD5Key(url.getHost()));
+          return new ByteArrayInputStream(asset.getImage());
+        }
       }
 
       BufferedImage img = ImageManager.getImageFromUrl(url);


### PR DESCRIPTION


### Requirements for Contributing a Bug Fix or Enhancement
* Fill out the template below. Any pull request that does not include enough information to be reviewed in timely manner will result in a request for you to update the pull request 
  and possibly closure of the pull request if it is not provided after this request.
* After you create the pull request, all status checks must pass before a maintainer will review your contribution. 


### Identify the Bug or Feature request
Addresses remaining part of #3037

This possibly affects other image types as well as webp, when returning an asset to be displayed in
html/html5 views the image will not be able to be displayed.


### Description of the Change
Unless the query parameter raw=true is specified, all assets fetched via the asset:// URL now default to the pre 1.10 behaviour where it will not fetch the raw asset. 


### Possible Drawbacks


This change will always fetch the png version of an asset unless the raw=true query flag is present. Unfortunately this introduces a small compatibility issues for anyone that started using animated GIFs between release of 1.10.0 and 1.10.2 but given the size of the compatibility issue of not requiring the
explicit request for raw breaking other exisiting functions this is by far the lesser of two evils.

### Documentation Notes
```html
[h: rawImg = getTokenImage() + "?raw=true"]
<img src="[r: rawImg]"/>
```

or 
```html
<img src="[r: getTokenImage()]?raw=true"/>
```

This is also detailed in Issue #3037 comments.

### Release Notes
- getTokenImage(), tblImage() etc work with webp images again.
- fetching a raw asset from URL requires ?raw=true query parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3046)
<!-- Reviewable:end -->
