### PR TITLE
update grgit dependancy so its no longer pulled from jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 // Access Git info from build script
 plugins {
     id "application"
-    id "org.ajoberstar.grgit" version "4.1.0"
+    id "org.ajoberstar.grgit" version "4.1.1"
     id "com.diffplug.spotless" version "5.14.3"
     id 'org.openjfx.javafxplugin' version '0.0.13'
     id 'org.beryx.runtime' version '1.12.7'
@@ -322,7 +322,7 @@ dependencies {
     implementation 'net.rptools.decktool:decktool:1.0.b1'
     implementation 'com.github.RPTools:maptool-resources:1.6.0'
     implementation 'com.github.RPTools:parser:1.8.3'
-    implementation 'net.rptools.dicelib:dicelib:1.8.3'
+    implementation 'net.rptools.dicelib:dicelib:1.8.6'
 
     // Currently hosted on nerps.net/repo
     implementation group: 'com.jidesoft', name: 'jide-common', version: '3.7.9'


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #3726


### Description of the Change
Fixes the build dependency issue due to the demise of jcenter.

### Possible Drawbacks
Hopefully none

### Documentation Notes
- Fixes the build dependency issue due to the demise of jcenter.
- Bump in library version for dicelib

### Release Notes
- Fixes the build dependency issue due to the demise of jcenter.
- Bump in library version for dicelib

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3727)
<!-- Reviewable:end -->
