### PR TITLE
add logging for initiative null pointer

### DIFF
--- a/src/main/java/net/rptools/maptool/model/InitiativeList.java
+++ b/src/main/java/net/rptools/maptool/model/InitiativeList.java
@@ -135,7 +135,12 @@ public class InitiativeList implements Serializable {
    * @return The token initiative data for the passed index.
    */
   public TokenInitiative getTokenInitiative(int index) {
-    return index < tokens.size() && index >= 0 ? tokens.get(index) : null;
+    if (index < tokens.size() && index >= 0) {
+      return tokens.get(index);
+    } else {
+      LOGGER.error("getTokenInitiative: index = " + index + ", size = " + tokens.size());
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION



### Identify the Bug or Feature request
Adds some logging to try and identify why the problem is occurring for issue 3310


### Description of the Change
The transfer of initiative details to newly created tokens on the campaign clone is throwing an NPE. This is occurring as the fetch of the old tokens initiative details is returning null for an unknown reason. There is a suspicious guard around the access to the list that contains this information which will return NULL when the index is out of range which is most likely the cause of this. I have added a log message to the error file to log the details of the index and the size of the list to help track down this error.


### Possible Drawbacks

None foreseeable

### Documentation Notes
Extra logging is added when an error is encountered reading the initiative list of a loaded campaign.

### Release Notes
-Extra logging is added when an error is encountered reading the initiative list of a loaded campaign.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3654)
<!-- Reviewable:end -->
