### PR TITLE
Move Context Menu for map explorer now moves selected map explorer to…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -110,6 +110,8 @@ public class PointerTool extends DefaultTool {
 
   private String currentPointerName;
 
+  private final Stack<Set<GUID>> savedTokenSelectionSet = new Stack<>();
+
   public PointerTool() {
     try {
       setIcon(
@@ -220,6 +222,13 @@ public class PointerTool extends DefaultTool {
     return "tool.pointer.tooltip";
   }
 
+  public void startTokenDrag(Token keyToken, Set<GUID> selectedTokens) {
+    savedTokenSelectionSet.push(new HashSet<>(renderer.getSelectedTokenSet()));
+    renderer.clearSelectedTokens();
+    renderer.selectTokens(selectedTokens);
+    startTokenDrag(keyToken);
+  }
+
   public void startTokenDrag(Token keyToken) {
     tokenBeingDragged = keyToken;
 
@@ -256,6 +265,10 @@ public class PointerTool extends DefaultTool {
     dragOffsetY = 0;
 
     exposeFoW(null);
+    if (!savedTokenSelectionSet.isEmpty()) {
+      renderer.clearSelectedTokens();
+      renderer.selectTokens(savedTokenSelectionSet.pop());
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -37,10 +37,12 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Stack;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -80,6 +82,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
   private boolean isResizingToken;
   private boolean isResizingRotatedToken;
   private Rectangle selectionBoundBox;
+
+  private final Stack<Set<GUID>> savedTokenSelectionSet = new Stack<>();
 
   // The position with greater than integer accuracy of a rotated stamp that is being resized.
   private Point2D.Double preciseStampZonePoint;
@@ -165,6 +169,13 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     return "tool.stamp.tooltip";
   }
 
+  public void startTokenDrag(Token keyToken, Set<GUID> selectedTokens) {
+    savedTokenSelectionSet.push(new HashSet<>(renderer.getSelectedTokenSet()));
+    renderer.clearSelectedTokens();
+    renderer.selectTokens(selectedTokens);
+    startTokenDrag(keyToken);
+  }
+
   public void startTokenDrag(Token keyToken) {
     tokenBeingDragged = keyToken;
 
@@ -193,6 +204,11 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
 
     dragOffsetX = 0;
     dragOffsetY = 0;
+
+    if (!savedTokenSelectionSet.isEmpty()) {
+      renderer.clearSelectedTokens();
+      renderer.selectTokens(savedTokenSelectionSet.pop());
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -939,10 +939,13 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
 
     public void actionPerformed(ActionEvent e) {
       Tool tool = MapTool.getFrame().getToolbox().getSelectedTool();
+      if (selectedTokenSet.isEmpty()) {
+        selectedTokenSet.addAll(renderer.getSelectedTokenSet());
+      }
       if (tool instanceof PointerTool) {
-        ((PointerTool) tool).startTokenDrag(tokenUnderMouse);
+        ((PointerTool) tool).startTokenDrag(tokenUnderMouse, selectedTokenSet);
       } else if (tool instanceof StampTool) {
-        ((StampTool) tool).startTokenDrag(tokenUnderMouse);
+        ((StampTool) tool).startTokenDrag(tokenUnderMouse, selectedTokenSet);
       }
     }
   }


### PR DESCRIPTION


### Identify the Bug or Feature request

fixes #3624


### Description of the Change
The Map Explorer Move context menu will now move the tokens (or objects) that are selected in the Map Explorer rather than those selected on the map. 


### Possible Drawbacks

None that I am aware of.

### Documentation Notes
The Map Explorer Move context menu will now move the tokens (or objects) that are selected in the Map Explorer rather than those selected on the map. 
Note: For the duration of the move the Tokens selected in the MapExplorer will be returned by any macros that fetch the selected Tokens (really only applicable if you have on token move macros).

### Release Notes
- Fixed the Move context menu on the MapExplorer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3625)
<!-- Reviewable:end -->
