### PR TITLE
Update getInfoFunction.java

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -358,7 +358,7 @@ public class getInfoFunction extends AbstractFunction {
       state.addProperty("opacity", bto.getOpacity());
       state.addProperty("order", bto.getOrder());
       if (bto instanceof FlowColorDotTokenOverlay) {
-        state.addProperty("grid", ((FlowColorDotTokenOverlay) bto).getGrid());
+        state.addProperty("gridSize", ((FlowColorDotTokenOverlay) bto).getGrid());
       }
       if (bto instanceof CornerImageTokenOverlay) {
         state.addProperty("corner", ((CornerImageTokenOverlay) bto).getCorner().name());

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -31,9 +31,7 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.htmlframe.HTMLDialog;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrame;
 import net.rptools.maptool.client.ui.htmlframe.HTMLOverlayManager;
-import net.rptools.maptool.client.ui.token.BarTokenOverlay;
-import net.rptools.maptool.client.ui.token.BooleanTokenOverlay;
-import net.rptools.maptool.client.ui.token.ImageTokenOverlay;
+import net.rptools.maptool.client.ui.token.*;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Campaign;
@@ -350,6 +348,7 @@ public class getInfoFunction extends AbstractFunction {
       JsonObject state = new JsonObject();
       state.addProperty("name", bto.getName());
       state.addProperty("type", bto.getClass().getSimpleName());
+      state.addProperty("group", group);
       state.addProperty("isShowGM", bto.isShowGM() ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty("isShowOwner", bto.isShowOwner() ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty("isShowOthers", bto.isShowOthers() ? BigDecimal.ONE : BigDecimal.ZERO);
@@ -358,6 +357,12 @@ public class getInfoFunction extends AbstractFunction {
       state.addProperty("mouseOver", bto.isMouseover() ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty("opacity", bto.getOpacity());
       state.addProperty("order", bto.getOrder());
+      if (bto instanceof FlowColorDotTokenOverlay) {
+        state.addProperty("grid", ((FlowColorDotTokenOverlay) bto).getGrid());
+      }
+      if (bto instanceof CornerImageTokenOverlay) {
+        state.addProperty("corner", ((CornerImageTokenOverlay) bto).getCorner().name());
+      }
 
       sgroup.add(state);
       sinfo.add(group, sgroup);


### PR DESCRIPTION
### Identify the Bug or Feature request

Update for #2935 .

### Description of the Change

Added Group, Corner & Grid (size) to the individual state info returned by getInfo("campaign").

### Possible Drawbacks

None anticipated.

### Documentation Notes

States result from `getInfo("campaign")` now includes `corner` info for Corner Image types, `grid` for the Grid * types and the `group` name is included in each state entry.

```JSON
{
  "Image": [  {
    "name": "Pipes",
    "type": "CornerImageTokenOverlay",
    "group": "Image",
    "isShowGM": 1,
    "isShowOwner": 1,
    "isShowOthers": 1,
    "isImageOverlay": 1,
    "mouseOver": 0,
    "opacity": 100,
    "order": 0,
    "corner": "NORTH_EAST"
  }],
  "Flow":   [
        {
      "name": "Square",
      "type": "FlowColorSquareTokenOverlay",
      "group": "Flow",
      "isShowGM": 1,
      "isShowOwner": 1,
      "isShowOthers": 1,
      "isImageOverlay": 0,
      "mouseOver": 0,
      "opacity": 100,
      "order": 1,
      "gridSize": 4
    },
        {
      "name": "Triangle",
      "type": "FlowTriangleTokenOverlay",
      "group": "Flow",
      "isShowGM": 1,
      "isShowOwner": 1,
      "isShowOthers": 1,
      "isImageOverlay": 0,
      "mouseOver": 0,
      "opacity": 100,
      "order": 2,
      "gridSize": 4
    },
        {
      "name": "Yield",
      "type": "FlowYieldTokenOverlay",
      "group": "Flow",
      "isShowGM": 1,
      "isShowOwner": 1,
      "isShowOthers": 1,
      "isImageOverlay": 0,
      "mouseOver": 0,
      "opacity": 100,
      "order": 3,
      "grid": 4
    },
        {
      "name": "Dot",
      "type": "FlowColorDotTokenOverlay",
      "group": "Flow",
      "isShowGM": 1,
      "isShowOwner": 1,
      "isShowOthers": 1,
      "isImageOverlay": 0,
      "mouseOver": 0,
      "opacity": 100,
      "order": 4,
      "gridSize": 3
    }
  ],
  "no group":   [
        {
      "name": "Diamond",
      "type": "FlowDiamondTokenOverlay",
      "group": "no group",
      "isShowGM": 1,
      "isShowOwner": 1,
      "isShowOthers": 1,
      "isImageOverlay": 0,
      "mouseOver": 0,
      "opacity": 100,
      "order": 5,
      "gridSize": 2
    },
        {
      "name": "Dead",
      "type": "XTokenOverlay",
      "group": "no group",
      "isShowGM": 1,
      "isShowOwner": 1,
      "isShowOthers": 1,
      "isImageOverlay": 0,
      "mouseOver": 0,
      "opacity": 100,
      "order": 6
    }, ...
  ]
}
```

### Release Notes
- getInfo("campaign") results now includes `grid` (size) and `corner` for states with those properties and all state entries include the `group` name as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3136)
<!-- Reviewable:end -->
