### PR TITLE
Fix for token size changing back to medium on sever start

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2472,6 +2472,18 @@ public class Token extends BaseModel implements Cloneable {
       exposedAreaGUID = new GUID();
     }
 
+    // Fix for pre 1.11.3 campaigns and token size issues
+    Map<Object, GUID> oldSizeMap = new HashMap<>(sizeMap);
+    sizeMap.clear();
+    for (var entry : oldSizeMap.entrySet()) {
+      var key = entry.getKey();
+      if (key instanceof Class<?> cl) {
+        sizeMap.put(cl.getName(), entry.getValue());
+      } else {
+        sizeMap.put(key.toString(), entry.getValue());
+      }
+    }
+
     return this;
   }
 


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #3225 (old campaigns)

### Description of the Change
Fixes the resetting of size to medium when reading old campaigns.


### Possible Drawbacks
None that I am aware of

### Release Notes
Fixes issue where loading old campaigns resets token size to medium

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3248)
<!-- Reviewable:end -->
