### PR TITLE
Pass frameValue through to overlays

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -163,7 +163,7 @@ public class HTMLFrameFactory {
           frameValue,
           html);
     } else if (frameType == FrameType.OVERLAY) {
-      MapTool.getFrame().getOverlayPanel().showOverlay(name, zOrder, html);
+      MapTool.getFrame().getOverlayPanel().showOverlay(name, zOrder, html, frameValue);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -236,7 +236,7 @@ public class HTMLOverlayPanel extends JFXPanel {
    * @param zOrder the zOrder of the overlay
    * @param html the HTML of the overlay
    */
-    public void showOverlay(String name, int zOrder, String html, Object frameValue) {
+  public void showOverlay(String name, int zOrder, String html, Object frameValue) {
     getDropTarget().setActive(false); // disables drop on overlay, drop goes to map
     setVisible(true);
     Platform.runLater(
@@ -267,9 +267,9 @@ public class HTMLOverlayPanel extends JFXPanel {
             sortOverlays();
           }
           overlayManager.updateContents(html, true);
-	  if (frameValue != null) {
-	    overlayManager.setValue(frameValue);
-	  }
+          if (frameValue != null) {
+            overlayManager.setValue(frameValue);
+          }
         });
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -236,7 +236,7 @@ public class HTMLOverlayPanel extends JFXPanel {
    * @param zOrder the zOrder of the overlay
    * @param html the HTML of the overlay
    */
-  public void showOverlay(String name, int zOrder, String html) {
+    public void showOverlay(String name, int zOrder, String html, Object frameValue) {
     getDropTarget().setActive(false); // disables drop on overlay, drop goes to map
     setVisible(true);
     Platform.runLater(
@@ -267,6 +267,9 @@ public class HTMLOverlayPanel extends JFXPanel {
             sortOverlays();
           }
           overlayManager.updateContents(html, true);
+	  if (frameValue != null) {
+	    overlayManager.setValue(frameValue);
+	  }
         });
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request
Related to #3503, this time for overlays in addition to frame5 and dialog5

### Description of the Change

Overlays already have the `value` userdata field, but it is currently left unset.  And currently the option parameter is parsed to extract the value, but it is then discarded.  This connects the two similarly to how frame5 and dialog5 set them.

### Documentation Notes
Inside an HTML5 overlay, `MapTool.getUserData()` now correctly returns a promise containing the user data in overlays.

### Release Notes

- MapTool.getUserData() now works correctly in overlays

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3537)
<!-- Reviewable:end -->
