### PR TITLE
Uvtt extend filter

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -770,9 +770,7 @@ public class MapToolFrame extends DefaultDockableHolder
     }
   }
 
-  /**
-   * Accepts 1 or more file extensions
-   */
+  /** Accepts 1 or more file extensions */
   private static class MTFileFilter extends FileFilter {
     private final String[] extensions;
     private final String description;
@@ -783,9 +781,7 @@ public class MapToolFrame extends DefaultDockableHolder
       description = desc;
     }
 
-    /**
-     * Accept directories and files matching any of the provided extensions
-     */
+    /** Accept directories and files matching any of the provided extensions */
     @Override
     public boolean accept(File f) {
       if (f.isDirectory()) {

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -208,9 +208,8 @@ public class MapToolFrame extends DefaultDockableHolder
       new MTFileFilter("mtmacset", I18N.getText("file.ext.mtmacset"));
   private final FileFilter tableFilter =
       new MTFileFilter("mttable", I18N.getText("file.ext.mttable"));
-
   private final FileFilter dungeonDraftFilter =
-      new MTFileFilter("dd2vtt", I18N.getText("file.ext.dungeondraft"));
+      new MTMultiFileFilter(I18N.getText("file.ext.dungeondraft"), "dd2vtt", "df2vtt", "uvtt");
   private EditTokenDialog tokenPropertiesDialog;
 
   private final CampaignPanel campaignPanel = new CampaignPanel();
@@ -811,6 +810,51 @@ public class MapToolFrame extends DefaultDockableHolder
     }
   }
 
