### PR TITLE
Fix VBL setters to always return arrays of valid polygons.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
@@ -257,7 +257,10 @@ public class Topology_Functions extends AbstractFunction {
       } else {
         // Build separate objects for each area.
         JsonArray allShapes = new JsonArray();
-        allShapes.add(getAreaShapeObject(topologyArea));
+        var areaShape = getAreaShapeObject(topologyArea);
+        if (areaShape != null) {
+          allShapes.add(areaShape);
+        }
         return allShapes.toString();
       }
     } else if (functionName.equalsIgnoreCase("getTokenVBL")) {
@@ -285,14 +288,15 @@ public class Topology_Functions extends AbstractFunction {
                 "macro.function.general.tooManyParam", "getTokenVBL", 1, parameters.size()));
       }
 
+      JsonArray allShapes = new JsonArray();
       Area vblArea = token.getVBL();
       if (vblArea != null) {
-        JsonArray allShapes = new JsonArray();
-        allShapes.add(getAreaShapeObject(vblArea));
-        return allShapes.toString();
-      } else {
-        return "";
+        var areaShape = getAreaShapeObject(vblArea);
+        if (areaShape != null) {
+          allShapes.add(areaShape);
+        }
       }
+      return allShapes.toString();
     } else if (functionName.equalsIgnoreCase("setTokenVBL")) {
       Token token = null;
 
@@ -1053,6 +1057,9 @@ public class Topology_Functions extends AbstractFunction {
           point.addProperty("y", y);
           points.add(point);
         });
+    if (points.isEmpty()) {
+      return null;
+    }
     polygon.add("points", points);
 
     return polygon;


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #2763

### Description of the Change

- `getTokenVBL()` now always returns an array and never an empty string.
- `getVBL()`, `getTokenVBL()`, `getHillVBL()`, and `getPitVBL()` now return an empty array where previously they
  returned a singleton array containing an invalid empty polygon.

### Possible Drawbacks

- If any code relied on specific return values to detect empty VBL, those checks will no longer be triggered.

### Documentation Notes

N/A

### Release Notes

- Fixed an issue where `set*VBL()` would error out when passed empty VBL from a previous `get*VBL()` call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3337)
<!-- Reviewable:end -->
