### PR TITLE
Retain GM macros across server start

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -743,10 +743,13 @@ public class Campaign {
     campaign.gmMacroButtonLastIndex = dto.getGmMacroButtonLastIndex();
     campaign.macroButtonProperties =
         dto.getMacroButtonPropertiesList().stream()
-            .map(p -> MacroButtonProperties.fromDto(p))
+            .map(MacroButtonProperties::fromDto)
             .collect(Collectors.toList());
-    var zoneList =
-        dto.getZonesList().stream().map(z -> Zone.fromDto(z)).collect(Collectors.toList());
+    campaign.gmMacroButtonProperties =
+        dto.getGmMacroButtonPropertiesList().stream()
+            .map(MacroButtonProperties::fromDto)
+            .collect(Collectors.toList());
+    var zoneList = dto.getZonesList().stream().map(Zone::fromDto).toList();
     zoneList.forEach(z -> campaign.zones.put(z.getId(), z));
     return campaign;
   }
@@ -766,8 +769,14 @@ public class Campaign {
     dto.setMacroButtonLastIndex(macroButtonLastIndex);
     dto.setGmMacroButtonLastIndex(gmMacroButtonLastIndex);
     dto.addAllMacroButtonProperties(
-        macroButtonProperties.stream().map(p -> p.toDto()).collect(Collectors.toList()));
-    dto.addAllZones(zones.values().stream().map(z -> z.toDto()).collect(Collectors.toList()));
+        macroButtonProperties.stream()
+            .map(MacroButtonProperties::toDto)
+            .collect(Collectors.toList()));
+    dto.addAllZones(zones.values().stream().map(Zone::toDto).collect(Collectors.toList()));
+    dto.addAllGmMacroButtonProperties(
+        gmMacroButtonProperties.stream()
+            .map(MacroButtonProperties::toDto)
+            .collect(Collectors.toList()));
     return dto.build();
   }
 }

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -44,6 +44,7 @@ message CampaignDto {
   int32 gm_macro_button_last_index = 8;
   repeated MacroButtonPropertiesDto macro_button_properties = 9;
   repeated ZoneDto zones = 10;
+  repeated MacroButtonPropertiesDto gm_macro_button_properties = 11;
 }
 
 message LookupTableDto {


### PR DESCRIPTION


### Identify the Bug or Feature request

fixes #3603

### Description of the Change
GM Macros were not being persisted to/from proto buff so when installing a new campaign at server start they were disappearing.

### Possible Drawbacks
None that I can foresee...

### Documentation Notes
Fix for disappearing GM Macro buttons in 1.12 betas.

### Release Notes
N/A Bug fix for a problem introduced in this pending release.

