### PR TITLE
Update MediaPlayerAdapter.java

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MediaPlayerAdapter.java
@@ -82,9 +82,9 @@ public class MediaPlayerAdapter {
           int cycCount = player.getCycleCount();
           if (cycCount != MediaPlayer.INDEFINITE && curCount >= cycCount) {
             player.stop(); // otherwise, status stuck on "PLAYING" at end
+            // make sure we use start property as editStream() above catches nulls
             player.seek(
-                Duration.millis(
-                    start)); // fixes the problem with getStreamProperties()/currentTime #2658
+                this.start); // fixes the problem with getStreamProperties()/currentTime #2658
           }
         });
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

#3250 

### Description of the Change

The passed in `start` parameter could be `null` causing an exception.  Using `this.start` avoids that as the prior `editStream()` call catches and fixes that.

### Possible Drawbacks

None expected.

### Documentation Notes

No change to functionality.

### Release Notes

Calling `playStream()` without specifying a start time would cause an exception when the stream ended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3251)
<!-- Reviewable:end -->
