### PR TITLE
Copy grid color when copying zones

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -442,6 +442,7 @@ public class Zone extends BaseModel {
     } catch (CloneNotSupportedException cnse) {
       MapTool.showError("Trying to copy the zone's grid; no grid assigned", cnse);
     }
+    gridColor = zone.gridColor;
     unitsPerCell = zone.unitsPerCell;
     tokenVisionDistance = zone.tokenVisionDistance;
     imageScaleX = zone.imageScaleX;


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3101

### Description of the Change

When a server is started, the zones are copied rather than being used as-is. The grid color was not being copied in this, unlike the other `Zone` properties, and this change fixes that.

The same thing affects copies of maps. Now copying a map will create a new map with the same grid color as the original.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

- Fix to grid color so they are preserved when copying maps and starting servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3341)
<!-- Reviewable:end -->
