### PR TITLE
Upgrade handshake cipher to AES CBC

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -2342,6 +2343,7 @@ public class AppActions {
                   MapTool.showError("msg.error.failedConnect", ioe);
                   failed = true;
                 } catch (NoSuchAlgorithmException
+                    | InvalidAlgorithmParameterException
                     | InvalidKeySpecException
                     | NoSuchPaddingException
                     | InvalidKeyException

--- a/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreferencesDialog.java
@@ -896,7 +896,7 @@ public class PreferencesDialog extends JDialog {
 
     regeneratePublicKey.addActionListener(
         e -> {
-          CompletableFuture<CipherUtil> keys = new PublicPrivateKeyStore().regenerateKeys();
+          CompletableFuture<CipherUtil.Key> keys = new PublicPrivateKeyStore().regenerateKeys();
 
           keys.thenAccept(
               cu -> {
@@ -1062,7 +1062,7 @@ public class PreferencesDialog extends JDialog {
     chatNotificationColor.setColor(AppPreferences.getChatNotificationColor());
     chatNotificationShowBackground.setSelected(AppPreferences.getChatNotificationShowBackground());
 
-    CompletableFuture<CipherUtil> keys = new PublicPrivateKeyStore().getKeys();
+    CompletableFuture<CipherUtil.Key> keys = new PublicPrivateKeyStore().getKeys();
 
     keys.thenAccept(
         cu -> {

--- a/src/main/java/net/rptools/maptool/client/ui/players/PlayerDatabaseEditController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/players/PlayerDatabaseEditController.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.ui.players;
 
 import java.net.URL;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -301,7 +302,8 @@ public class PlayerDatabaseEditController implements SwingJavaFXDialogController
           } catch (NoSuchAlgorithmException
               | InvalidKeySpecException
               | NoSuchPaddingException
-              | InvalidKeyException e) {
+              | InvalidKeyException
+              | InvalidAlgorithmParameterException e) {
             isValidPk = false;
             break;
           }

--- a/src/main/java/net/rptools/maptool/model/player/DefaultPlayerDatabase.java
+++ b/src/main/java/net/rptools/maptool/model/player/DefaultPlayerDatabase.java
@@ -31,8 +31,8 @@ import net.rptools.maptool.util.cipher.CipherUtil;
  */
 public class DefaultPlayerDatabase implements PlayerDatabase {
 
-  private final CipherUtil playerPassword;
-  private final CipherUtil gmPassword;
+  private final CipherUtil.Key playerPassword;
+  private final CipherUtil.Key gmPassword;
   private final LoggedInPlayers loggedInPlayers = new LoggedInPlayers();
 
   DefaultPlayerDatabase(String playerPassword, String gmPassword)
@@ -51,7 +51,7 @@ public class DefaultPlayerDatabase implements PlayerDatabase {
   @Override
   public Player getPlayer(String playerName) {
     // If role is not specified always return player!
-    return new Player(playerName, Player.Role.PLAYER, playerPassword.getKey());
+    return new Player(playerName, Player.Role.PLAYER, playerPassword);
   }
 
   @Override
@@ -61,7 +61,7 @@ public class DefaultPlayerDatabase implements PlayerDatabase {
 
   @Override
   public byte[] getPlayerPasswordSalt(String playerName) {
-    return playerPassword.getKey().salt(); // Player and GM password salt are the same
+    return playerPassword.salt(); // Player and GM password salt are the same
   }
 
   @Override
@@ -73,9 +73,9 @@ public class DefaultPlayerDatabase implements PlayerDatabase {
   public Optional<CipherUtil.Key> getRolePassword(Player.Role role) {
     switch (role) {
       case PLAYER:
-        return Optional.of(playerPassword.getKey());
+        return Optional.of(playerPassword);
       case GM:
-        return Optional.of(gmPassword.getKey());
+        return Optional.of(gmPassword);
       default:
         return Optional.empty();
     }
@@ -122,7 +122,7 @@ public class DefaultPlayerDatabase implements PlayerDatabase {
   }
 
   @Override
-  public CompletableFuture<CipherUtil> getPublicKey(Player player, MD5Key md5key) {
+  public CompletableFuture<CipherUtil.Key> getPublicKey(Player player, MD5Key md5key) {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/src/main/java/net/rptools/maptool/model/player/LocalPlayerDatabase.java
+++ b/src/main/java/net/rptools/maptool/model/player/LocalPlayerDatabase.java
@@ -144,7 +144,7 @@ public class LocalPlayerDatabase implements PlayerDatabase {
   }
 
   @Override
-  public CompletableFuture<CipherUtil> getPublicKey(Player player, MD5Key md5key) {
+  public CompletableFuture<CipherUtil.Key> getPublicKey(Player player, MD5Key md5key) {
     return new PublicPrivateKeyStore().getKeys();
   }
 
@@ -157,7 +157,7 @@ public class LocalPlayerDatabase implements PlayerDatabase {
   public CompletableFuture<Boolean> hasPublicKey(Player player, MD5Key md5key) {
     return new PublicPrivateKeyStore()
         .getKeys()
-        .thenApply(k -> CipherUtil.publicKeyMD5(k.getKey().publicKey()).equals(md5key));
+        .thenApply(k -> CipherUtil.publicKeyMD5(k.publicKey()).equals(md5key));
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/player/PasswordFilePlayerDatabase.java
+++ b/src/main/java/net/rptools/maptool/model/player/PasswordFilePlayerDatabase.java
@@ -34,6 +34,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -117,7 +118,7 @@ public final class PasswordFilePlayerDatabase
 
   public void readPasswordFile()
       throws PasswordDatabaseException, NoSuchAlgorithmException, InvalidKeySpecException,
-          NoSuchPaddingException, InvalidKeyException {
+          NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
 
     try {
       passwordFileLock.lock();
@@ -137,7 +138,7 @@ public final class PasswordFilePlayerDatabase
 
   public void initialize()
       throws PasswordDatabaseException, NoSuchAlgorithmException, InvalidKeySpecException,
-          NoSuchPaddingException, InvalidKeyException {
+          NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
     transientPlayerDetails.clear();
     readPasswordFile();
     savedDetails.putAll(playerDetails);
@@ -147,7 +148,7 @@ public final class PasswordFilePlayerDatabase
 
   private Map<String, PlayerDetails> readPasswordFile(File file)
       throws PasswordDatabaseException, NoSuchAlgorithmException, InvalidKeySpecException,
-          NoSuchPaddingException, InvalidKeyException {
+          NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
 
     try {
       passwordFileLock.lock();
@@ -448,7 +449,7 @@ public final class PasswordFilePlayerDatabase
   @Override
   public void addPlayerAsymmetricKey(String name, Role role, Set<String> publicKeyStrings)
       throws NoSuchAlgorithmException, InvalidKeySpecException, PasswordDatabaseException,
-          NoSuchPaddingException, InvalidKeyException {
+          NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
     if (playerExists(name)) {
       throw new PasswordDatabaseException(I18N.getText("Password.playerExists", name));
     }
@@ -520,7 +521,7 @@ public final class PasswordFilePlayerDatabase
   @Override
   public void setAsymmetricKeys(String name, Set<String> keys)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
-          PasswordDatabaseException, InvalidKeyException {
+          PasswordDatabaseException, InvalidKeyException, InvalidAlgorithmParameterException {
 
     var pd = getPlayerDetails(name);
 
@@ -535,7 +536,7 @@ public final class PasswordFilePlayerDatabase
   @Override
   public void addAsymmetricKeys(String name, Set<String> keys)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
-          PasswordDatabaseException, InvalidKeyException {
+          PasswordDatabaseException, InvalidKeyException, InvalidAlgorithmParameterException {
     if (!playerExists(name)) {
       throw new PasswordDatabaseException(I18N.getText("msg.error.playerNotInDatabase", name));
     }
@@ -768,7 +769,7 @@ public final class PasswordFilePlayerDatabase
   private PlayerDetails putUncommittedPlayer(
       String name, Role role, Set<String> publicKeyStrings, String blockedReason, boolean persisted)
       throws NoSuchAlgorithmException, InvalidKeySpecException, PasswordDatabaseException,
-          NoSuchPaddingException, InvalidKeyException {
+          NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
     return putUncommittedPlayer(
         name, role, null, createPublicKeyDetails(publicKeyStrings, name), blockedReason, persisted);
   }
@@ -865,7 +866,7 @@ public final class PasswordFilePlayerDatabase
   private Set<PublicKeyDetails> createPublicKeyDetails(
       Set<String> publicKeyStrings, String playerName)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
-          InvalidKeyException {
+          InvalidKeyException, InvalidAlgorithmParameterException {
     Set<PublicKeyDetails> pkDetails = new HashSet<>();
 
     String pkFilename = derivePublicKeyFilename(playerName);

--- a/src/main/java/net/rptools/maptool/model/player/PersistedPlayerDatabase.java
+++ b/src/main/java/net/rptools/maptool/model/player/PersistedPlayerDatabase.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.model.player;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -67,7 +68,7 @@ public interface PersistedPlayerDatabase {
    */
   void addPlayerAsymmetricKey(String name, Role role, Set<String> publicKeyStrings)
       throws NoSuchAlgorithmException, InvalidKeySpecException, PasswordDatabaseException,
-          NoSuchPaddingException, InvalidKeyException;
+          NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException;
 
   /**
    * Sets the shared password for the specified player. If the player does not exist then a {@link
@@ -102,7 +103,7 @@ public interface PersistedPlayerDatabase {
    */
   void setAsymmetricKeys(String name, Set<String> keys)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
-          PasswordDatabaseException, InvalidKeyException;
+          PasswordDatabaseException, InvalidKeyException, InvalidAlgorithmParameterException;
 
   /**
    * Adds the keys to the existing keys for the specified player. This will remove any shared key
@@ -120,7 +121,7 @@ public interface PersistedPlayerDatabase {
    */
   void addAsymmetricKeys(String name, Set<String> keys)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
-          PasswordDatabaseException, InvalidKeyException;
+          PasswordDatabaseException, InvalidKeyException, InvalidAlgorithmParameterException;
 
   /**
    * Returns if the specified player is persisted or not. Persisted players include those that are

--- a/src/main/java/net/rptools/maptool/model/player/PersonalServerPlayerDatabase.java
+++ b/src/main/java/net/rptools/maptool/model/player/PersonalServerPlayerDatabase.java
@@ -83,7 +83,7 @@ public class PersonalServerPlayerDatabase implements PlayerDatabase {
   }
 
   @Override
-  public CompletableFuture<CipherUtil> getPublicKey(Player player, MD5Key md5key)
+  public CompletableFuture<CipherUtil.Key> getPublicKey(Player player, MD5Key md5key)
       throws ExecutionException, InterruptedException {
     return CompletableFuture.completedFuture(null);
   }

--- a/src/main/java/net/rptools/maptool/model/player/PlayerDatabase.java
+++ b/src/main/java/net/rptools/maptool/model/player/PlayerDatabase.java
@@ -172,7 +172,7 @@ public interface PlayerDatabase {
    *     decode with * the public key, the {@code CompletableFuture} can return {@code null} if
    *     there is no public key.
    */
-  CompletableFuture<CipherUtil> getPublicKey(Player player, MD5Key md5key)
+  CompletableFuture<CipherUtil.Key> getPublicKey(Player player, MD5Key md5key)
       throws ExecutionException, InterruptedException;
 
   /**

--- a/src/main/java/net/rptools/maptool/model/player/Players.java
+++ b/src/main/java/net/rptools/maptool/model/player/Players.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.model.player;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -330,6 +331,7 @@ public class Players {
         playerDb.addPlayerAsymmetricKey(name, role, pkeys);
         return ChangePlayerStatus.OK;
       } catch (NoSuchAlgorithmException
+          | InvalidAlgorithmParameterException
           | InvalidKeySpecException
           | PasswordDatabaseException
           | NoSuchPaddingException
@@ -364,6 +366,7 @@ public class Players {
         playerDb.setAsymmetricKeys(name, pkeys);
       } catch (NoSuchPaddingException
           | NoSuchAlgorithmException
+          | InvalidAlgorithmParameterException
           | InvalidKeySpecException
           | PasswordDatabaseException
           | InvalidKeyException e) {

--- a/src/main/java/net/rptools/maptool/server/ClientHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ClientHandshake.java
@@ -127,8 +127,7 @@ public class ClientHandshake implements Handshake, MessageHandler {
 
   @Override
   public void startHandshake() throws ExecutionException, InterruptedException {
-    var md5key =
-        CipherUtil.publicKeyMD5(new PublicPrivateKeyStore().getKeys().get().getKey().publicKey());
+    var md5key = CipherUtil.publicKeyMD5(new PublicPrivateKeyStore().getKeys().get().publicKey());
     var clientInitMsg =
         ClientInitMsg.newBuilder()
             .setPlayerName(player.getName())
@@ -269,10 +268,10 @@ public class ClientHandshake implements Handshake, MessageHandler {
     HandshakeChallenge handshakeChallenge = null;
 
     if (useAuthTypeMsg.getAuthType() == AuthTypeEnum.ASYMMETRIC_KEY) {
-      CipherUtil cipherUtil = new PublicPrivateKeyStore().getKeys().get();
+      CipherUtil.Key publicKey = new PublicPrivateKeyStore().getKeys().get();
       handshakeChallenge =
           HandshakeChallenge.fromChallengeBytes(
-              player.getName(), useAuthTypeMsg.getChallenge(0).toByteArray(), cipherUtil.getKey());
+              player.getName(), useAuthTypeMsg.getChallenge(0).toByteArray(), publicKey);
     } else {
       player.setPasswordSalt(useAuthTypeMsg.getSalt().toByteArray());
       for (int i = 0; i < useAuthTypeMsg.getChallengeCount(); i++) {

--- a/src/main/java/net/rptools/maptool/server/ClientHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ClientHandshake.java
@@ -19,8 +19,10 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -263,24 +265,36 @@ public class ClientHandshake implements Handshake, MessageHandler {
   private void handle(UseAuthTypeMsg useAuthTypeMsg)
       throws ExecutionException, InterruptedException, IllegalBlockSizeException,
           BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException,
-          InvalidKeyException, InvalidKeySpecException {
+          InvalidKeyException, InvalidKeySpecException, InvalidAlgorithmParameterException {
 
-    HandshakeChallenge handshakeChallenge = null;
+    var clientAuthMsg = ClientAuthMsg.newBuilder();
 
     if (useAuthTypeMsg.getAuthType() == AuthTypeEnum.ASYMMETRIC_KEY) {
       CipherUtil.Key publicKey = new PublicPrivateKeyStore().getKeys().get();
-      handshakeChallenge =
-          HandshakeChallenge.fromChallengeBytes(
+      var handshakeChallenge =
+          HandshakeChallenge.fromAsymmetricChallengeBytes(
               player.getName(), useAuthTypeMsg.getChallenge(0).toByteArray(), publicKey);
+      var expectedResponse = handshakeChallenge.getExpectedResponse();
+      clientAuthMsg = clientAuthMsg.setChallengeResponse(ByteString.copyFrom(expectedResponse));
     } else {
+      SecureRandom rnd = new SecureRandom();
+      byte[] responseIv = new byte[CipherUtil.CIPHER_BLOCK_SIZE];
+      rnd.nextBytes(responseIv);
+
       player.setPasswordSalt(useAuthTypeMsg.getSalt().toByteArray());
+      var iv = useAuthTypeMsg.getIv().toByteArray();
       for (int i = 0; i < useAuthTypeMsg.getChallengeCount(); i++) {
         try {
           Key key = player.getPassword();
           // Key key = playerDatabase.getPlayerPassword(player.getName()).get();
-          handshakeChallenge =
-              HandshakeChallenge.fromChallengeBytes(
-                  player.getName(), useAuthTypeMsg.getChallenge(i).toByteArray(), key);
+          var handshakeChallenge =
+              HandshakeChallenge.fromSymmetricChallengeBytes(
+                  player.getName(), useAuthTypeMsg.getChallenge(i).toByteArray(), key, iv);
+          var expectedResponse = handshakeChallenge.getExpectedResponse(responseIv);
+          clientAuthMsg =
+              clientAuthMsg
+                  .setChallengeResponse(ByteString.copyFrom(expectedResponse))
+                  .setIv(ByteString.copyFrom(responseIv));
           break;
         } catch (Exception e) {
           // ignore exception unless is the last one
@@ -290,10 +304,6 @@ public class ClientHandshake implements Handshake, MessageHandler {
         }
       }
     }
-
-    var clientAuthMsg =
-        ClientAuthMsg.newBuilder()
-            .setChallengeResponse(ByteString.copyFrom(handshakeChallenge.getExpectedResponse()));
 
     var handshakeMsg = HandshakeMsg.newBuilder().setClientAuthMessage(clientAuthMsg).build();
     sendMessage(handshakeMsg);

--- a/src/main/java/net/rptools/maptool/server/HandshakeChallenge.java
+++ b/src/main/java/net/rptools/maptool/server/HandshakeChallenge.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.server;
 
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.BadPaddingException;
@@ -26,49 +27,110 @@ import net.rptools.maptool.util.cipher.CipherUtil;
 public class HandshakeChallenge {
   private final byte[] challenge;
   private final byte[] expectedResponse;
+  private final CipherUtil.Key key;
+
+  private HandshakeChallenge(byte[] challenge, byte[] expectedResponse, CipherUtil.Key key) {
+    this.challenge = challenge;
+    this.expectedResponse = expectedResponse;
+    this.key = key;
+  }
 
   private HandshakeChallenge(byte[] challenge, byte[] expectedResponse) {
     this.challenge = challenge;
     this.expectedResponse = expectedResponse;
+    this.key = null;
   }
 
-  static HandshakeChallenge createChallenge(String username, String password, CipherUtil.Key key)
+  static HandshakeChallenge createSymmetricChallenge(
+      String username, String password, CipherUtil.Key key, byte[] iv)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-          IllegalBlockSizeException, BadPaddingException {
-    Cipher encryptor = CipherUtil.createEncryptor(key);
+          IllegalBlockSizeException, BadPaddingException, AssertionError,
+          InvalidAlgorithmParameterException {
+    if (key.asymmetric()) {
+      throw new AssertionError("Expected Symmetric algorithm and IV, got Asymmetric algorithm");
+    }
+    return createChallenge(username, password, key, iv);
+  }
+
+  static HandshakeChallenge createAsymmetricChallenge(
+      String username, String password, CipherUtil.Key key)
+      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+          IllegalBlockSizeException, BadPaddingException, AssertionError,
+          InvalidAlgorithmParameterException {
+    if (!key.asymmetric()) {
+      throw new AssertionError("Expected Asymmetric algorithm without IV, got Symmetric algorithm");
+    }
+    return createChallenge(username, password, key, null);
+  }
+
+  private static HandshakeChallenge createChallenge(
+      String username, String password, CipherUtil.Key key, byte[] iv)
+      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+          IllegalBlockSizeException, BadPaddingException, InvalidAlgorithmParameterException {
+    Cipher encryptor;
+    if (key.asymmetric()) {
+      encryptor = CipherUtil.createAsymmetricEncryptor(key);
+    } else {
+      encryptor = CipherUtil.createSymmetricEncryptor(key, iv);
+    }
     String toEncrypt = username + password;
     byte[] challenge = encryptor.doFinal(toEncrypt.getBytes(StandardCharsets.UTF_8));
-    byte[] response;
     var revPassword = new StringBuilder(password).reverse().toString();
+    var response = revPassword.getBytes(StandardCharsets.UTF_8);
+
     if (key.asymmetric()) {
-      response = revPassword.getBytes(StandardCharsets.UTF_8);
+      return new HandshakeChallenge(challenge, response);
     } else {
-      response = encryptor.doFinal(revPassword.getBytes(StandardCharsets.UTF_8));
+      return new HandshakeChallenge(challenge, response, key);
     }
-    return new HandshakeChallenge(challenge, response);
   }
 
-  static HandshakeChallenge fromChallengeBytes(
+  static HandshakeChallenge fromSymmetricChallengeBytes(
+      String username, byte[] challenge, CipherUtil.Key key, byte[] iv)
+      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+          IllegalBlockSizeException, BadPaddingException, AssertionError,
+          InvalidAlgorithmParameterException {
+    if (key.asymmetric()) {
+      throw new AssertionError("Expected Symmetric algorithm and IV, got Asymmetric algorithm");
+    }
+    return fromChallengeBytes(username, challenge, key, iv);
+  }
+
+  static HandshakeChallenge fromAsymmetricChallengeBytes(
       String username, byte[] challenge, CipherUtil.Key key)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-          IllegalBlockSizeException, BadPaddingException {
-    Cipher decryptor = CipherUtil.createDecryptor(key);
+          IllegalBlockSizeException, BadPaddingException, AssertionError,
+          InvalidAlgorithmParameterException {
+    if (!key.asymmetric()) {
+      throw new AssertionError("Expected Symmetric algorithm and IV, got Asymmetric algorithm");
+    }
+    return fromChallengeBytes(username, challenge, key, null);
+  }
+
+  private static HandshakeChallenge fromChallengeBytes(
+      String username, byte[] challenge, CipherUtil.Key key, byte[] iv)
+      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+          IllegalBlockSizeException, BadPaddingException, InvalidAlgorithmParameterException {
+    Cipher decryptor;
+    if (key.asymmetric()) {
+      decryptor = CipherUtil.createAsymmetricDecryptor(key);
+    } else {
+      decryptor = CipherUtil.createSymmetricDecryptor(key, iv);
+    }
     String challengeString = new String(decryptor.doFinal(challenge));
     if (!challengeString.startsWith(username)) {
       throw new IllegalStateException(
           "Handhshake challenge " + challengeString + " does not start with username " + username);
     }
     String responseString = challengeString.substring(username.length());
-    byte[] response;
     var revPassword = new StringBuilder(responseString).reverse().toString();
-    if (key.asymmetric()) {
-      response = revPassword.getBytes(StandardCharsets.UTF_8);
-    } else {
-      Cipher encryptor = CipherUtil.createEncryptor(key);
-      response = encryptor.doFinal(revPassword.getBytes(StandardCharsets.UTF_8));
-    }
+    var response = revPassword.getBytes(StandardCharsets.UTF_8);
 
-    return new HandshakeChallenge(challenge, response);
+    if (key.asymmetric()) {
+      return new HandshakeChallenge(challenge, response);
+    } else {
+      return new HandshakeChallenge(challenge, response, key);
+    }
   }
 
   public byte[] getChallenge() {
@@ -77,5 +139,12 @@ public class HandshakeChallenge {
 
   public byte[] getExpectedResponse() {
     return expectedResponse;
+  }
+
+  public byte[] getExpectedResponse(byte[] iv)
+      throws NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException,
+          BadPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
+    Cipher encryptor = CipherUtil.createSymmetricEncryptor(key, iv);
+    return encryptor.doFinal(expectedResponse);
   }
 }

--- a/src/main/java/net/rptools/maptool/server/HandshakeChallenge.java
+++ b/src/main/java/net/rptools/maptool/server/HandshakeChallenge.java
@@ -58,7 +58,7 @@ public class HandshakeChallenge {
       throw new IllegalStateException(
           "Handhshake challenge " + challengeString + " does not start with username " + username);
     }
-    String responseString = challengeString.replace(username, "");
+    String responseString = challengeString.substring(username.length());
     byte[] response;
     var revPassword = new StringBuilder(responseString).reverse().toString();
     if (key.asymmetric()) {

--- a/src/main/java/net/rptools/maptool/server/ServerHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ServerHandshake.java
@@ -521,10 +521,10 @@ public class ServerHandshake implements Handshake, MessageHandler {
       }
       return State.AwaitingPublicKey;
     }
-    CipherUtil cipherUtil = playerDatabase.getPublicKey(player, playerPublicKeyMD5).get();
+    CipherUtil.Key publicKey = playerDatabase.getPublicKey(player, playerPublicKeyMD5).get();
     String password = new PasswordGenerator().getPassword();
     handshakeChallenges[0] =
-        HandshakeChallenge.createChallenge(player.getName(), password, cipherUtil.getKey());
+        HandshakeChallenge.createChallenge(player.getName(), password, publicKey);
 
     var authTypeMsg =
         UseAuthTypeMsg.newBuilder()

--- a/src/main/java/net/rptools/maptool/server/ServerHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ServerHandshake.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.server;
 
 import com.google.protobuf.ByteString;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -302,6 +303,7 @@ public class ServerHandshake implements Handshake, MessageHandler {
       setCurrentState(State.AwaitingClientInit);
     } catch (NoSuchPaddingException
         | NoSuchAlgorithmException
+        | InvalidAlgorithmParameterException
         | InvalidKeySpecException
         | InvalidKeyException
         | PasswordDatabaseException e) {
@@ -312,13 +314,17 @@ public class ServerHandshake implements Handshake, MessageHandler {
 
   private void handle(ClientAuthMsg clientAuthMessage)
       throws NoSuchAlgorithmException, InvalidKeySpecException, ExecutionException,
-          InterruptedException {
+          InterruptedException, NoSuchPaddingException, IllegalBlockSizeException,
+          NoSuchAlgorithmException, BadPaddingException, InvalidKeyException,
+          InvalidAlgorithmParameterException {
     byte[] response = clientAuthMessage.getChallengeResponse().toByteArray();
     if (handshakeChallenges.length > 1) {
-      if (Arrays.compare(response, handshakeChallenges[GM_CHALLENGE].getExpectedResponse()) == 0) {
+      var iv = clientAuthMessage.getIv().toByteArray();
+      if (Arrays.compare(response, handshakeChallenges[GM_CHALLENGE].getExpectedResponse(iv))
+          == 0) {
         setPlayer(playerDatabase.getPlayerWithRole(player.getName(), Role.GM));
       } else if (Arrays.compare(
-              response, handshakeChallenges[PLAYER_CHALLENGE].getExpectedResponse())
+              response, handshakeChallenges[PLAYER_CHALLENGE].getExpectedResponse(iv))
           == 0) {
         setPlayer(playerDatabase.getPlayerWithRole(player.getName(), Role.PLAYER));
       } else {
@@ -326,7 +332,8 @@ public class ServerHandshake implements Handshake, MessageHandler {
         return;
       }
     } else if (currentState == State.AwaitingClientPasswordAuth) {
-      if (Arrays.compare(response, handshakeChallenges[0].getExpectedResponse()) != 0) {
+      var iv = clientAuthMessage.getIv().toByteArray();
+      if (Arrays.compare(response, handshakeChallenges[0].getExpectedResponse(iv)) != 0) {
         sendErrorResponseAndNotify(HandshakeResponseCodeMsg.INVALID_PASSWORD);
         return;
       }
@@ -369,7 +376,7 @@ public class ServerHandshake implements Handshake, MessageHandler {
   private void handle(ClientInitMsg clientInitMsg)
       throws ExecutionException, InterruptedException, NoSuchPaddingException,
           IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException,
-          InvalidKeyException {
+          InvalidKeyException, InvalidAlgorithmParameterException {
     var server = MapTool.getServer();
     if (server.isPlayerConnected(clientInitMsg.getPlayerName())) {
       setErrorMessage(I18N.getText("Handshake.msg.duplicateName"));
@@ -447,17 +454,23 @@ public class ServerHandshake implements Handshake, MessageHandler {
    */
   private void sendSharedPasswordAuthType()
       throws NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException,
-          BadPaddingException, InvalidKeyException {
+          BadPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
     byte[] playerPasswordSalt = playerDatabase.getPlayerPasswordSalt(player.getName());
+
+    SecureRandom rnd = new SecureRandom();
+    byte[] iv = new byte[CipherUtil.CIPHER_BLOCK_SIZE];
+    rnd.nextBytes(iv);
     String password = new PasswordGenerator().getPassword();
     handshakeChallenges = new HandshakeChallenge[1];
     Key key = playerDatabase.getPlayerPassword(player.getName()).get();
-    handshakeChallenges[0] = HandshakeChallenge.createChallenge(player.getName(), password, key);
+    handshakeChallenges[0] =
+        HandshakeChallenge.createSymmetricChallenge(player.getName(), password, key, iv);
 
     var authTypeMsg =
         UseAuthTypeMsg.newBuilder()
             .setAuthType(AuthTypeEnum.SHARED_PASSWORD)
             .setSalt(ByteString.copyFrom(playerPasswordSalt))
+            .setIv(ByteString.copyFrom(iv))
             .addChallenge(ByteString.copyFrom(handshakeChallenges[0].getChallenge()));
     var handshakeMsg = HandshakeMsg.newBuilder().setUseAuthTypeMsg(authTypeMsg).build();
     sendMessage(handshakeMsg);
@@ -474,27 +487,33 @@ public class ServerHandshake implements Handshake, MessageHandler {
    */
   private void sendRoleSharedPasswordAuthType()
       throws NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException,
-          BadPaddingException, InvalidKeyException {
+          BadPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
     byte[] playerPasswordSalt = playerDatabase.getPlayerPasswordSalt(player.getName());
     String[] password = new String[2];
     password[GM_CHALLENGE] = new PasswordGenerator().getPassword();
     password[PLAYER_CHALLENGE] = new PasswordGenerator().getPassword();
 
+    SecureRandom rnd = new SecureRandom();
+    byte[] iv = new byte[CipherUtil.CIPHER_BLOCK_SIZE];
+    rnd.nextBytes(iv);
     handshakeChallenges[GM_CHALLENGE] =
-        HandshakeChallenge.createChallenge(
+        HandshakeChallenge.createSymmetricChallenge(
             player.getName(),
             password[GM_CHALLENGE],
-            playerDatabase.getRolePassword(Role.GM).get());
+            playerDatabase.getRolePassword(Role.GM).get(),
+            iv);
     handshakeChallenges[PLAYER_CHALLENGE] =
-        HandshakeChallenge.createChallenge(
+        HandshakeChallenge.createSymmetricChallenge(
             player.getName(),
             password[GM_CHALLENGE],
-            playerDatabase.getRolePassword(Role.PLAYER).get());
+            playerDatabase.getRolePassword(Role.PLAYER).get(),
+            iv);
 
     var authTypeMsg =
         UseAuthTypeMsg.newBuilder()
             .setAuthType(AuthTypeEnum.SHARED_PASSWORD)
             .setSalt(ByteString.copyFrom(playerPasswordSalt))
+            .setIv(ByteString.copyFrom(iv))
             .addChallenge(ByteString.copyFrom(handshakeChallenges[GM_CHALLENGE].getChallenge()))
             .addChallenge(
                 ByteString.copyFrom(handshakeChallenges[PLAYER_CHALLENGE].getChallenge()));
@@ -517,7 +536,7 @@ public class ServerHandshake implements Handshake, MessageHandler {
   private State sendAsymmetricKeyAuthType()
       throws ExecutionException, InterruptedException, NoSuchPaddingException,
           IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException,
-          InvalidKeyException {
+          InvalidKeyException, InvalidAlgorithmParameterException {
     handshakeChallenges = new HandshakeChallenge[1];
     if (!playerDatabase.hasPublicKey(player, playerPublicKeyMD5).join()) {
       if (useEasyConnect) {
@@ -530,7 +549,7 @@ public class ServerHandshake implements Handshake, MessageHandler {
     CipherUtil.Key publicKey = playerDatabase.getPublicKey(player, playerPublicKeyMD5).get();
     String password = new PasswordGenerator().getPassword();
     handshakeChallenges[0] =
-        HandshakeChallenge.createChallenge(player.getName(), password, publicKey);
+        HandshakeChallenge.createAsymmetricChallenge(player.getName(), password, publicKey);
 
     var authTypeMsg =
         UseAuthTypeMsg.newBuilder()

--- a/src/main/java/net/rptools/maptool/util/cipher/CipherUtil.java
+++ b/src/main/java/net/rptools/maptool/util/cipher/CipherUtil.java
@@ -27,9 +27,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
-import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -46,6 +44,9 @@ public class CipherUtil {
 
   /** The algorithm to use for encoding / decoding. */
   private static final String CIPHER_ALGORITHM = "AES";
+
+  /** The format of generated keys. */
+  private static final String KEY_ALGORITHM = "AES";
 
   /** The algorithm used for turning the password into a 256 bit key. */
   private static final String MESSAGE_DIGEST_ALGORITHM = "SHA3-256";
@@ -71,14 +72,6 @@ public class CipherUtil {
   private static final String PUBLIC_KEY_FIRST_LINE = "====== Begin Public Key ======";
   private static final String PUBLIC_KEY_LAST_LINE = "====== End Public Key ======";
 
-  private final Key key;
-  private final Cipher encryptionCipher;
-  private final Cipher decryptionCipher;
-  ;
-
-  /** {@link MessageDigest} used for generating a 256 bit key from the password. */
-  private final MessageDigest messageDigest;
-
   public static record Key(
       SecretKeySpec secretKeySpec,
       byte[] salt,
@@ -93,63 +86,47 @@ public class CipherUtil {
     public Key(PublicKey publicKey, PrivateKey privateKey) {
       this(null, null, publicKey, privateKey, true);
     }
+
+    public String getEncodedPublicKeyText() {
+      return encodedPublicKeyText(publicKey());
+    }
   }
   ;
 
-  private CipherUtil(Key keyToUse)
-      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-    messageDigest = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
-    key = keyToUse;
-    encryptionCipher = createEncryptor(key);
-    if (!key.asymmetric() || key.privateKey() != null) {
-      decryptionCipher = createDecryptor(key);
-    } else {
-      decryptionCipher = null;
-    }
-  }
-
-  public static CipherUtil fromPublicPrivatePair(File publicKeyFile, File privateKeyFile)
+  public static CipherUtil.Key fromPublicPrivatePair(File publicKeyFile, File privateKeyFile)
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
           InvalidKeyException {
     KeyPair keyPair = readKeyPair(publicKeyFile, privateKeyFile);
     return CipherUtil.fromPublicPrivatePair(keyPair.getPublic(), keyPair.getPrivate());
   }
 
-  public static CipherUtil fromPublicPrivatePair(PublicKey publicKey, PrivateKey privateKey)
+  public static CipherUtil.Key fromPublicPrivatePair(PublicKey publicKey, PrivateKey privateKey)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-    return new CipherUtil(new Key(publicKey, privateKey));
+    return new Key(publicKey, privateKey);
   }
 
-  public static CipherUtil fromPublicKeyString(String pk)
+  public static CipherUtil.Key fromPublicKeyString(String pk)
       throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
           InvalidKeyException {
-    return new CipherUtil(new Key(CipherUtil.decodePublicKeyString(pk), null));
+    return new Key(CipherUtil.decodePublicKeyString(pk), null);
   }
 
-  public static CipherUtil fromSharedKey(String pass, byte[] salt)
+  public static CipherUtil.Key fromSharedKey(String pass, byte[] salt)
       throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
           InvalidKeyException {
-    Key key = createKey(pass, salt);
-    return new CipherUtil(key);
+    return createKey(pass, salt);
   }
 
-  public static CipherUtil fromSharedKeyNewSalt(String pass)
+  public static CipherUtil.Key fromSharedKeyNewSalt(String pass)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
           InvalidKeyException {
     byte[] salt = createSalt();
     return fromSharedKey(pass, salt);
   }
 
-  public static CipherUtil fromKey(Key key)
+  public static CipherUtil.Key fromSecretKeySpec(SecretKeySpec keySpec)
       throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-    return new CipherUtil(key);
-  }
-
-  public static CipherUtil fromSecretKeySpec(SecretKeySpec keySpec)
-      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-    Key keyTo = new Key(keySpec, createSalt());
-
-    return new CipherUtil(keyTo);
+    return new Key(keySpec, createSalt());
   }
 
   /**
@@ -169,9 +146,9 @@ public class CipherUtil {
             "Expected Algorithm " + ASYNC_KEY_ALGORITHM + " got " + key.privateKey.getAlgorithm());
       }
     } else {
-      if (!key.secretKeySpec.getAlgorithm().equals(CIPHER_ALGORITHM)) {
+      if (!key.secretKeySpec.getAlgorithm().equals(KEY_ALGORITHM)) {
         throw new AssertionError(
-            "Expected Algorithm " + CIPHER_ALGORITHM + " got " + key.secretKeySpec.getAlgorithm());
+            "Expected Algorithm " + KEY_ALGORITHM + " got " + key.secretKeySpec.getAlgorithm());
       }
     }
     return createCipher(Cipher.DECRYPT_MODE, key);
@@ -194,9 +171,9 @@ public class CipherUtil {
             "Expected Algorithm " + ASYNC_KEY_ALGORITHM + " got " + key.publicKey.getAlgorithm());
       }
     } else {
-      if (!key.secretKeySpec.getAlgorithm().equals(CIPHER_ALGORITHM)) {
+      if (!key.secretKeySpec.getAlgorithm().equals(KEY_ALGORITHM)) {
         throw new AssertionError(
-            "Expected Algorithm " + CIPHER_ALGORITHM + " got " + key.secretKeySpec.getAlgorithm());
+            "Expected Algorithm " + KEY_ALGORITHM + " got " + key.secretKeySpec.getAlgorithm());
       }
     }
     return createCipher(Cipher.ENCRYPT_MODE, key);
@@ -226,22 +203,6 @@ public class CipherUtil {
     }
   }
 
-  private Cipher createPublicKeyCipher(PublicKey key)
-      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-    Cipher cipher = Cipher.getInstance(ASYNC_KEY_ALGORITHM);
-    cipher.init(Cipher.DECRYPT_MODE, key);
-
-    return cipher;
-  }
-
-  private Cipher createPrivateKeyCipher(PrivateKey key)
-      throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-    Cipher cipher = Cipher.getInstance(ASYNC_KEY_ALGORITHM);
-    cipher.init(Cipher.ENCRYPT_MODE, key);
-
-    return cipher;
-  }
-
   public static byte[] createSalt(int size) {
     SecureRandom secureRandom = new SecureRandom();
     byte salt[] = new byte[size];
@@ -254,35 +215,13 @@ public class CipherUtil {
     return createSalt(DEFAULT_SALT_SIZE);
   }
 
-  public Cipher createEncryptor(String key, byte[] salt)
-      throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
-          InvalidKeyException {
-    Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
-    cipher.init(Cipher.ENCRYPT_MODE, createKey(key, salt).secretKeySpec);
-
-    return cipher;
-  }
-
-  public Cipher createDecryptor(String key, byte[] salt)
-      throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
-          InvalidKeyException {
-    Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
-    cipher.init(Cipher.DECRYPT_MODE, createKey(key, salt).secretKeySpec);
-
-    return cipher;
-  }
-
   public static Key createKey(String key, byte[] salt)
       throws NoSuchAlgorithmException, InvalidKeySpecException {
     KeySpec spec = new PBEKeySpec(key.toCharArray(), salt, KEY_ITERATION_KEY_COUNT, 128);
     SecretKeyFactory factory = SecretKeyFactory.getInstance(KEY_GENERATION_ALGORITHM);
 
     return new Key(
-        new SecretKeySpec(factory.generateSecret(spec).getEncoded(), CIPHER_ALGORITHM), salt);
-  }
-
-  public Key createKey(String key) throws NoSuchAlgorithmException, InvalidKeySpecException {
-    return createKey(key, createSalt());
+        new SecretKeySpec(factory.generateSecret(spec).getEncoded(), KEY_ALGORITHM), salt);
   }
 
   public static byte[] generateMacAndSalt(String password) throws IOException {
@@ -372,7 +311,7 @@ public class CipherUtil {
   }
 
   public static SecretKeySpec decodeBase64(String encoded) {
-    return new SecretKeySpec(Base64.getDecoder().decode(encoded), CIPHER_ALGORITHM);
+    return new SecretKeySpec(Base64.getDecoder().decode(encoded), KEY_ALGORITHM);
   }
 
   public static KeyPair generateKeyPair() throws NoSuchAlgorithmException {
@@ -393,22 +332,6 @@ public class CipherUtil {
     try (FileOutputStream fos = new FileOutputStream(privateFile)) {
       fos.write(keyPair.getPrivate().getEncoded());
     }
-  }
-
-  public String getEncodedPublicKeyText() {
-    return encodedPublicKeyText(key.publicKey());
-  }
-
-  public Key getKey() {
-    return key;
-  }
-
-  public Cipher getEncryptionCipher() {
-    return encryptionCipher;
-  }
-
-  public Cipher getDecryptionCipher() {
-    return decryptionCipher;
   }
 
   private static String encodedPublicKeyText(PublicKey publicKey) {
@@ -451,21 +374,6 @@ public class CipherUtil {
 
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     return keyFactory.generatePublic(publicSpec);
-  }
-
-  public PublicKey decodePublicKeyBytes(byte[] bytes)
-      throws NoSuchAlgorithmException, InvalidKeySpecException {
-    PKCS8EncodedKeySpec publicSpec = new PKCS8EncodedKeySpec(bytes);
-    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-    return keyFactory.generatePublic(publicSpec);
-  }
-
-  public byte[] encode(byte[] toEncode) throws IllegalBlockSizeException, BadPaddingException {
-    return encryptionCipher.doFinal(toEncode);
-  }
-
-  public byte[] decode(byte[] toDecode) throws IllegalBlockSizeException, BadPaddingException {
-    return decryptionCipher.doFinal(toDecode);
   }
 
   public static String[] splitPublicKeys(String concatKeys) {

--- a/src/main/java/net/rptools/maptool/util/cipher/PublicPrivateKeyStore.java
+++ b/src/main/java/net/rptools/maptool/util/cipher/PublicPrivateKeyStore.java
@@ -38,7 +38,7 @@ public class PublicPrivateKeyStore {
    *
    * @return the keys.
    */
-  public CompletableFuture<CipherUtil> getKeys() {
+  public CompletableFuture<CipherUtil.Key> getKeys() {
 
     return CompletableFuture.supplyAsync(
         () -> {
@@ -65,7 +65,7 @@ public class PublicPrivateKeyStore {
    *
    * @return the newly generated keys.
    */
-  public CompletableFuture<CipherUtil> regenerateKeys() {
+  public CompletableFuture<CipherUtil.Key> regenerateKeys() {
     return CompletableFuture.supplyAsync(
         () -> {
           try {

--- a/src/main/java/net/rptools/maptool/util/cipher/PublicPrivateKeyStore.java
+++ b/src/main/java/net/rptools/maptool/util/cipher/PublicPrivateKeyStore.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.util.cipher;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -51,6 +52,7 @@ public class PublicPrivateKeyStore {
             return CipherUtil.fromPublicPrivatePair(PUBLIC_KEY_FILE, PRIVATE_KEY_FILE);
           } catch (NoSuchAlgorithmException
               | IOException
+              | InvalidAlgorithmParameterException
               | InvalidKeySpecException
               | NoSuchPaddingException
               | InvalidKeyException e) {
@@ -75,6 +77,7 @@ public class PublicPrivateKeyStore {
             return CipherUtil.fromPublicPrivatePair(PUBLIC_KEY_FILE, PRIVATE_KEY_FILE);
           } catch (IOException
               | NoSuchAlgorithmException
+              | InvalidAlgorithmParameterException
               | InvalidKeySpecException
               | NoSuchPaddingException
               | InvalidKeyException e) {

--- a/src/main/proto/handshake.proto
+++ b/src/main/proto/handshake.proto
@@ -40,11 +40,13 @@ message ClientInitMsg {
 message UseAuthTypeMsg {
   AuthTypeEnum auth_type = 1;
   bytes salt = 2;
+  bytes iv = 4;
   repeated bytes challenge = 3;
 }
 
 message ClientAuthMsg {
   bytes challenge_response = 1;
+  bytes iv = 2;
 }
 
 message ConnectionSuccessfulMsg {


### PR DESCRIPTION
### Identify the Bug or Feature request

resolves #3360 

### Description of the Change

Changes the CryptoUtil cipher to "AES/CBC/PKCS5Padding", adds an IV field to handshake messages, and generates a new IV per message.

In the process, found a couple of bugs, and removed CipherUtil objects, which were only used to immediately retrieve the key out of.

### Possible Drawbacks

Slightly more CPU cost involved in generating and transmitting the IV, and chaining blocks together.

It's more changes to cryptography that could result in a vulnerability.

### Release Notes

- Fixed a bug which could rarely cause a false handshake failure
- Fixed error message reporting public key authentication failure while using password authentication.
- Upgraded handshake cipher to CBC for better interoperability and precaution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3361)
<!-- Reviewable:end -->
