### PR TITLE
Stop non GM from drag and drop of MTLIB

### DIFF
--- a/src/main/java/net/rptools/maptool/client/TransferableHelper.java
+++ b/src/main/java/net/rptools/maptool/client/TransferableHelper.java
@@ -620,19 +620,23 @@ public class TransferableHelper extends TransferHandler {
       for (Object working : assets) {
         if (working instanceof Asset asset) {
           if (asset.getType() == Type.MTLIB) {
-            try {
-              var addOnLibrary = new AddOnLibraryImporter().importFromAsset(asset);
-              new LibraryManager().reregisterAddOnLibrary(addOnLibrary);
-              SwingUtilities.invokeLater(
-                  () -> {
-                    MapTool.showInformation(
-                        I18N.getText("library.imported", addOnLibrary.getNamespace().join()));
-                  });
-            } catch (IOException e) {
-              SwingUtilities.invokeLater(
-                  () -> {
-                    MapTool.showError(I18N.getText("library.import.error", asset.getName()), e);
-                  });
+            if (MapTool.getPlayer().isGM()) {
+              try {
+                var addOnLibrary = new AddOnLibraryImporter().importFromAsset(asset);
+                new LibraryManager().reregisterAddOnLibrary(addOnLibrary);
+                SwingUtilities.invokeLater(
+                    () -> {
+                      MapTool.showInformation(
+                          I18N.getText("library.imported", addOnLibrary.getNamespace().join()));
+                    });
+              } catch (IOException e) {
+                SwingUtilities.invokeLater(
+                    () -> {
+                      MapTool.showError(I18N.getText("library.import.error", asset.getName()), e);
+                    });
+              }
+            } else {
+              MapTool.showError(I18N.getText("library.import.error.notGM"));
             }
           } else {
             Token token = new Token(asset.getName(), asset.getMD5Key());

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2604,6 +2604,7 @@ library.error.emptyVersion     = Version can''t be empty for add-on library {0}.
 library.dialog.import.title    = Import Add-On Library.
 library.import.ioError         = IO Error importing Drop In Library.
 library.import.error           = Error importing Drop In Library {0}.
+library.import.error.notGM     = Only GM can import a Drop in Library.
 library.imported               = Library {0} imported.
 library.error.libtoken.no.access = Allow URI Access is not allowed for {0}.
 library.error.addOn.no.access = Allow URI Access is not allowed for {0} add-on library.


### PR DESCRIPTION

### Identify the Bug or Feature request

resolves #3481



### Description of the Change
Stops non GMs from adding a MTLIB via drag and drop


### Possible Drawbacks

Hopefully none :)

### Documentation Notes
N/A

### Release Notes
N/A this is how the functionality should work and modifies it before release so previous release note will do
