### PR TITLE
Issue 3254 protobuf null pointer exceptions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -646,7 +646,7 @@ public class ServerCommandClientImpl implements ServerCommand {
 
   @Override
   public void updateTokenProperty(Token token, Token.Update update) {
-    updateTokenProperty(token, update);
+    updateTokenProperty(token, update, new TokenPropertyValueDto[]{});
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -646,7 +646,7 @@ public class ServerCommandClientImpl implements ServerCommand {
 
   @Override
   public void updateTokenProperty(Token token, Token.Update update) {
-    updateTokenProperty(token, update, new TokenPropertyValueDto[]{});
+    updateTokenProperty(token, update, new TokenPropertyValueDto[] {});
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -126,6 +126,14 @@ public class Campaign {
     gmMacroButtonProperties = new ArrayList<MacroButtonProperties>();
   }
 
+  private Object readResolve() {
+    if (exportSettings == null) {
+      exportSettings = new HashMap<>();
+    }
+
+    return this;
+  }
+
   private void checkCampaignPropertyConversion() {
     if (campaignProperties == null) {
       campaignProperties = new CampaignProperties();

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -391,6 +391,14 @@ public class LookupTable {
       this.imageId = imageId;
     }
 
+    private Object readResolve() {
+      if (picked == null) {
+        picked = false;
+      }
+
+      return this;
+    }
+
     public MD5Key getImageId() {
       return imageId;
     }
@@ -525,7 +533,9 @@ public class LookupTable {
     var dto = LookupTableDto.newBuilder();
     dto.addAllEntries(entryList.stream().map(e -> e.toDto()).collect(Collectors.toList()));
     dto.setName(name);
-    dto.setDefaultRoll(defaultRoll);
+    if (defaultRoll != null) {
+      dto.setDefaultRoll(defaultRoll);
+    }
     if (tableImage != null) {
       dto.setTableImage(StringValue.of(tableImage.toString()));
     }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2871,7 +2871,7 @@ public class Token extends BaseModel implements Cloneable {
     dto.setVisibleOnlyToOwner(visibleOnlyToOwner);
     dto.setVblColorSensitivity(vblColorSensitivity);
     dto.setAlwaysVisibleTolerance(alwaysVisibleTolerance);
-    dto.setIsAlwaysVisible(isVisible);
+    dto.setIsAlwaysVisible(isAlwaysVisible);
     if (vbl != null) {
       dto.setVbl(Mapper.map(vbl));
     }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -263,7 +263,7 @@ public class Token extends BaseModel implements Cloneable {
   private Area vbl;
 
   private String name;
-  private final Set<String> ownerList = new HashSet<>();
+  private Set<String> ownerList = new HashSet<>();
 
   private int ownerType;
 
@@ -323,7 +323,7 @@ public class Token extends BaseModel implements Cloneable {
   private MD5Key charsheetImage;
   private MD5Key portraitImage;
 
-  private final List<AttachedLightSource> lightSourceList = new ArrayList<>();
+  private List<AttachedLightSource> lightSourceList = new ArrayList<>();
   private String sightType;
   private boolean hasSight;
   private Boolean hasImageTable = false;
@@ -353,12 +353,12 @@ public class Token extends BaseModel implements Cloneable {
   // help XStream move the data around.
   private Map<String, Object> propertyMap; // 1.3b77 and earlier
 
-  private final CaseInsensitiveHashMap<Object> propertyMapCI = new CaseInsensitiveHashMap<>();
+  private CaseInsensitiveHashMap<Object> propertyMapCI = new CaseInsensitiveHashMap<>();
 
   private Map<String, String> macroMap;
-  private final Map<Integer, MacroButtonProperties> macroPropertiesMap = new HashMap<>();
+  private Map<Integer, MacroButtonProperties> macroPropertiesMap = new HashMap<>();
 
-  private final Map<String, String> speechMap = new HashMap<>();
+  private Map<String, String> speechMap = new HashMap<>();
 
   private HeroLabData heroLabData;
 
@@ -2378,6 +2378,9 @@ public class Token extends BaseModel implements Cloneable {
     // a pre-1.3b78 token that actually has the CaseInsensitiveHashMap<?>.
     // Newer tokens will use propertyMapCI so we only need to make corrections
     // if the old field has data in it.
+    if (propertyMapCI == null) {
+      propertyMapCI = new CaseInsensitiveHashMap<>();
+    }
     if (propertyMap != null) {
       propertyMapCI.putAll(propertyMap);
       propertyMap.clear(); // It'll never be written out, but we should free the memory.
@@ -2400,6 +2403,34 @@ public class Token extends BaseModel implements Cloneable {
           sizeMap.put(key.toString(), entry.getValue());
         }
       }
+    }
+
+    if (ownerList == null) {
+      ownerList = new HashSet<>();
+    }
+    if (lightSourceList == null) {
+      lightSourceList = new ArrayList<>();
+    }
+    if (macroPropertiesMap == null) {
+      macroPropertiesMap = new HashMap<>();
+    }
+    if (speechMap == null) {
+      speechMap = new HashMap<>();
+    }
+    if (isFlippedIso == null) {
+      isFlippedIso = false;
+    }
+    if (hasImageTable == null) {
+      hasImageTable = false;
+    }
+    if (tokenShape == null) {
+      tokenShape = TokenShape.SQUARE.toString();
+    }
+    if (tokenType == null) {
+      tokenType = Type.NPC.toString();
+    }
+    if (speechName == null) {
+      speechName = "";
     }
 
     return this;

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2266,8 +2266,12 @@ public class Zone extends BaseModel {
     dto.addAllLabels(labels.values().stream().map(l -> l.toDto()).collect(Collectors.toList()));
     dto.addAllTokens(tokenMap.values().stream().map(t -> t.toDto()).collect(Collectors.toList()));
     exposedAreaMeta.forEach(
-        (id, area) ->
-            dto.putExposedAreaMeta(id.toString(), Mapper.map(area.getExposedAreaHistory())));
+        (id, area) -> {
+          if (id == null) {
+            return;
+          }
+          dto.putExposedAreaMeta(id.toString(), Mapper.map(area.getExposedAreaHistory()));
+        });
     dto.setInitiative(initiativeList.toDto());
     dto.setExposedArea(Mapper.map(exposedArea));
     dto.setHasFog(hasFog);


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #3254

### Description of the Change

There are several model types that have fields that aren't expected to be `null` but which can be made `null` as a result of deserialization. This made it impossible to open many campaign files, possibly also affecting other actions that require deserialization. This changes primarly adds or modifies `readResolve()` methods for various model types to avoid undesirable `null`s.

A couple smaller fixes are also included:
- Infinite recursion for parameterless token updates.
- Fix for tokens marked **Visible to players** also becoming **Visible over FoW** when a server is started.
- Handle `null` exposed area GUIDs by ignoring them while serializing.

### Possible Drawbacks

Shouldn't be any drawbacks in behaviour. There may be a better way to handle deserialization with missing / `null` fields that could avoid some of these checks.

Skipping the `null` keys for `Zone.exposedAreaMeta` is kind of the wildcard in this change. Those keys shouldn't be possible and yet they exist, so _maybe_ there could be some edge case where they can be read back out again.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3353)
<!-- Reviewable:end -->
