### PR TITLE
Fix XMLHttpRequest issues

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/MTXMLHttpRequest.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/MTXMLHttpRequest.java
@@ -56,7 +56,9 @@ public class MTXMLHttpRequest {
 
     responseHeaders.forEach(
         (key, value) -> {
-          jheaders.setMember(key, value);
+          if (!key.equals(":Status")) {
+            jheaders.setMember(key, value);
+          }
         });
   }
 

--- a/src/main/java/net/rptools/maptool/model/library/url/RequestHandler.java
+++ b/src/main/java/net/rptools/maptool/model/library/url/RequestHandler.java
@@ -121,7 +121,7 @@ public class RequestHandler {
       }
       responseHeaders.put(":Status", "200");
       try {
-        c.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_16));
+        c.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
         return c;
       } catch (IOException e) {
         responseHeaders.put(":Status", "500 Internal Exception");

--- a/src/main/resources/net/rptools/maptool/client/html5/javascript/XMLHttpRequest.js
+++ b/src/main/resources/net/rptools/maptool/client/html5/javascript/XMLHttpRequest.js
@@ -107,7 +107,7 @@ class XMLHttpRequest {
 }
 
 
-function fetch(target, optionObject) {
+async function fetch(target, optionObject) {
     let request;
     if (target instanceof Request) {
 	request = target;
@@ -126,7 +126,8 @@ function fetch(target, optionObject) {
     for (let header of request.headers) {
 	x.setRequestHeader(header[0], header[1])
     }
-    let body = request.text();
+    let body = await request.text();
+    
 
     let _resolve;
     let _reject;


### PR DESCRIPTION

### Identify the Bug or Feature request
#3236 
#3235 

### Description of the Change

Changes the decoding for lib:// targets to UTF-8
Changes `fetch` to an `async` function, and internally `await`s the body of the Request object.  
Filters out the pseudo-header `:Status` from the responseHeaders for the `fetch` API if the underlying response fails.

### Possible Drawbacks

Binary data returned from lib:// targets will be improperly decoded.  Binary data should be stored in asset:// instead.

### Documentation Notes
Sending `body:` argument via `fetch` API now works.
`lib://` URIs now return sensible output.

### Release Notes


Examples:

- Sending `body:` argument via `fetch` API now works.
- `lib://` URIs now return sensible output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3237)
<!-- Reviewable:end -->
