### PR TITLE
fix for empty string passed to setTokenPortrait and setTokenHandout

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -286,15 +286,13 @@ public class TokenImage extends AbstractFunction {
   }
 
   private static void setPortrait(Token token, String assetName) throws ParserException {
-    MD5Key md5key = "".equals(assetName) ? null : getMD5Key(assetName, SET_PORTRAIT);
-    MapTool.serverCommand()
-        .updateTokenProperty(token, Token.Update.setPortraitImage, md5key.toString());
+    var md5key = "".equals(assetName) ? "" : getMD5Key(assetName, SET_PORTRAIT).toString();
+    MapTool.serverCommand().updateTokenProperty(token, Token.Update.setPortraitImage, md5key);
   }
 
   private static void setHandout(Token token, String assetName) throws ParserException {
-    MD5Key md5key = "".equals(assetName) ? null : getMD5Key(assetName, SET_HANDOUT);
-    MapTool.serverCommand()
-        .updateTokenProperty(token, Token.Update.setCharsheetImage, md5key.toString());
+    var md5key = "".equals(assetName) ? "" : getMD5Key(assetName, SET_HANDOUT).toString();
+    MapTool.serverCommand().updateTokenProperty(token, Token.Update.setCharsheetImage, md5key);
   }
 
   private static Token findImageToken(final String name, String functionName) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -2719,10 +2719,18 @@ public class Token extends BaseModel implements Cloneable {
         panelLookChanged = true;
         break;
       case setPortraitImage:
-        setPortraitImage(new MD5Key(parameters.get(0).getStringValue()));
+        if (parameters.get(0).hasStringValue() && !parameters.get(0).getStringValue().isEmpty()) {
+          setPortraitImage(new MD5Key(parameters.get(0).getStringValue()));
+        } else {
+          setPortraitImage(null);
+        }
         break;
       case setCharsheetImage:
-        setCharsheetImage(new MD5Key(parameters.get(0).getStringValue()));
+        if (parameters.get(0).hasStringValue() && !parameters.get(0).getStringValue().isEmpty()) {
+          setCharsheetImage(new MD5Key(parameters.get(0).getStringValue()));
+        } else {
+          setCharsheetImage(null);
+        }
         break;
       case setLayout:
         setSizeScale(parameters.get(0).getDoubleValue());
@@ -3005,12 +3013,11 @@ public class Token extends BaseModel implements Cloneable {
     }
     state.forEach(
         (key, state) -> {
-          if (Boolean.class.equals(state.getClass())) {
-            var value = (boolean) state;
-            dto.putState(key, TokenDto.State.newBuilder().setBoolValue(value).build());
-          } else if (BigDecimal.class.equals(state.getClass())) {
-            var value = ((BigDecimal) state).doubleValue();
-            dto.putState(key, TokenDto.State.newBuilder().setDoubleValue(value).build());
+          if (state instanceof Boolean bstate) {
+            dto.putState(key, TokenDto.State.newBuilder().setBoolValue(bstate).build());
+          } else if (state instanceof Number nstate) {
+            dto.putState(
+                key, TokenDto.State.newBuilder().setDoubleValue(nstate.doubleValue()).build());
           } else {
             log.warn("unknown state type:" + state.getClass());
           }


### PR DESCRIPTION


### Identify the Bug or Feature request

fixes #3611



### Description of the Change
The protobuf changes were choking when an empty string was passed to setTokenPortrait and setTokenHandout, this change restores the original behaviour.

### Possible Drawbacks

None Foreseeable

### Documentation Notes
Fixed a problem where Empty Strings for setTokenPortrait and setTokenHandout caused errors.

### Release Notes
- Fixed a problem where Empty Strings for setTokenPortrait and setTokenHandout caused errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3612)
<!-- Reviewable:end -->
