### PR TITLE
Respect the fact that Zone requires a LinkedList for its drawables

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -240,10 +240,10 @@ public class Zone extends BaseModel {
   private AStarRoundingOptions aStarRounding = AStarRoundingOptions.NONE;
   private TopologyTypeSet topologyTypes = null; // get default from AppPreferences
 
-  private List<DrawnElement> drawables = new LinkedList<DrawnElement>();
-  private List<DrawnElement> gmDrawables = new LinkedList<DrawnElement>();
-  private List<DrawnElement> objectDrawables = new LinkedList<DrawnElement>();
-  private List<DrawnElement> backgroundDrawables = new LinkedList<DrawnElement>();
+  private LinkedList<DrawnElement> drawables = new LinkedList<DrawnElement>();
+  private LinkedList<DrawnElement> gmDrawables = new LinkedList<DrawnElement>();
+  private LinkedList<DrawnElement> objectDrawables = new LinkedList<DrawnElement>();
+  private LinkedList<DrawnElement> backgroundDrawables = new LinkedList<DrawnElement>();
 
   private final Map<GUID, Label> labels = new LinkedHashMap<GUID, Label>();
   /** Map each token GUID to the corresponding token. */
@@ -1323,16 +1323,16 @@ public class Zone extends BaseModel {
     // items that are drawn first are at the "back"
     switch (drawnElement.getDrawable().getLayer()) {
       case OBJECT:
-        ((LinkedList<DrawnElement>) objectDrawables).addFirst(drawnElement);
+        objectDrawables.addFirst(drawnElement);
         break;
       case BACKGROUND:
-        ((LinkedList<DrawnElement>) backgroundDrawables).addFirst(drawnElement);
+        backgroundDrawables.addFirst(drawnElement);
         break;
       case GM:
-        ((LinkedList<DrawnElement>) gmDrawables).addFirst(drawnElement);
+        gmDrawables.addFirst(drawnElement);
         break;
       default:
-        ((LinkedList<DrawnElement>) drawables).addFirst(drawnElement);
+        drawables.addFirst(drawnElement);
     }
     fireModelChangeEvent(new ModelChangeEvent(this, Event.DRAWABLE_ADDED, drawnElement));
   }
@@ -2189,19 +2189,19 @@ public class Zone extends BaseModel {
     zone.drawables =
         dto.getDrawablesList().stream()
             .map(d -> DrawnElement.fromDto(d))
-            .collect(Collectors.toList());
+            .collect(Collectors.toCollection(LinkedList::new));
     zone.gmDrawables =
         dto.getGmDrawablesList().stream()
             .map(d -> DrawnElement.fromDto(d))
-            .collect(Collectors.toList());
+            .collect(Collectors.toCollection(LinkedList::new));
     zone.objectDrawables =
         dto.getObjectDrawablesList().stream()
             .map(d -> DrawnElement.fromDto(d))
-            .collect(Collectors.toList());
+            .collect(Collectors.toCollection(LinkedList::new));
     zone.backgroundDrawables =
         dto.getBackgroundDrawablesList().stream()
             .map(d -> DrawnElement.fromDto(d))
-            .collect(Collectors.toList());
+            .collect(Collectors.toCollection(LinkedList::new));
     dto.getLabelsList().stream()
         .map(d -> Label.fromDto(d))
         .forEach(l -> zone.labels.put(l.getId(), l));


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3489

### Description of the Change

While the various drawables fields in `Zone` are typed as `List<DrawnElement>`, they are specifically required to be `LinkedList<DrawnElement>` for the `addFirst()` method. This change avoids the need for downcasts by making the field type match expectations. The type returned by the `getDrawnElements()` and others is still `List<DrawnElement>` as others do not need to rely on the implementation.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3490)
<!-- Reviewable:end -->
