### PR TITLE
Add UVTT topology and lights to zone before adding to campaign

### DIFF
--- a/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
+++ b/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
@@ -166,8 +166,8 @@ public class DungeonDraftImporter {
     dialog.forceGridType(GridFactory.SQUARE);
     dialog.forceMap(asset);
     dialog.setVisible(true);
-    if (dialog.getStatus() == MapPropertiesDialog.Status.OK) {
-      MapTool.addZone(zone);
+    if (dialog.getStatus() != MapPropertiesDialog.Status.OK) {
+      return;
     }
 
     /**
@@ -245,6 +245,9 @@ public class DungeonDraftImporter {
     if (lights != null && lights.size() > 0) {
       placeLights(zone, lights, pixelsPerCell);
     }
+
+    // If everything has been successful, we can add the zone to the campaign.
+    MapTool.addZone(zone);
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request
#3440 

### Description of the Change
Previously VBL/MBL and light tokens would no be synced to clients since the new `Zone` was modified directly rather than
being updated via server commands. This change avoids the issue by performing all the modifications to the zone first,
then adding the zone to the campaign.

One other minor improvement here is that the UVTT map's topology and lights are no longer processed if the user cancels
the import from the dialog..

### Possible Drawbacks

Shouldn't be any

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where UVTT maps imported on a running server would not have its VBL/MBL or light tokens synced to the clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3441)
<!-- Reviewable:end -->
