### PR TITLE
Resolves #3199 by forcing getMapDisplayName() to only run from truste…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -69,6 +69,7 @@ public class MapFunctions extends AbstractFunction {
         return currentZR.getZone().getName();
       }
     } else if (functionName.equalsIgnoreCase("getMapDisplayName")) {
+      checkTrusted(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
       if (parameters.size() == 0) {
         ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
@@ -81,9 +82,6 @@ public class MapFunctions extends AbstractFunction {
         List<ZoneRenderer> rendererList =
             new LinkedList<ZoneRenderer>(
                 MapTool.getFrame().getZoneRenderers()); // copied from ZoneSelectionPopup
-        if (!MapTool.getPlayer().isGM()) {
-          rendererList.removeIf(renderer -> !renderer.getZone().isVisible());
-        }
         String searchMap = parameters.get(0).toString();
         String foundMap = null;
         for (int i = 0; i < rendererList.size(); i++) {


### PR DESCRIPTION
Resolves #3199 by forcing getMapDisplayName() to only run from trusted situations and allows access to all maps on all clients when called.

### Identify the Bug or Feature request
Limited utility was available from getMapDisplayName 


### Description of the Change

Makes sure macro is called from trusted source and gives display name of any input map similar to getMapName()


### Possible Drawbacks


### Documentation Notes
Probably make a note on the wiki that hidden maps will now also be searched with getMapDisplayName().

### Release Notes

- Changed getMapDisplayName to work on any map (including hidden maps) and restricted the function to trusted sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3210)
<!-- Reviewable:end -->
