### PR TITLE
Fix macro editor theme name for case-sensitive file systems

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -185,7 +185,7 @@ public class AppPreferences {
   private static final boolean DEFAULT_VBL_BLOCKS_MOVE = true;
 
   private static final String MACRO_EDITOR_THEME = "macroEditorTheme";
-  private static final String DEFAULT_MACRO_EDITOR_THEME = "default";
+  private static final String DEFAULT_MACRO_EDITOR_THEME = "Default";
 
   // When hill VBL was introduced, older versions of MapTool were unable to read the new topology
   // modes. So we use a different preference key than in the past so older versions would not


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement
* Fill out the template below. Any pull request that does not include enough information to be reviewed in timely manner will result in a request for you to update the pull request 
  and possibly closure of the pull request if it is not provided after this request.
* After you create the pull request, all status checks must pass before a maintainer will review your contribution. 


### Identify the Bug or Feature request

Fixes #3146 

### Description of the Change

In the app preferences, the default theme name was lowercased while the corresponding XML file had a leading capital. On linux that was causing an error to be logged and the macro editor to be themed incorrectly.

### Possible Drawbacks

Linux users on the that haven't set a theme may find the change to the true default a bit jarring. We used to see something akin to the Default Alt theme:
![theming-with-file-not-found](https://user-images.githubusercontent.com/7492219/149677919-2c3b1193-60ed-4539-b567-b40269005162.png)
But now we'll see the true default:
![theming-with-file-found](https://user-images.githubusercontent.com/7492219/149677922-a5625da5-efb4-431c-9033-7c50c50b8f3f.png)

### Documentation Notes

N/A

### Release Notes

- Fixed the default theming for macro editors on case sensitive file systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3338)
<!-- Reviewable:end -->
