### PR TITLE
Bugfix/3561 vbl orientation error

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
@@ -137,7 +137,7 @@ public class AreaMeta {
       vertices.add(first);
     }
 
-    isHole = Orientation.isCCW(vertices.toArray(Coordinate[]::new));
+    isHole = vertices.size() >= 4 && Orientation.isCCW(vertices.toArray(Coordinate[]::new));
 
     // Don't need this anymore
     path = null;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
@@ -46,6 +46,13 @@ public class AreaMeta {
     return new Area(area);
   }
 
+  /** @return true if this object does not have any edges. */
+  public boolean isEmpty() {
+    // Note: vertices is a closed loop, so we can only have edges if we have at least 3 points with
+    // which to form a line.
+    return vertices.size() < 3;
+  }
+
   /**
    * @param origin
    * @param faceAway If `true`, only return segments facing away from origin.

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaTree.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaTree.java
@@ -67,7 +67,7 @@ public class AreaTree {
     // Break the big area into independent areas
     double[] coords = new double[6];
     AreaMeta areaMeta = new AreaMeta();
-    for (PathIterator iter = area.getPathIterator(null); !iter.isDone(); iter.next()) {
+    for (PathIterator iter = area.getPathIterator(null, 1e-2); !iter.isDone(); iter.next()) {
       int type = iter.currentSegment(coords);
       switch (type) {
         case PathIterator.SEG_CLOSE:

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaTree.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaTree.java
@@ -74,10 +74,12 @@ public class AreaTree {
           areaMeta.close();
 
           // Holes are oceans, solids are islands
-          if (areaMeta.isHole()) {
-            oceanList.add(new AreaOcean(areaMeta));
-          } else {
-            islandList.add(new AreaIsland(areaMeta));
+          if (!areaMeta.isEmpty()) {
+            if (areaMeta.isHole()) {
+              oceanList.add(new AreaOcean(areaMeta));
+            } else {
+              islandList.add(new AreaIsland(areaMeta));
+            }
           }
           break;
         case PathIterator.SEG_LINETO:


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3561

### Description of the Change

This adds code to handle `AreaMeta`s that have fewer than three points, i.e. it handles lines and points. We now consider lines to not be holes, and we do that without requiring an orientation test. As for points, we consider those "empty" and do not add them to the `AreaTree` as they would not have an impact on vision anyways.

We also now handle `PathIterator.SEG_QUADTO` and `PathIterator.SEG_CUBICTO` segments by using a flat path iterator to interpolate those segments so that `AreaTree` doesn't have to deal with them. There are other places that should probably use a flat path iterator, but that is beyond the scope of this PR.

### Possible Drawbacks

If someone has managed to produce many cubic segments on a map, they could see a performance hit from the increased number of points that are generated. 

### Documentation Notes

N/A

### Release Notes

N/A (fixes a new bug)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3562)
<!-- Reviewable:end -->
