### PR TITLE
bump version of gradle javafx plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "application"
     id "org.ajoberstar.grgit" version "4.1.0"
     id "com.diffplug.spotless" version "5.14.3"
-    id 'org.openjfx.javafxplugin' version '0.0.10'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
     id 'org.beryx.runtime' version '1.12.7'
     id "com.google.protobuf" version "0.8.19"
 }


### PR DESCRIPTION

### Identify the Bug or Feature request

resolves #3477

### Description of the Change
Move to the latest version of the gradle javafx plugin to support apple silicon.


### Possible Drawbacks
Will need to ensure packaged app still works correctly on apple silicon (who knows whats happening with Rosetta2 here)

### Release Notes

- Upgraded to latest patch version of JavaFX to support developing on Apple Silicone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3478)
<!-- Reviewable:end -->