+  /**
+   * File filter for multiple extensions.
+   */
+  private static class MTMultiFileFilter extends FileFilter {
+    private final String[] extensions;
+    private final String description;
+
+    MTMultiFileFilter(String desc, String... extens) {
+      super();
+      extensions = extens;
+      description = desc;
+    }
+
+    // Accept directories and files matching extension
+    @Override
+    public boolean accept(File f) {
+      if (f.isDirectory()) {
+        return true;
+      }
+      String fext = getExtension(f);
+      for (String ext : extensions) {
+        if (fext != null && fext.equals(ext)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    public String getExtension(File f) {
+      String ext = null;
+      String s = f.getName();
+      int i = s.lastIndexOf('.');
+
+      if (i > 0 && i < s.length() - 1) {
+        ext = s.substring(i + 1).toLowerCase();
+      }
+      return ext;
+    }
+  }
+
   public FileFilter getCmpgnFileFilter() {
     return campaignFilter;
   }
@@ -820,9 +864,9 @@ public class MapToolFrame extends DefaultDockableHolder
   }
 
   /**
-   * Returns the {@link FileFilter} for dungeondraft VTT export files.
+   * Returns the {@link FileFilter} for Univerasl VTT export files.
    *
-   * @return the {@link FileFilter} for dungeondraft VTT export files.
+   * @return the {@link FileFilter} for Universal VTT export files.
    */
   public FileFilter getDungeonDraftFilter() {
     return dungeonDraftFilter;

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -198,18 +198,18 @@ public class MapToolFrame extends DefaultDockableHolder
   private Layer lastSelectedLayer = Zone.Layer.TOKEN;
 
   private final FileFilter campaignFilter =
-      new MTFileFilter("cmpgn", I18N.getText("file.ext.cmpgn"));
-  private final FileFilter mapFilter = new MTFileFilter("rpmap", I18N.getText("file.ext.rpmap"));
+      new MTFileFilter(I18N.getText("file.ext.cmpgn"), "cmpgn");
+  private final FileFilter mapFilter = new MTFileFilter(I18N.getText("file.ext.rpmap"), "rpmap");
   private final FileFilter propertiesFilter =
-      new MTFileFilter("mtprops", I18N.getText("file.ext.mtprops"));
+      new MTFileFilter(I18N.getText("file.ext.mtprops"), "mtprops");
   private final FileFilter macroFilter =
-      new MTFileFilter("mtmacro", I18N.getText("file.ext.mtmacro"));
+      new MTFileFilter(I18N.getText("file.ext.mtmacro"), "mtmacro");
   private final FileFilter macroSetFilter =
-      new MTFileFilter("mtmacset", I18N.getText("file.ext.mtmacset"));
+      new MTFileFilter(I18N.getText("file.ext.mtmacset"), "mtmacset");
   private final FileFilter tableFilter =
-      new MTFileFilter("mttable", I18N.getText("file.ext.mttable"));
+      new MTFileFilter(I18N.getText("file.ext.mttable"), "mttable");
   private final FileFilter dungeonDraftFilter =
-      new MTMultiFileFilter(I18N.getText("file.ext.dungeondraft"), "dd2vtt", "df2vtt", "uvtt");
+      new MTFileFilter(I18N.getText("file.ext.dungeondraft"), "dd2vtt", "df2vtt", "uvtt");
   private EditTokenDialog tokenPropertiesDialog;
 
   private final CampaignPanel campaignPanel = new CampaignPanel();
@@ -770,60 +770,22 @@ public class MapToolFrame extends DefaultDockableHolder
     }
   }
 
-  private static class MTFileFilter extends FileFilter {
-    private final String extension;
-    private final String description;
-
-    MTFileFilter(String exten, String desc) {
-      super();
-      extension = exten;
-      description = desc;
-    }
-
-    // Accept directories and files matching extension
-    @Override
-    public boolean accept(File f) {
-      if (f.isDirectory()) {
-        return true;
-      }
-      String ext = getExtension(f);
-      if (ext != null) {
-        return ext.equals(extension);
-      }
-      return false;
-    }
-
-    @Override
-    public String getDescription() {
-      return description;
-    }
-
-    public String getExtension(File f) {
-      String ext = null;
-      String s = f.getName();
-      int i = s.lastIndexOf('.');
-
-      if (i > 0 && i < s.length() - 1) {
-        ext = s.substring(i + 1).toLowerCase();
-      }
-      return ext;
-    }
-  }
-
   /**
-   * File filter for multiple extensions.
+   * Accepts 1 or more file extensions
    */
-  private static class MTMultiFileFilter extends FileFilter {
+  private static class MTFileFilter extends FileFilter {
     private final String[] extensions;
     private final String description;
 
-    MTMultiFileFilter(String desc, String... extens) {
+    MTFileFilter(String desc, String... extens) {
       super();
       extensions = extens;
       description = desc;
     }
 
-    // Accept directories and files matching extension
+    /**
+     * Accept directories and files matching any of the provided extensions
+     */
     @Override
     public boolean accept(File f) {
       if (f.isDirectory()) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1478,7 +1478,7 @@ file.ext.mtprops  = MapTool Campaign Properties
 file.ext.mttable  = MapTool Table
 file.ext.rpmap    = MapTool Map
 file.ext.rptok    = MapTool Token
-file.ext.dungeondraft = Dungeondraft VTT Export
+file.ext.dungeondraft = Universal VTT Map (.dd2vtt, .df2vtt, .uvtt)
 file.ext.addOnLib    = Maptool Add-On Library
 
 goto.description = Goto location or token.  /goto X,Y or /goto tokenname.


### PR DESCRIPTION
### Identify the Bug or Feature request

For #3540 

### Description of the Change

Updated MTFileFilter to accept multiple file extensions and changed text description for the UVTT import.

### Possible Drawbacks

None anticipated.

### Documentation Notes

UVTT import now recognizes file extensions from DungeonFog (.df2vtt) and Master's Toolkit (.uvtt).

### Release Notes

UVTT import now recognizes file extensions from DungeonFog (.df2vtt) and Master's Toolkit (.uvtt).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3547)
<!-- Reviewable:end -->
