### PR TITLE
Always size the BufferedImagePool to the ZoneRenderer size

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -841,15 +841,16 @@ public class ZoneRenderer extends JComponent
     Graphics2D g2d = (Graphics2D) g;
 
     timer.start("paintComponent:allocateBuffer");
-    final var bounds = g2d.getClipBounds();
-    tempBufferPool.setWidth(bounds.width);
-    tempBufferPool.setHeight(bounds.height);
+    tempBufferPool.setWidth(getSize().width);
+    tempBufferPool.setHeight(getSize().height);
     tempBufferPool.setConfiguration(g2d.getDeviceConfiguration());
     timer.stop("paintComponent:allocateBuffer");
 
     try (final var bufferHandle = tempBufferPool.acquire()) {
       final var buffer = bufferHandle.get();
       final var bufferG2d = buffer.createGraphics();
+      // Keep the clip so we don't render more than we have to.
+      bufferG2d.setClip(g2d.getClip());
 
       timer.start("paintComponent:createView");
       PlayerView pl = getPlayerView();


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3583

### Description of the Change

Rather than using the graphics clip to set a size for the image buffers, we now always size them to the component. This
is better for performance as we destroy fewer buffers, and easily avoids clip-related bugs.

### Possible Drawbacks

Should only be improvements

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3584)
<!-- Reviewable:end -->
