### PR TITLE
Issue 2755 terrain vbl app preference compatibility with old versions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -185,7 +185,11 @@ public class AppPreferences {
   private static final String MACRO_EDITOR_THEME = "macroEditorTheme";
   private static final String DEFAULT_MACRO_EDITOR_THEME = "default";
 
-  private static final String KEY_TOPOLOGY_DRAWING_MODE = "topologyDrawingMode";
+  // When terrain VBL was introduced, older versions of MapTool were unable to read the new topology
+  // modes. So we use a different preference key than in the past so older versions would not
+  // unexpectedly break.
+  private static final String KEY_TOPOLOGY_DRAWING_MODE = "topologyMode";
+  private static final String KEY_OLD_TOPOLOGY_DRAWING_MODE = "topologyDrawingMode";
   private static final String DEFAULT_TOPOLOGY_DRAWING_MODE = "VBL";
 
   private static final String KEY_WEB_END_POINT_PORT = "webEndPointPort";
@@ -1246,8 +1250,15 @@ public class AppPreferences {
   }
 
   public static TopologyMode getTopologyDrawingMode() {
-    return TopologyMode.valueOf(
-        prefs.get(KEY_TOPOLOGY_DRAWING_MODE, DEFAULT_TOPOLOGY_DRAWING_MODE));
+    try {
+      String oldDrawingMode =
+          prefs.get(KEY_OLD_TOPOLOGY_DRAWING_MODE, DEFAULT_TOPOLOGY_DRAWING_MODE);
+      String drawingMode = prefs.get(KEY_TOPOLOGY_DRAWING_MODE, oldDrawingMode);
+
+      return TopologyMode.valueOf(drawingMode);
+    } catch (Exception exc) {
+      return TopologyMode.VBL;
+    }
   }
 
   public static void setWebEndPointPort(int value) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #2755.

### Description of the Change

Topology drawing modes are read from and written to application preferences so that the selection is preserved in future runs of MapTool. With the introduction of terrain VBL, the number of modes has increased and older versions of MapTool do not recognize the new modes. Unfortunately, there is also no error handling around this, so older versions cannot be run if a new mode has been set in preferences. This is a problem for anyone running multiple versions, or even testing development versions while still primarily using versions 1.10.* and earlier.

This change introduces a new preference key to use for topology modes so that we do not interfere with older versions. It also adds error handling around the preference so that any future changes will not cause similar issues.

### Possible Drawbacks

I don't see any.

### Documentation Notes

N/A

### Release Notes

- Fixed an issue where new topology modes cannot be read by older versions of MapTool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3086)
<!-- Reviewable:end -->
