### PR TITLE
Allow unknown fields in the library json files

### DIFF
--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
@@ -140,7 +140,9 @@ public class AddOnLibraryImporter {
         throw new IOException(I18N.getText("library.error.addOn.noConfigFile", file.getPath()));
       }
       var builder = AddOnLibraryDto.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(zip.getInputStream(entry)), builder);
+      JsonFormat.parser()
+          .ignoringUnknownFields()
+          .merge(new InputStreamReader(zip.getInputStream(entry)), builder);
 
       // MT MacroScript properties
       var pathAssetMap = processAssets(builder.getNamespace(), zip);
@@ -148,6 +150,7 @@ public class AddOnLibraryImporter {
       ZipEntry mtsPropsZipEntry = zip.getEntry(MACROSCRIPT_PROPERTY_FILE);
       if (mtsPropsZipEntry != null) {
         JsonFormat.parser()
+            .ignoringUnknownFields()
             .merge(new InputStreamReader(zip.getInputStream(mtsPropsZipEntry)), mtsPropBuilder);
       }
 
@@ -156,6 +159,7 @@ public class AddOnLibraryImporter {
       ZipEntry eventsZipEntry = zip.getEntry(EVENT_PROPERTY_FILE);
       if (eventsZipEntry != null) {
         JsonFormat.parser()
+            .ignoringUnknownFields()
             .merge(new InputStreamReader(zip.getInputStream(eventsZipEntry)), eventPropBuilder);
       }
       var addOnLib = builder.build();


### PR DESCRIPTION

### Identify the Bug or Feature request
resolves #3498


### Description of the Change

Ignores unknown fields in the json metadata files in an add-on library, this will ease the pain of adding new fields as adopting them shouldn't rule out older versions.

### Possible Drawbacks

Typos in optional fields wont be picked up.


### Documentation Notes
N/A

### Release Notes

- Tweaks to parsing add-on metadata files to ease future development

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3502)
<!-- Reviewable:end -->
