### PR TITLE
Bump javafx to version 18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ spotless {
 
 // org.openjfx.javafxplugin
 javafx {
-    version = '17'
+    version = '18'
     // modules = ['javafx.fxml', 'javafx.graphics']
     modules = ['javafx.base', 'javafx.controls', 'javafx.media', 'javafx.swing', 'javafx.web', 'javafx.fxml', 'javafx.graphics']
 }


### PR DESCRIPTION

resolves #3500


### Description of the Change
Update the version of JavaFX to 18

### Possible Drawbacks
The usual risks associated with upgrading libraries.

### Documentation Notes
N/A

### Release Notes
- Upgrade to JavaFx 18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3501)
<!-- Reviewable:end -->
