### PR TITLE
Validate lastPath when loading tokens

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2476,6 +2476,16 @@ public class Token extends BaseModel implements Cloneable {
       sizeMap = new HashMap<>();
     }
 
+    // Check to make sure lastPath has valid data
+    if (lastPath != null) {
+      // The second condition seems like it shouldn't be possible, but at some point in the past it
+      // was possible for paths of AStarCellPoints to exist and these can persist in older tokens.
+      if (lastPath.getCellPath().size() == 0
+          || !(lastPath.getCellPath().get(0) instanceof AbstractPoint)) {
+        lastPath = null;
+      }
+    }
+
     return this;
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request
#3254

### Description of the Change
This adds a check to make sure `lastPath` has valid data when loading tokens and throws the data out if it doesn't. 

This is necessary because some older tokens have now invalid paths made up of `AStarCellPoint` nodes, and with the switch to protobuf campaigns with such tokens in them will fail to load (and in the current stable release, if a user tries to revert the path of one of these tokens it will result in an exception).

### Possible Drawbacks
This change does result in the loss of the legacy `lastPath` data and while it would probably be technically possible to restore the path, it seems unlikely anyone will care about the loss of the last path on a token that probably hasn't been touched in at least 7+ years.

### Documentation Notes
N/A

### Release Notes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3504)
<!-- Reviewable:end -->
