### PR TITLE
fix for loading campaign files < 1.5.6

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -773,10 +773,13 @@ public class Campaign {
             .map(MacroButtonProperties::toDto)
             .collect(Collectors.toList()));
     dto.addAllZones(zones.values().stream().map(Zone::toDto).collect(Collectors.toList()));
-    dto.addAllGmMacroButtonProperties(
-        gmMacroButtonProperties.stream()
-            .map(MacroButtonProperties::toDto)
-            .collect(Collectors.toList()));
+    // gmMacroButtonProperties is null if you are loading an old campaign file < 1.5.6
+    if (gmMacroButtonProperties != null) {
+      dto.addAllGmMacroButtonProperties(
+          gmMacroButtonProperties.stream()
+              .map(MacroButtonProperties::toDto)
+              .collect(Collectors.toList()));
+    }
     return dto.build();
   }
 }


### PR DESCRIPTION

### Identify the Bug or Feature request

fixes #3646


### Description of the Change
Campaigns before 1.5.6 have no GM macros, when loading these campaigns the code checked for null in the GM macro list field and created an empty list. Unfortunately, the protobuf changes did not also check this an was fialing.


### Possible Drawbacks
None foreseeable

### Documentation Notes
Fixed a problem loading campaigns saved in versions older than 1.5.6

### Release Notes
- Fixed a problem loading campaigns saved in versions older than 1.5.6

