### PR TITLE
Fix issue with trusted macros

### DIFF
--- a/src/main/java/net/rptools/maptool/model/framework/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/framework/LibraryToken.java
@@ -317,7 +317,7 @@ class LibraryToken implements Library {
                   new MTScriptMacroInfo(
                       macroName,
                       buttonProps.getCommand(),
-                      !buttonProps.getAllowPlayerEdits(),
+                      library.getOwners().size() == 0 || !buttonProps.getAllowPlayerEdits(),
                       !buttonProps.getAllowPlayerEdits() && buttonProps.getAutoExecute(),
                       buttonProps.getEvaluatedToolTip()));
             });


### PR DESCRIPTION


### Identify the Bug or Feature request
Addresses #3088 

### Description of the Change
Fixes problem where a macro that has the player editable ticked but is on a token with no owners wasnt recognised as trusted. Even though player editable is ticked the players wouldn't be able to select the lib token. This brings the functionality back into line pre add on change.


### Possible Drawbacks
None

### Release Notes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3089)
<!-- Reviewable:end -->
