### PR TITLE
Fix for NPE generated by Sights/Lights with syntax errors

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -203,7 +203,7 @@ public class CampaignPropertiesDialog extends JDialog {
       status = Status.OK;
       setVisible(false);
     } catch (IllegalArgumentException iae) {
-      MapTool.showError(iae.getMessage(), iae);
+      MapTool.showError(iae.getMessage());
     }
   }
 
@@ -574,7 +574,7 @@ public class CampaignPropertiesDialog extends JDialog {
       // Show the user a list of errors so they can (attempt to) correct all of them at once
       MapTool.showFeedback(errlog.toArray());
       errlog.clear();
-      throw new IllegalArgumentException(); // Don't save sights...
+      throw new IllegalArgumentException("msg.error.mtprops.sight.definition"); // Don't save sights...
     }
     campaign.setSightTypes(sightList);
   }
@@ -778,7 +778,7 @@ public class CampaignPropertiesDialog extends JDialog {
     if (!errlog.isEmpty()) {
       MapTool.showFeedback(errlog.toArray());
       errlog.clear();
-      throw new IllegalArgumentException(); // Don't save lights...
+      throw new IllegalArgumentException("msg.error.mtprops.light.definition"); // Don't save lights...
     }
     return lightMap;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -574,7 +574,8 @@ public class CampaignPropertiesDialog extends JDialog {
       // Show the user a list of errors so they can (attempt to) correct all of them at once
       MapTool.showFeedback(errlog.toArray());
       errlog.clear();
-      throw new IllegalArgumentException("msg.error.mtprops.sight.definition"); // Don't save sights...
+      throw new IllegalArgumentException(
+          "msg.error.mtprops.sight.definition"); // Don't save sights...
     }
     campaign.setSightTypes(sightList);
   }
@@ -778,7 +779,8 @@ public class CampaignPropertiesDialog extends JDialog {
     if (!errlog.isEmpty()) {
       MapTool.showFeedback(errlog.toArray());
       errlog.clear();
-      throw new IllegalArgumentException("msg.error.mtprops.light.definition"); // Don't save lights...
+      throw new IllegalArgumentException(
+          "msg.error.mtprops.light.definition"); // Don't save lights...
     }
     return lightMap;
   }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1998,6 +1998,7 @@ msg.error.macro.exportSetFail                 = <html><body>Macro set could not 
 msg.error.macro.importFail                    = <html><body>Macro could not be imported:<br><br>{0}</body></html>
 msg.error.macro.importSetFail                 = <html><body>Macro set could not be imported:<br><br>{0}</body></html>
 msg.error.mtprops.light.arc                   = Light:line {0,number}:unrecognizable arc "{1}"
+msg.error.mtprops.light.definition            = Error(s) in Light definitions. Correct error(s) or select Cancel on the Campaign Properties dialog.
 msg.error.mtprops.light.distance              = Light:line {0,number}:unrecognizable distance "{1}"
 msg.error.mtprops.light.gmOrOwner             = Light:line {0,number}:GM and OWNER can only be specified for auras.
 msg.error.mtprops.light.ioexception           = Error reading Light definition from string -- shouldn't happen!
@@ -2007,6 +2008,7 @@ msg.error.mtprops.properties.duplicateComment = The line "{0}" appears to be a c
 msg.error.mtprops.properties.ending           = You will be placed back into edit mode.
 msg.error.mtprops.properties.title            = The following errors occurred:
 msg.error.mtprops.sight.arc                   = Sight:line {0,number}:unrecognizable arc "{1}"
+msg.error.mtprops.sight.definition            = Error(s) in Sight definitions. Correct error(s) or select Cancel on the Campaign Properties dialog.
 msg.error.mtprops.sight.distance              = Sight:line {0,number}:unrecognizable distance "{1}"
 msg.error.mtprops.sight.ioexception           = Error reading Sight definition from string -- shouldn't happen!
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fix for #3633 

### Description of the Change

No message was being passed with the IAE being thrown and so when it finally trickled down to MapTool.showError() the log() call was being passed a null producing the NPE.

Added localized message to thrown IAE calls so that null wasn't passed on to log() call and Error dialog now displays guidance.

### Possible Drawbacks

None expected.

### Documentation Notes

Error dialog now provides some guidance to user.

### Release Notes

Syntax errors in Sights/Lights definitions no longer produce an NPE.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3635)
<!-- Reviewable:end -->
