### PR TITLE
Fix test deadlock and other failures

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -65,10 +65,15 @@ public class getInfoFunction extends AbstractFunction {
     sysInfoProvider = new MapToolSysInfoProvider();
   }
 
-  // the following is here mostly for testing purpose, until we find a better way to inject
+  // region the following is here mostly for testing purpose, until we find a better way to inject
   protected void setSysInfoProvider(SysInfoProvider sysInfoProvider) {
     this.sysInfoProvider = sysInfoProvider;
   }
+
+  protected void resetSysInfoProvider() {
+    sysInfoProvider = new MapToolSysInfoProvider();
+  }
+  // endregion
 
   /**
    * Gets the instance of getInfoFunction.

--- a/src/test/java/net/rptools/maptool/client/functions/GetInfoFunctionTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/GetInfoFunctionTest.java
@@ -22,9 +22,15 @@ import java.util.List;
 import net.rptools.maptool.util.SysInfoProvider;
 import net.rptools.parser.ParserException;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 public class GetInfoFunctionTest {
+  @AfterAll
+  static void tearDown() {
+    getInfoFunction function = getInfoFunction.getInstance();
+    function.resetSysInfoProvider();
+  }
 
   @Test
   public void debugInfo() throws ParserException {

--- a/src/test/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialogTest.java
+++ b/src/test/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialogTest.java
@@ -17,8 +17,10 @@ package net.rptools.maptool.client.ui.campaignproperties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.SwingUtilities;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.language.I18N;
 import org.junit.jupiter.api.Test;
@@ -26,48 +28,58 @@ import org.junit.jupiter.api.Test;
 public class CampaignPropertiesDialogTest {
 
   @Test
-  public void importPredefinedButton() {
-    CampaignPropertiesDialog cpd = new CampaignPropertiesDialog(null);
+  public void importPredefinedButton() throws InterruptedException, InvocationTargetException {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          CampaignPropertiesDialog cpd = new CampaignPropertiesDialog(null);
 
-    JButton button = cpd.getImportPredefinedButton();
+          JButton button = cpd.getImportPredefinedButton();
 
-    assertEquals(button.getText(), I18N.getText("CampaignPropertiesDialog.button.import"));
+          assertEquals(button.getText(), I18N.getText("CampaignPropertiesDialog.button.import"));
+        });
   }
 
   @Test
-  public void predefinedPropertiesComboBox_noFiles() {
-    CampaignPropertiesDialog cpd =
-        new CampaignPropertiesDialog(null) {
-          @Override
-          protected File[] getPredefinedPropertyFiles(File propertyDir) {
-            return null;
-          }
-        };
+  public void predefinedPropertiesComboBox_noFiles()
+      throws InterruptedException, InvocationTargetException {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          CampaignPropertiesDialog cpd =
+              new CampaignPropertiesDialog(null) {
+                @Override
+                protected File[] getPredefinedPropertyFiles(File propertyDir) {
+                  return null;
+                }
+              };
 
-    JComboBox<String> comboBox = cpd.getPredefinedPropertiesComboBox();
+          JComboBox<String> comboBox = cpd.getPredefinedPropertiesComboBox();
 
-    assertEquals(comboBox.getModel().getSize(), 0);
+          assertEquals(comboBox.getModel().getSize(), 0);
+        });
   }
 
   @Test
-  public void predefinedPropertiesComboBox_twoFiles() {
+  public void predefinedPropertiesComboBox_twoFiles()
+      throws InterruptedException, InvocationTargetException {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          String one = new String("a" + AppConstants.CAMPAIGN_PROPERTIES_FILE_EXTENSION);
+          String two = new String("b" + AppConstants.CAMPAIGN_PROPERTIES_FILE_EXTENSION);
 
-    String one = new String("a" + AppConstants.CAMPAIGN_PROPERTIES_FILE_EXTENSION);
-    String two = new String("b" + AppConstants.CAMPAIGN_PROPERTIES_FILE_EXTENSION);
+          CampaignPropertiesDialog cpd =
+              new CampaignPropertiesDialog(null) {
+                @Override
+                protected File[] getPredefinedPropertyFiles(File propertyDir) {
 
-    CampaignPropertiesDialog cpd =
-        new CampaignPropertiesDialog(null) {
-          @Override
-          protected File[] getPredefinedPropertyFiles(File propertyDir) {
+                  return new File[] {new File(one), new File(two)};
+                }
+              };
 
-            return new File[] {new File(one), new File(two)};
-          }
-        };
+          JComboBox<String> comboBox = cpd.getPredefinedPropertiesComboBox();
 
-    JComboBox<String> comboBox = cpd.getPredefinedPropertiesComboBox();
-
-    assertEquals(comboBox.getModel().getSize(), 2);
-    assertEquals(comboBox.getModel().getElementAt(0), "a");
-    assertEquals(comboBox.getModel().getElementAt(1), "b");
+          assertEquals(comboBox.getModel().getSize(), 2);
+          assertEquals(comboBox.getModel().getElementAt(0), "a");
+          assertEquals(comboBox.getModel().getElementAt(1), "b");
+        });
   }
 }

--- a/src/test/java/net/rptools/maptool/model/gamedata/MemoryDataStoreTest.java
+++ b/src/test/java/net/rptools/maptool/model/gamedata/MemoryDataStoreTest.java
@@ -762,7 +762,7 @@ class MemoryDataStoreTest {
   }
 
   @Test
-  void createNamespaceWithInitialData() {
+  void createNamespaceWithInitialData() throws ExecutionException, InterruptedException {
     var jsonArray1 = new JsonArray();
     var jsonArray2 = new JsonArray();
     var jsonArray3 = new JsonArray();
@@ -771,37 +771,40 @@ class MemoryDataStoreTest {
     var jsonObject3 = new JsonObject();
     var mds = new MemoryDataStore();
     mds.createNamespaceWithInitialData(
-        "testType",
-        "testNamespace",
-        Set.of(
-            DataValueFactory.fromBoolean("boolean1", true),
-            DataValueFactory.fromLong("long1", 12),
-            DataValueFactory.fromDouble("double1", 65.8),
-            DataValueFactory.fromString("string1", "test"),
-            DataValueFactory.fromJsonObject("jsonObject1", jsonObject1),
-            DataValueFactory.fromJsonArray("jsonArray1", jsonArray1)));
+            "testType",
+            "testNamespace",
+            Set.of(
+                DataValueFactory.fromBoolean("boolean1", true),
+                DataValueFactory.fromLong("long1", 12),
+                DataValueFactory.fromDouble("double1", 65.8),
+                DataValueFactory.fromString("string1", "test"),
+                DataValueFactory.fromJsonObject("jsonObject1", jsonObject1),
+                DataValueFactory.fromJsonArray("jsonArray1", jsonArray1)))
+        .get();
 
     mds.createNamespaceWithInitialData(
-        "testType2",
-        "testNamespace2",
-        Set.of(
-            DataValueFactory.fromBoolean("boolean2", false),
-            DataValueFactory.fromLong("long2", 44),
-            DataValueFactory.fromDouble("double2", 99.8),
-            DataValueFactory.fromString("string2", "test2"),
-            DataValueFactory.fromJsonObject("jsonObject2", jsonObject2),
-            DataValueFactory.fromJsonArray("jsonArray2", jsonArray2)));
+            "testType2",
+            "testNamespace2",
+            Set.of(
+                DataValueFactory.fromBoolean("boolean2", false),
+                DataValueFactory.fromLong("long2", 44),
+                DataValueFactory.fromDouble("double2", 99.8),
+                DataValueFactory.fromString("string2", "test2"),
+                DataValueFactory.fromJsonObject("jsonObject2", jsonObject2),
+                DataValueFactory.fromJsonArray("jsonArray2", jsonArray2)))
+        .get();
 
     mds.createNamespaceWithInitialData(
-        "testType2",
-        "testNamespace3",
-        Set.of(
-            DataValueFactory.fromBoolean("boolean3", true),
-            DataValueFactory.fromLong("long3", 24),
-            DataValueFactory.fromDouble("double3", 29.8),
-            DataValueFactory.fromString("string3", "test3"),
-            DataValueFactory.fromJsonObject("jsonObject3", jsonObject3),
-            DataValueFactory.fromJsonArray("jsonArray3", jsonArray3)));
+            "testType2",
+            "testNamespace3",
+            Set.of(
+                DataValueFactory.fromBoolean("boolean3", true),
+                DataValueFactory.fromLong("long3", 24),
+                DataValueFactory.fromDouble("double3", 29.8),
+                DataValueFactory.fromString("string3", "test3"),
+                DataValueFactory.fromJsonObject("jsonObject3", jsonObject3),
+                DataValueFactory.fromJsonArray("jsonArray3", jsonArray3)))
+        .get();
 
     assertAll(
         () -> assertEquals(1, mds.getPropertyNamespaces("testType").get().size()),


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes (hopefully) #3750

### Description of the Change

The `CampaignPropertiesDialogTest` is now run on the Swing thread in order to avoid deadlocks that would sometimes occur when running on the main test thread.

The `GetInfoFunctionTest` is now repeatable and not dependent on the order of the tests. The problem was that one test was injecting a dummy `SysInfoProvider` that could be consumed by the other test. This is fixed by always restoring the `SysInfoProvider` implementation after each test.

The `MemoryDataStoreTest` was sensitive to the ordering of its various asynchronous calls. Meanwhile, `MemoryDataStore` does not guarantee the ordering of effects as it runs everything on the common fork-join pool. Sprinkling in some more `.get()` fixes that.

Prior to this change, I could only complete a few test suite runs before encountering a deadlock or other failure. With this change, I have been consistently able to complete thousands of test suite runs, each completing promptly.

### Possible Drawbacks

Should be sunshine and rainbows.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3751)
<!-- Reviewable:end -->
