### PR TITLE
Fix issue with setBarVisible() caused by protobuf changes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenBarFunction.java
@@ -110,8 +110,7 @@ public class TokenBarFunction extends AbstractFunction {
    * @return If the bar visible or not
    */
   public static BigDecimal setVisible(Token token, String bar, boolean show) {
-    BigDecimal value = show ? BigDecimal.ONE : null;
-    MapTool.serverCommand().updateTokenProperty(token, Token.Update.setState, bar, value);
+    MapTool.serverCommand().updateTokenProperty(token, Token.Update.setState, bar, show);
     return show ? BigDecimal.ONE : BigDecimal.ZERO;
   }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1718,9 +1718,19 @@ public class Token extends BaseModel implements Cloneable {
    * @return The original value of the state, if any.
    */
   public Object setState(String aState, Object aValue) {
+    // the GUI sends null to mean remove a state/bar
     if (aValue == null) {
       return state.remove(aState);
     }
+    // setBarVisible sends a boolean to show/hide a bar
+    if (aValue instanceof Boolean) {
+      if ((Boolean) aValue) {
+        return state.put(aState, 1.0);
+      } else {
+        return state.remove(aState);
+      }
+    }
+    // Either enable a state or set the value of a bar
     return state.put(aState, aValue);
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3558 

### Description of the Change

Passing a null through is problematic now.  Passing the boolean on through and catching it in Token.setState().

### Possible Drawbacks

None expected.

### Documentation Notes

No change to behavior of bars/states.

### Release Notes

Fixed issue where using `setBarVisible()` was throwing an NPE.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3564)
<!-- Reviewable:end -->
