### PR TITLE
Update DungeonDraftImporter.java

### DIFF
--- a/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
+++ b/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
@@ -184,12 +184,8 @@ public class DungeonDraftImporter {
     if (vbl != null) {
       vbl.forEach(
           v -> {
-            Area vblArea =
-                new Area(
-                    OBJECT_VBL_STROKE.createStrokedShape(
-                        getVBLPath(v.getAsJsonArray(), pixelsPerCell)));
-            zone.addTopology(vblArea, TopologyMode.VBL);
-            zone.addTopology(vblArea, TopologyMode.MBL);
+            Area vblArea = new Area(getVBLPath(v.getAsJsonArray(), pixelsPerCell));
+            zone.addTopology(vblArea, TopologyMode.TERRAIN_VBL);
           });
     }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3098 

### Description of the Change

Changed the generated VBL for Object LOS blocking to use TERRAIN_VBL.

### Possible Drawbacks

None.

### Documentation Notes

Using Terrain VBL will allow the object imagery baked into the map to be visible while still blocking vision through the object.

### Release Notes

-  Universal VTT maps will now use Terrain VBL for object LOS blocking.
-

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3099)
<!-- Reviewable:end -->
