### PR TITLE
Update all imageio libs to 3.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,12 +295,12 @@ dependencies {
 
     // Image processing lib
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.8.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.7.0'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.7.0'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.7.0'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.7.0'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.8.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.8.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.8.2'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.8.2'
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tga', version: '3.8.2'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-bmp', version: '3.7.0'
+    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-bmp', version: '3.8.2'
 
     implementation 'org.apache.xmlgraphics:batik-all:1.14' // For Twelvemonkey SVG
 


### PR DESCRIPTION
### Identify the Bug or Feature request
Changes for #3398.

### Description of the Change

Updates the other imageio libs that dependabot missed.

### Possible Drawbacks

n/a

### Documentation Notes

n/a

### Release Notes

ImageIO libs updated to 3.8.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3399)
<!-- Reviewable:end -->
