### PR TITLE
Hide macro created frames and placeholders after restoring layout

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -14,15 +14,12 @@
  */
 package net.rptools.maptool.client.ui;
 
+import com.jidesoft.docking.DockingManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.swing.*;
@@ -459,7 +456,19 @@ public class AppMenuBar extends JMenuBar {
           }
 
           public void actionPerformed(ActionEvent e) {
-            MapTool.getFrame().getDockingManager().resetToDefault();
+            DockingManager dm = MapTool.getFrame().getDockingManager();
+            dm.resetToDefault();
+
+            /* Issue #2485
+             * Calling resetToDefault() will expose all macro created frames and placeholders,
+             * so they need to hidden after
+             */
+            List<String> mtFrameNames =
+                Stream.of(MapToolFrame.MTFrame.values()).map(Enum::name).toList();
+            dm.getAllFrames().stream()
+                .filter(f -> !mtFrameNames.contains(f))
+                .forEach(dm::hideFrame);
+            /* /Issue #2485 */
           }
         });
 

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1953,8 +1953,10 @@ public class MapToolFrame extends DefaultDockableHolder
      */
     try {
       List<String> mtFrameNames = Stream.of(MapToolFrame.MTFrame.values()).map(Enum::name).toList();
-      Collection<String> namesToSave = getDockingManager().getAllFrames();
-      namesToSave.removeAll(mtFrameNames);
+      List<String> namesToSave =
+          getDockingManager().getAllFrames().stream()
+              .filter(frame -> !mtFrameNames.contains(frame))
+              .toList();
 
       Path path = Paths.get(AppUtil.getAppHome("config").getAbsolutePath() + "/frames.dat");
       Files.writeString(path, String.join("\0", namesToSave), StandardCharsets.UTF_8);


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #3215

### Description of the Change
Calling `resetToDefault()` to restore the default layout exposes all the placeholder frames needed to maintain layout between launches, so they all need to be hidden again after that is done.

Also, a bit of an aside, in the process of fixing this I learned that `DockingManager.getAllFrames()` exposes the actual key set of the internal map of frames and not a copy, which makes it very dangerous to manipulate. So, that's why I changed that little bit in `MapToolFrame`, because even though it _technically_ hasn't broken anything (yet), I don't want to give the impression that was a safe thing to do.

### Possible Drawbacks
None I know of

### Documentation Notes
N/A

### Release Notes
* Restore Layout could open extra empty windows. Fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3623)
<!-- Reviewable:end -->
