### PR TITLE
fix setTokenImage macro

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -621,11 +621,17 @@ public class ServerCommandClientImpl implements ServerCommand {
 
   @Override
   public void updateTokenProperty(Token token, Token.Update update, String value1, String value2) {
-    updateTokenProperty(
-        token,
-        update,
-        TokenPropertyValueDto.newBuilder().setStringValue(value1).build(),
-        TokenPropertyValueDto.newBuilder().setStringValue(value2).build());
+    var value1Dto = TokenPropertyValueDto.newBuilder();
+    if (value1 != null) {
+      value1Dto.setStringValue(value1);
+    }
+
+    var value2Dto = TokenPropertyValueDto.newBuilder();
+    if (value2 != null) {
+      value2Dto.setStringValue(value2);
+    }
+
+    updateTokenProperty(token, update, value1Dto.build(), value2Dto.build());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2704,7 +2704,8 @@ public class Token extends BaseModel implements Cloneable {
         }
       case setImageAsset:
         setImageAsset(
-            parameters.get(0).getStringValue(), new MD5Key(parameters.get(1).getStringValue()));
+            parameters.get(0).hasStringValue() ? parameters.get(0).getStringValue() : null,
+            new MD5Key(parameters.get(1).getStringValue()));
         panelLookChanged = true;
         break;
       case setPortraitImage:


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes #3542 

### Description of the Change

Fixes a NPE resulting from trying to put null into a protobuf StringValue


### Possible Drawbacks
None.

### Release Notes
- Fixed an issue where `setTokenImage()` produces a NPE

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3555)
<!-- Reviewable:end -->
