### PR TITLE
Fix to invalidate the `ZoneView.topologyAreas` cache on topology changes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -788,6 +788,7 @@ public class ZoneView implements ModelChangeListener {
         personalBrightLightCache.clear();
         personalDrawableLightCache.clear();
         visibleAreaMap.clear();
+        topologyAreas.clear();
         topologyTrees.clear();
         tokenVisibleAreaCache.clear();
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #3052

### Description of the Change

In the previous PR #3430, I forgot to invalidate the topology cache used by `ZoneView`. This PR fixes this so that topology changes are actually respected by the `ZoneView`.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3446)
<!-- Reviewable:end -->
