### PR TITLE
Add a converter to make CellPoint from pre-1.9.0 AStarCellPoint XML

### DIFF
--- a/src/main/java/net/rptools/lib/FileUtil.java
+++ b/src/main/java/net/rptools/lib/FileUtil.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
+import net.rptools.maptool.model.AStarCellPointConverter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -506,6 +507,7 @@ public class FileUtil {
     XStream xStream = new XStream();
     XStream.setupDefaultSecurity(xStream);
     xStream.allowTypesByWildcard(new String[] {"net.rptools.**", "java.awt.**", "sun.awt.**"});
+    xStream.registerConverter(new AStarCellPointConverter());
     return xStream;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AStarCellPoint.java
@@ -17,7 +17,7 @@ package net.rptools.maptool.client.walker.astar;
 import java.util.Objects;
 import net.rptools.maptool.model.CellPoint;
 
-class AStarCellPoint {
+public class AStarCellPoint {
   final CellPoint position;
   final boolean isOddStepOfOneTwoOneMovement;
 

--- a/src/main/java/net/rptools/maptool/model/AStarCellPointConverter.java
+++ b/src/main/java/net/rptools/maptool/model/AStarCellPointConverter.java
@@ -1,0 +1,94 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import com.google.common.collect.ImmutableMap;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import net.rptools.maptool.client.walker.astar.AStarCellPoint;
+
+/** Converts pre-1.9.0 AStarCellPoint data to the CellPoints they should have been all along. */
+public class AStarCellPointConverter implements Converter {
+  @Override
+  public boolean canConvert(Class type) {
+    return AStarCellPoint.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Read a CellPoint from pre-1.9.0 AStarCellPoint XML.
+   *
+   * <p>An AStarCellPoint that was serialized prior to 1.9.0 will have all the fields of a
+   * CellPoint, since AStarCellPoint extended CellPoint back then. This implementation reads that
+   * data but creates a CellPoint instances instead of an AStarCellPoint
+   *
+   * <p>However, if an AStarCellPoint object was serialized prior to 1.9.0, then was deserialized in
+   * 1.9.0 and then serialized again, it would no longer have the CellPoint fields. There is no way
+   * to recover the original CellPoint in this case, so we return null if this happens.
+   *
+   * @param reader The stream to read the text from.
+   * @param context
+   * @return A CellPoint that contains the position information of a pre-1.9.0 AStarCellPoint, or
+   *     null if there is no position information.
+   */
+  @Override
+  public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+    CellPoint result = new CellPoint(0, 0);
+    boolean hasCellPointData = false;
+
+    final var properties =
+        ImmutableMap.<String, Runnable>builder()
+            .put("x", () -> result.x = (int) context.convertAnother(result, int.class))
+            .put("y", () -> result.y = (int) context.convertAnother(result, int.class))
+            .put(
+                "distanceTraveled",
+                () ->
+                    result.distanceTraveled = (double) context.convertAnother(result, double.class))
+            .put(
+                "distanceTraveledWithoutTerrain",
+                () ->
+                    result.distanceTraveledWithoutTerrain =
+                        (double) context.convertAnother(result, double.class))
+            .put(
+                "isAStarCanceled",
+                () ->
+                    result.setAStarCanceled(
+                        (boolean) context.convertAnother(result, boolean.class)))
+            .build();
+
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      try {
+        final var name = reader.getNodeName();
+        final var action = properties.get(name);
+        if (action != null) {
+          hasCellPointData = true;
+          action.run();
+        }
+      } finally {
+        reader.moveUp();
+      }
+    }
+
+    return hasCellPointData ? result : null;
+  }
+}

--- a/src/main/java/net/rptools/maptool/model/Path.java
+++ b/src/main/java/net/rptools/maptool/model/Path.java
@@ -28,6 +28,17 @@ public class Path<T extends AbstractPoint> {
   private final List<T> cellList = new LinkedList<T>();
   private final List<T> waypointList = new LinkedList<T>();
 
+  protected Object readResolve() {
+    // If any AStarCellPoints could not be converted to CellPoint, we get `null`s in these lists.
+    // In such a case, the path is meaningless so we just clear it.
+    if (cellList.contains(null) || waypointList.contains(null)) {
+      cellList.clear();
+      waypointList.clear();
+    }
+
+    return this;
+  }
+
   public void addPathCell(T point) {
     cellList.add(point);
   }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2477,13 +2477,8 @@ public class Token extends BaseModel implements Cloneable {
     }
 
     // Check to make sure lastPath has valid data
-    if (lastPath != null) {
-      // The second condition seems like it shouldn't be possible, but at some point in the past it
-      // was possible for paths of AStarCellPoints to exist and these can persist in older tokens.
-      if (lastPath.getCellPath().size() == 0
-          || !(lastPath.getCellPath().get(0) instanceof AbstractPoint)) {
-        lastPath = null;
-      }
+    if (lastPath != null && lastPath.getCellPath().isEmpty()) {
+      lastPath = null;
     }
 
     return this;


### PR DESCRIPTION
### Identify the Bug or Feature request

#3530

### Description of the Change

There are two cases in which an `AStarCellPoint` can end up having being saved:
- In campaigns created before 1.9.0, `AStarCellPoint` could be freely added to `Path` as it was a subclass of
  `CellPoint`/`AbstractPoint`.
- In campaigns loaded in 1.9.0 or later, if it already had an `AStarCellPoint` in a `Path` it would be deserialized to a
  mostly meaningless object (`null` position in particular). If that campaign is then saved again, the serialized
  `AStarCellPoint` will not have any `CellPoint` fields anymore.

In the former case, the converter builds a `CellPoint` so that the position information is not lost. In the latter
case. the information is already lost so we don't build anything. To account for this, `Path` will clear itself if it
encounters any null points, and `Token` will `null` out any empty `Path`.

### Possible Drawbacks

Because a path now clears itself in some circumstances, the length of the last path will be lost for tokens that have an `AStarCellPoint` in them and which were loaded and saved post-1.9.0.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug causing last path information to be lost when loading campaigns created before 1.9.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3532)
<!-- Reviewable:end -->
