### PR TITLE
add data.getStaticData macro function

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1541,7 +1541,7 @@ public class MapToolLineParser {
    * @return the current context.
    */
   public MapToolMacroContext getContext() {
-    return contextStack.peek();
+    return contextStack.size() > 0 ? contextStack.peek() : null;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -565,22 +565,18 @@ public class TokenPropertyFunctions extends AbstractFunction {
         libName = location;
       }
 
-      try {
-        var library =
-            new LibraryManager()
-                .getLibrary(libName)
-                .orElseThrow(
-                    () ->
-                        new ParserException(
-                            I18N.getText(
-                                "macro.function.tokenProperty.unknownLibToken",
-                                functionName,
-                                libName)));
-        library.getLibraryData().thenCompose(libData -> libData.setStringData(property, value));
-        return "";
-      } catch (ExecutionException | InterruptedException e) {
-        throw new ParserException(e.getCause());
-      }
+      var library =
+          new LibraryManager()
+              .getLibrary(libName)
+              .orElseThrow(
+                  () ->
+                      new ParserException(
+                          I18N.getText(
+                              "macro.function.tokenProperty.unknownLibToken",
+                              functionName,
+                              libName)));
+      library.getLibraryData().thenCompose(libData -> libData.setStringData(property, value));
+      return "";
     }
 
     /*

--- a/src/main/java/net/rptools/maptool/model/gamedata/MTScriptDataConversion.java
+++ b/src/main/java/net/rptools/maptool/model/gamedata/MTScriptDataConversion.java
@@ -15,10 +15,20 @@
 package net.rptools.maptool.model.gamedata;
 
 import java.math.BigDecimal;
+import net.rptools.maptool.model.gamedata.data.DataType;
 import net.rptools.maptool.model.gamedata.data.DataValue;
 
+/** Class for converting between GameData and MT Macro Script types. */
 public class MTScriptDataConversion {
 
+  /**
+   * Converts a DataValue to a MT Script type. For Asset DataValues the asset handle is returned. If
+   * you want to return the actual contents of an Asset DataValue use {@link
+   * #convertToMTScriptDereferenceType(DataValue)}
+   *
+   * @param value The DataValue to convert.
+   * @return The converted value.
+   */
   public Object convertToMTScriptType(DataValue value) {
     if (value == null || value.isUndefined()) {
       return "";
@@ -34,5 +44,25 @@ public class MTScriptDataConversion {
       case ASSET -> "asset://" + value.asAsset().getMD5Key();
       case UNDEFINED -> "";
     };
+  }
+
+  /**
+   * Converts a DataType to a MT Script type fetching the contents of an Asset and returning that
+   * instead of just and asset handle where it makes sense. If the asset is a type that can not be
+   * handled in MTScript then the asset handle will be returned.
+   *
+   * @param value The DataValue to convert.
+   * @return The converted value.
+   */
+  public Object convertToMTScriptDereferenceType(DataValue value) {
+    if (value != null && value.getDataType() == DataType.ASSET) {
+      return switch (value.asAsset().getType()) {
+        case HTML, TEXT, MARKDOWN, CSS, JAVASCRIPT, XML -> value.asAsset().getDataAsString();
+        case JSON -> value.asAsset().getDataAsJson();
+        default -> convertToMTScriptType(value);
+      };
+    } else {
+      return convertToMTScriptType(value);
+    }
   }
 }

--- a/src/main/java/net/rptools/maptool/model/library/Library.java
+++ b/src/main/java/net/rptools/maptool/model/library/Library.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.library.data.LibraryData;
 
@@ -179,4 +180,13 @@ public interface Library {
    * @return the token associated with this library.
    */
   CompletableFuture<Optional<Token>> getAssociatedToken();
+
+  /**
+   * Returns if the context is able to access the private values in the library.
+   *
+   * @param context the current MTScript context to check.
+   * @param namespace the namespace of the library.
+   * @return if the context is able to access the private values in the library.
+   */
+  boolean canMTScriptAccessPrivate(MapToolMacroContext context, String namespace);
 }

--- a/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
@@ -236,14 +236,11 @@ public class LibraryManager {
    *
    * @param namespace the namespace of the library to return.
    * @return the library.
-   * @throws ExecutionException if an error occurs while extracting information about the library.
-   * @throws InterruptedException if an error occurs while extracting information about the library.
    */
-  public Optional<Library> getLibrary(String namespace)
-      throws ExecutionException, InterruptedException {
+  public Optional<Library> getLibrary(String namespace) {
     var lib = addOnLibraryManager.getLibrary(namespace);
     if (lib == null) {
-      lib = libraryTokenManager.getLibrary(namespace).get();
+      lib = libraryTokenManager.getLibrary(namespace).join();
     }
 
     if (lib == null) {

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
@@ -30,12 +30,15 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.Asset.Type;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.gamedata.data.DataValue;
+import net.rptools.maptool.model.gamedata.data.DataValueFactory;
 import net.rptools.maptool.model.library.Library;
 import net.rptools.maptool.model.library.LibraryInfo;
 import net.rptools.maptool.model.library.LibraryNotValidException;
@@ -312,6 +315,12 @@ public class AddOnLibrary implements Library {
   }
 
   @Override
+  public boolean canMTScriptAccessPrivate(MapToolMacroContext context, String namespace) {
+    String source = context.getSource().replaceFirst("(?i)^lib:", "");
+    return context == null || source.equalsIgnoreCase(namespace);
+  }
+
+  @Override
   public CompletableFuture<String> getVersion() {
     return CompletableFuture.completedFuture(version);
   }
@@ -464,5 +473,18 @@ public class AddOnLibrary implements Library {
               MapTool.getParser().runMacro(resolver, null, name + "@lib:" + namespace, "");
               return null;
             });
+  }
+
+  CompletableFuture<DataValue> readFile(String path) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          String filePath = path.replaceFirst("^/", "");
+          var val = pathAssetMap.get(filePath);
+          if (val == null) {
+            return DataValueFactory.undefined(path);
+          }
+          Asset asset = AssetManager.getAsset(val.getValue0());
+          return DataValueFactory.fromAsset(filePath, asset);
+        });
   }
 }

