### PR TITLE
Correct parameter number

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2547,7 +2547,7 @@ public class Token extends BaseModel implements Cloneable {
         else setState(state, BigDecimal.valueOf(stateValue.getDoubleValue()));
         break;
       case setAllStates:
-        stateValue = parameters.get(1);
+        stateValue = parameters.get(0);
         if (stateValue.hasBoolValue()) setAllStates(stateValue.getBoolValue());
         else setAllStates(BigDecimal.valueOf(stateValue.getDoubleValue()));
         break;


### PR DESCRIPTION
### Identify the Bug or Feature request
#3514 

### Description of the Change

Corrected parameter number.

### Possible Drawbacks

None expected.

### Documentation Notes

None.  Restores existing functionality.

### Release Notes

Fixes ArrayIndexOutOfBoundsException when using `setAllStates()` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3526)
<!-- Reviewable:end -->
