### PR TITLE
Restrict A* to exposed areas when FoW is enabled.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
@@ -65,16 +66,19 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
   protected int crossY = 0;
   private boolean debugCosts = false; // Manually set this to view H, G & F costs as rendered labels
   private Area vbl = new Area();
+  private Area fowExposedArea = new Area();
   private double cell_cost = zone.getUnitsPerCell();
   private double distance = -1;
   private ShapeReader shapeReader = new ShapeReader(geometryFactory);
   private PreparedGeometry vblGeometry = null;
+  private PreparedGeometry fowExposedAreaGeometry = null;
   // private long avgRetrieveTime;
   // private long avgTestTime;
   // private long retrievalCount;
   // private long testCount;
   private TokenFootprint footprint = new TokenFootprint();
-  private Map<CellPoint, Map<CellPoint, Boolean>> blockedMovesByGoal = new ConcurrentHashMap<>();
+  private Map<CellPoint, Map<CellPoint, Boolean>> vblBlockedMovesByGoal = new ConcurrentHashMap<>();
+  private Map<CellPoint, Map<CellPoint, Boolean>> fowBlockedMovesByGoal = new ConcurrentHashMap<>();
   private final Map<CellPoint, List<TerrainModifier>> terrainCells = new HashMap<>();
 
   public AbstractAStarWalker(Zone zone) {
@@ -124,7 +128,15 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
 
   public Map<CellPoint, Set<CellPoint>> getBlockedMoves() {
     final Map<CellPoint, Set<CellPoint>> result = new HashMap<>();
-    for (var entry : blockedMovesByGoal.entrySet()) {
+    for (var entry : vblBlockedMovesByGoal.entrySet()) {
+      result.put(
+          entry.getKey(),
+          entry.getValue().entrySet().stream()
+              .filter(Map.Entry::getValue)
+              .map(Map.Entry::getKey)
+              .collect(Collectors.toSet()));
+    }
+    for (var entry : fowBlockedMovesByGoal.entrySet()) {
       result.put(
           entry.getKey(),
           entry.getValue().entrySet().stream()
@@ -169,14 +181,13 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     // Render VBL to Geometry class once and store.
     // Note: zoneRenderer will be null if map is not visible to players.
     Area newVbl = new Area();
-    if (MapTool.getFrame().getCurrentZoneRenderer() != null) {
+    Area newFowExposedArea = new Area();
+    final var zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
+    if (zoneRenderer != null) {
       if (MapTool.getServerPolicy().getVblBlocksMove()) {
-        var vbl =
-            MapTool.getFrame().getCurrentZoneRenderer().getZoneView().getTopologyTree().getArea();
-        var hillVbl =
-            MapTool.getFrame().getCurrentZoneRenderer().getZoneView().getHillVblTree().getArea();
-        var pitVbl =
-            MapTool.getFrame().getCurrentZoneRenderer().getZoneView().getPitVblTree().getArea();
+        var vbl = zoneRenderer.getZoneView().getTopologyTree().getArea();
+        var hillVbl = zoneRenderer.getZoneView().getHillVblTree().getArea();
+        var pitVbl = zoneRenderer.getZoneView().getPitVblTree().getArea();
         newVbl.add(vbl);
         newVbl.add(hillVbl);
         newVbl.add(pitVbl);
@@ -190,13 +201,18 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
       } else {
         newVbl = zone.getTopologyTerrain();
       }
+
+      newFowExposedArea =
+          zoneRenderer.getZone().hasFog()
+              ? zoneRenderer.getZone().getExposedArea(zoneRenderer.getPlayerView())
+              : null;
     }
 
+    boolean blockedMovesHasChanged = false;
     if (!newVbl.equals(vbl)) {
+      blockedMovesHasChanged = true;
       vbl = newVbl;
 
-      // The move cache may no longer accurately reflect the VBL limitations.
-      this.blockedMovesByGoal.clear();
       // VBL has changed. Let's update the JTS geometry to match.
       if (vbl.isEmpty()) {
         this.vblGeometry = null;
@@ -220,6 +236,39 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
       }
 
       // log.info("vblGeometry bounds: " + vblGeometry.toString());
+    }
+    if (!Objects.equals(newFowExposedArea, fowExposedArea)) {
+      blockedMovesHasChanged = true;
+      fowExposedArea = newFowExposedArea;
+
+      // FoW has changed. Let's update the JTS geometry to match.
+      if (fowExposedArea == null || fowExposedArea.isEmpty()) {
+        this.fowExposedAreaGeometry = null;
+      } else {
+        try {
+          var fowExposedAreaGeometry =
+              shapeReader.read(new ReverseShapePathIterator(fowExposedArea.getPathIterator(null)));
+
+          // polygons
+          if (!fowExposedAreaGeometry.isValid()) {
+            log.info(
+                "FoW Geometry is invalid! May cause issues. Check for self-intersecting polygons.");
+            log.debug(
+                "Invalid FoW Geometry: "
+                    + new IsValidOp(fowExposedAreaGeometry).getValidationError());
+          }
+
+          fowExposedAreaGeometry =
+              fowExposedAreaGeometry.buffer(1); // .buffer always creates valid geometry.
+          this.fowExposedAreaGeometry = PreparedGeometryFactory.prepare(fowExposedAreaGeometry);
+        } catch (Exception e) {
+          log.info("FoW Geometry oh oh: ", e);
+        }
+      }
+    }
+    if (blockedMovesHasChanged) {
+      // The move cache may no longer accurately reflect the VBL limitations.
+      this.vblBlockedMovesByGoal.clear();
     }
 
     // Erase previous debug labels, this actually erases ALL labels! Use only when debugging!
@@ -410,6 +459,10 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
             blockNode = true;
             break;
           }
+          if (fowBlocksMovement(cellPoint, cellNeighbor)) {
+            blockNode = true;
+            break;
+          }
         }
 
         if (blockNode) {
@@ -509,7 +562,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
 
     // Stopwatch stopwatch = Stopwatch.createStarted();
     Map<CellPoint, Boolean> blockedMoves =
-        blockedMovesByGoal.computeIfAbsent(goal, pos -> new HashMap<>());
+        vblBlockedMovesByGoal.computeIfAbsent(goal, pos -> new HashMap<>());
     Boolean test = blockedMoves.get(start);
     // if it's null then the test for that direction hasn't been set yet otherwise just return the
     // previous result
@@ -547,6 +600,60 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     boolean blocksMovement;
     try {
       blocksMovement = vblGeometry.intersects(centerRay);
+    } catch (Exception e) {
+      log.info("clipped.intersects oh oh: ", e);
+      return true;
+    }
+
+    // avgTestTime += stopwatch.elapsed(TimeUnit.NANOSECONDS);
+    // testCount++;
+
+    blockedMoves.put(start, blocksMovement);
+
+    return blocksMovement;
+  }
+
+  private boolean fowBlocksMovement(CellPoint start, CellPoint goal) {
+    if (MapTool.getPlayer().isEffectiveGM()) {
+      return false;
+    }
+
+    if (fowExposedAreaGeometry == null) {
+      return false;
+    }
+
+    // Stopwatch stopwatch = Stopwatch.createStarted();
+    Map<CellPoint, Boolean> blockedMoves =
+        fowBlockedMovesByGoal.computeIfAbsent(goal, pos -> new HashMap<>());
+    Boolean test = blockedMoves.get(start);
+    // if it's null then the test for that direction hasn't been set yet otherwise just return the
+    // previous result
+    if (test != null) {
+      // log.info("Time to retrieve: " + stopwatch.elapsed(TimeUnit.NANOSECONDS));
+      // avgRetrieveTime += stopwatch.elapsed(TimeUnit.NANOSECONDS);
+      // retrievalCount++;
+      return test;
+    }
+
+    Rectangle startBounds = zone.getGrid().getBounds(start);
+    Rectangle goalBounds = zone.getGrid().getBounds(goal);
+
+    if (goalBounds.isEmpty() || startBounds.isEmpty()) {
+      return false;
+    }
+
+    // Check whether a center-to-center line touches hard FoW.
+    double x1 = startBounds.getCenterX();
+    double y1 = startBounds.getCenterY();
+    double x2 = goalBounds.getCenterX();
+    double y2 = goalBounds.getCenterY();
+    LineString centerRay =
+        geometryFactory.createLineString(
+            new Coordinate[] {new Coordinate(x1, y1), new Coordinate(x2, y2)});
+
+    boolean blocksMovement;
+    try {
+      blocksMovement = !fowExposedAreaGeometry.covers(centerRay);
     } catch (Exception e) {
       log.info("clipped.intersects oh oh: ", e);
       return true;


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3293


### Description of the Change

This change prevents pathfinding from showing paths through hard FoW, so as to avoid revealing details that would otherwise be unknown to the player. The check is entirely analogous to the existing MBL check: for each step, the line from one cell center to the next is required to lie completely within the exposed area or else it will be prohibited.

The area considered to be FoW relies on server settings as well as the effective player role:
- If FoW is disabled, FoW will be ignored for pathfinding.
- If the **Use Individual FoW** server setting is enabled, each client will pathfind according to their own token's exposed area.
- If the GM has **Show As Player** enabled, FoW will be enforced as though a player were moving the token.
- If the GM does not have **Show As Player**, then FoW will be ignored.

Since pathfinding is computed for each client separately, this means each client may potentially see different paths. However, the path seen by the client doing the move will be the authoratative path. This is the path that will be passed to `onTokenMove`, and is the path that will be returned by `getLastPath()`, regardless of which client calls the function.

### Possible Drawbacks

- The fact that different clients can see different paths may cause confusion, particularly if one path triggers certain effects while the other doesn't.

### Documentation Notes

N/A

### Release Notes

- Pathfinding no longer navigates through hard FoW

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3325)
<!-- Reviewable:end -->
