### PR TITLE
Change getAllPropertyNames to return empty string/JSON array if type invalid

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -1176,10 +1176,10 @@ public class TokenPropertyFunctions extends AbstractFunction {
    * @throws ParserException
    */
   private String getAllPropertyNames(String type, String delim) throws ParserException {
+    ArrayList<String> namesList = new ArrayList<String>();
     if (type == null || type.length() == 0 || type.equals("*")) {
       Map<String, List<TokenProperty>> pmap =
           MapTool.getCampaign().getCampaignProperties().getTokenTypeMap();
-      ArrayList<String> namesList = new ArrayList<String>();
 
       for (Entry<String, List<TokenProperty>> entry : pmap.entrySet()) {
         for (TokenProperty tp : entry.getValue()) {
@@ -1196,14 +1196,10 @@ public class TokenPropertyFunctions extends AbstractFunction {
     } else {
       List<TokenProperty> props =
           MapTool.getCampaign().getCampaignProperties().getTokenPropertyList(type);
-      if (props == null) {
-        throw new ParserException(
-            I18N.getText(
-                "macro.function.tokenProperty.unknownPropType", "getAllPropertyNames", type));
-      }
-      ArrayList<String> namesList = new ArrayList<String>();
-      for (TokenProperty tp : props) {
-        namesList.add(tp.getName());
+      if (props != null) {
+        for (TokenProperty tp : props) {
+          namesList.add(tp.getName());
+        }
       }
       if ("json".equals(delim)) {
         JsonArray jarr = new JsonArray();

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -1196,6 +1196,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     } else {
       List<TokenProperty> props =
           MapTool.getCampaign().getCampaignProperties().getTokenPropertyList(type);
+      // If property type not found return an empty string or JSON array
       if (props != null) {
         for (TokenProperty tp : props) {
           namesList.add(tp.getName());


### PR DESCRIPTION
### Identify the Bug or Feature request

For #3387 

### Description of the Change

Instead of throwing a parser exception, calls to `getAllPropertyNames()` will return an empty string or an empty JSON array if the property type is not found.

### Possible Drawbacks

None expected.

### Documentation Notes

If property type is not found on current token an empty string or empty JSON array will be returned.

### Release Notes

`getAllPropertyNames()` now returns empty string/JSON array if property type is invalid

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3548)
<!-- Reviewable:end -->
