### PR TITLE
fix clean up of UDF on loading new campaign

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
@@ -237,12 +237,16 @@ public class UserDefinedMacroFunctions implements Function, AdditionalFunctionDe
     return userDefinedFunctions.containsKey(name);
   }
 
+  /** Clears any user defined macros. */
+  public void clearUserDefinedFunctions() {
+    userDefinedFunctions.clear();
+  }
+
   /**
-   * Clears any previously mapped UDFs and handles the {@value #ON_LOAD_CAMPAIGN_CALLBACK} macro
-   * event. Suppresses chat output on the called macros.
+   * Handles the {@value #ON_LOAD_CAMPAIGN_CALLBACK} macro event. Suppresses chat output on the
+   * called macros.
    */
   public void handleCampaignLoadMacroEvent() {
-    userDefinedFunctions.clear();
     List<Token> libTokens = EventMacroUtil.getEventMacroTokens(ON_LOAD_CAMPAIGN_CALLBACK);
     String prefix = ON_LOAD_CAMPAIGN_CALLBACK + "@";
     for (Token handler : libTokens) {
@@ -378,6 +382,9 @@ public class UserDefinedMacroFunctions implements Function, AdditionalFunctionDe
       } else {
         // token macro
         try {
+          if (macroLocation.length() <= 4) {
+            return I18N.getText("msg.error.udf.tooltip.loading", theDef.macroName);
+          }
           var lib = new LibraryManager().getLibrary(macroLocation.substring(4));
           if (lib.isEmpty()) {
             return I18N.getText("msg.error.udf.tooltip.loading", theDef.macroName);

--- a/src/main/java/net/rptools/maptool/model/campaign/CampaignManager.java
+++ b/src/main/java/net/rptools/maptool/model/campaign/CampaignManager.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.model.campaign;
 
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.functions.UserDefinedMacroFunctions;
 import net.rptools.maptool.client.script.javascript.JSScriptEngine;
 import net.rptools.maptool.model.Campaign;
 import net.rptools.maptool.model.gamedata.DataStoreManager;
@@ -35,5 +36,6 @@ public class CampaignManager {
     JSScriptEngine.resetContexts();
     new LibraryManager().deregisterAllLibraries();
     new DataStoreManager().getDefaultDataStoreForRemoteUpdate().clear();
+    UserDefinedMacroFunctions.getInstance().clearUserDefinedFunctions();
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

resolves #3334


### Description of the Change
Fixes the issue where user defined functions are cleared in the onCampaignLoad which may happen before or after add on initialisation. This now moves the clearing of user defined functions to before either onCampaignLoad or add-ons are initialised.


### Possible Drawbacks

None unless I have done something wrong.



### Release Notes

- Fixed an issue with creating user defined functions in add-on library onInit function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3499)
<!-- Reviewable:end -->
