### PR TITLE
Fix for the resetting of the Allow URI Access flag when server is started

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -490,6 +490,7 @@ public class Token extends BaseModel implements Cloneable {
     }
 
     speechName = token.speechName;
+    allowURIAccess = token.allowURIAccess;
   }
 
   public Token() {


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #3159 

### Description of the Change
The constructor to create a new token based on an existing token was not copying the All URI Access flag so it was defaulting to false. (Starting a new server copies zones/tokens from existing ones). This was causing the value of this flag to be lost when the server started.

### Possible Drawbacks

None that I can think of

### Documentation Notes
N/A Fixes a bug that was causing things to not work way people expected/was documented.


### Release Notes
Fix for bug where Allow URI Access was being reset on server start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3160)
<!-- Reviewable:end -->
