### PR TITLE
Fixes for rptok files with old formats and image issues (big red X for all!) 

### DIFF
--- a/src/main/java/net/rptools/lib/io/LegacyAsset.java
+++ b/src/main/java/net/rptools/lib/io/LegacyAsset.java
@@ -1,0 +1,35 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.lib.io;
+
+import net.rptools.lib.MD5Key;
+
+public class LegacyAsset {
+  private MD5Key id;
+  private byte[] image;
+  private String name;
+
+  public MD5Key getId() {
+    return id;
+  }
+
+  public byte[] getImageData() {
+    return image;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/main/java/net/rptools/lib/io/LegacyAsset.java
+++ b/src/main/java/net/rptools/lib/io/LegacyAsset.java
@@ -16,19 +16,41 @@ package net.rptools.lib.io;
 
 import net.rptools.lib.MD5Key;
 
+/**
+ * This class represents a legacy asset where the asset is serialized with xstream including the
+ * image data. This is only used for xstream serialization.
+ */
 public class LegacyAsset {
+  /** the key of the asset */
   private MD5Key id;
+  /** The image data */
   private byte[] image;
+  /** The name of the asset */
   private String name;
 
+  /**
+   * Returns the key of the asset.
+   *
+   * @return the key of the asset.
+   */
   public MD5Key getId() {
     return id;
   }
 
+  /**
+   * Returns the image data.
+   *
+   * @return the image data.
+   */
   public byte[] getImageData() {
     return image;
   }
 
+  /**
+   * Returns the name of the asset.
+   *
+   * @return the name of the asset.
+   */
   public String getName() {
     return name;
   }

--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.lib.io;
 
+import com.google.common.io.CharStreams;
 import com.thoughtworks.xstream.XStream;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -29,6 +30,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -558,7 +560,29 @@ public class PackedFile implements AutoCloseable {
       xstream
           .ignoreUnknownElements(); // Jamz: Should we use this? This will ignore new classes/fields
       // added.
-      return xstream.fromXML(r);
+      var obj = xstream.fromXML(r);
+      return obj;
+    } catch (InstantiationError ie) {
+      log.error("Found at line number " + r.getLineNumber());
+      log.error("Cannot convert XML to Object", ie);
+      throw ie;
+    }
+  }
+
+  public LegacyAsset getLegacyAsset(String path) throws IOException {
+    var reader = getFileAsReader(path);
+    var bytes =
+        CharStreams.toString(reader)
+            .replace("<net.rptools.maptool.model.Asset>", "<net.rptools.lib.io.LegacyAsset>")
+            .replace("</net.rptools.maptool.model.Asset>", "</net.rptools.lib.io.LegacyAsset>")
+            .getBytes();
+    var r = new LineNumberReader(new StringReader(new String(bytes)));
+
+    try (r) {
+      xstream.ignoreUnknownElements();
+      // added.
+      var obj = xstream.fromXML(r);
+      return (LegacyAsset) obj;
     } catch (InstantiationError ie) {
       log.error("Found at line number " + r.getLineNumber());
       log.error("Cannot convert XML to Object", ie);
@@ -585,6 +609,8 @@ public class PackedFile implements AutoCloseable {
         String name = null;
         String extension = null;
         String type = null;
+        String imageString = null;
+        byte[] embeddedImage = null;
 
         NodeList childNodes = doc.getChildNodes().item(0).getChildNodes();
         for (int i = 0; i < childNodes.getLength(); i++) {
@@ -607,6 +633,12 @@ public class PackedFile implements AutoCloseable {
             extension = item.getTextContent();
           } else if ("type".equals(item.getNodeName())) {
             type = item.getTextContent();
+          } else if ("image".equalsIgnoreCase(item.getNodeName())) {
+            imageString = item.getTextContent();
+            System.out.println("here");
+            var legacyAsset = getLegacyAsset(path);
+            System.out.println(legacyAsset);
+            System.out.println("here2");
           }
         }
 
@@ -615,9 +647,12 @@ public class PackedFile implements AutoCloseable {
           return null;
         }
 
-        byte[] image = getFileAsInputStream(path + "." + extension).readAllBytes();
-
-        return Asset.createImageAsset(name, image);
+        if (embeddedImage == null) {
+          byte[] image = getFileAsInputStream(path + "." + extension).readAllBytes();
+          return Asset.createImageAsset(name, image);
+        } else {
+          return Asset.createImageAsset(name, embeddedImage);
+        }
 
       } catch (ParserConfigurationException | SAXException | IOException e) {
         log.error("Error reading asset", e);

--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -643,8 +643,10 @@ public class PackedFile implements AutoCloseable {
           } else if ("type".equals(item.getNodeName())) {
             type = item.getTextContent();
           } else if ("image".equalsIgnoreCase(item.getNodeName())) {
-            var legacyAsset = getLegacyAsset(path);
-            embeddedImage = legacyAsset.getImageData();
+            if (!item.getTextContent().isEmpty()) {
+              var legacyAsset = getLegacyAsset(path);
+              embeddedImage = legacyAsset.getImageData();
+            }
           }
         }
 

--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -249,9 +249,11 @@ public class AssetManager {
       }
     }
 
-    var oldAsset = assetMap.get(asset.getMD5Key());
-    if (oldAsset == null || oldAsset.getData() == null || oldAsset.getData().length == 0) {
-      assetMap.put(asset.getMD5Key(), asset);
+    synchronized (assetMap) {
+      var oldAsset = assetMap.get(asset.getMD5Key());
+      if (oldAsset == null || oldAsset.getData() == null || oldAsset.getData().length == 0) {
+        assetMap.put(asset.getMD5Key(), asset);
+      }
     }
 
     // Invalid images are represented by empty assets.
@@ -478,9 +480,11 @@ public class AssetManager {
         return null;
       }
 
-      var oldAsset = assetMap.get(id);
-      if (oldAsset == null || oldAsset.getData() == null || oldAsset.getData().length == 0) {
-        assetMap.put(id, asset);
+      synchronized (assetMap) {
+        var oldAsset = assetMap.get(id);
+        if (oldAsset == null || oldAsset.getData() == null || oldAsset.getData().length == 0) {
+          assetMap.put(id, asset);
+        }
       }
 
       return asset;


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #3232 
Fixes #3238
Fixes #3239


### Description of the Change
Various fixes for image and rptok issues. 

### Possible Drawbacks
Not so much a drawback but something I need help testing, one of my computers is out of commission (battery expanded badly) so I am unable to currently test on 2 different machines. I have run 2 instances of MapTool with 2 different data directories which should ensure assets are transferred correctly but it would be great if someone else can test on 2 different machines (with client asset cache being empty) both
* rptok file from resource library
* rptok file not in resource library drag and drop from explorer/finder

### Documentation Notes
N/A

### Release Notes
Various fixes for red X and rptok file problems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3240)
<!-- Reviewable:end -->
