### PR TITLE
make sure add-ons are added to the in memory asset cache correctly

### DIFF
--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
@@ -212,7 +212,8 @@ public class AddOnLibraryImporter {
    * @param asset the {@link Asset} to add.
    */
   private void addAsset(Asset asset) {
-    if (!AssetManager.hasAsset(asset)) {
+    if (!AssetManager.hasAsset(asset)
+        || AssetManager.getAsset(asset.getMD5Key()).getData().length == 0) {
       AssetManager.putAsset(asset);
     }
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #3609


### Description of the Change
When an Add-On is imported ensure that it is added to the in-memory cache correctly.


### Possible Drawbacks
None foreseeable

### Documentation Notes
Fix for add-ons not being saved correctly in the campaign in some circumstances


### Release Notes
Fix for add-ons not being saved correctly in the campaign in some circumstances

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3610)
<!-- Reviewable:end -->
