### PR TITLE
Improve performance of light rendering

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/BufferedImagePool.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/BufferedImagePool.java
@@ -1,0 +1,137 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone;
+
+import java.awt.AlphaComposite;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A single-element pool of BufferedImages.
+ *
+ * <p>This is particularly useful for rendering the lighting overlays in ZoneRenderer.
+ */
+public class BufferedImagePool {
+  private static final Logger log = LogManager.getLogger(BufferedImagePool.class);
+
+  public final class Handle implements AutoCloseable {
+    private final BufferedImage image;
+
+    private Handle(BufferedImage image) {
+      this.image = image;
+    }
+
+    public BufferedImage get() {
+      return image;
+    }
+
+    @Override
+    public void close() {
+      release(image);
+    }
+  }
+
+  private int width;
+  private int height;
+  private @Nonnull GraphicsConfiguration configuration;
+
+  private final int maxSize;
+  private final Deque<BufferedImage> available = new ArrayDeque<>();
+  private final Set<BufferedImage> checkedOut = Collections.newSetFromMap(new IdentityHashMap<>());
+
+  public BufferedImagePool(int maxSize) {
+    this.maxSize = maxSize;
+    this.width = 0;
+    this.height = 0;
+    this.configuration =
+        GraphicsEnvironment.getLocalGraphicsEnvironment()
+            .getDefaultScreenDevice()
+            .getDefaultConfiguration();
+  }
+
+  /** Removes all images from the pool. */
+  private void clear() {
+    this.available.clear();
+    this.checkedOut.clear();
+  }
+
+  public void setWidth(int width) {
+    if (width != this.width) {
+      this.width = width;
+      this.clear();
+    }
+  }
+
+  public void setHeight(int height) {
+    if (height != this.height) {
+      this.height = height;
+      this.clear();
+    }
+  }
+
+  public void setConfiguration(GraphicsConfiguration configuration) {
+    if (!this.configuration.equals(configuration)) {
+      this.configuration = configuration;
+      this.clear();
+    }
+  }
+
+  public Handle acquire() {
+    if (available.isEmpty()) {
+      final var newInstance =
+          this.configuration.createCompatibleImage(width, height, Transparency.TRANSLUCENT);
+
+      // If there is still space available in the pool, start tracking the newly created image.
+      // Otherwise, we can just return it and forget about it.
+      if (available.size() + checkedOut.size() < maxSize) {
+        checkedOut.add(newInstance);
+      } else {
+        log.info("Needed new instance but pool is full.");
+      }
+
+      return new Handle(newInstance);
+    }
+
+    // We've got an existing instance. We'll need to make sure it's cleared before yielding it.
+    final var instance = available.removeLast();
+    checkedOut.add(instance);
+
+    final var g = instance.createGraphics();
+    g.setComposite(AlphaComposite.Clear);
+    g.fillRect(0, 0, instance.getWidth(), instance.getHeight());
+    g.dispose();
+
+    return new Handle(instance);
+  }
+
+  private void release(BufferedImage image) {
+    final var wasCheckedOut = checkedOut.remove(image);
+    if (wasCheckedOut) {
+      available.addLast(image);
+    } else {
+      log.info("Attempted to release an instance not in the pool.");
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -836,26 +836,46 @@ public class ZoneRenderer extends JComponent
     timer.setEnabled(AppState.isCollectProfilingData() || log.isDebugEnabled());
     timer.clear();
     timer.setThreshold(10);
+    timer.start("paintComponent");
 
     Graphics2D g2d = (Graphics2D) g;
 
-    timer.start("paintComponent:createView");
-    PlayerView pl = getPlayerView();
-    timer.stop("paintComponent:createView");
+    timer.start("paintComponent:allocateBuffer");
+    final var bounds = g2d.getClipBounds();
+    tempBufferPool.setWidth(bounds.width);
+    tempBufferPool.setHeight(bounds.height);
+    tempBufferPool.setConfiguration(g2d.getDeviceConfiguration());
+    timer.stop("paintComponent:allocateBuffer");
 
-    renderZone(g2d, pl);
-    int noteVPos = 20;
-    if (MapTool.getFrame().areFullScreenToolsShown()) noteVPos += 40;
+    try (final var bufferHandle = tempBufferPool.acquire()) {
+      final var buffer = bufferHandle.get();
+      final var bufferG2d = buffer.createGraphics();
 
-    if (!AppPreferences.getMapVisibilityWarning() && (!zone.isVisible() && pl.isGMView())) {
-      GraphicsUtil.drawBoxedString(
-          g2d, I18N.getText("zone.map_not_visible"), getSize().width / 2, noteVPos);
-      noteVPos += 20;
+      timer.start("paintComponent:createView");
+      PlayerView pl = getPlayerView();
+      timer.stop("paintComponent:createView");
+
+      renderZone(bufferG2d, pl);
+      int noteVPos = 20;
+      if (MapTool.getFrame().areFullScreenToolsShown()) noteVPos += 40;
+
+      if (!AppPreferences.getMapVisibilityWarning() && (!zone.isVisible() && pl.isGMView())) {
+        GraphicsUtil.drawBoxedString(
+            bufferG2d, I18N.getText("zone.map_not_visible"), getSize().width / 2, noteVPos);
+        noteVPos += 20;
+      }
+      if (AppState.isShowAsPlayer()) {
+        GraphicsUtil.drawBoxedString(
+            bufferG2d, I18N.getText("zone.player_view"), getSize().width / 2, noteVPos);
+      }
+
+      timer.start("paintComponent:renderBuffer");
+      bufferG2d.dispose();
+      g2d.drawImage(buffer, null, 0, 0);
+      timer.stop("paintComponent:renderBuffer");
     }
-    if (AppState.isShowAsPlayer()) {
-      GraphicsUtil.drawBoxedString(
-          g2d, I18N.getText("zone.player_view"), getSize().width / 2, noteVPos);
-    }
+
+    timer.stop("paintComponent");
     if (timer.isEnabled()) {
       String results = timer.toString();
       MapTool.getProfilingNoteFrame().addText(results);
@@ -1422,6 +1442,14 @@ public class ZoneRenderer extends JComponent
   }
 
   /**
+   * Cache of images for rendering overlays.
+   *
+   * <p>Size is set to two: one for the buffer to draw the entire zone, and one for drawing each
+   * overlay in turn.
+   */
+  private final BufferedImagePool tempBufferPool = new BufferedImagePool(2);
+
+  /**
    * Cached set of lights arranged by lumens for some stability. TODO Token draw order would be
    * nice.
    */
@@ -1436,18 +1464,22 @@ public class ZoneRenderer extends JComponent
    */
   private void renderLights(Graphics2D g, PlayerView view) {
     // Collect and organize lights
-    timer.start("lights-1");
+    timer.start("renderLights:getLights");
     if (drawableLights == null) {
+      timer.start("renderLights:populateCache");
       drawableLights = new ArrayList<>(zoneView.getDrawableLights(view));
       drawableLights.removeIf(light -> light.getType() != LightSource.Type.NORMAL);
+      timer.stop("renderLights:populateCache");
     }
+    timer.start("renderLights:filterLights");
     final var darknessLights =
         drawableLights.stream().filter(light -> light.getLumens() < 0).toList();
     final var nonDarknessLights =
         drawableLights.stream().filter(light -> light.getLumens() >= 0).toList();
-    timer.stop("lights-1");
+    timer.stop("renderLights:filterLights");
+    timer.stop("renderLights:getLights");
 
-    timer.start("lights-2");
+    timer.start("renderLights:renderLightOverlay");
     renderLightOverlay(
         g,
         new BlendingComposite(BlendingComposite.Operation.SCREEN),
@@ -1455,8 +1487,10 @@ public class ZoneRenderer extends JComponent
         nonDarknessLights,
         new Color(255, 255, 255, 255),
         AppPreferences.getLightOverlayOpacity() / 255.0f);
+    timer.stop("renderLights:renderLightOverlay");
     // Players should not be able to discern the nature of the darkness, so we always render it as
     // black for them.
+    timer.start("renderLights:renderDarknessOverlay");
     renderLightOverlay(
         g,
         view.isGMView()
@@ -1466,7 +1500,7 @@ public class ZoneRenderer extends JComponent
         darknessLights,
         new Color(0, 0, 0, 255),
         view.isGMView() ? (AppPreferences.getDarknessOverlayOpacity() / 255.0f) : 1.0f);
-    timer.stop("lights-2");
+    timer.stop("renderLights:renderDarknessOverlay");
   }
 
   /** Holds the auras from lightSourceMap after they have been combined. */
@@ -1481,13 +1515,13 @@ public class ZoneRenderer extends JComponent
    */
   private void renderAuras(Graphics2D g, PlayerView view) {
     // Setup
-    timer.start("auras-1");
+    timer.start("renderAuras:getAuras");
     if (drawableAuras == null) {
       drawableAuras = new ArrayList<>(zoneView.getLights(LightSource.Type.AURA));
     }
-    timer.stop("auras-1");
+    timer.stop("renderAuras:getAuras");
 
-    timer.start("auras-2");
+    timer.start("renderAuras:renderAuraOverlay");
     renderLightOverlay(
         g,
         new BlendingComposite(BlendingComposite.Operation.SCREEN),
@@ -1495,7 +1529,7 @@ public class ZoneRenderer extends JComponent
         drawableAuras,
         new Color(255, 255, 255, 150),
         AppPreferences.getAuraOverlayOpacity() / 255.0f);
-    timer.stop("auras-2");
+    timer.stop("renderAuras:renderAuraOverlay");
   }
 
   /**
@@ -1516,53 +1550,58 @@ public class ZoneRenderer extends JComponent
       List<DrawableLight> lights,
       Paint defaultPaint,
       float overlayOpacity) {
+    if (lights.isEmpty()) {
+      // No points spending resources accomplishing nothing.
+      return;
+    }
+
     // Set up a buffer image for lights to be drawn onto before the map
-    timer.start("light-overlay-1");
-    BufferedImage lightOverlay =
-        new BufferedImage(
-            g.getClip().getBounds().width,
-            g.getClip().getBounds().height,
-            BufferedImage.TYPE_INT_ARGB);
-    Graphics2D newG = lightOverlay.createGraphics();
+    timer.start("renderLightOverlay:allocateBuffer");
+    try (final var bufferHandle = tempBufferPool.acquire()) {
+      BufferedImage lightOverlay = bufferHandle.get();
+      timer.stop("renderLightOverlay:allocateBuffer");
 
-    if (clipStyle != null && visibleScreenArea != null) {
-      Area clip = new Area(g.getClip());
-      switch (clipStyle) {
-        case CLIP_TO_VISIBLE_AREA -> clip.intersect(visibleScreenArea);
-        case CLIP_TO_NOT_VISIBLE_AREA -> clip.subtract(visibleScreenArea);
+      Graphics2D newG = lightOverlay.createGraphics();
+      SwingUtil.useAntiAliasing(newG);
+
+      if (clipStyle != null && visibleScreenArea != null) {
+        timer.start("renderLightOverlay:setClip");
+        Area clip = new Area(g.getClip());
+        switch (clipStyle) {
+          case CLIP_TO_VISIBLE_AREA -> clip.intersect(visibleScreenArea);
+          case CLIP_TO_NOT_VISIBLE_AREA -> clip.subtract(visibleScreenArea);
+        }
+        newG.setClip(clip);
+        timer.stop("renderLightOverlay:setClip");
       }
-      newG.setClip(clip);
+
+      timer.start("renderLightOverlay:setTransform");
+      AffineTransform af = new AffineTransform();
+      af.translate(getViewOffsetX(), getViewOffsetY());
+      af.scale(getScale(), getScale());
+      newG.setTransform(af);
+      timer.stop("renderLightOverlay:setTransform");
+
+      newG.setComposite(composite);
+
+      // Draw lights onto the buffer image so the map doesn't affect how they blend
+      timer.start("renderLightOverlay:drawLights");
+      for (var light : lights) {
+        var paint = light.getPaint() != null ? light.getPaint().getPaint() : defaultPaint;
+        newG.setPaint(paint);
+        newG.fill(light.getArea());
+      }
+      timer.stop("renderLightOverlay:drawLights");
+      newG.dispose();
+
+      // Draw the buffer image with all the lights onto the map
+      timer.start("renderLightOverlay:drawBuffer");
+      Composite previousComposite = g.getComposite();
+      g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, overlayOpacity));
+      g.drawImage(lightOverlay, null, 0, 0);
+      g.setComposite(previousComposite);
+      timer.stop("renderLightOverlay:drawBuffer");
     }
-
-    timer.stop("light-overlay-1");
-
-    timer.start("light-overlay-2");
-    AffineTransform af = new AffineTransform();
-    af.translate(getViewOffsetX(), getViewOffsetY());
-    af.scale(getScale(), getScale());
-    newG.setTransform(af);
-
-    newG.setComposite(composite);
-    timer.stop("light-overlay-2");
-
-    // Draw lights onto the buffer image so the map doesn't affect how they blend
-    timer.start("light-overlay-3");
-    for (var light : lights) {
-      var paint = light.getPaint() != null ? light.getPaint().getPaint() : defaultPaint;
-      newG.setPaint(paint);
-      newG.fill(light.getArea());
-    }
-    timer.stop("light-overlay-3");
-
-    // Draw the buffer image with all the lights onto the map
-    timer.start("light-overlay-4");
-    Composite previousComposite = g.getComposite();
-    g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, overlayOpacity));
-    g.drawImage(lightOverlay, null, 0, 0);
-    g.setComposite(previousComposite);
-    timer.stop("light-overlay-4");
-
-    newG.dispose();
   }
 
   /**


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement
* Fill out the template below. Any pull request that does not include enough information to be reviewed in timely manner will result in a request for you to update the pull request 
  and possibly closure of the pull request if it is not provided after this request.
* After you create the pull request, all status checks must pass before a maintainer will review your contribution. 


### Identify the Bug or Feature request

Implemented #3519

### Description of the Change

A pool of device-compatible `BufferedImage`s is maintained by `BufferedImagePool` that can be used whenever an image
buffer is needed that is that size of the `ZoneRenderer`. This change puts it to use for rendering the entire zone to a
buffer as well as for rendering the light/darkness/aura overlays.

More timings have been added around lighting rendering, and the timings have been renamed so that they are more
descriptive and not reliant on number sequences.

As an optimization, in the case that no light sources are present on a light/darkness/aura overlay, that overlay will
not be rendered.

### Possible Drawbacks

Additional memory usage due to buffers could impact memory-constrained systems.

### Documentation Notes

N/A

### Release Notes

N/A - fixes performance issue not present in any release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3580)
<!-- Reviewable:end -->
