### PR TITLE
Fixes for Adjust Grid panel bugs

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/GridTool.java
@@ -154,14 +154,15 @@ public class GridTool extends DefaultTool {
 
   private void copyGridToControlPanel() {
     Zone zone = renderer.getZone();
-
     Grid grid = zone.getGrid();
 
     updateSecondDimension(grid, true);
-    gridSizeSpinner.setValue(grid.getSize());
     gridOffsetXTextField.setText(Integer.toString(grid.getOffsetX()));
     gridOffsetYTextField.setText(Integer.toString(grid.getOffsetY()));
     colorWell.setColor(new Color(zone.getGridColor()));
+    // Setting the size must be done last as it triggers a ChangeEvent
+    // which causes copyControlPanelToGrid() to be called.
+    gridSizeSpinner.setValue(grid.getSize());
 
     resetZoomSlider();
   }
@@ -190,10 +191,10 @@ public class GridTool extends DefaultTool {
     Grid grid = zone.getGrid();
 
     updateSecondDimension(grid, false);
-    grid.setSize(Math.max((Integer) gridSizeSpinner.getValue(), Grid.MIN_GRID_SIZE));
     updateSecondDimension(grid, true);
     grid.setOffset(getInt(gridOffsetXTextField, 0), getInt(gridOffsetYTextField, 0));
     zone.setGridColor(colorWell.getColor().getRGB());
+    grid.setSize(Math.max((Integer) gridSizeSpinner.getValue(), Grid.MIN_GRID_SIZE));
 
     renderer.repaint();
   }

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -951,7 +951,7 @@ public abstract class Grid implements Cloneable {
     var dto = GridDto.newBuilder();
     fillDto(dto);
     dto.setOffsetX(offsetX);
-    dto.setOffsetX(offsetY);
+    dto.setOffsetY(offsetY);
     dto.setSize(size);
     if (cellShape != null) {
       dto.setCellShape(Mapper.map(cellShape));


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #3702
Fixes #3703

### Description of the Change
- Fixed a typo in `Grid.toDto()` method that caused offsets to get messed up.
- Fixed an issue where initialization of the size spinner in the Adjust Grid panel was causing the grid to be reset.

### Possible Drawbacks

None hopefully.

### Documentation Notes

No change to intended functionality.

### Release Notes
- Fixes grid offsets and grid color being reset when starting server or when opening the Adjust Grid on an existing map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3704)
<!-- Reviewable:end -->
