### PR TITLE
Misc fixes for protobuf migration

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2666,7 +2666,7 @@ public class AppActions {
         if (t.getCause() instanceof AppState.FailedToAcquireLockException) {
           MapTool.showError("msg.error.failedLoadCampaignLock");
         } else {
-            MapTool.showError("msg.error.failedLoadCampaign", t);
+          MapTool.showError("msg.error.failedLoadCampaign", t);
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2666,7 +2666,7 @@ public class AppActions {
         if (t.getCause() instanceof AppState.FailedToAcquireLockException) {
           MapTool.showError("msg.error.failedLoadCampaignLock");
         } else {
-          MapTool.showError("msg.error.failedLoadCampaign", t.getCause());
+            MapTool.showError("msg.error.failedLoadCampaign", t);
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -293,7 +293,7 @@ public class MapTool {
    */
   public static void showError(String msgKey, Throwable t) {
     String msg = generateMessage(msgKey, t);
-    log.error(msgKey, t);
+    log.error(I18N.getString(msgKey), t);
     showMessage(msg, "msg.title.messageDialogError", JOptionPane.ERROR_MESSAGE);
   }
 

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2109,6 +2109,10 @@ public class Zone extends BaseModel {
     if (topologyTerrain == null) {
       topologyTerrain = new Area();
     }
+
+    if (aStarRounding == null) {
+      aStarRounding = AStarRoundingOptions.NONE;
+    }
     return this;
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Issue #3254 

### Description of the Change

AppActions - showError() call incorrectly using t.getCause()
MapTool - log.error() was using message key and not the message string.
Zone - added check for aStarRounding being null to readResolve().

### Possible Drawbacks

None expected.

### Documentation Notes

n/a

### Release Notes

Failing to load a campaign now more likely to produce a useful message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3354)
<!-- Reviewable:end -->
