### PR TITLE
Fix for NPE when using removeTokenFacing()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -675,7 +675,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equalsIgnoreCase("removeTokenFacing")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      MapTool.serverCommand().updateTokenProperty(token, Token.Update.setFacing, (Integer) null);
+      MapTool.serverCommand().updateTokenProperty(token, Token.Update.removeFacing);
       return "";
     }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -213,7 +213,8 @@ public class Token extends BaseModel implements Cloneable {
     flipX,
     flipY,
     flipIso,
-    setSpeechName
+    setSpeechName,
+    removeFacing
   }
 
   public static final Comparator<Token> NAME_COMPARATOR =
@@ -2610,6 +2611,9 @@ public class Token extends BaseModel implements Cloneable {
           lightChanged = true;
         }
         setFacing(parameters.get(0).getIntValue());
+        break;
+      case removeFacing:
+        setFacing(null);
         break;
       case clearAllOwners:
         clearAllOwners();

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -632,6 +632,7 @@ enum TokenUpdateDto {
     flipY = 52;
     flipIso = 53;
     setSpeechName = 54;
+    removeFacing = 55;
 }
 
 message AssetTransferHeaderDto {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3700 

### Description of the Change

Rather than try to pass a null through the DTO process, added new update type for removeFacing that doesn't take a parameter.

### Possible Drawbacks

None expected.

### Documentation Notes

n/a

### Release Notes

- Using `removeTokenFacing()` on a token with no facing would throw an NPE. Fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3706)
<!-- Reviewable:end -->
