### PR TITLE
Reduce precision model precision

### DIFF
--- a/src/main/java/net/rptools/lib/GeometryUtil.java
+++ b/src/main/java/net/rptools/lib/GeometryUtil.java
@@ -18,7 +18,7 @@ import java.awt.geom.Point2D;
 import org.locationtech.jts.geom.PrecisionModel;
 
 public class GeometryUtil {
-  private static final PrecisionModel precisionModel = new PrecisionModel(1_000_000_000_000.0);
+  private static final PrecisionModel precisionModel = new PrecisionModel(1_000_000.0);
 
   public static double getAngle(Point2D origin, Point2D target) {
     double angle =

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
@@ -119,9 +119,9 @@ public class AreaMeta {
 
     if (path == null) {
       path = new GeneralPath();
-      path.moveTo(x, y);
+      path.moveTo(vertex.x, vertex.y);
     } else {
-      path.lineTo(x, y);
+      path.lineTo(vertex.x, vertex.y);
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3541

### Description of the Change

In #3521 I made VBL coordinates precise by applying a precision model which was good to 1 part in a trillion. But it turns out that is still too precise than is reasonable for our vision blocking algorithm. This PR changes that to 1 part in a million which should still be plenty precise for real maps.

Included is a change to make sure that internally our topology uses the same precision for its vertices as it does for it boundary represented as an `Area`.

### Possible Drawbacks

Shouldn't be any in practice.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3545)
<!-- Reviewable:end -->
