### PR TITLE
Only init campaign props with default values when wanted

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -949,7 +949,7 @@ public class MapTool {
 
   public static Campaign getCampaign() {
     if (campaign == null) {
-      campaign = new Campaign();
+      campaign = CampaignFactory.createBasicCampaign();
     }
     return campaign;
   }

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -725,6 +725,10 @@ public class Campaign {
     return campaignExportDialog;
   }
 
+  public void initDefault() {
+    campaignProperties.initDefaultProperties();
+  }
+
   public static Campaign fromDto(CampaignDto dto) {
     var campaign = new Campaign();
     campaign.id = GUID.valueOf(dto.getId());

--- a/src/main/java/net/rptools/maptool/model/CampaignFactory.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignFactory.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.model;
 public class CampaignFactory {
   public static Campaign createBasicCampaign() {
     Campaign campaign = new Campaign();
+    campaign.initDefault();
     campaign.putZone(ZoneFactory.createZone());
     return campaign;
   }

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -116,7 +116,7 @@ message FtpLocationDto {
 
 message CampaignPropertiesDto {
   map<string, TokenPropertyListDto> token_types = 1;
-  string default_sight_type = 2;
+  google.protobuf.StringValue default_sight_type = 2;
   repeated BooleanTokenOverlayDto token_states = 3;
   repeated BarTokenOverlayDto token_bars = 4;
   map<string, string> character_sheets = 5;


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes 3487


### Description of the Change

Removed all initialisation code from the getters. Default values are now only initialised with Campaign::initDefault(). This is currently only used in CampaignFactory::createBasicCampaign(). I noticed that we can't set a defaultSight if we have not sights defined so I changed this from string to StringValue in protobuf. I also added readResolve() to CampaignProperties. So all campaigns created with older versions of MT will initialise the various lists and hashmaps even if they were null.


### Possible Drawbacks
I don't think there are any.

### Release Notes

- Fixed an issue where empty lights, states etc. in campaign properties get set to default values automatically

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3492)
<!-- Reviewable:end -->
