### PR TITLE
Update preferencesDialog.xml

### DIFF
--- a/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/preferencesDialog.xml
@@ -13597,7 +13597,6 @@
             </at>
             <at name="width">1652</at>
             <at name="tabCount">6</at>
-            <at name="toolTipText">Prefernces.</at>
             <at name="height">832</at>
            </object>
           </at>


### PR DESCRIPTION
Remove (misspelled) tooltip from Preferences dialog.


### Identify the Bug or Feature request
Handle #3062 

### Description of the Change

Removed the misspelled tooltip entirely.

### Possible Drawbacks

Someone might not recognize the Preferences dialog as being for "Prefernces."

### Documentation Notes

None needed.

### Release Notes

- Removed misspelled tooltip for Preferences dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3063)
<!-- Reviewable:end -->
