### PR TITLE
Create release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - repo-admin
+    authors:
+      - rptools-automation
+  categories:
+    - title: Breaking Changes 💣
+      labels:
+        - breaking-change
+    - title: New Features 🥳
+      labels:
+        - feature
+    - title: Performance Improvements 🏎️	
+      labels:
+        - performance
+    - title: Bug Fixes 🩹		
+      labels:
+        - bug
+    - title: Other Changes 💬	
+      labels:
+        - "*"


### PR DESCRIPTION
Create release note template for GitHub generate release notes functionality.



### Identify the Bug or Feature request
fixes #3132 


### Description of the Change
Create a template to format/exclude pull requests using GitHub's create release note feature.
We can try it, see if we like it and if so move to this as it will save time.


### Possible Drawbacks
- PRs have to have the label applied to fall into the correct category, it won't pick up the label from the issue (we could possibly create a GitHub action to copy from issue to PR)
- PRs appear in the release note not the issue, this may require a change to how we do things a little.


### Release Notes
N/A this is for repo maintenance not part of a release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3133)
<!-- Reviewable:end -->
