### PR TITLE
Fix for token size changing back to medium on sever start

### DIFF
--- a/src/main/java/net/rptools/clientserver/hessian/HessianUtils.java
+++ b/src/main/java/net/rptools/clientserver/hessian/HessianUtils.java
@@ -31,8 +31,10 @@ public class HessianUtils {
     HessianInput in = hessianFactory.createHessianInput(is);
     in.getSerializerFactory().setAllowNonSerializable(true);
     in.getSerializerFactory().getClassFactory().setWhitelist(true);
+    in.getSerializerFactory().getClassFactory().deny("net.rptools.model.Asset");
     hessianSecurity.getAllowed().forEach(a -> in.getSerializerFactory().getClassFactory().allow(a));
     hessianSecurity.getDenied().forEach(d -> in.getSerializerFactory().getClassFactory().deny(d));
+    in.getSerializerFactory().getClassFactory().deny("net.rptools.model.Asset");
     return in;
   }
 

--- a/src/main/java/net/rptools/clientserver/hessian/HessianUtils.java
+++ b/src/main/java/net/rptools/clientserver/hessian/HessianUtils.java
@@ -31,10 +31,8 @@ public class HessianUtils {
     HessianInput in = hessianFactory.createHessianInput(is);
     in.getSerializerFactory().setAllowNonSerializable(true);
     in.getSerializerFactory().getClassFactory().setWhitelist(true);
-    in.getSerializerFactory().getClassFactory().deny("net.rptools.model.Asset");
     hessianSecurity.getAllowed().forEach(a -> in.getSerializerFactory().getClassFactory().allow(a));
     hessianSecurity.getDenied().forEach(d -> in.getSerializerFactory().getClassFactory().deny(d));
-    in.getSerializerFactory().getClassFactory().deny("net.rptools.model.Asset");
     return in;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMethodHandler.java
@@ -37,6 +37,7 @@ import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.client.ui.zone.ZoneRendererFactory;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
+import net.rptools.maptool.model.AssetDetails;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Campaign;
 import net.rptools.maptool.model.CampaignProperties;
@@ -93,7 +94,9 @@ public class ClientMethodHandler extends AbstractMethodHandler {
     // to be on the EDT (See next section)
     switch (cmd) {
       case putAsset:
-        AssetManager.putAsset((Asset) parameters[0]);
+        var assetDetails = (AssetDetails) parameters[0];
+
+        AssetManager.putAsset(Asset.fromAssetDetails(assetDetails));
         MapTool.getFrame().getCurrentZoneRenderer().flushDrawableRenderer();
         MapTool.getFrame().refresh();
         return;

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -363,11 +363,6 @@ public class ServerCommandClientImpl implements ServerCommand {
   }
 
   private static void makeServerCall(ServerCommand.COMMAND command, Object... params) {
-    for (Object obj : params) {
-      if (obj instanceof Asset) {
-        System.out.println("Asset!!!");
-      }
-    }
     if (MapTool.getConnection() != null) {
       MapTool.getConnection().callMethod(command.name(), params);
     }

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -122,7 +122,7 @@ public class ServerCommandClientImpl implements ServerCommand {
   }
 
   public void putAsset(Asset asset) {
-    makeServerCall(COMMAND.putAsset, asset);
+    makeServerCall(COMMAND.putAsset, asset.getAssetDetails());
   }
 
   public void getAsset(MD5Key assetID) {
@@ -363,6 +363,11 @@ public class ServerCommandClientImpl implements ServerCommand {
   }
 
   private static void makeServerCall(ServerCommand.COMMAND command, Object... params) {
+    for (Object obj : params) {
+      if (obj instanceof Asset) {
+        System.out.println("Asset!!!");
+      }
+    }
     if (MapTool.getConnection() != null) {
       MapTool.getConnection().callMethod(command.name(), params);
     }

--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -738,4 +738,23 @@ public final class Asset {
   private boolean isBroken() {
     return broken;
   }
+
+  /**
+   * Returns a transferable asset from the values of this asset.
+   *
+   * @return a transferable asset from the values of this asset.
+   */
+  public AssetDetails getAssetDetails() {
+    return new AssetDetails(md5Key, name, extension, type, data);
+  }
+
+  public static Asset fromAssetDetails(AssetDetails asset) {
+    return new Asset(
+        asset.getMd5Key(),
+        asset.getName(),
+        asset.getData(),
+        asset.getType(),
+        asset.getExtension(),
+        asset.getData() == null);
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/AssetDetails.java
+++ b/src/main/java/net/rptools/maptool/model/AssetDetails.java
@@ -1,0 +1,55 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import net.rptools.lib.MD5Key;
+import net.rptools.maptool.model.Asset.Type;
+
+public class AssetDetails {
+  private final MD5Key md5Key;
+  private final String name;
+
+  private final String extension;
+  private final Asset.Type type;
+  private final byte[] data;
+
+  public AssetDetails(MD5Key md5Key, String name, String extension, Type type, byte[] data) {
+    this.md5Key = md5Key;
+    this.name = name;
+    this.extension = extension;
+    this.type = type;
+    this.data = data;
+  }
+
+  public MD5Key getMd5Key() {
+    return md5Key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+}

--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -291,7 +291,7 @@ public class AssetManager {
           Asset asset = getAsset(id);
 
           // Simplest case, we already have it
-          if (asset != null) {
+          if (asset != null && asset.getData() != null && asset.getData().length > 0) {
             for (AssetAvailableListener listener : listeners) {
               listener.assetAvailable(id);
             }

--- a/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMethodHandler.java
@@ -31,6 +31,7 @@ import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.common.MapToolConstants;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
+import net.rptools.maptool.model.AssetDetails;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Campaign;
 import net.rptools.maptool.model.CampaignProperties;
@@ -147,7 +148,7 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
           execLink((String) context.get(0), (String) context.get(1), (String) context.get(2));
           break;
         case putAsset:
-          putAsset((Asset) context.get(0));
+          putAsset(Asset.fromAssetDetails((AssetDetails) context.get(0)));
           break;
         case putLabel:
           putLabel(context.getGUID(0), (Label) context.get(1));
@@ -529,7 +530,10 @@ public class ServerMethodHandler extends AbstractMethodHandler implements Server
       Asset asset = Asset.createBrokenImageAsset(assetID);
       server
           .getConnection()
-          .callMethod(RPCContext.getCurrent().id, ClientCommand.COMMAND.putAsset.name(), asset);
+          .callMethod(
+              RPCContext.getCurrent().id,
+              ClientCommand.COMMAND.putAsset.name(),
+              asset.getAssetDetails());
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #3232 
Fixes #3238
Fixes #3239


### Description of the Change
Various fixes for image and rptok issues. This also fixes the error when image is added by the client. It should also fix issues with assets that have been around for a while but don't crop up as often. 

### Possible Drawbacks
Not so much a drawback but something I need help testing, one of my computers is out of commission (battery expanded badly) so I am unable to currently test on 2 different machines. I have run 2 instances of MapTool with 2 different data directories which should ensure assets are transferred correctly but it would be great if someone else can test on 2 different machines (with client asset cache being empty) both
* rptok file from resource library
* rptok file not in resource library drag and drop from explorer/finder

### Documentation Notes
N/A

### Release Notes
Various fixes for red X and rptok file problems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3240)
<!-- Reviewable:end -->
