### PR TITLE
Change JSAPIToken.setProperty() to accept Objects instead of Strings

### DIFF
--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -125,11 +125,11 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   }
 
   @HostAccess.Export
-  public void setProperty(String name, String value) {
+  public void setProperty(String name, Object value) {
     boolean trusted = JSScriptEngine.inTrustedContext();
     String playerId = MapTool.getPlayer().getName();
     if (trusted || token.isOwner(playerId)) {
-      this.token.setProperty(name, value);
+      this.token.setProperty(name, value.toString());
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fix #3102 

### Description of the Change

Changed method signature on `JSAPIToken.setProperty()` to take an `Object` for `value` instead of `String` and instead use the `toString()` method of `Object` to pass it on to the `Token.setProperty()` method.

### Possible Drawbacks

Should be none.

### Documentation Notes

n/a

### Release Notes

Fixed issue where numbers passed to `JSAPIToken.setProperty()` would cause a PolyglotEngineException error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3550)
<!-- Reviewable:end -->
