### PR TITLE
Do not assume a server connection exists when retrieving images

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AssetLoader.java
+++ b/src/main/java/net/rptools/maptool/model/AssetLoader.java
@@ -324,11 +324,18 @@ public class AssetLoader {
         }
       }
 
-      // Last resort, ask the MT server
-      // We can drop off the end of this runnable because it'll background load the
-      // image from the server
       // System.out.println("Got " + id + " from MT");
-      MapTool.serverCommand().getAsset(id);
+      // Last resort, ask the MT server
+      final var serverCommand = MapTool.serverCommand();
+      if (serverCommand != null) {
+        // We can drop off the end of this runnable because it'll background load the
+        // image from the server
+        serverCommand.getAsset(id);
+      } else {
+        // This could be too early in the loading process for a server command to be set.
+        AssetManager.putAsset(Asset.createBrokenImageAsset(id));
+        completeRequest(id);
+      }
     }
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request
Address #3425 

### Description of the Change

It can happen that - early in the initialization process - assets are requested to populate the UI
even before any personal server has been started or `ServerCommand` created. In this case, we cannot rely on a server
call to resolve and image and call pending listeners. To work around this problem, we fallback to using a broken image
if the server is not available.

### Possible Drawbacks

Yet one more bit of magic has been added to the codebase.

### Documentation Notes

N/A

### Release Notes

Fixed a problem where missing assets in Global macro labels would cause MT to hang on start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3428)
<!-- Reviewable:end -->
