### PR TITLE
Fixes for older campaign compatibility issues.

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2296,7 +2296,11 @@ public class Zone extends BaseModel {
     dto.setExposedArea(Mapper.map(exposedArea));
     dto.setHasFog(hasFog);
     dto.setTopology(Mapper.map(topology));
-    dto.setFogPaint(fogPaint.toDto());
+    if (fogPaint == null) { // Account for old campaigns without fog paint
+      dto.setFogPaint(DEFAULT_FOG.toDto());
+    } else {
+      dto.setFogPaint(fogPaint.toDto());
+    }
     dto.setHillVbl(Mapper.map(hillVbl));
     dto.setPitVbl(Mapper.map(pitVbl));
     dto.setTopologyTerrain(Mapper.map(topologyTerrain));

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
@@ -188,9 +188,13 @@ public abstract class AbstractTemplate extends AbstractDrawing {
    * @param area Paint the area?
    */
   protected void paint(Graphics2D g, boolean border, boolean area) {
-    if (radius == 0) return;
+    if (radius == 0) {
+      return;
+    }
     Zone zone = MapTool.getCampaign().getZone(zoneId);
-    if (zone == null) return;
+    if (zone == null) {
+      return;
+    }
 
     // Find the proper distance
     int gridSize = zone.getGrid().getSize();

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -139,11 +139,15 @@ public interface Drawable {
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        drawable.setQuadrant(AbstractTemplate.Quadrant.valueOf(dto.getQuadrant()));
+        if (!dto.getQuadrant().isEmpty()) {
+          drawable.setQuadrant(AbstractTemplate.Quadrant.valueOf(dto.getQuadrant()));
+        }
         drawable.setMouseSlopeGreater(dto.getMouseSlopeGreater());
         var pathVertex = dto.getPathVertex();
         drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
+        if (dto.hasName()) {
+          drawable.setName(dto.getName().getValue());
+        }
         drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
         return drawable;
       }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -122,9 +122,15 @@ public class LineCellTemplate extends AbstractTemplate {
       return;
     }
     // Need to paint? We need a line and to translate the painting
-    if (pathVertex == null) return;
-    if (getRadius() == 0) return;
-    if (calcPath() == null) return;
+    if (pathVertex == null) {
+      return;
+    }
+    if (getRadius() == 0) {
+      return;
+    }
+    if (calcPath() == null) {
+      return;
+    }
 
     // Paint each element in the path
     int gridSize = MapTool.getCampaign().getZone(getZoneId()).getGrid().getSize();
@@ -164,7 +170,9 @@ public class LineCellTemplate extends AbstractTemplate {
   /** @see net.rptools.maptool.model.drawing.AbstractTemplate#setRadius(int) */
   @Override
   public void setRadius(int squares) {
-    if (squares == getRadius()) return;
+    if (squares == getRadius()) {
+      return;
+    }
     clearPath();
     super.setRadius(squares);
   }
@@ -179,13 +187,19 @@ public class LineCellTemplate extends AbstractTemplate {
    * @return The new path or <code>null</code> if there is no path.
    */
   protected List<CellPoint> calcPath() {
-    if (getRadius() == 0) return null;
-    if (pathVertex == null) return null;
+    if (getRadius() == 0) {
+      return null;
+    }
+    if (pathVertex == null) {
+      return null;
+    }
     int radius = getRadius();
 
     // Is there a slope?
     ZonePoint vertex = getVertex();
-    if (vertex.equals(pathVertex)) return null;
+    if (vertex.equals(pathVertex)) {
+      return null;
+    }
 
     double dx = pathVertex.x - vertex.x;
     double dy = pathVertex.y - vertex.y;
@@ -298,14 +312,18 @@ public class LineCellTemplate extends AbstractTemplate {
    * @param pathVertex The pathVertex to set.
    */
   public void setPathVertex(ZonePoint pathVertex) {
-    if (pathVertex.equals(this.pathVertex)) return;
+    if (pathVertex.equals(this.pathVertex)) {
+      return;
+    }
     clearPath();
     this.pathVertex = pathVertex;
   }
 
   /** Clear the current path. This will cause it to be recalculated during the next draw. */
   public void clearPath() {
-    if (path != null) pool = path;
+    if (path != null) {
+      pool = path;
+    }
     path = null;
   }
 
@@ -315,7 +333,9 @@ public class LineCellTemplate extends AbstractTemplate {
    * @return Returns the current value of quadrant.
    */
   public Quadrant getQuadrant() {
-    if (quadrant != null) return Quadrant.valueOf(quadrant);
+    if (quadrant != null)  {
+      return Quadrant.valueOf(quadrant);
+    }
     return null;
   }
 
@@ -325,8 +345,11 @@ public class LineCellTemplate extends AbstractTemplate {
    * @param quadrant The quadrant to set.
    */
   public void setQuadrant(Quadrant quadrant) {
-    if (quadrant != null) this.quadrant = quadrant.name();
-    else this.quadrant = null;
+    if (quadrant != null) {
+      this.quadrant = quadrant.name();
+    } else {
+      this.quadrant = null;
+    }
   }
 
   /**
@@ -461,17 +484,30 @@ public class LineCellTemplate extends AbstractTemplate {
 
   @Override
   public DrawableDto toDto() {
+
+    if (getQuadrant() == null) {
+      calcPath(); // force calculation of the quadrent
+    }
+
     var dto = LineCellTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
         .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto())
-        .setQuadrant(getQuadrant().name())
-        .setMouseSlopeGreater(isMouseSlopeGreater())
-        .setPathVertex(getPathVertex().toDto());
+        .setMouseSlopeGreater(isMouseSlopeGreater());
 
-    if (getName() != null) dto.setName(StringValue.of(getName()));
+    if (getQuadrant() != null) {
+      dto.setQuadrant(getQuadrant().name());
+    }
+    if (getPathVertex() != null) {
+      dto.setPathVertex(getPathVertex().toDto());
+    }
+
+
+    if (getName() != null) {
+      dto.setName(StringValue.of(getName()));
+    }
 
     return DrawableDto.newBuilder().setLineCellTemplate(dto).build();
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -333,7 +333,7 @@ public class LineCellTemplate extends AbstractTemplate {
    * @return Returns the current value of quadrant.
    */
   public Quadrant getQuadrant() {
-    if (quadrant != null)  {
+    if (quadrant != null) {
       return Quadrant.valueOf(quadrant);
     }
     return null;
@@ -503,7 +503,6 @@ public class LineCellTemplate extends AbstractTemplate {
     if (getPathVertex() != null) {
       dto.setPathVertex(getPathVertex().toDto());
     }
-
 
     if (getName() != null) {
       dto.setName(StringValue.of(getName()));


### PR DESCRIPTION


### Identify the Bug or Feature request
fixes #3645


### Description of the Change
The new protobuf code was not accounting for situations where templates values for line templates could be null. Also in pre 1.5.6 there was no way to set the texture for fog so it will be null from campaigns before 1.5.6.



### Possible Drawbacks

Hopefully none

### Documentation Notes
Fix compatibility issues for some older campaigns with line templates and campaigns last saved in a version before 1.5.6

### Release Notes
- Fix compatibility issues for some older campaigns with line templates 
- Fix compatibility issues for campaigns that were saved in a version before 1.5.6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3653)
<!-- Reviewable:end -->
