### PR TITLE
Bump log4j-1.2-api to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,7 @@ repositories {
 dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.13.0'	// Bridges v1 to v2 for other code in other libs
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.15.0'	// Bridges v1 to v2 for other code in other libs
 
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.31'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'


### PR DESCRIPTION
### Identify the Bug or Feature request

N/A

### Description of the Change

This is just a follow up to #3264 and #3265. Dependabot for some reason didn't pick up on the update for this dependency.


### Possible Drawbacks


### Release Notes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3266)
<!-- Reviewable:end -->
