### PR TITLE
Fix for recalcitrant bar overlays

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/BarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/BarTokenOverlay.java
@@ -18,6 +18,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.server.proto.BarTokenOverlayDto;
+import net.rptools.maptool.server.proto.BarTokenOverlayDto.SideDto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -199,24 +200,33 @@ public abstract class BarTokenOverlay extends AbstractTokenOverlay {
   // }
 
   public static BarTokenOverlay fromDto(BarTokenOverlayDto dto) {
-    switch (dto.getType()) {
-      case DRAWN -> {
-        return DrawnBarTokenOverlay.fromDto(dto);
-      }
-      case MULTIPLE_IMAGE -> {
-        return MultipleImageBarTokenOverlay.fromDto(dto);
-      }
-      case SINGLE_IMAGE -> {
-        return SingleImageBarTokenOverlay.fromDto(dto);
-      }
-      case TWO_IMAGES -> {
-        return TwoImageBarTokenOverlay.fromDto(dto);
-      }
-      case TWO_TONE -> {
-        return TwoToneBarTokenOverlay.fromDto(dto);
+    var bar =
+        switch (dto.getType()) {
+          case DRAWN -> DrawnBarTokenOverlay.fromDto(dto);
+          case MULTIPLE_IMAGE -> MultipleImageBarTokenOverlay.fromDto(dto);
+          case SINGLE_IMAGE -> SingleImageBarTokenOverlay.fromDto(dto);
+          case TWO_IMAGES -> TwoImageBarTokenOverlay.fromDto(dto);
+          case TWO_TONE -> TwoToneBarTokenOverlay.fromDto(dto);
+          case UNRECOGNIZED -> null;
+        };
+    if (bar != null) {
+      switch (dto.getSide()) {
+        case TOP -> bar.setSide(Side.TOP);
+        case LEFT -> bar.setSide(Side.LEFT);
+        case RIGHT -> bar.setSide(Side.RIGHT);
+        case BOTTOM -> bar.setSide(Side.BOTTOM);
       }
     }
-    return null;
+    return bar;
+  }
+
+  protected void setSideDto(BarTokenOverlayDto.Builder dto) {
+    switch (side) {
+      case TOP -> dto.setSide(SideDto.TOP);
+      case BOTTOM -> dto.setSide(SideDto.BOTTOM);
+      case LEFT -> dto.setSide(SideDto.LEFT);
+      case RIGHT -> dto.setSide(SideDto.RIGHT);
+    }
   }
 
   public abstract BarTokenOverlayDto toDto();

--- a/src/main/java/net/rptools/maptool/client/ui/token/DrawnBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/DrawnBarTokenOverlay.java
@@ -134,6 +134,7 @@ public class DrawnBarTokenOverlay extends BarTokenOverlay {
     dto.setCommon(getCommonDto());
     dto.setThickness(thickness);
     dto.setColor(barColor.getRGB());
+    setSideDto(dto);
     return dto;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/MultipleImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/MultipleImageBarTokenOverlay.java
@@ -126,6 +126,7 @@ public class MultipleImageBarTokenOverlay extends BarTokenOverlay {
 
   public BarTokenOverlayDto toDto() {
     var dto = BarTokenOverlayDto.newBuilder().setCommon(getCommonDto());
+    setSideDto(dto);
     dto.addAllAssetIds(
         Arrays.asList(assetIds).stream().map(a -> a.toString()).collect(Collectors.toList()));
     return dto.setType(BarTokenOverlayDto.BarTokenOverlayTypeDto.MULTIPLE_IMAGE).build();

--- a/src/main/java/net/rptools/maptool/client/ui/token/SingleImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/SingleImageBarTokenOverlay.java
@@ -150,6 +150,7 @@ public class SingleImageBarTokenOverlay extends BarTokenOverlay {
   public BarTokenOverlayDto toDto() {
     var dto = BarTokenOverlayDto.newBuilder().setCommon(getCommonDto());
     dto.addAssetIds(assetId.toString());
+    setSideDto(dto);
     return dto.setType(BarTokenOverlayDto.BarTokenOverlayTypeDto.SINGLE_IMAGE).build();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/TwoImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TwoImageBarTokenOverlay.java
@@ -174,6 +174,7 @@ public class TwoImageBarTokenOverlay extends BarTokenOverlay {
     var dto = BarTokenOverlayDto.newBuilder().setCommon(getCommonDto());
     dto.addAssetIds(bottomAssetId.toString());
     dto.addAssetIds(topAssetId.toString());
+    setSideDto(dto);
     return dto.setType(BarTokenOverlayDto.BarTokenOverlayTypeDto.TWO_IMAGES).build();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/TwoToneBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TwoToneBarTokenOverlay.java
@@ -120,6 +120,7 @@ public class TwoToneBarTokenOverlay extends DrawnBarTokenOverlay {
   public BarTokenOverlayDto toDto() {
     var dto = getDto();
     dto.setBgColor(bgColor.getRGB());
+    setSideDto(dto);
     return dto.setType(BarTokenOverlayDto.BarTokenOverlayTypeDto.TWO_TONE).build();
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes #3669




### Description of the Change
Fixes the wandering bar that wanted to float to the top just like so much... 
This was happening because the to/fromDto methods for protobuf were not seralizing the side that the bar was on.


### Possible Drawbacks

Should be none.

### Documentation Notes
Bars now worky better

### Release Notes
- Fix for bars being reset to the top when starting a server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3683)
<!-- Reviewable:end -->
