### PR TITLE
Allow whitespace with --pointermap CSS

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
@@ -191,7 +191,7 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
     if (element == null) {
       return HTMLOverlayPanel.mousePassResult.BLOCK;
     } else {
-      String pe = (String) element.eval(SCRIPT_GET_POINTERMAP);
+      String pe = ((String) element.eval(SCRIPT_GET_POINTERMAP)).trim();
       if ("blockopaque".equals(pe)) return HTMLOverlayPanel.mousePassResult.CHECK_OPACITY;
       if ("block".equals(pe)) return HTMLOverlayPanel.mousePassResult.BLOCK;
       return HTMLOverlayPanel.mousePassResult.PASS;


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #2348

### Description of the Change

Any leading or trailing whitespace is now removed from the value for the `--pointermap` CSS property. This allows it to act more like a standard CSS property where leading and trailing whitespace is not significant, and it allows the CSS author to format their code more freely.

### Possible Drawbacks

Anyone who has uses `--pointermap: block` but has forgotten about it and has gotten used to it's non-functional behaviour will get a fun surprise upon updating.

### Documentation Notes

N/A

### Release Notes

- Fix custom CSS property `--pointermap` to allow leading and trailing whitespace in its value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3267)
<!-- Reviewable:end -->
