### PR TITLE
Fix for getting state status

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1725,7 +1725,7 @@ public class Token extends BaseModel implements Cloneable {
     // setBarVisible sends a boolean to show/hide a bar
     if (aValue instanceof Boolean) {
       if ((Boolean) aValue) {
-        return state.put(aState, 1.0);
+        return state.put(aState, aValue);
       } else {
         return state.remove(aState);
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fix for #3642 

### Description of the Change

Code for State macro functions didn't handle doubles in State values.  Changed Token.setState code to store a Boolean when set to true with a Boolean.

### Possible Drawbacks

None expected.

### Documentation Notes

No changes to State usage beyond fix.

### Release Notes

Fix for issue reading States always returning false.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3648)
<!-- Reviewable:end -->
