### PR TITLE
make playerAlias getter return null if not DisplayName was set. Accou…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1578,25 +1578,13 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     String campaignName = " - [" + MapTool.getCampaign().getName() + "]";
     String versionString =
         MapTool.getVersion().equals("unspecified") ? "Development" : "v" + MapTool.getVersion();
-    setTitle(
-        AppConstants.APP_NAME
-            + " "
-            + versionString
-            + " - "
-            + MapTool.getPlayer()
-            + campaignName
-            + (renderer != null
-                ? " - "
-                    + (((renderer.getZone().getPlayerAlias() != null)
-                            && !MapTool.getPlayer().isGM())
-                        ? renderer.getZone().getPlayerAlias()
-                        : (renderer.getZone().getPlayerAlias().equals(renderer.getZone().getName())
-                            ? renderer.getZone().getName()
-                            : renderer.getZone().getPlayerAlias()
-                                + " ("
-                                + renderer.getZone().getName()
-                                + ")"))
-                : ""));
+    var title =
+        AppConstants.APP_NAME + " " + versionString + " - " + MapTool.getPlayer() + campaignName;
+
+    if (renderer != null) {
+      title += "-" + renderer.getZone().toString();
+    }
+    setTitle(title);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/ZoneSelectionPopup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ZoneSelectionPopup.java
@@ -65,8 +65,8 @@ public class ZoneSelectionPopup extends JScrollPopupMenu {
       else
         rendererList.sort(
             (o1, o2) -> {
-              String name1 = o1.getZone().getPlayerAlias();
-              String name2 = o2.getZone().getPlayerAlias();
+              String name1 = o1.getZone().toString();
+              String name2 = o2.getZone().toString();
 
               return String.CASE_INSENSITIVE_ORDER.compare(name1, name2);
             });
@@ -93,12 +93,7 @@ public class ZoneSelectionPopup extends JScrollPopupMenu {
 
     ZoneItem(ZoneRenderer renderer) {
       this.renderer = renderer;
-      String name =
-          MapTool.getPlayer().isGM()
-              ? renderer.getZone().getName().equals(renderer.getZone().getPlayerAlias())
-                  ? renderer.getZone().getName()
-                  : renderer.getZone().getPlayerAlias() + " (" + renderer.getZone().getName() + ")"
-              : renderer.getZone().getPlayerAlias();
+      String name = renderer.getZone().toString();
       if ("".equals(name)) {
         name = I18N.getText("Button.map");
       }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -367,18 +367,13 @@ public class Zone {
     fogPaint = paint;
   }
 
-  @Override
-  public String toString() {
-    return name;
-  }
-
   /** @return name of the zone */
   public String getName() {
     return name;
   }
 
   public String getPlayerAlias() {
-    return playerAlias == null ? name : playerAlias;
+    return playerAlias;
   }
 
   public void setName(String name) {
@@ -395,6 +390,17 @@ public class Zone {
     }
     this.playerAlias = playerAlias.equals("") || playerAlias.equals(name) ? null : playerAlias;
     return true;
+  }
+
+  @Override
+  public String toString() {
+    if (!MapTool.getPlayer().isGM()) {
+      return playerAlias != null ? playerAlias : name;
+    } else if (playerAlias == null || name.equals(playerAlias)) {
+      return name;
+    } else {
+      return playerAlias + " (" + name + ")";
+    }
   }
 
   public MD5Key getMapAssetId() {


### PR DESCRIPTION
…nt for that change. Centralize generation of String from map in ToString of zone.

### Identify the Bug or Feature request
fixes 3247


### Description of the Change
Make playerAlias getter return null if not DisplayName was set. Account for that change. Centralize generation of String from map in ToString of zone.


### Possible Drawbacks
Maybe some code depends on zone.toString() to only display the name. I didn't find anything like that though.


### Release Notes
- only show display name of maps if explicitly set

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3787)
<!-- Reviewable:end -->
