### PR TITLE
Add drawings to the correct lists of the zone DTO

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2260,9 +2260,10 @@ public class Zone extends BaseModel {
               .collect(Collectors.toList()));
     }
     dto.addAllDrawables(drawables.stream().map(d -> d.toDto()).collect(Collectors.toList()));
-    dto.addAllDrawables(gmDrawables.stream().map(d -> d.toDto()).collect(Collectors.toList()));
-    dto.addAllDrawables(objectDrawables.stream().map(d -> d.toDto()).collect(Collectors.toList()));
-    dto.addAllDrawables(
+    dto.addAllGmDrawables(gmDrawables.stream().map(d -> d.toDto()).collect(Collectors.toList()));
+    dto.addAllObjectDrawables(
+        objectDrawables.stream().map(d -> d.toDto()).collect(Collectors.toList()));
+    dto.addAllBackgroundDrawables(
         backgroundDrawables.stream().map(d -> d.toDto()).collect(Collectors.toList()));
     dto.addAllLabels(labels.values().stream().map(l -> l.toDto()).collect(Collectors.toList()));
     dto.addAllTokens(tokenMap.values().stream().map(t -> t.toDto()).collect(Collectors.toList()));


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3488

### Description of the Change

All drawings were being added to the token layer list of drawables in `Zone::toDto()`. This fixes that so they all get put in separate lists for each type.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A