### PR TITLE
Override theme text color in chat and other Swing HTML documents

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/HTMLPanelRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/swing/HTMLPanelRenderer.java
@@ -37,7 +37,7 @@ public class HTMLPanelRenderer extends JTextPane {
     setDoubleBuffered(false);
 
     styleSheet = ((HTMLDocument) getDocument()).getStyleSheet();
-    styleSheet.addRule("body { font-family: sans-serif; font-size: 11pt}");
+    styleSheet.addRule("body { color: black; font-family: sans-serif; font-size: 11pt}");
     rendererPane.add(this);
     Document document = getDocument();
 

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
@@ -136,7 +136,9 @@ public class MessagePanel extends JPanel {
     // Create the style
     StyleSheet style = document.getStyleSheet();
     style.addRule(
-        "body { font-family: sans-serif; font-size: " + AppPreferences.getFontSize() + "pt}");
+        "body { color: black; font-family: sans-serif; font-size: "
+            + AppPreferences.getFontSize()
+            + "pt}");
     style.addRule("div {margin-bottom: 5px}");
     style.addRule(".roll {background:#efefef}");
     setTrustedMacroPrefixColors(

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
@@ -54,7 +54,7 @@ public class HTMLPane extends JEditorPane {
 
   /** The default rule for the body tag. */
   private static final String CSS_RULE_BODY =
-      "body { font-family: sans-serif; font-size: %dpt; background: #ECE9D8}";
+      "body { color: black; font-family: sans-serif; font-size: %dpt; background: #ECE9D8}";
   /** The default rule for the div tag. */
   private static final String CSS_RULE_DIV = "div {margin-bottom: 5px}";
   /** The default rule for the span tag. */


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #3589

### Description of the Change
This sets the text color for the chat and Swing HTML panels to black. This doesn't need to be done for anything using WebView because the themes don't affect them. It also might be unnecessary to add the CSS rule in `HTMLPanelRenderer`, but I figure better safe than sorry.

### Possible Drawbacks
Should be none.

### Documentation Notes
N/A

### Release Notes
* Fixed poor text contrast in chat and other HTML contexts when using dark themes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3590)
<!-- Reviewable:end -->
