### PR TITLE
Rename TopologyMode to TopologyTypeSet

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -189,9 +189,9 @@ public class AppPreferences {
   // When hill VBL was introduced, older versions of MapTool were unable to read the new topology
   // modes. So we use a different preference key than in the past so older versions would not
   // unexpectedly break.
-  private static final String KEY_TOPOLOGY_DRAWING_MODE = "topologyMode";
+  private static final String KEY_TOPOLOGY_TYPES = "topologyTypes";
   private static final String KEY_OLD_TOPOLOGY_DRAWING_MODE = "topologyDrawingMode";
-  private static final String DEFAULT_TOPOLOGY_DRAWING_MODE = "VBL";
+  private static final String DEFAULT_TOPOLOGY_TYPE = "VBL";
 
   private static final String KEY_WEB_END_POINT_PORT = "webEndPointPort";
   private static final int DEFAULT_WEB_END_POINT = 654555;
@@ -1258,25 +1258,24 @@ public class AppPreferences {
     prefs.put(MACRO_EDITOR_THEME, type);
   }
 
-  public static Zone.TopologyMode getTopologyDrawingMode() {
+  public static Zone.TopologyTypeSet getTopologyTypes() {
     try {
-      String drawingMode = prefs.get(KEY_TOPOLOGY_DRAWING_MODE, "");
-      if ("".equals(drawingMode)) {
+      String typeNames = prefs.get(KEY_TOPOLOGY_TYPES, "");
+      if ("".equals(typeNames)) {
         // Fallback to the key used prior to the introduction of various VBL types.
-        String oldDrawingMode =
-            prefs.get(KEY_OLD_TOPOLOGY_DRAWING_MODE, DEFAULT_TOPOLOGY_DRAWING_MODE);
+        String oldDrawingMode = prefs.get(KEY_OLD_TOPOLOGY_DRAWING_MODE, DEFAULT_TOPOLOGY_TYPE);
         return switch (oldDrawingMode) {
-          default -> new Zone.TopologyMode(Zone.TopologyType.WALL_VBL);
-          case "VBL" -> new Zone.TopologyMode(Zone.TopologyType.WALL_VBL);
-          case "MBL" -> new Zone.TopologyMode(Zone.TopologyType.MBL);
-          case "COMBINED" -> new Zone.TopologyMode(
+          default -> new Zone.TopologyTypeSet(Zone.TopologyType.WALL_VBL);
+          case "VBL" -> new Zone.TopologyTypeSet(Zone.TopologyType.WALL_VBL);
+          case "MBL" -> new Zone.TopologyTypeSet(Zone.TopologyType.MBL);
+          case "COMBINED" -> new Zone.TopologyTypeSet(
               Zone.TopologyType.WALL_VBL, Zone.TopologyType.MBL);
         };
       } else {
-        return Zone.TopologyMode.valueOf(drawingMode);
+        return Zone.TopologyTypeSet.valueOf(typeNames);
       }
     } catch (Exception exc) {
-      return new Zone.TopologyMode(Zone.TopologyType.WALL_VBL);
+      return new Zone.TopologyTypeSet(Zone.TopologyType.WALL_VBL);
     }
   }
 
@@ -1309,13 +1308,13 @@ public class AppPreferences {
   /**
    * Sets the topology mode preference.
    *
-   * @param mode the mode. A value of null resets to default.
+   * @param types the topology types. A value of null resets to default.
    */
-  public static void setTopologyDrawingMode(Zone.TopologyMode mode) {
-    if (mode == null) {
-      prefs.remove(KEY_TOPOLOGY_DRAWING_MODE);
+  public static void setTopologyTypes(Zone.TopologyTypeSet types) {
+    if (types == null) {
+      prefs.remove(KEY_TOPOLOGY_TYPES);
     } else {
-      prefs.put(KEY_TOPOLOGY_DRAWING_MODE, mode.toString());
+      prefs.put(KEY_TOPOLOGY_TYPES, types.toString());
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1366,7 +1366,7 @@ public class MapTool {
     MapTool.getFrame()
         .getCurrentZoneRenderer()
         .getZone()
-        .setTopologyMode(AppPreferences.getTopologyDrawingMode());
+        .setTopologyTypes(AppPreferences.getTopologyTypes());
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
@@ -51,27 +51,27 @@ public class TopologyModeSelectionPanel extends JToolBar {
     modeButtons = new EnumMap<>(Zone.TopologyType.class);
 
     try {
-      var initialMode = AppPreferences.getTopologyDrawingMode();
+      var initiallySelectedTypes = AppPreferences.getTopologyTypes();
       createAndAddModeButton(
           Zone.TopologyType.WALL_VBL,
           "net/rptools/maptool/client/image/tool/wall-vbl-only.png",
           "tools.topology_mode_selection.vbl.tooltip",
-          initialMode);
+          initiallySelectedTypes);
       createAndAddModeButton(
           Zone.TopologyType.HILL_VBL,
           "net/rptools/maptool/client/image/tool/hill-vbl-only.png",
           "tools.topology_mode_selection.hill_vbl.tooltip",
-          initialMode);
+          initiallySelectedTypes);
       createAndAddModeButton(
           Zone.TopologyType.PIT_VBL,
           "net/rptools/maptool/client/image/tool/pit-vbl-only.png",
           "tools.topology_mode_selection.pit_vbl.tooltip",
-          initialMode);
+          initiallySelectedTypes);
       createAndAddModeButton(
           Zone.TopologyType.MBL,
           "net/rptools/maptool/client/image/tool/mbl-only.png",
           "tools.topology_mode_selection.mbl.tooltip",
-          initialMode);
+          initiallySelectedTypes);
     } catch (IOException ioe) {
       ioe.printStackTrace();
     }
@@ -80,11 +80,14 @@ public class TopologyModeSelectionPanel extends JToolBar {
   }
 
   private void createAndAddModeButton(
-      Zone.TopologyType type, String imageFile, String toolTipKey, Zone.TopologyMode initialMode)
+      Zone.TopologyType type,
+      String imageFile,
+      String toolTipKey,
+      Zone.TopologyTypeSet initiallySelectedTypes)
       throws IOException {
     final var button = new JToggleButton(new ImageIcon(ImageUtil.getImage(imageFile)));
     button.setToolTipText(I18N.getText(toolTipKey));
-    button.setSelected(initialMode.contains(type));
+    button.setSelected(initiallySelectedTypes.contains(type));
     this.add(button);
     modeButtons.put(type, button);
     button.addChangeListener(
@@ -94,7 +97,7 @@ public class TopologyModeSelectionPanel extends JToolBar {
             ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
             if (zr != null) {
               var zone = zr.getZone();
-              var mode = zone.getTopologyMode();
+              var mode = zone.getTopologyTypes();
               if (button.isSelected()) {
                 mode = mode.with(type);
               } else {
@@ -107,24 +110,24 @@ public class TopologyModeSelectionPanel extends JToolBar {
         });
   }
 
-  public void setMode(Zone.TopologyMode topologyMode) {
-    AppPreferences.setTopologyDrawingMode(topologyMode);
-    if (topologyMode == null) {
-      topologyMode = AppPreferences.getTopologyDrawingMode();
+  public void setMode(Zone.TopologyTypeSet topologyTypes) {
+    AppPreferences.setTopologyTypes(topologyTypes);
+    if (topologyTypes == null) {
+      topologyTypes = AppPreferences.getTopologyTypes();
     }
 
     for (final var entry : modeButtons.entrySet()) {
       final var topologyType = entry.getKey();
       final var button = entry.getValue();
 
-      button.setSelected(topologyMode.contains(topologyType));
+      button.setSelected(topologyTypes.contains(topologyType));
     }
 
     // Since setting selection also triggers change listeners, we need this work even early on.
     ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
     // Check if there is a map. Fix #1605
     if (zr != null) {
-      zr.getZone().setTopologyMode(topologyMode);
+      zr.getZone().setTopologyTypes(topologyTypes);
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/CrossTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/CrossTopologyTool.java
@@ -108,10 +108,11 @@ public class CrossTopologyTool extends AbstractDrawingTool implements MouseMotio
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
         // TODO: send this to the server

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondTopologyTool.java
@@ -97,10 +97,11 @@ public class DiamondTopologyTool extends AbstractDrawingTool implements MouseMot
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
         // TODO: send this to the server

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/HollowDiamondTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/HollowDiamondTopologyTool.java
@@ -96,10 +96,11 @@ public class HollowDiamondTopologyTool extends AbstractDrawingTool implements Mo
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
         // TODO: send this to the server

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/HollowOvalTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/HollowOvalTopologyTool.java
@@ -113,10 +113,11 @@ public class HollowOvalTopologyTool extends AbstractDrawingTool implements Mouse
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
 

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/HollowRectangleTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/HollowRectangleTopologyTool.java
@@ -105,10 +105,11 @@ public class HollowRectangleTopologyTool extends AbstractDrawingTool
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
         // TODO: send this to the server

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/OvalTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/OvalTopologyTool.java
@@ -101,10 +101,11 @@ public class OvalTopologyTool extends AbstractDrawingTool implements MouseMotion
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
         oval = null;

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonTopologyTool.java
@@ -115,10 +115,10 @@ public class PolygonTopologyTool extends LineTool implements MouseMotionListener
     }
     if (pen.isEraser()) {
       getZone().removeTopology(area);
-      MapTool.serverCommand().removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+      MapTool.serverCommand().removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
     } else {
       getZone().addTopology(area);
-      MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+      MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyTypes());
     }
     renderer.repaint();
   }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleTopologyTool.java
@@ -96,10 +96,11 @@ public class RectangleTopologyTool extends AbstractDrawingTool implements MouseM
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()
-              .removeTopology(getZone().getId(), area, getZone().getTopologyMode());
+              .removeTopology(getZone().getId(), area, getZone().getTopologyTypes());
         } else {
           getZone().addTopology(area);
-          MapTool.serverCommand().addTopology(getZone().getId(), area, getZone().getTopologyMode());
+          MapTool.serverCommand()
+              .addTopology(getZone().getId(), area, getZone().getTopologyTypes());
         }
         renderer.repaint();
         // TODO: send this to the server

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1579,7 +1579,7 @@ public class MapToolFrame extends DefaultDockableHolder
           .fireEvent(MapTool.ZoneEvent.Activated, this, oldZone, renderer.getZone());
       renderer.requestFocusInWindow();
       // Updates the VBL/MBL button. Fixes #1642.
-      TopologyModeSelectionPanel.getInstance().setMode(renderer.getZone().getTopologyMode());
+      TopologyModeSelectionPanel.getInstance().setMode(renderer.getZone().getTopologyTypes());
     }
     AppActions.updateActions();
     repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -588,11 +588,11 @@ public class DrawPanelPopupMenu extends JPopupMenu {
     if (isEraser) {
       renderer.getZone().removeTopology(area);
       MapTool.serverCommand()
-          .removeTopology(renderer.getZone().getId(), area, renderer.getZone().getTopologyMode());
+          .removeTopology(renderer.getZone().getId(), area, renderer.getZone().getTopologyTypes());
     } else {
       renderer.getZone().addTopology(area);
       MapTool.serverCommand()
-          .addTopology(renderer.getZone().getId(), area, renderer.getZone().getTopologyMode());
+          .addTopology(renderer.getZone().getId(), area, renderer.getZone().getTopologyTypes());
     }
     renderer.repaint();
   }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -157,10 +157,10 @@ public class Zone extends BaseModel {
     MBL;
   }
 
-  public static final class TopologyMode implements Iterable<TopologyType> {
+  public static final class TopologyTypeSet implements Iterable<TopologyType> {
     private final Set<TopologyType> topologyTypes;
 
-    public static TopologyMode valueOf(String value) {
+    public static TopologyTypeSet valueOf(String value) {
       List<TopologyType> topologyTypes = new ArrayList<>();
       for (var topologyType : TopologyType.values()) {
         var topologyTypeName = topologyType.toString();
@@ -169,10 +169,10 @@ public class Zone extends BaseModel {
         }
       }
 
-      return new TopologyMode(topologyTypes.toArray(TopologyType[]::new));
+      return new TopologyTypeSet(topologyTypes.toArray(TopologyType[]::new));
     }
 
-    public TopologyMode(TopologyType... types) {
+    public TopologyTypeSet(TopologyType... types) {
       // I would prefer using an enum set, but Hessian can't handle it properly.
       topologyTypes = new HashSet<>();
       topologyTypes.addAll(Arrays.asList(types));
@@ -182,15 +182,15 @@ public class Zone extends BaseModel {
       return topologyTypes.contains(type);
     }
 
-    public TopologyMode with(TopologyType type) {
-      var newMode = new TopologyMode();
+    public TopologyTypeSet with(TopologyType type) {
+      var newMode = new TopologyTypeSet();
       newMode.topologyTypes.addAll(this.topologyTypes);
       newMode.topologyTypes.add(type);
       return newMode;
     }
 
-    public TopologyMode without(TopologyType type) {
-      var newMode = new TopologyMode();
+    public TopologyTypeSet without(TopologyType type) {
+      var newMode = new TopologyTypeSet();
       newMode.topologyTypes.addAll(this.topologyTypes);
       newMode.topologyTypes.remove(type);
       return newMode;
@@ -232,7 +232,7 @@ public class Zone extends BaseModel {
 
   private double unitsPerCell = DEFAULT_UNITS_PER_CELL;
   private AStarRoundingOptions aStarRounding = AStarRoundingOptions.NONE;
-  private TopologyMode topologyMode = null; // get default from AppPreferences
+  private TopologyTypeSet topologyTypes = null; // get default from AppPreferences
 
   private List<DrawnElement> drawables = new LinkedList<DrawnElement>();
   private List<DrawnElement> gmDrawables = new LinkedList<DrawnElement>();
@@ -530,7 +530,7 @@ public class Zone extends BaseModel {
     pitVbl = (Area) zone.pitVbl.clone();
     topologyTerrain = (Area) zone.topologyTerrain.clone();
     aStarRounding = zone.aStarRounding;
-    topologyMode = zone.topologyMode;
+    topologyTypes = zone.topologyTypes;
     isVisible = zone.isVisible;
     hasFog = zone.hasFog;
   }
@@ -841,7 +841,7 @@ public class Zone extends BaseModel {
   }
 
   public void addTopology(Area area) {
-    for (var topologyType : getTopologyMode()) {
+    for (var topologyType : getTopologyTypes()) {
       addTopology(area, topologyType);
     }
   }
@@ -866,7 +866,7 @@ public class Zone extends BaseModel {
   }
 
   public void removeTopology(Area area) {
-    for (var topologyType : getTopologyMode()) {
+    for (var topologyType : getTopologyTypes()) {
       removeTopology(area, topologyType);
     }
   }
@@ -1191,16 +1191,16 @@ public class Zone extends BaseModel {
     this.aStarRounding = aStarRounding;
   }
 
-  public TopologyMode getTopologyMode() {
-    if (topologyMode == null) {
-      topologyMode = AppPreferences.getTopologyDrawingMode();
+  public TopologyTypeSet getTopologyTypes() {
+    if (topologyTypes == null) {
+      topologyTypes = AppPreferences.getTopologyTypes();
     }
 
-    return topologyMode;
+    return topologyTypes;
   }
 
-  public void setTopologyMode(TopologyMode topologyMode) {
-    this.topologyMode = topologyMode;
+  public void setTopologyTypes(TopologyTypeSet topologyTypes) {
+    this.topologyTypes = topologyTypes;
   }
 
   public int getLargestZOrder() {

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -118,16 +118,16 @@ public interface ServerCommand {
 
   public void setFoW(GUID zoneGUID, Area area, Set<GUID> selectedToks);
 
-  public default void addTopology(GUID zoneGUID, Area area, Zone.TopologyMode topologyMode) {
-    for (var topologyType : topologyMode) {
+  public default void addTopology(GUID zoneGUID, Area area, Zone.TopologyTypeSet topologyTypes) {
+    for (var topologyType : topologyTypes) {
       addTopology(zoneGUID, area, topologyType);
     }
   }
 
   public void addTopology(GUID zoneGUID, Area area, Zone.TopologyType topologyType);
 
-  public default void removeTopology(GUID zoneGUID, Area area, Zone.TopologyMode topologyMode) {
-    for (var topologyType : topologyMode) {
+  public default void removeTopology(GUID zoneGUID, Area area, Zone.TopologyTypeSet topologyTypes) {
+    for (var topologyType : topologyTypes) {
       removeTopology(zoneGUID, area, topologyType);
     }
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses backwards compat issue for #2755

### Description of the Change

Campaigns that predate terrain VBL could not be loaded without error due to the refactoring in #3148. This was because the old `Zone.topologyMode` field has the same name and type name as before the refactoring, but is structurally distinct and so could not be correctly deserialized.
    
To avoid this, and to avoid potential other confusions with the previous enum `TopologyMode`, the new class has been renamed to `TopologyTypeSet` and methods and variable names have been updated accordingly.

### Possible Drawbacks

None expected

### Documentation Notes

### Release Notes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3156)
<!-- Reviewable:end -->
