### PR TITLE
fix for initiative change event where there is no request event defined

### DIFF
--- a/src/main/java/net/rptools/maptool/model/InitiativeList.java
+++ b/src/main/java/net/rptools/maptool/model/InitiativeList.java
@@ -697,7 +697,7 @@ public class InitiativeList implements Serializable {
     try {
       var libs =
           new LibraryManager()
-              .getLegacyEventTargets(ON_INITIATIVE_CHANGE_VETOABLE_MACRO_CALLBACK)
+              .getLegacyEventTargets(ON_INITIATIVE_CHANGE_COMMIT_MACRO_CALLBACK)
               .get();
       if (!libs.isEmpty()) {
         JsonObject args = new JsonObject();


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #3245

### Description of the Change
The onInitativeChange() call back was not being called if the token didn't also have an onInitativeChangeRequest() function.

### Possible Drawbacks
None that I am aware of

### Release Notes
Fix for lib:tokens where onInitativeChange() was not being called if there was no onInitativeChangeRequest()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3249)
<!-- Reviewable:end -->
