### PR TITLE
reenable heartbeat thread

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -701,7 +701,7 @@ public class MapTool {
     ChatAutoSave.changeTimeout(AppPreferences.getChatAutosaveTime());
 
     // TODO: make this more formal when we switch to mina
-    // new ServerHeartBeatThread().start();
+    new ServerHeartBeatThread().start();
   }
 
   public static NoteFrame getProfilingNoteFrame() {


### PR DESCRIPTION
### Identify the Bug or Feature request
releated to #3720 

### Description of the Change
This change reenabled the heartbeat thread that does nothing but sending a message to the server regulary.


### Possible Drawbacks
Nothing.

### Release Notes
- reenable server heartbeat

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3721)
<!-- Reviewable:end -->
