### PR TITLE
Fix for add on libproperty compat layer treating everything as strings

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DataFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DataFunctions.java
@@ -19,11 +19,8 @@ import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.gamedata.DataStore;
 import net.rptools.maptool.model.gamedata.DataStoreManager;
 import net.rptools.maptool.model.gamedata.MTScriptDataConversion;
@@ -43,15 +40,14 @@ public class DataFunctions extends AbstractFunction {
     super(
         0,
         4,
-        /* Commented out are only used for debugging.
         "data.listTypes",
         "data.listNamespaces",
-        "data.createNamespace",
+        /*"data.createNamespace",*/
         "data.setData",
         "data.getData",
         "data.listData",
-        "data.clearData",
-        "data.clearNamespace",
+        "data.removeData",
+        /*"data.clearNamespace",
         "data.clearAllData",*/
         "data.getStaticData");
   }
@@ -62,13 +58,15 @@ public class DataFunctions extends AbstractFunction {
       throws ParserException {
 
     String fName = functionName.toLowerCase();
+    if (!MapTool.getParser().isMacroTrusted()) {
+      throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
+    }
+
     try {
       var dataStore = new DataStoreManager().getDefaultDataStore();
 
       switch (fName) {
         case "data.listtypes" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
-          FunctionUtil.checkNumberParam(functionName, parameters, 0, 0);
           JsonArray json = new JsonArray();
           for (String type : dataStore.getPropertyTypes().get()) {
             json.add(type);
@@ -76,7 +74,6 @@ public class DataFunctions extends AbstractFunction {
           return json;
         }
         case "data.listnamespaces" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
           FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
           JsonArray json = new JsonArray();
           for (String namespace :
@@ -86,63 +83,27 @@ public class DataFunctions extends AbstractFunction {
           return json;
         }
         case "data.createnamespace" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
           FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
           dataStore.createNamespace(parameters.get(0).toString(), parameters.get(1).toString());
           return "";
         }
         case "data.setdata" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
           FunctionUtil.checkNumberParam(functionName, parameters, 4, 4);
           String type = parameters.get(0).toString();
           String namespace = parameters.get(1).toString();
           String name = parameters.get(2).toString();
           Object value = parameters.get(3);
-          if (value instanceof JsonObject jo) {
-            dataStore.setJsonObjectProperty(type, namespace, name, jo);
-          } else if (value instanceof JsonArray ja) {
-            dataStore.setJsonArrayProperty(type, namespace, name, ja);
-          } else if (value instanceof String s) {
-            if (s.trim().startsWith("asset://")) {
-              var asset = AssetManager.getAsset(new MD5Key(s.substring(8)));
-              dataStore.setAssetProperty(type, namespace, name, asset);
-            } else {
-              if (s.trim().startsWith("{") || s.trim().startsWith("[")) {
-                var json = JSONMacroFunctions.getInstance().asJsonElement(s);
-                if (json.isJsonObject()) {
-                  dataStore.setJsonObjectProperty(type, namespace, name, json.getAsJsonObject());
-                } else if (json.isJsonArray()) {
-                  dataStore.setJsonArrayProperty(type, namespace, name, json.getAsJsonArray());
-                } else {
-                  dataStore.setStringProperty(type, namespace, name, s);
-                }
-              } else {
-                dataStore.setStringProperty(type, namespace, name, s);
-              }
-            }
-          } else if (value instanceof Boolean b) {
-            dataStore.setBooleanProperty(type, namespace, name, b);
-          } else if (value instanceof Number n) {
-            if (n.intValue() == n.doubleValue()) {
-              dataStore.setLongProperty(type, namespace, name, n.longValue());
-            } else {
-              dataStore.setDoubleProperty(type, namespace, name, n.doubleValue());
-            }
-          } else {
-            dataStore.setStringProperty(type, namespace, name, value.toString());
-          }
-
+          dataStore.setProperty(
+              type, namespace, new MTScriptDataConversion().parseMTScriptString(name, value));
           return "";
         }
         case "data.listdata" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
           FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
           String type = parameters.get(0).toString();
           String namespace = parameters.get(1).toString();
           return listData(dataStore, type, namespace);
         }
         case "data.getdata" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
           FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
           String type = parameters.get(0).toString();
           String namespace = parameters.get(1).toString();
@@ -166,7 +127,6 @@ public class DataFunctions extends AbstractFunction {
           return "";
         }
         case "data.clearnamespace" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
           FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
           String type = parameters.get(0).toString();
           String namespace = parameters.get(1).toString();
@@ -177,8 +137,7 @@ public class DataFunctions extends AbstractFunction {
 
           return "";
         }
-        case "data.cleardata" -> {
-          MapTool.addLocalMessage(I18N.getText("msg.warning.prerelease.only", functionName));
+        case "data.removedata" -> {
           FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
           String type = parameters.get(0).toString();
           String namespace = parameters.get(1).toString();

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -549,7 +549,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equalsIgnoreCase("setLibProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 3);
       String property = parameters.get(0).toString();
-      String value = parameters.get(1).toString();
+      Object value = parameters.get(1);
 
       String location;
       if (parameters.size() > 2) {
@@ -575,7 +575,12 @@ public class TokenPropertyFunctions extends AbstractFunction {
                               "macro.function.tokenProperty.unknownLibToken",
                               functionName,
                               libName)));
-      library.getLibraryData().thenCompose(libData -> libData.setStringData(property, value));
+      library
+          .getLibraryData()
+          .thenCompose(
+              libData ->
+                  libData.setData(
+                      new MTScriptDataConversion().parseMTScriptString(property, value)));
       return "";
     }
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement

### Identify the Bug or Feature request

resolves #3322

### Description of the Change

Fixes Add-On LibProperty compatibility layer so that things are no longer always treated as strings.


### Possible Drawbacks

MTScript is a fickle mistress and there is sure to be edge cases where conversion between types is not exactly what you want.


### Documentation Notes

See https://docs.rptools.info/docs/add-ons/mtscript-lib-functions#add-on-libraries-and-data

One thing to note is the type is saved along with the data so any lib properties created before this patch will remain strings. To fix this you will need to use the functions from https://docs.rptools.info/docs/data/mtscript-data-functions to fix it.

You will need to remove the value as follows 
```
[h: data.removeData("addon:", "com.example.myaddon", "myVar")]
```
You can then set the value using the functions you used before and it will have the correct type

It is probably better to use the data.* functions than the compatibility LibProperty functions for new code as you have better control over types.


### Release Notes
- Add-On lib properties will no longer always be treated as strings.
- Add data MTScript functions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3528)
<!-- Reviewable:end -->
