### PR TITLE
Fix for default database player.getConnectedPlayers()

### DIFF
--- a/src/main/java/net/rptools/maptool/model/player/Players.java
+++ b/src/main/java/net/rptools/maptool/model/player/Players.java
@@ -194,7 +194,17 @@ public class Players {
       if (!playerDatabase.playerExists(name)) {
         return null;
       }
-      Player player = playerDatabase.getPlayer(name);
+      Player player;
+      if (playerDatabase instanceof DefaultPlayerDatabase dpdb) {
+        player =
+            dpdb.getAllPlayers().stream()
+                .filter(p -> p.getName().equals(name))
+                .findFirst()
+                .orElse(dpdb.getPlayer(name));
+      } else {
+        player = playerDatabase.getPlayer(name);
+      }
+
       Role role = player.getRole();
       boolean supportsBlocking = playerDatabase.supportsDisabling();
       String blockedReason = "";


### PR DESCRIPTION

### Identify the Bug or Feature request

resolves #3356



### Description of the Change
player.getConnectedPlayers() will now work correctly for role authenticated players


### Possible Drawbacks
Not Sure

### Documentation Notes

- player.getConnectedPlayers() will now work correctly for role authenticated players

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3531)
<!-- Reviewable:end -->
