### PR TITLE
Fixes disappearing templates on server start

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -32,6 +32,7 @@ import net.rptools.maptool.client.ui.zone.ZoneView;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.InitiativeList.TokenInitiative;
 import net.rptools.maptool.model.Token.TerrainModifierOperation;
+import net.rptools.maptool.model.drawing.AbstractTemplate;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
@@ -456,21 +457,49 @@ public class Zone extends BaseModel {
       drawables = new LinkedList<DrawnElement>();
       drawables.addAll(Collections.nCopies(zone.drawables.size(), null));
       Collections.copy(drawables, zone.drawables);
+
+      // Classes that extend Abstract template have a zone id so we need to make sure to update it
+      for (DrawnElement de : drawables) {
+        if (de.getDrawable() instanceof AbstractTemplate at) {
+          at.setZoneId(id);
+        }
+      }
     }
     if (zone.objectDrawables != null && !zone.objectDrawables.isEmpty()) {
       objectDrawables = new LinkedList<DrawnElement>();
       objectDrawables.addAll(Collections.nCopies(zone.objectDrawables.size(), null));
       Collections.copy(objectDrawables, zone.objectDrawables);
+
+      // Classes that extend Abstract template have a zone id so we need to make sure to update it
+      for (DrawnElement de : objectDrawables) {
+        if (de.getDrawable() instanceof AbstractTemplate at) {
+          at.setZoneId(id);
+        }
+      }
     }
     if (zone.backgroundDrawables != null && !zone.backgroundDrawables.isEmpty()) {
       backgroundDrawables = new LinkedList<DrawnElement>();
       backgroundDrawables.addAll(Collections.nCopies(zone.backgroundDrawables.size(), null));
       Collections.copy(backgroundDrawables, zone.backgroundDrawables);
+
+      // Classes that extend Abstract template have a zone id so we need to make sure to update it
+      for (DrawnElement de : backgroundDrawables) {
+        if (de.getDrawable() instanceof AbstractTemplate at) {
+          at.setZoneId(id);
+        }
+      }
     }
     if (zone.gmDrawables != null && !zone.gmDrawables.isEmpty()) {
       gmDrawables = new LinkedList<DrawnElement>();
       gmDrawables.addAll(Collections.nCopies(zone.gmDrawables.size(), null));
       Collections.copy(gmDrawables, zone.gmDrawables);
+
+      // Classes that extend Abstract template have a zone id so we need to make sure to update it
+      for (DrawnElement de : gmDrawables) {
+        if (de.getDrawable() instanceof AbstractTemplate at) {
+          at.setZoneId(id);
+        }
+      }
     }
     if (zone.labels != null && !zone.labels.isEmpty()) {
       for (GUID guid : zone.labels.keySet()) {


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #3256 

### Description of the Change
Templates record the id of the zone that they are in, when a server is started the zone gets a new id (in the copy constructor) so the templates no longer render properly as the zone they belong to can't be found. The least problematic solution is to update the zone id on copy. Retaining the zone id on copy has too many things it could potentially break.


### Possible Drawbacks
None foreseen


### Documentation Notes
N/A


### Release Notes
The radius, radius centered on grid, line, line centered on grid, wall templates will no longer disappear on server start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3258)
<!-- Reviewable:end -->
