### PR TITLE
Fix for freeze when loading old campaign with assets missing from...

### DIFF
--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -610,8 +610,8 @@ public class PackedFile implements AutoCloseable {
           }
         }
 
-        if (id == null || name == null || extension == null || type == null) {
-          log.error("Error reading asset, missing id, name, extension, or type.");
+        if (id == null || name == null || extension == null) {
+          log.error("Error reading asset, missing id, name, extension.");
           return null;
         }
 


### PR DESCRIPTION
Fix for freeze when loading old campaign with assets missing from asset cache


### Identify the Bug or Feature request
Resolves #3216


### Description of the Change
Fixes the failure to read asset files from a pre 1.11 campaign file.


### Possible Drawbacks
None

### Documentation Notes
N/A


### Release Notes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3217)
<!-- Reviewable:end -->