--- a/src/main/java/net/rptools/maptool/model/library/data/LibraryData.java
+++ b/src/main/java/net/rptools/maptool/model/library/data/LibraryData.java
@@ -133,4 +133,44 @@ public interface LibraryData {
    * @return a future that completes when the data value is set
    */
   CompletableFuture<Void> setAssetData(String name, Asset value);
+
+  /**
+   * Returns if this library supports storing of static data.
+   *
+   * @return {@code true} if this library supports storing of static data, {@code false} otherwise.
+   */
+  boolean supportsStaticData();
+
+  /**
+   * Does the library have the specified static data.
+   *
+   * @param path the path of the static data to check for.
+   * @return {@code true} if the library has the specified static data, {@code false} otherwise.
+   */
+  CompletableFuture<Boolean> hasStaticData(String path);
+
+  /**
+   * Does the library have the specified public static data.
+   *
+   * @param path the path of the public static data to check for.
+   * @return {@code true} if the library has the specified public static data, {@code false}
+   *     otherwise.
+   */
+  CompletableFuture<Boolean> hasPublicStaticData(String path);
+
+  /**
+   * Returns the static data value of the specified path.
+   *
+   * @param path the path of the static data to get.
+   * @return the static data value of the specified path.
+   */
+  CompletableFuture<DataValue> getStaticData(String path);
+
+  /**
+   * Returns the public static data value of the specified path.
+   *
+   * @param path the path of the public static data to get.
+   * @return the public static data value of the specified path.
+   */
+  CompletableFuture<DataValue> getPublicStaticData(String path);
 }

--- a/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.MacroButtonProperties;
@@ -330,6 +331,11 @@ class LibraryToken implements Library {
   @Override
   public CompletableFuture<Optional<Token>> getAssociatedToken() {
     return getToken().thenApply(Optional::of);
+  }
+
+  @Override
+  public boolean canMTScriptAccessPrivate(MapToolMacroContext context, String namespace) {
+    return false; // Library Tokens don't have private data
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/library/token/TokenLibraryData.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/TokenLibraryData.java
@@ -155,4 +155,29 @@ public class TokenLibraryData implements LibraryData {
   public CompletableFuture<Void> setAssetData(String name, Asset value) {
     return setData(DataValueFactory.fromAsset(name, value));
   }
+
+  @Override
+  public boolean supportsStaticData() {
+    return false;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasStaticData(String path) {
+    return CompletableFuture.completedFuture(false);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasPublicStaticData(String path) {
+    return CompletableFuture.completedFuture(false);
+  }
+
+  @Override
+  public CompletableFuture<DataValue> getStaticData(String path) {
+    return CompletableFuture.completedFuture(DataValueFactory.undefined(path));
+  }
+
+  @Override
+  public CompletableFuture<DataValue> getPublicStaticData(String path) {
+    return CompletableFuture.completedFuture(DataValueFactory.undefined(path));
+  }
 }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2620,3 +2620,4 @@ data.error.receivingUpdate       = Error receiving game data update.
 data.error.importGameData         = Error importing game data.
 data.error.clearingNamespace     = Error clearing data namespace {0} from type {1}.
 data.error.removingData          = Error data data from {0] namespace {1} from type {2}.
+


### PR DESCRIPTION
### Identify the Bug or Feature request
Addresses #3164 3164


### Description of the Change
Add the new macro function data.getStaticData(namespace, path) that will return the data at the specified path (or asset:// if t can't be converted to a macro script type). 

If the function is run from the add-on then it is able to access any file, if it is not run from the add-on then it is only able to access files in the public/ dir and only if allow URI access is enabled.

This does not work for Lib:Tokens.

Also due to the fact that MTScript doesnt have a null value if the path does not exist an empty string will be returned, but this shouldn't be a big issue as its not likely that add writers will be including empty strings as static data.

An Example has been added to  https://github.com/cwisniew/test-maptool-add-on-lib


### Possible Drawbacks
None that I can think of

### Documentation Notes
See above

### Release Notes
Added Macro Script function to read static data from add-ons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3165)
<!-- Reviewable:end -->
