### PR TITLE
Fix for Hero Lab tokens

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2473,14 +2473,16 @@ public class Token extends BaseModel implements Cloneable {
     }
 
     // Fix for pre 1.11.3 campaigns and token size issues
-    Map<Object, GUID> oldSizeMap = new HashMap<>(sizeMap);
-    sizeMap.clear();
-    for (var entry : oldSizeMap.entrySet()) {
-      var key = entry.getKey();
-      if (key instanceof Class<?> cl) {
-        sizeMap.put(cl.getName(), entry.getValue());
-      } else {
-        sizeMap.put(key.toString(), entry.getValue());
+    if (sizeMap != null && sizeMap.size() > 0) {
+      Map<Object, GUID> oldSizeMap = new HashMap<>(sizeMap);
+      sizeMap.clear();
+      for (var entry : oldSizeMap.entrySet()) {
+        var key = entry.getKey();
+        if (key instanceof Class<?> cl) {
+          sizeMap.put(cl.getName(), entry.getValue());
+        } else {
+          sizeMap.put(key.toString(), entry.getValue());
+        }
       }
     }
 


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #3274

### Description of the Change
Fixes issue in the readResolve method of Token where it was trying to correct size map problems but HeroLab tokens have null size map (not an empty one).


### Possible Drawbacks
None that I can imagine.

### Documentation Notes
N/A

### Release Notes
Fix error that occurred while trying to drag HeroLab tokens from the resource library to the map

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3285)
<!-- Reviewable:end -->
