### PR TITLE
Fix fullscreen tools toggle so it can be used while connected to a server

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -662,7 +662,7 @@ public class AppActions {
       };
 
   public static final Action TOGGLE_FULLSCREEN_TOOLS =
-      new AdminClientAction() {
+      new DefaultClientAction() {
         {
           init("action.toggleFullScreenTools");
         }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #2764

### Description of the Change

The fullscreen tools toggle was marked as an admin action and so is only available on a GM client. This change makes it a regular action so anyone can show or hide their tools even when acting as a player connected to a server.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

- Fix to allow players to toggle fullscreen tools

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3340)
<!-- Reviewable:end -->
