### PR TITLE
Mark uber JAR as multi-release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,8 +296,6 @@ repositories {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    // Jamz: Do NOT update log4j libs without testing with uberjar build, 2.13.0 currently does not work
-    // See open issue: https://issues.apache.org/jira/browse/LOG4J2-673
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.13.0'	// Bridges v1 to v2 for other code in other libs
@@ -494,7 +492,8 @@ task uberJar(type: Jar) {
                 'Built-JDK': System.getProperty('java.version'),
                 'Source-Compatibility': project.sourceCompatibility,
                 'Target-Compatibility': project.targetCompatibility,
-                'Main-Class': project.mainClassName
+                'Main-Class': project.mainClassName,
+                'Multi-Release': true
     }
 
     from {


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3218

### Description of the Change

This fixes calls to `LogManager.getLogger()` in the uber JAR. Without the multi-release flag, log4j will use the wrong implementation when trying to find the calling class, throwing an exception and preventing MapTool from running.

### Possible Drawbacks

- Log4j is not the only multi-release library we use. We could see a change in behaviour in some other dependencies, though such a change would only impact the uber JAR and would likely end up matching the other modes of running MapTool.

### Documentation Notes

In order to run the uber JAR, all the usual command line options are still required. This means a verbose command like the following is required to run the JAR:
```
java --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web -Xss8M -XX:+ShowCodeDetailsInExceptionMessages --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/java.awt.geom=ALL-UNNAMED --add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED --add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED --add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED --add-opens=java.desktop/javax.swing=ALL-UNNAMED --add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED -jar MapTool.jar
```

### Release Notes

- Mark the JAR release as multi-release in order for log4j to work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3261)
<!-- Reviewable:end -->
