### PR TITLE
Support temporarily disconnected WebRTCClientConnections

### DIFF
--- a/src/main/java/net/rptools/clientserver/simple/client/WebRTCClientConnection.java
+++ b/src/main/java/net/rptools/clientserver/simple/client/WebRTCClientConnection.java
@@ -182,8 +182,10 @@ public class WebRTCClientConnection extends AbstractConnection
   public void sendMessage(Object channel, byte[] message) {
     log.debug(prefix() + "added message");
     addMessage(channel, message);
-    synchronized (sendThread) {
-      sendThread.notify();
+    if (peerConnection.getConnectionState() == RTCPeerConnectionState.CONNECTED) {
+      synchronized (sendThread) {
+        sendThread.notify();
+      }
     }
   }
 
@@ -191,7 +193,10 @@ public class WebRTCClientConnection extends AbstractConnection
   public boolean isAlive() {
     if (peerConnection == null) return false;
 
-    return peerConnection.getConnectionState() == RTCPeerConnectionState.CONNECTED;
+    return switch (peerConnection.getConnectionState()) {
+      case CONNECTED, DISCONNECTED -> true;
+      default -> false;
+    };
   }
 
   @Override
@@ -303,10 +308,19 @@ public class WebRTCClientConnection extends AbstractConnection
   @Override
   public void onConnectionChange(RTCPeerConnectionState state) {
     log.info(prefix() + "PeerConnection.onConnectionChange " + state);
-    if (state == RTCPeerConnectionState.DISCONNECTED) {
-      lastError = "PeerConnection disconnected";
-      peerConnection = null;
-      fireDisconnectAsync();
+    switch (state) {
+      case FAILED -> {
+        lastError = "PeerConnection failed";
+        peerConnection = null;
+        fireDisconnectAsync();
+      }
+      case CONNECTED -> {
+        if (hasMoreMessages()) {
+          synchronized (sendThread) {
+            sendThread.notify();
+          }
+        }
+      }
     }
   }
 
@@ -505,7 +519,8 @@ public class WebRTCClientConnection extends AbstractConnection
       log.debug(prefix() + " sendThread started");
       try {
         while (!stopRequested && connection.isAlive()) {
-          while (connection.hasMoreMessages()) {
+          while (connection.hasMoreMessages()
+              && peerConnection.getConnectionState() == RTCPeerConnectionState.CONNECTED) {
             byte[] message = connection.nextMessage();
             if (message == null) {
               continue;


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes #3298

### Description of the Change

WebRTC is tolerant to temporarily disconnected peer connections,
which can happen if a client doesn't send the heartbeat in time,
or a network link goes down,
but this is recoverable since the client may resume responding
and other routes may be active.

For this reason there is a separate RTCPeerConnectionState of
FAILED, which is distinct from DISCONNECTED
because a DISCONNECTED connection may become re-CONNECTED.

To handle potential disconnections, the sendThread is put to sleep if
there are no more messages or the peer connection is DISCONNECTED,
and is woken up on either sendMessage or connection state change
if there are both messages and it is CONNECTED.

RTCDataChannel.send may throw an Exception if its buffer is full,
which may be more likely to happen if the connection is disconnected,
but is not expected to throw while disconnected.

### Possible Drawbacks

I'm not super familiar with the MapTool codebase, so may have missed something.

### Release Notes

- When clients connect using WebRTC and the peer connection is temporarily interrupted, sent messages are queued until the peer connection either reconnects or fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3299)
<!-- Reviewable:end -->
