### PR TITLE
add-on javascript context

### DIFF
--- a/src/main/java/net/rptools/maptool/client/script/javascript/JSContext.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/JSContext.java
@@ -20,14 +20,5 @@ import javax.script.*;
 import org.graalvm.polyglot.*;
 import org.graalvm.polyglot.HostAccess.*;
 
-public class JSContext {
-  public boolean isTrusted;
-  public Context context;
-  public String name;
-
-  public JSContext(boolean t, Context c, String name) {
-    this.isTrusted = t;
-    this.context = c;
-    this.name = name;
-  }
-}
+public record JSContext(boolean trusted, Context context, String name) {}
+;

--- a/src/main/java/net/rptools/maptool/client/script/javascript/JSScriptEngine.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/JSScriptEngine.java
@@ -35,6 +35,7 @@ public class JSScriptEngine {
   private static final JSScriptEngine jsScriptEngine = new JSScriptEngine();
   private static final Logger log = LogManager.getLogger(JSScriptEngine.class);
   private static final Map<String, JSContext> contexts = new HashMap<String, JSContext>();
+  private static final Map<String, JSContext> addOnContexts = new HashMap<String, JSContext>();
   private static final Stack<JSContext> contextStack = new Stack<>();
 
   public static JSContext getCurrentContext() {
@@ -42,10 +43,10 @@ public class JSScriptEngine {
   }
 
   public static boolean inTrustedContext() {
-    if (jsScriptEngine.contextStack.empty()) {
+    if (JSScriptEngine.contextStack.empty()) {
       return false;
     }
-    return jsScriptEngine.contextStack.peek().isTrusted;
+    return JSScriptEngine.contextStack.peek().trusted();
   }
 
   private void registerAPIObject(Value bindings, MapToolJSAPIInterface apiObj) {
@@ -91,7 +92,7 @@ public class JSScriptEngine {
       return;
     }
     JSContext c = contexts.get(name);
-    if (c == null || c.isTrusted) {
+    if (c == null || c.trusted()) {
       throw new ParserException(I18N.getText("macro.function.general.noPermJS", name));
     }
     contexts.remove(name);
@@ -101,6 +102,29 @@ public class JSScriptEngine {
   public static void resetContexts() {
     JSMacro.clear();
     contexts.clear();
+    addOnContexts.clear();
+  }
+
+  public static JSContext registerAddOnContext(String name) {
+    JSContext c = new JSContext(true, jsScriptEngine.makeContext(), name);
+    addOnContexts.put(name, c);
+    return c;
+  }
+
+  public static void removeAddOnContext(String name) {
+    addOnContexts.remove(name);
+  }
+
+  public static boolean hasContext(String name) {
+    return contexts.containsKey(name);
+  }
+
+  public static boolean hasAddOnContext(String name) {
+    return addOnContexts.containsKey(name);
+  }
+
+  public static Set<JSContext> getContexts() {
+    return new HashSet<>(contexts.values());
   }
 
   public Context makeContext() {
@@ -130,23 +154,37 @@ public class JSScriptEngine {
 
   public Value evalScript(String contextName, String script)
       throws ScriptException, ParserException {
+    return evalScript(contextName, script, MapTool.getParser().isMacroTrusted());
+  }
+
+  public Value evalScript(String contextName, String script, boolean trusted)
+      throws ScriptException, ParserException {
     if (contextName == null) {
       return evalAnonymous(script);
     }
     JSContext jc = contexts.get(contextName);
     if (jc == null) {
-      jc =
-          registerContext(
-              contextName,
-              MapTool.getParser().isMacroTrusted(),
-              MapTool.getParser().isMacroTrusted());
+      jc = registerContext(contextName, trusted, trusted);
     }
-    if (jc.isTrusted && !MapTool.getParser().isMacroTrusted()) {
-      throw new ParserException(I18N.getText("macro.function.general.noPermJS", contextName));
+
+    return evalScript(jc, script, trusted);
+  }
+
+  public Value evalAddOnScript(String contextName, String script, boolean trusted)
+      throws ScriptException, ParserException {
+    JSContext jc = addOnContexts.get(contextName);
+    return evalScript(jc, script, trusted);
+  }
+
+  public Value evalScript(JSContext context, String script, boolean trusted)
+      throws ScriptException, ParserException {
+
+    if (context.trusted() && !trusted) {
+      throw new ParserException(I18N.getText("macro.function.general.noPermJS", context.name()));
     }
-    contextStack.push(jc);
+    contextStack.push(context);
     try {
-      return jc.context.eval("js", script);
+      return context.context().eval("js", script);
     } finally {
       contextStack.pop();
     }

--- a/src/main/java/net/rptools/maptool/model/gamedata/data/AssetDataValue.java
+++ b/src/main/java/net/rptools/maptool/model/gamedata/data/AssetDataValue.java
@@ -107,7 +107,7 @@ public class AssetDataValue implements DataValue {
     if (undefined) {
       throw InvalidDataOperation.createUndefined(name);
     } else {
-      throw InvalidDataOperation.createInvalidConversion(DataType.ASSET, DataType.DOUBLE);
+      return asset.toString();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/library/Library.java
+++ b/src/main/java/net/rptools/maptool/model/library/Library.java
@@ -203,4 +203,10 @@ public interface Library {
    * @return the {@link Asset} for the library license file if it has one.
    */
   CompletableFuture<Optional<Asset>> getLicenseAsset();
+
+  /**
+   * Clean up any resources used by the library, This should be called when the library is no longer
+   * needed.
+   */
+  void cleanup();
 }

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryManager.java
@@ -93,6 +93,7 @@ public class AddOnLibraryManager {
   public void deregisterLibrary(String namespace) {
     var removed = namespaceLibraryMap.remove(namespace.toLowerCase());
     if (removed != null) {
+      removed.cleanup();
       new MapToolEventBus()
           .getMainEventBus()
           .post(new AddOnsRemovedEvent(Set.of(removed.getLibraryInfo().join())));
@@ -172,6 +173,9 @@ public class AddOnLibraryManager {
 
     if (libs.size() > 0) {
       new MapToolEventBus().getMainEventBus().post(new AddOnsRemovedEvent(libs));
+      for (var library : namespaceLibraryMap.values()) {
+        library.cleanup();
+      }
       namespaceLibraryMap.clear();
     }
   }

--- a/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
@@ -363,6 +363,11 @@ class LibraryToken implements Library {
     return CompletableFuture.completedFuture(Optional.empty());
   }
 
+  @Override
+  public void cleanup() {
+    // No cleanup needed
+  }
+
   /**
    * @param id the id of the token Lib:Token to get.
    * @return the Token for the library.


### PR DESCRIPTION

### Identify the Bug or Feature request

resolves #3551 
resolves #3552 
resolves #3553 


### Description of the Change
Adds JavaScript for each add-on, and allows add-ons to run JavaScript files for the add-on 'onFirstInit' and 'onInit' events.
Also adds the macro script command `js.listNS` to list available JavaScript contexts. This will not list the contexts created for add-ons.


The onInit/onFirstInit + add-on javascript context can be tested with the following add on, adding it should print to the log (there is not really a way to access it yet so the log output is best way)
[test-add-on.zip](https://github.com/RPTools/maptool/files/9374268/test-add-on.zip)


### Possible Drawbacks

None foreseeable.

### Documentation Notes

For JavaScript Add-On contexts
https://docs.rptools.info/docs/add-ons/java-script#javascript-context

For running JavaScript on events
https://docs.rptools.info/docs/add-ons/creation/#format-of-the-events-configuration-file

For js.listNS

usage: `[r: js.listNS()]`

### Release Notes
- Added js.listNS() MTScript command
- Each Add-On now creates a private JavaScript context
- The Add-On 'onFirstInit' and 'inInit' events can now run a JavaScript script from the Add-On

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3554)
<!-- Reviewable:end -->
