### PR TITLE
Feature campaign dir

### DIFF
--- a/src/main/java/net/rptools/lib/BackupManager.java
+++ b/src/main/java/net/rptools/lib/BackupManager.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import net.rptools.maptool.util.PersistenceUtil;
 
 public class BackupManager {
 
@@ -47,11 +48,15 @@ public class BackupManager {
     maxBackupSize = size;
   }
 
-  public void backup(File file) throws IOException {
+  public File backup(File file) throws IOException {
+    return backup(file, false);
+  }
+
+  public File backup(File file, boolean forceBackup) throws IOException {
 
     // Active ?
-    if (maxBackupSize < 1) {
-      return;
+    if (maxBackupSize < 1 && !forceBackup) {
+      return null;
     }
 
     // Enough room ?
@@ -70,7 +75,14 @@ public class BackupManager {
     }
 
     // Save
-    FileUtil.copyFile(file, newFile);
+    if (file.isDirectory()) {
+      PersistenceUtil.pack(file, newFile);
+      // FileUtil.copyDirectory(file, newFile);
+    } else {
+      FileUtil.copyFile(file, newFile);
+    }
+
+    return newFile;
   }
 
   /** List of existing backup files, with the oldest at the front */

--- a/src/main/java/net/rptools/lib/FileUtil.java
+++ b/src/main/java/net/rptools/lib/FileUtil.java
@@ -340,6 +340,19 @@ public class FileUtil {
   }
 
   /**
+   * Copies <code>sourceFile</code> to <code>destFile</code> overwriting as required, and <b>not</b>
+   * preserving the source file's last modified time. The destination directory is created if it
+   * does not exist, and if the destination file exists, it is overwritten.
+   *
+   * @param sourceFile
+   * @param destFile
+   * @throws IOException
+   */
+  public static void copyDirectory(File sourceFile, File destFile) throws IOException {
+    FileUtils.copyDirectory(sourceFile, destFile, false);
+  }
+
+  /**
    * Unzips the indicated file from the <code>classpathFile</code> location into the indicated
    * <code>destDir</code>.
    *

--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -275,8 +275,6 @@ public class PackedFile implements AutoCloseable {
     } catch (NullPointerException npe) {
       log.error("Problem finding/converting content file", npe);
       return null;
-    } finally {
-      IOUtils.closeQuietly(r);
     }
   }
 

--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -106,7 +106,7 @@ import org.xml.sax.SAXException;
 public class PackedFile implements AutoCloseable {
 
   private static final String PROPERTY_FILE = "properties.xml";
-  private static final String CONTENT_FILE = "content.xml";
+  public static final String CONTENT_FILE = "content.xml";
 
   private static final Logger log = LogManager.getLogger(PackedFile.class);
 
@@ -213,11 +213,12 @@ public class PackedFile implements AutoCloseable {
    * Retrieves the contents of the <code>CONTENT_FILE</code> as a POJO. This object is the top-level
    * data structure for all information regarding the content of the PackedFile.
    *
+   * @param file file to load
    * @return the results of the deserialization
    * @throws IOException when the property file is missing
    */
-  public Object getContent() throws IOException {
-    return getContent(versionManager, (String) getProperty("version"));
+  public Object getContent(String file) throws IOException {
+    return getContent(versionManager, (String) getProperty("version"), file);
   }
 
   /**
@@ -227,11 +228,26 @@ public class PackedFile implements AutoCloseable {
    * the transformation as a simplified XSTL process.)
    *
    * @param fileVersion such as "1.3.70"
+   * @param file file to load
    * @return the results of the deserialization
    * @throws IOException when the property file is missing
    */
-  public Object getContent(String fileVersion) throws IOException {
-    return getContent(versionManager, fileVersion);
+  public Object getContent(String fileVersion, String file) throws IOException {
+    return getContent(versionManager, fileVersion, file);
+  }
+
+  /**
+   * Same as {@link #getContent()} except that the version can be specified. This allows a newer
+   * release of an application to provide automatic transformation information that will be applied
+   * to the content. The default transformation manager is used.
+   *
+   * @param fileVersion such as "1.3.70"
+   * @param file file to load
+   * @return the results of the deserialization
+   * @throws IOException
+   */
+  public String getContentAsString(String fileVersion, String file) throws IOException {
+    return getContentAsString(versionManager, fileVersion, file);
   }
 
   /**
@@ -240,10 +256,11 @@ public class PackedFile implements AutoCloseable {
    *
    * @param versionManager which set of transforms to apply to older file versions
    * @param fileVersion such as "1.3.70"
+   * @param file file to load
    * @return the results of the deserialization
    * @throws IOException when the property file is missing
    */
-  public Object getContent(ModelVersionManager versionManager, String fileVersion)
+  public Object getContent(ModelVersionManager versionManager, String fileVersion, String file)
       throws IOException {
     try (Reader r = getFileAsReader(CONTENT_FILE)) {
       if (versionManager != null && versionManager.isTransformationRequired(fileVersion)) {
@@ -253,7 +270,39 @@ public class PackedFile implements AutoCloseable {
         // classes/fields added.
         return xstream.fromXML(xml);
       } else {
-        return getFileObject(CONTENT_FILE);
+        return getFileObject(file);
+      }
+    } catch (NullPointerException npe) {
+      log.error("Problem finding/converting content file", npe);
+      return null;
+    } finally {
+      IOUtils.closeQuietly(r);
+    }
+  }
+
+  /**
+   * Same as {@link #getContent(String)} except that the transformation manager, <code>
+   * versionManager</code>, is specified as a parameter.
+   *
+   * @param versionManager which set of transforms to apply to older file versions
+   * @param fileVersion such as "1.3.70"
+   * @param file file to load
+   * @return the results of the deserialization
+   * @throws IOException
+   */
+  public String getContentAsString(
+      ModelVersionManager versionManager, String fileVersion, String file) throws IOException {
+    Reader r = null;
+    try {
+      if (versionManager != null && versionManager.isTransformationRequired(fileVersion)) {
+        r = getFileAsReader(file);
+        String content = IOUtils.toString(r);
+        content = versionManager.transform(content, fileVersion);
+        return content;
+      } else {
+        r = getFileAsReader(file);
+        String content = IOUtils.toString(r);
+        return content;
       }
     } catch (NullPointerException npe) {
       log.error("Problem finding/converting content file", npe);
@@ -499,6 +548,23 @@ public class PackedFile implements AutoCloseable {
 
       bw.newLine(); // Not necessary but editing the file looks nicer. ;-)
     }
+  }
+
+  /**
+   * Write the String to the given path in the ZIP file; character set encoding will take place as
+   * the data is written to the (temporary) file.
+   *
+   * @param path location within the ZIP file
+   * @param obj the object to be written
+   * @throws IOException
+   */
+  public void putFileAsString(String path, String content) throws IOException {
+    File explodedFile = putFileImpl(path);
+    FileOutputStream fos = new FileOutputStream(explodedFile);
+    OutputStreamWriter osw = new OutputStreamWriter(fos, "UTF-8");
+    BufferedWriter bw = new BufferedWriter(osw);
+    bw.append(content);
+    IOUtils.closeQuietly(bw);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2724,8 +2724,7 @@ public class AppActions {
 
         @Override
         protected void executeAction() {
-          boolean saveUnpackedAsDirectory = AppState.getCampaignFile().isDirectory();
-          doSaveCampaign(null, saveUnpackedAsDirectory);
+          doSaveCampaign(null);
         }
       };
 
@@ -2746,11 +2745,12 @@ public class AppActions {
         }
       };
 
-  public static void doSaveCampaign(Runnable onSuccess, boolean saveUnpackedAsDirectory) {
+  public static void doSaveCampaign(Runnable onSuccess) {
     if (AppState.getCampaignFile() == null) {
       doSaveCampaignAs(onSuccess);
       return;
     }
+    boolean saveUnpackedAsDirectory = AppState.getCampaignFile() .isDirectory();
     doSaveCampaign(AppState.getCampaignFile(), onSuccess, saveUnpackedAsDirectory);
   }
 

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2564,6 +2564,17 @@ public class AppActions {
     }
 
     @Override
+    public void approveSelection() {
+        var file = getSelectedFile();
+        if(getFileFilter() instanceof MTFileFilter mtFilter) {
+            if (file == null || file.isDirectory() && !mtFilter.isDirectory())
+                return;
+
+            super.approveSelection();
+        }
+    }
+
+    @Override
     protected File getImageFileOfSelectedFile() {
       if (getSelectedFile() == null) {
         return null;

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2636,7 +2636,7 @@ public class AppActions {
         }
 
         // Load
-        return PersistenceUtil.loadCampaign(campaignFile);
+        return PersistenceUtil.loadCampaign(loadFile);
       } finally {
         AppState.releaseBackgroundTaskLock();
       }
@@ -2750,7 +2750,7 @@ public class AppActions {
       doSaveCampaignAs(onSuccess);
       return;
     }
-    boolean saveUnpackedAsDirectory = AppState.getCampaignFile() .isDirectory();
+    boolean saveUnpackedAsDirectory = AppState.getCampaignFile().isDirectory();
     doSaveCampaign(AppState.getCampaignFile(), onSuccess, saveUnpackedAsDirectory);
   }
 
@@ -2880,7 +2880,10 @@ public class AppActions {
 
   private static File getFileWithExtension(File file, String extension) {
     if (!file.getName().toLowerCase().endsWith(extension)) {
-      file = new File(file.getAbsolutePath() + extension);
+      // if it is a directory and it exists already do not add an extension
+      if (!file.isDirectory() || !file.exists()) {
+        file = new File(file.getAbsolutePath() + extension);
+      }
     }
     return file;
   }

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2565,13 +2565,12 @@ public class AppActions {
 
     @Override
     public void approveSelection() {
-        var file = getSelectedFile();
-        if(getFileFilter() instanceof MTFileFilter mtFilter) {
-            if (file == null || file.isDirectory() && !mtFilter.isDirectory())
-                return;
+      var file = getSelectedFile();
+      if (getFileFilter() instanceof MTFileFilter mtFilter) {
+        if (file == null || file.isDirectory() && !mtFilter.isDirectory()) return;
 
-            super.approveSelection();
-        }
+        super.approveSelection();
+      }
     }
 
     @Override

--- a/src/main/java/net/rptools/maptool/client/AppConstants.java
+++ b/src/main/java/net/rptools/maptool/client/AppConstants.java
@@ -55,6 +55,7 @@ public class AppConstants {
       };
 
   public static final String CAMPAIGN_FILE_EXTENSION = ".cmpgn";
+  public static final String CAMPAIGN_DIRECTIORY_EXTENSION = ".cmpgndir";
   public static final String CAMPAIGN_FILE_EXTENSION_ND = "cmpgn";
   public static final String CAMPAIGN_PROPERTIES_FILE_EXTENSION = ".mtprops";
   public static final String MAP_FILE_EXTENSION = ".rpmap";

--- a/src/main/java/net/rptools/maptool/client/AutoSaveManager.java
+++ b/src/main/java/net/rptools/maptool/client/AutoSaveManager.java
@@ -125,7 +125,7 @@ public class AutoSaveManager {
       try {
         long startSave = System.currentTimeMillis();
         log.info("Starting autosave..."); // $NON-NLS-1$
-        PersistenceUtil.saveCampaign(campaign, AUTOSAVE_FILE, null);
+        PersistenceUtil.saveCampaign(campaign, AUTOSAVE_FILE, null, false);
         String msg =
             I18N.getText(
                 "AutoSaveManager.status.autoSaveComplete", System.currentTimeMillis() - startSave);

--- a/src/main/java/net/rptools/maptool/client/TransferableHelper.java
+++ b/src/main/java/net/rptools/maptool/client/TransferableHelper.java
@@ -646,7 +646,7 @@ public class TransferableHelper extends TransferHandler {
             configureTokens.add(true);
           }
         } else if (working instanceof Token) {
-          Token token = new Token((Token) working);
+          Token token = new Token((Token) working, true);
           // token.setName(MapToolUtil.nextTokenId(zone, token));
           tokens.add(token);
           // A token from an .rptok file is already fully configured.
@@ -659,7 +659,7 @@ public class TransferableHelper extends TransferHandler {
           // Make a copy so that it gets a new unique GUID
           tokens =
               Collections.singletonList(
-                  new Token((Token) t.getTransferData(TransferableToken.dataFlavor)));
+                  new Token((Token) t.getTransferData(TransferableToken.dataFlavor), true));
           // A token from the Resource Library is already fully configured.
           configureTokens = Collections.singletonList(Boolean.FALSE);
         } catch (Exception e) {

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -178,7 +178,7 @@ public class MapFunctions extends AbstractFunction {
       String oldName = parameters.get(0).toString();
       String newName = parameters.get(1).toString();
       Zone oldMap = getNamedMap(functionName, oldName).getZone();
-      Zone newMap = new Zone(oldMap);
+      Zone newMap = new Zone(oldMap, false);
       newMap.setName(newName);
       MapTool.addZone(newMap, false);
       MapTool.serverCommand().putZone(newMap);

--- a/src/main/java/net/rptools/maptool/client/ui/CampaignExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/CampaignExportDialog.java
@@ -46,6 +46,7 @@ public class CampaignExportDialog extends JDialog {
   private static JEditorPane versionNotesText;
   private static JComboBox selectVersionCombo;
   private static File campaignFile;
+  private static MTFileFilter selectedFileFilter;
   private static int saveStatus = -1;
 
   private static final CampaignExportDialog instance = new CampaignExportDialog();
@@ -122,11 +123,16 @@ public class CampaignExportDialog extends JDialog {
     return campaignFile;
   }
 
+  public MTFileFilter getSelectedMTFileFilter() {
+    return selectedFileFilter;
+  }
+
   private void exportButtonAction() {
     try {
       JFileChooser chooser = MapTool.getFrame().getSaveCmpgnFileChooser();
       saveStatus = chooser.showSaveDialog(MapTool.getFrame());
       campaignFile = chooser.getSelectedFile();
+      selectedFileFilter = (MTFileFilter) chooser.getFileFilter();
     } catch (Exception ex) {
       MapTool.showError(I18N.getString("dialog.campaignexport.error.failedExporting"), ex);
     } finally {

--- a/src/main/java/net/rptools/maptool/client/ui/CampaignExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/CampaignExportDialog.java
@@ -46,7 +46,7 @@ public class CampaignExportDialog extends JDialog {
   private static JEditorPane versionNotesText;
   private static JComboBox selectVersionCombo;
   private static File campaignFile;
-  private static MTFileFilter selectedFileFilter;
+  private static MapToolFrame.MTFileFilter selectedFileFilter;
   private static int saveStatus = -1;
 
   private static final CampaignExportDialog instance = new CampaignExportDialog();
@@ -123,7 +123,7 @@ public class CampaignExportDialog extends JDialog {
     return campaignFile;
   }
 
-  public MTFileFilter getSelectedMTFileFilter() {
+  public MapToolFrame.MTFileFilter getSelectedMTFileFilter() {
     return selectedFileFilter;
   }
 
@@ -132,7 +132,7 @@ public class CampaignExportDialog extends JDialog {
       JFileChooser chooser = MapTool.getFrame().getSaveCmpgnFileChooser();
       saveStatus = chooser.showSaveDialog(MapTool.getFrame());
       campaignFile = chooser.getSelectedFile();
-      selectedFileFilter = (MTFileFilter) chooser.getFileFilter();
+      selectedFileFilter = (MapToolFrame.MTFileFilter) chooser.getFileFilter();
     } catch (Exception ex) {
       MapTool.showError(I18N.getString("dialog.campaignexport.error.failedExporting"), ex);
     } finally {

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -865,7 +865,18 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   public JFileChooser getSaveCmpgnFileChooser() {
     if (saveCmpgnFileChooser == null) {
-      saveCmpgnFileChooser = new JFileChooser();
+      saveCmpgnFileChooser = new JFileChooser() {
+        @Override
+        public void approveSelection() {
+          var file = getSelectedFile();
+          if(getFileFilter() instanceof MTFileFilter mtFilter) {
+            if (file == null || file.isDirectory() && !mtFilter.isDirectory())
+              return;
+
+            super.approveSelection();
+          }
+        }
+      };
       saveCmpgnFileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
       saveCmpgnFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
       saveCmpgnFileChooser.addChoosableFileFilter(campaignFilter);

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -196,6 +196,8 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   private final FileFilter campaignFilter =
       new MTFileFilter(I18N.getText("file.ext.cmpgn"), "cmpgn");
+  private final FileFilter campaignDirectoryFilter =
+          new MTFileFilter("cmpgndir", I18N.getText("file.ext.cmpgnDirectory"), true);
   private final FileFilter mapFilter = new MTFileFilter(I18N.getText("file.ext.rpmap"), "rpmap");
   private final FileFilter propertiesFilter =
       new MTFileFilter(I18N.getText("file.ext.mtprops"), "mtprops");
@@ -764,15 +766,23 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   }
 
   /** Accepts 1 or more file extensions */
-  private static class MTFileFilter extends FileFilter {
+  public static class MTFileFilter extends FileFilter {
     private final String[] extensions;
+    private final String extension;
     private final String description;
+    private final boolean directory;
 
     MTFileFilter(String desc, String... extens) {
+      this(desc, false, extens);
+    }
+
+    MTFileFilter(String desc, boolean dir, String... extens) {
       super();
       extensions = extens;
       description = desc;
+      directory = directory;
     }
+
 
     /** Accept directories and files matching any of the provided extensions */
     @Override
@@ -780,6 +790,11 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
       if (f.isDirectory()) {
         return true;
       }
+
+      if (this.directory && !f.isDirectory()) {
+        return false;
+      }
+
       String fext = getExtension(f);
       for (String ext : extensions) {
         if (fext != null && fext.equals(ext)) {
@@ -789,9 +804,17 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
       return false;
     }
 
+    public boolean isDirectory() {
+      return directory;
+    }
+
     @Override
     public String getDescription() {
       return description;
+    }
+
+    public String getExtension() {
+      return extension;
     }
 
     public String getExtension(File f) {
@@ -808,6 +831,10 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   public FileFilter getCmpgnFileFilter() {
     return campaignFilter;
+  }
+
+  public FileFilter getCmpgnDirectoryFileFilter() {
+    return campaignDirectoryFilter;
   }
 
   public FileFilter getMapFileFilter() {
@@ -845,8 +872,10 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveCmpgnFileChooser() {
     if (saveCmpgnFileChooser == null) {
       saveCmpgnFileChooser = new JFileChooser();
+      saveCmpgnFileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
       saveCmpgnFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
       saveCmpgnFileChooser.addChoosableFileFilter(campaignFilter);
+      saveCmpgnFileChooser.addChoosableFileFilter(campaignDirectoryFilter);
       saveCmpgnFileChooser.setDialogTitle(I18N.getText("msg.title.saveCampaign"));
     }
     saveCmpgnFileChooser.setAcceptAllFileFilterUsed(true);

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -197,7 +197,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   private final FileFilter campaignFilter =
       new MTFileFilter(I18N.getText("file.ext.cmpgn"), "cmpgn");
   private final FileFilter campaignDirectoryFilter =
-          new MTFileFilter("cmpgndir", I18N.getText("file.ext.cmpgnDirectory"), true);
+      new MTFileFilter(I18N.getText("file.ext.cmpgnDirectory"), true, "cmpgndir");
   private final FileFilter mapFilter = new MTFileFilter(I18N.getText("file.ext.rpmap"), "rpmap");
   private final FileFilter propertiesFilter =
       new MTFileFilter(I18N.getText("file.ext.mtprops"), "mtprops");
@@ -768,7 +768,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   /** Accepts 1 or more file extensions */
   public static class MTFileFilter extends FileFilter {
     private final String[] extensions;
-    private final String extension;
     private final String description;
     private final boolean directory;
 
@@ -780,9 +779,8 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
       super();
       extensions = extens;
       description = desc;
-      directory = directory;
+      directory = dir;
     }
-
 
     /** Accept directories and files matching any of the provided extensions */
     @Override
@@ -811,10 +809,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     @Override
     public String getDescription() {
       return description;
-    }
-
-    public String getExtension() {
-      return extension;
     }
 
     public String getExtension(File f) {
@@ -1919,7 +1913,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
           return;
         }
         if (result == JOptionPane.YES_OPTION) {
-          AppActions.doSaveCampaign(() -> MapTool.getFrame().close());
+          AppActions.doSaveCampaign(() -> MapTool.getFrame().close(), false);
           return;
         }
       } else {

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -865,18 +865,18 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   public JFileChooser getSaveCmpgnFileChooser() {
     if (saveCmpgnFileChooser == null) {
-      saveCmpgnFileChooser = new JFileChooser() {
-        @Override
-        public void approveSelection() {
-          var file = getSelectedFile();
-          if(getFileFilter() instanceof MTFileFilter mtFilter) {
-            if (file == null || file.isDirectory() && !mtFilter.isDirectory())
-              return;
+      saveCmpgnFileChooser =
+          new JFileChooser() {
+            @Override
+            public void approveSelection() {
+              var file = getSelectedFile();
+              if (getFileFilter() instanceof MTFileFilter mtFilter) {
+                if (file == null || file.isDirectory() && !mtFilter.isDirectory()) return;
 
-            super.approveSelection();
-          }
-        }
-      };
+                super.approveSelection();
+              }
+            }
+          };
       saveCmpgnFileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
       saveCmpgnFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
       saveCmpgnFileChooser.addChoosableFileFilter(campaignFilter);

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1913,7 +1913,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
           return;
         }
         if (result == JOptionPane.YES_OPTION) {
-          AppActions.doSaveCampaign(() -> MapTool.getFrame().close(), false);
+          AppActions.doSaveCampaign(() -> MapTool.getFrame().close());
           return;
         }
       } else {

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenLayoutPanel.java
@@ -155,7 +155,7 @@ public class TokenLayoutPanel extends JPanel {
   }
 
   public void setToken(Token token) {
-    this.token = new Token(token);
+    this.token = new Token(token, false);
     setTokenImage(token.getImageAssetId());
   }
 

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -57,8 +57,7 @@ public class Campaign {
   private GUID id = new GUID();
 
   /** The {@link Zone}s that make up this {@code Campaign}. */
-  private final Map<GUID, Zone> zones =
-      Collections.synchronizedMap(new LinkedHashMap<GUID, Zone>());
+  private Map<GUID, Zone> zones = Collections.synchronizedMap(new LinkedHashMap<GUID, Zone>());
 
   private String name; // the name of the campaign, to be displayed in the MapToolFrame title bar
 
@@ -746,6 +745,26 @@ public class Campaign {
 
   public CampaignExportDialog getExportCampaignDialog() {
     return campaignExportDialog;
+  }
+
+  public List<MacroButtonProperties> getMacroButtonProperties() {
+    return macroButtonProperties;
+  }
+
+  public Location getExportLocation() {
+    return exportLocation;
+  }
+
+  public Map<String, Boolean> getExportSettings() {
+    return exportSettings;
+  }
+
+  public int getMacroButtonLastIndex() {
+    return macroButtonLastIndex;
+  }
+
+  public Boolean getHasUsedFogToolbar() {
+    return hasUsedFogToolbar;
   }
 
   public void initDefault() {

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -134,6 +134,29 @@ public class Campaign {
     return this;
   }
 
+  public Campaign(
+      GUID id,
+      CampaignProperties campaignProperties,
+      Map<String, Boolean> exportSettings,
+      Location exportLocation,
+      Boolean hasUsedFogToolbar,
+      Integer macroButtonLastIndex,
+      ArrayList<MacroButtonProperties> macroButtonPropertiesList,
+      Map<GUID, Zone> zones) {
+    this.id = id;
+    this.exportLocation = exportLocation;
+    this.exportSettings = exportSettings;
+    this.campaignProperties = campaignProperties;
+    this.macroButtonProperties = macroButtonPropertiesList;
+    this.zones = zones;
+    if (macroButtonLastIndex != null) {
+      this.macroButtonLastIndex = macroButtonLastIndex;
+    }
+    if (hasUsedFogToolbar != null) {
+      this.hasUsedFogToolbar = hasUsedFogToolbar;
+    }
+  }
+
   private void checkCampaignPropertyConversion() {
     if (campaignProperties == null) {
       campaignProperties = new CampaignProperties();
@@ -168,7 +191,7 @@ public class Campaign {
    */
   public Campaign(Campaign campaign) {
     name = campaign.getName();
-
+    id = campaign.id;
     /*
      * Don't forget that since these are new zones AND new tokens created here from the old one,
      * if you have any data that needs to transfer over you will need to manually copy it

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -142,7 +142,11 @@ public class Campaign {
       Integer macroButtonLastIndex,
       ArrayList<MacroButtonProperties> macroButtonPropertiesList,
       Map<GUID, Zone> zones) {
-    this.id = id;
+
+    if (id != null) {
+      this.id = id;
+    }
+
     this.exportLocation = exportLocation;
     this.exportSettings = exportSettings;
     this.campaignProperties = campaignProperties;

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -388,8 +388,6 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     commonMacro = true;
   }
 
-  public MacroButtonProperties(MacroButtonProperties orginal) {}
-
   public MacroButtonProperties(Token token, Map<String, String> props) {
     this(
         props.containsKey("index")

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -330,6 +330,35 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     this(token, index, properties, true);
   }
 
+  // constructor for creating a new copy of an existing token button, auto-saves
+  public MacroButtonProperties(Token token, MacroButtonProperties properties) {
+    this(properties.index);
+    setSaveLocation("Token");
+    setTokenId(token);
+    setColorKey(properties.getColorKey());
+    // use the default hot key
+    setCommand(properties.getCommand());
+    setLabel(properties.getLabel());
+    setGroup(properties.getGroup());
+    setSortby(properties.getSortby());
+    setAutoExecute(properties.getAutoExecute());
+    setIncludeLabel(properties.getIncludeLabel());
+    setApplyToTokens(properties.getApplyToTokens());
+    setFontColorKey(properties.getFontColorKey());
+    setFontSize(properties.getFontSize());
+    setMinWidth(properties.getMinWidth());
+    setMaxWidth(properties.getMaxWidth());
+    setAllowPlayerEdits(properties.getAllowPlayerEdits());
+    setCompareIncludeLabel(properties.getCompareIncludeLabel());
+    setCompareAutoExecute(properties.getCompareAutoExecute());
+    setCompareApplyToSelectedTokens(properties.getCompareApplyToSelectedTokens());
+    setCompareGroup(properties.getCompareGroup());
+    setCompareSortPrefix(properties.getCompareSortPrefix());
+    setCompareCommand(properties.getCompareCommand());
+    setToolTip(properties.getToolTip());
+    macroUUID = null;
+  }
+
   // constructor for creating common macro buttons on selection panel
   public MacroButtonProperties(int index, MacroButtonProperties properties) {
     this(index);
@@ -358,6 +387,8 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setToolTip(properties.getToolTip());
     commonMacro = true;
   }
+
+  public MacroButtonProperties(MacroButtonProperties orginal) {}
 
   public MacroButtonProperties(Token token, Map<String, String> props) {
     this(
@@ -1096,6 +1127,11 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
   public String getMacroUUID() {
     if (macroUUID == null) macroUUID = UUID.randomUUID().toString();
 
+    return macroUUID;
+  }
+
+  public String resetMacroUUID() {
+    macroUUID = UUID.randomUUID().toString();
     return macroUUID;
   }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1070,6 +1070,9 @@ public class Token implements Cloneable {
 
   @Override
   public int hashCode() {
+    if (id == null) {
+      return -1;
+    }
     return id.hashCode();
   }
 
@@ -1178,7 +1181,23 @@ public class Token implements Cloneable {
   }
 
   public GUID getId() {
+    if (id == null) {
+      resetId();
+    }
     return id;
+  }
+
+  public GUID resetId() {
+    id = new GUID();
+    return id;
+  }
+
+  /**
+   * needed so that when copy/pasting the ID can be cleared on copy and a new one is generated for
+   * every paste.
+   */
+  public void clearID() {
+    id = null;
   }
 
   public ZoneRenderer getZoneRenderer() { // Returns the ZoneRenderer the token is on

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -384,11 +384,15 @@ public class Zone {
     List<ZoneRenderer> rendererList =
         new LinkedList<ZoneRenderer>(MapTool.getFrame().getZoneRenderers());
     for (ZoneRenderer z : rendererList) {
-      if (z.getZone().getPlayerAlias().equals(playerAlias)) {
+      if (z.getZone().getPlayerAlias() != null
+          && z.getZone().getPlayerAlias().equals(playerAlias)) {
         return false;
       }
     }
-    this.playerAlias = playerAlias.equals("") || playerAlias.equals(name) ? null : playerAlias;
+    this.playerAlias =
+        playerAlias == null || playerAlias.equals("") || playerAlias.equals(name)
+            ? null
+            : playerAlias;
     return true;
   }
 

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -244,12 +244,12 @@ public class Zone {
 
   private final Map<GUID, Label> labels = new LinkedHashMap<GUID, Label>();
   /** Map each token GUID to the corresponding token. */
-  private final Map<GUID, Token> tokenMap = new HashMap<GUID, Token>();
+  private Map<GUID, Token> tokenMap = new HashMap<GUID, Token>();
   /** Map each token GUID to its exposed area metadata */
   private Map<GUID, ExposedAreaMetaData> exposedAreaMeta = new HashMap<GUID, ExposedAreaMetaData>();
 
   /** Token list ordered by Z. */
-  private final List<Token> tokenOrderedList = new LinkedList<Token>();
+  private List<Token> tokenOrderedList = new LinkedList<Token>();
 
   private InitiativeList initiativeList = new InitiativeList(this);
 
@@ -2115,6 +2115,13 @@ public class Zone {
       if (de.getDrawable() instanceof AbstractTemplate at) {
         at.setZoneId(id);
       }
+    }
+
+    if (tokenOrderedList == null) {
+      tokenOrderedList = new LinkedList<Token>();
+    }
+    if (tokenMap == null) {
+      tokenMap = new HashMap<GUID, Token>();
     }
 
     return this;

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -585,6 +585,11 @@ public class Zone {
     return id;
   }
 
+  public GUID resetId() {
+    id = new GUID();
+    return id;
+  }
+
   /**
    * Should be invoked only when a Zone has been imported from an external source and needs to be
    * cleaned up before being used. Currently this cleanup consists of allocating a new GUID, setting
@@ -2077,24 +2082,9 @@ public class Zone {
         visionType = VisionType.OFF;
       }
     }
-    // Look for the bizarre z-ordering disappearing trick
-    boolean foundZero = false;
-    boolean fixZOrder = false;
-    for (Token token : tokenOrderedList) {
-      if (token.getZOrder() == 0) {
-        if (foundZero) {
-          fixZOrder = true;
-          break;
-        }
-        foundZero = true;
-      }
-    }
-    if (fixZOrder) {
-      int z = 0;
-      for (Token token : tokenOrderedList) {
-        token.setZOrder(z++);
-      }
-    }
+
+    fixZOrder();
+
     // Transient "undo" field added in 1.3.b88
     // This will be true; it's just in case we decide to make it persistent in the future
     if (undo == null) {
@@ -2128,6 +2118,30 @@ public class Zone {
     }
 
     return this;
+  }
+
+  public void fixZOrder() {
+    // Look for the bizarre z-ordering disappearing trick
+    boolean foundZero = false;
+    boolean fixZOrder = false;
+
+    if (tokenOrderedList != null) {
+      for (Token token : tokenOrderedList) {
+        if (token.getZOrder() == 0) {
+          if (foundZero) {
+            fixZOrder = true;
+            break;
+          }
+          foundZero = true;
+        }
+      }
+      if (fixZOrder) {
+        int z = 0;
+        for (Token token : tokenOrderedList) {
+          token.setZOrder(z++);
+        }
+      }
+    }
   }
 
   /** @return the exposedAreaMeta. */

--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -80,6 +80,22 @@ import org.apache.logging.log4j.Logger;
 
 /** @author trevor */
 public class PersistenceUtil {
+  private static final String TABLES_DIRECTORY = "tbl/";
+  private static final String ZONES_DIRECTORY = "z/";
+  private static final String TOKENS_DIRECTORY = "t/";
+  private static final String MACROS_DIRECTORY = "m/";
+
+  private static final String TABLE_FILE_PREFIX = "";
+  private static final String ZONE_FILE_PREFIX = "";
+  private static final String TOKEN_FILE_PREFIX = "";
+  private static final String MACRO_FILE_PREFIX = "";
+
+  private static final String TABLE_FILE_SUFFIX = ".tbl";
+  private static final String ZONE_FILE_SUFFIX = ".zone";
+  private static final String TOKEN_FILE_SUFFIX = ".tok";
+  private static final String MACRO_FILE_SUFFIX = ".m";
+  private static final String MTSCRIPT_FILE_SUFFIX = ".mtscript";
+
   private static final Logger log = LogManager.getLogger(PersistenceUtil.class);
 
   public static final String PROP_VERSION = "version"; // $NON-NLS-1$
@@ -179,6 +195,32 @@ public class PersistenceUtil {
     public String mapToolVersion;
   }
 
+  public static class CampaignWrapper {
+    public Location exportLocation;
+    public Map<String, Boolean> exportSettings;
+    public int macroButtonLastIndex;
+    public Boolean hasUsedFogToolbar;
+    public GUID id;
+    public GUID currentZoneId;
+    public String mapToolVersion;
+    public List<MacroFileWrapper> macroFiles;
+  }
+
+  public static class ZoneWrapper {
+    public Zone zone;
+  }
+
+  public static class TokenWrapper {
+    public List<MacroFileWrapper> macroFiles;
+    public Token token;
+  }
+
+  public static class MacroFileWrapper {
+    public String macroFile;
+    public int index;
+    public String saveLocation;
+  }
+
   public static void saveMap(Zone z, File mapFile) throws IOException {
     PersistedMap pMap = new PersistedMap();
     pMap.zone = z;
@@ -209,7 +251,7 @@ public class PersistenceUtil {
       String progVersion = (String) pakFile.getProperty(PROP_VERSION);
       if (!versionCheck(progVersion)) return null;
 
-      Object o = pakFile.getContent();
+      Object o = pakFile.getContent(PackedFile.CONTENT_FILE);
       if (o instanceof PersistedMap) {
         persistedMap = (PersistedMap) o;
 
@@ -268,7 +310,8 @@ public class PersistenceUtil {
     return n;
   }
 
-  public static void saveCampaign(Campaign campaign, File campaignFile, String campaignVersion)
+  public static void saveCampaign(
+      Campaign campaign, File campaignFile, String campaignVersion, boolean saveUnpackedAsDirectory)
       throws IOException {
     CodeTimer saveTimer; // FJE Previously this was 'private static' -- why?
     saveTimer = new CodeTimer("CampaignSave");
@@ -282,12 +325,16 @@ public class PersistenceUtil {
     File tmpFile = new File(tmpDir.getAbsolutePath(), campaignFile.getName());
     if (tmpFile.exists()) tmpFile.delete();
 
+    if (campaignFile.isDirectory() && campaignFile.exists()) {
+      FileUtil.delete(campaignFile);
+    }
+
     PackedFile pakFile = null;
     try {
       pakFile = new PackedFile(tmpFile);
+
       // Configure the meta file (this is for legacy support)
       PersistedCampaign persistedCampaign = new PersistedCampaign();
-
       persistedCampaign.campaign = campaign;
 
       // Keep track of the current view
@@ -327,8 +374,148 @@ public class PersistenceUtil {
         // specified campaignVersion
         if (campaignVersion != null) {
           pakFile = CampaignExport.stripContent(pakFile, persistedCampaign, campaignVersion);
-        } else {
-          pakFile.setContent(persistedCampaign);
+        }
+
+        // save in new splitted file format
+        // if not exporting to an old version that used the content.xml file
+        if (campaignVersion == null || !pakFile.hasFile(PackedFile.CONTENT_FILE)) {
+          pakFile.putFile("assetMap.xml", persistedCampaign.assetMap);
+          pakFile.putFile("currentView.xml", persistedCampaign.currentView);
+
+          pakFile.getXStream().omitField(Campaign.class, "zones");
+          pakFile.getXStream().omitField(Campaign.class, "macroButtonProperties");
+          pakFile.getXStream().omitField(CampaignProperties.class, "characterSheets");
+          pakFile.getXStream().omitField(CampaignProperties.class, "lookupTableMap");
+          pakFile.putFile("characterSheets.xml", persistedCampaign.campaign.getCharacterSheets());
+          pakFile.putFile(
+              "campaignProperties.xml", persistedCampaign.campaign.getCampaignProperties());
+
+          // save tables
+          for (Entry<String, LookupTable> tableEntry :
+              persistedCampaign.campaign.getLookupTableMap().entrySet()) {
+            String tableFile =
+                joinFilePaths(
+                    TABLES_DIRECTORY,
+                    TABLE_FILE_PREFIX + fixFileName(tableEntry.getKey()) + TABLE_FILE_SUFFIX);
+            pakFile.putFile(tableFile, tableEntry.getValue());
+          }
+
+          // save campaign macros
+          List<MacroFileWrapper> macroFilesWrapper = new LinkedList<MacroFileWrapper>();
+          pakFile.getXStream().omitField(MacroButtonProperties.class, "command");
+          for (MacroButtonProperties macro :
+              persistedCampaign.campaign.getMacroButtonProperties()) {
+            String macroFile =
+                joinFilePaths(
+                    MACROS_DIRECTORY,
+                    fixFileName(macro.getLabel()) + "_" + macro.getMacroUUID() + MACRO_FILE_SUFFIX);
+            String macroContentFile =
+                joinFilePaths(
+                    MACROS_DIRECTORY,
+                    MACRO_FILE_PREFIX
+                        + fixFileName(macro.getLabel())
+                        + "_"
+                        + macro.getMacroUUID()
+                        + MTSCRIPT_FILE_SUFFIX);
+            MacroFileWrapper macroFileWrapper = new MacroFileWrapper();
+            macroFileWrapper.index = macro.getIndex();
+            macroFileWrapper.saveLocation = macro.getSaveLocation();
+            macroFileWrapper.macroFile = macroFile;
+            macroFilesWrapper.add(macroFileWrapper);
+            pakFile.putFile(macroFile, macro);
+            if (macro.getCommand() != null) {
+              pakFile.putFileAsString(macroContentFile, macro.getCommand().toString());
+            }
+          }
+
+          pakFile.getXStream().omitField(Zone.class, "tokenOrderedList");
+          pakFile.getXStream().omitField(Zone.class, "tokenMap");
+          pakFile.getXStream().omitField(Token.class, "macroPropertiesMap");
+          pakFile.getXStream().omitField(Token.class, "macroMap");
+
+          // save zone
+          for (Zone zone : persistedCampaign.campaign.getZones()) {
+            String zonePath =
+                joinFilePaths(
+                    ZONES_DIRECTORY,
+                    fixFileName(zone.getName()) + "_" + fixFileName(zone.getId().toString()));
+
+            // save tokens in zone
+            List<String> tokenFiles = new LinkedList<String>();
+            for (Token token : zone.getAllTokens()) {
+              String tokenPath =
+                  joinFilePaths(
+                      TOKENS_DIRECTORY,
+                      fixFileName(token.getName()) + "_" + fixFileName(token.getId().toString()));
+              String tokenFile =
+                  joinFilePaths(
+                      zonePath,
+                      tokenPath,
+                      TOKEN_FILE_PREFIX + fixFileName(token.getName()) + TOKEN_FILE_SUFFIX);
+              tokenFiles.add(tokenFile);
+
+              // save token macros
+              List<MacroFileWrapper> tokenMacroFiles = new LinkedList<MacroFileWrapper>();
+              for (Map.Entry<Integer, Object> macroEntry :
+                  token.getMacroPropertiesMap(false).entrySet()) {
+                MacroButtonProperties macro = (MacroButtonProperties) macroEntry.getValue();
+                String macroFile =
+                    joinFilePaths(
+                        zonePath,
+                        tokenPath,
+                        MACROS_DIRECTORY,
+                        MACRO_FILE_PREFIX
+                            + fixFileName(macro.getLabel())
+                            + "_"
+                            + macro.getMacroUUID()
+                            + MACRO_FILE_SUFFIX);
+                String macroContentFile =
+                    joinFilePaths(
+                        zonePath,
+                        tokenPath,
+                        MACROS_DIRECTORY,
+                        MACRO_FILE_PREFIX
+                            + fixFileName(macro.getLabel())
+                            + "_"
+                            + macro.getMacroUUID()
+                            + MTSCRIPT_FILE_SUFFIX);
+                MacroFileWrapper tokenMacroFileWrapper = new MacroFileWrapper();
+                tokenMacroFileWrapper.index = macro.getIndex();
+                tokenMacroFileWrapper.saveLocation = macro.getSaveLocation();
+                tokenMacroFileWrapper.macroFile = macroFile;
+                tokenMacroFiles.add(tokenMacroFileWrapper);
+                pakFile.putFile(macroFile, macro);
+                if (macro.getCommand() != null) {
+                  pakFile.putFileAsString(macroContentFile, macro.getCommand().toString());
+                }
+              }
+
+              TokenWrapper tokenWrapper = new TokenWrapper();
+              tokenWrapper.macroFiles = tokenMacroFiles;
+              tokenWrapper.token = token;
+              pakFile.putFile(tokenFile, tokenWrapper);
+            }
+
+            String zoneFile =
+                joinFilePaths(
+                    zonePath, ZONE_FILE_PREFIX + fixFileName(zone.getName()) + ZONE_FILE_SUFFIX);
+            ZoneWrapper zoneWrapper = new ZoneWrapper();
+            zoneWrapper.zone = zone;
+
+            pakFile.putFile(zoneFile, zoneWrapper);
+          }
+
+          CampaignWrapper campaignWrapper = new CampaignWrapper();
+          campaignWrapper.mapToolVersion = persistedCampaign.mapToolVersion;
+          campaignWrapper.currentZoneId = persistedCampaign.currentZoneId;
+          campaignWrapper.exportLocation = persistedCampaign.campaign.getExportLocation();
+          campaignWrapper.exportSettings = persistedCampaign.campaign.getExportSettings();
+          campaignWrapper.macroButtonLastIndex =
+              persistedCampaign.campaign.getMacroButtonLastIndex();
+          campaignWrapper.hasUsedFogToolbar = persistedCampaign.campaign.getHasUsedFogToolbar();
+          campaignWrapper.macroFiles = macroFilesWrapper;
+          pakFile.putFile("campaign.xml", campaignWrapper);
+
           pakFile.setProperty(PROP_CAMPAIGN_VERSION, CAMPAIGN_VERSION);
           pakFile.setProperty(PROP_VERSION, MapTool.getVersion());
         }
@@ -336,6 +523,7 @@ public class PersistenceUtil {
         saveTimer.stop("Set content");
         saveTimer.start("Save");
         pakFile.save();
+
         saveTimer.stop("Save");
       } catch (OutOfMemoryError oom) {
         /*
@@ -376,13 +564,23 @@ public class PersistenceUtil {
 
     if (campaignFile.exists()) {
       saveTimer.start("Backup campaignFile");
-      FileUtil.copyFile(campaignFile, bakFile);
+
+      if (campaignFile.isDirectory()) {
+        campaignFile.renameTo(bakFile);
+      } else {
+        FileUtil.copyFile(campaignFile, bakFile);
+      }
       // campaignFile.delete();
       saveTimer.stop("Backup campaignFile");
     }
 
     saveTimer.start("Backup tmpFile");
-    FileUtil.copyFile(tmpFile, campaignFile);
+
+    if (saveUnpackedAsDirectory) {
+      unpack(tmpFile, campaignFile);
+    } else {
+      FileUtil.copyFile(tmpFile, campaignFile);
+    }
     tmpFile.delete();
     saveTimer.stop("Backup tmpFile");
     if (bakFile.exists()) bakFile.delete();
@@ -396,6 +594,154 @@ public class PersistenceUtil {
     if (log.isDebugEnabled()) {
       log.debug(saveTimer);
     }
+  }
+
+  private static final Pattern PATTERN = Pattern.compile("[^A-Za-z0-9_\\-]");
+
+  // max name for each file path component that is checked
+  private static final int MAX_LENGTH = 50;
+
+  public static String joinFilePaths(String... paths) {
+    StringBuilder sb = new StringBuilder();
+    for (String path : paths) {
+      if (sb.toString().length() > 0
+          && !sb.toString().endsWith("/")
+          && !path.startsWith("/")
+          && path.length() > 0) {
+        sb.append("/");
+      }
+      sb.append(path);
+    }
+
+    return sb.toString();
+  }
+
+  public static String fixFileName(String in) {
+
+    StringBuffer sb = new StringBuffer();
+    Matcher m = PATTERN.matcher(in);
+
+    while (m.find()) {
+      // Convert matched character to percent-encoded.
+      // which is everything that is not allowed
+      String replacement = "_"; // "%" + Integer.toHexString(m.group().charAt(0)).toUpperCase();
+      m.appendReplacement(sb, replacement);
+    }
+    m.appendTail(sb);
+
+    String encoded = sb.toString();
+
+    // Truncate the string.
+    int end = Math.min(encoded.length(), MAX_LENGTH);
+    return encoded.substring(0, end);
+  }
+
+  private static String removeLeadingSlash(String fileName) {
+    if (fileName != null && fileName.startsWith("/")) {
+      return fileName.substring(1);
+    }
+    return fileName;
+  }
+
+  private static String changeFileEndingTo(String fileName, String ending) {
+    if (fileName != null && fileName.contains(".")) {
+      return fileName.substring(0, fileName.lastIndexOf(".")) + ending;
+    }
+    return fileName + ending;
+  }
+
+  public static void unpack(File src, File dest) throws IOException {
+    byte[] buffer = new byte[1024];
+    ZipInputStream zis = null;
+
+    if (!dest.exists()) {
+      dest.mkdirs();
+    }
+
+    try {
+      zis = new ZipInputStream(new FileInputStream(src));
+      ZipEntry zipEntry = zis.getNextEntry();
+      while (zipEntry != null) {
+        File newFile = newFile(dest, zipEntry);
+        if (!newFile.getParentFile().exists()) {
+          newFile.getParentFile().mkdirs();
+        }
+        FileOutputStream fos = new FileOutputStream(newFile);
+        int len;
+        while ((len = zis.read(buffer)) > 0) {
+          fos.write(buffer, 0, len);
+        }
+        fos.close();
+        zipEntry = zis.getNextEntry();
+      }
+    } finally {
+      if (zis != null) {
+        zis.closeEntry();
+        zis.close();
+      }
+    }
+  }
+
+  public static void pack(File src, File dest) throws IOException {
+    try (FileOutputStream fos = new FileOutputStream(dest);
+        ZipOutputStream zipOut = new ZipOutputStream(fos)) {
+      zipFile(src, "", zipOut, true);
+    }
+  }
+
+  private static void zipFile(
+      File fileToZip, String fileName, ZipOutputStream zipOut, boolean ignoreRoot)
+      throws IOException {
+
+    if (fileToZip.isHidden()) {
+      return;
+    }
+
+    if (fileName == null) {
+      fileName = "";
+    }
+
+    if (fileToZip.isDirectory()) {
+
+      File[] children = fileToZip.listFiles();
+
+      if (fileName.length() > 0 && !fileName.endsWith("/")) {
+        fileName = fileName + "/";
+      }
+
+      if (fileName.length() > 1 && children.length == 0) {
+        zipOut.putNextEntry(new ZipEntry(fileName));
+        zipOut.closeEntry();
+      }
+
+      for (File childFile : children) {
+        zipFile(childFile, fileName + childFile.getName(), zipOut, false);
+      }
+      return;
+    }
+
+    try (FileInputStream fis = new FileInputStream(fileToZip)) {
+      ZipEntry zipEntry = new ZipEntry(fileName);
+      zipOut.putNextEntry(zipEntry);
+      byte[] bytes = new byte[1024];
+      int length;
+      while ((length = fis.read(bytes)) >= 0) {
+        zipOut.write(bytes, 0, length);
+      }
+    }
+  }
+
+  private static File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
+    File destFile = new File(destinationDir, zipEntry.getName());
+
+    String destDirPath = destinationDir.getCanonicalPath();
+    String destFilePath = destFile.getCanonicalPath();
+
+    if (!destFilePath.startsWith(destDirPath + File.separator)) {
+      throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+    }
+
+    return destFile;
   }
 
   /*
@@ -435,6 +781,7 @@ public class PersistenceUtil {
     return new File(AppUtil.getAppHome("campaignthumbs"), fileName + ".jpg");
   }
 
+  @SuppressWarnings("unchecked")
   public static PersistedCampaign loadCampaign(File campaignFile) throws IOException {
     PersistedCampaign persistedCampaign = null;
 
@@ -453,7 +800,208 @@ public class PersistenceUtil {
       campaignVersion = campaignVersion == null ? "1.3.50" : campaignVersion;
 
       try {
-        persistedCampaign = (PersistedCampaign) pakFile.getContent(campaignVersion);
+        if (!pakFile.hasFile("campaignProperties.xml")) {
+          // pre 1.5.1 way to save/load a file with on content.xml
+          persistedCampaign =
+              (PersistedCampaign) pakFile.getContent(campaignVersion, PackedFile.CONTENT_FILE);
+        } else {
+          // load campaign as a directory structure
+          persistedCampaign = new PersistedCampaign();
+
+          // load the campaign properties files.
+          persistedCampaign.assetMap =
+              (Map<MD5Key, Asset>) pakFile.getContent(campaignVersion, "assetMap.xml");
+          persistedCampaign.currentView =
+              (Scale) pakFile.getContent(campaignVersion, "currentView.xml");
+          CampaignProperties campaignProperties =
+              (CampaignProperties) pakFile.getContent(campaignVersion, "campaignProperties.xml");
+          Map<String, String> characterSheets =
+              (Map<String, String>) pakFile.getContent(campaignVersion, "characterSheets.xml");
+          campaignProperties.setCharacterSheets(characterSheets);
+          CampaignWrapper campaignWrapper =
+              (CampaignWrapper) pakFile.getContent(campaignVersion, "campaign.xml");
+
+          Map<String, String> guids = new HashMap<>();
+
+          // load tables
+          if (campaignProperties.getLookupTableMap().isEmpty()) {
+            // load tables if they were not part of the properties file
+            // which they shouldn't be. but could have been while migrating in test phase.
+            Map<String, LookupTable> lookupTableMap = new HashMap<String, LookupTable>();
+            for (String potentialFile : pakFile.getPaths()) {
+              String fileName = getFileName(potentialFile);
+              String filePath = getPath(potentialFile);
+              if (filePath.startsWith(joinFilePaths(TABLES_DIRECTORY))
+                  && fileName.startsWith(TABLE_FILE_PREFIX)
+                  && fileName.endsWith(TABLE_FILE_SUFFIX)) {
+                String tableFile = removeLeadingSlash(potentialFile);
+                // we add it dynamically
+                LookupTable lookupTable =
+                    (LookupTable) pakFile.getContent(campaignVersion, tableFile);
+                lookupTableMap.put(lookupTable.getName(), lookupTable);
+              }
+            }
+            campaignProperties.setLookupTableMap(lookupTableMap);
+          }
+
+          // load the campaign macros
+          ArrayList<MacroButtonProperties> macroButtonPropertiesList =
+              new ArrayList<MacroButtonProperties>();
+          List<String> definedMacroFiles = new LinkedList<>();
+          if (campaignWrapper.macroFiles != null) {
+            // check for macros that are configured in campaign save file
+            for (MacroFileWrapper macroFileWrapper : campaignWrapper.macroFiles) {
+              String macroFile = removeLeadingSlash(macroFileWrapper.macroFile);
+              String macroContentFile = changeFileEndingTo(macroFile, MTSCRIPT_FILE_SUFFIX);
+              // make sure file was not removed
+              if (pakFile.hasFile(macroFile)) {
+                MacroButtonProperties macroButtonProperties =
+                    (MacroButtonProperties) pakFile.getContent(campaignVersion, macroFile);
+                loadMacroContentFile(
+                    pakFile, campaignVersion, macroContentFile, macroButtonProperties);
+                macroButtonProperties.setIndex(macroFileWrapper.index);
+                macroButtonProperties.setSaveLocation(macroFileWrapper.saveLocation);
+                macroButtonPropertiesList.add(macroButtonProperties);
+                definedMacroFiles.add(macroFile);
+                checkIDs(guids, macroButtonProperties, macroFile);
+              } else {
+                // just ignore not found file and show message
+                MapTool.addLocalMessage(
+                    I18N.getText("PersistenceUtil.warn.fileNotFound", macroFile));
+              }
+            }
+          }
+          // check for macro files that are added to directories but not in campaign file
+          for (String potentialFile : pakFile.getPaths()) {
+            String fileName = getFileName(potentialFile);
+            String filePath = getPath(potentialFile);
+            if (filePath.startsWith(joinFilePaths(MACROS_DIRECTORY))
+                && fileName.startsWith(MACRO_FILE_PREFIX)
+                && fileName.endsWith(MACRO_FILE_SUFFIX)) {
+              String macroFile = removeLeadingSlash(potentialFile);
+              String macroContentFile = changeFileEndingTo(macroFile, MTSCRIPT_FILE_SUFFIX);
+              if (!definedMacroFiles.contains(macroFile)) {
+                // it's a new file not in the campaign xml yet
+                // we add it dynamically
+                MacroButtonProperties macroButtonProperties =
+                    (MacroButtonProperties) pakFile.getContent(campaignVersion, macroFile);
+                loadMacroContentFile(
+                    pakFile, campaignVersion, macroContentFile, macroButtonProperties);
+                campaignWrapper.macroButtonLastIndex++;
+                macroButtonProperties.setIndex(campaignWrapper.macroButtonLastIndex);
+                macroButtonPropertiesList.add(macroButtonProperties);
+                checkIDs(guids, macroButtonProperties, macroFile);
+              }
+            }
+          }
+
+          // load zones dynamically from zones directory
+          Map<GUID, Zone> zones = Collections.synchronizedMap(new LinkedHashMap<GUID, Zone>());
+          for (String potentialFile : pakFile.getPaths()) {
+            String fileName = getFileName(potentialFile);
+            String filePath = getPath(potentialFile);
+            if (filePath.startsWith(joinFilePaths(ZONES_DIRECTORY))
+                && fileName.startsWith(ZONE_FILE_PREFIX)
+                && fileName.endsWith(ZONE_FILE_SUFFIX)) {
+
+              String zoneFile = potentialFile;
+              ZoneWrapper zoneWrapper =
+                  (ZoneWrapper) pakFile.getContent(campaignVersion, removeLeadingSlash(zoneFile));
+              Zone zone = zoneWrapper.zone;
+              checkIDs(guids, zone, zoneFile);
+              zones.put(zone.getId(), zone);
+
+              String zoneDirectory = filePath;
+
+              // load token dynamically if there are token files
+              for (String potentialTokenFile : pakFile.getPaths()) {
+                String fileNameToken = getFileName(potentialTokenFile);
+                String filePathToken = getPath(potentialTokenFile);
+                if (potentialTokenFile.contains("tok")) {
+                  System.out.println(potentialFile);
+                }
+                if (filePathToken.startsWith(joinFilePaths(zoneDirectory, TOKENS_DIRECTORY))
+                    && fileNameToken.startsWith(TOKEN_FILE_PREFIX)
+                    && fileNameToken.endsWith(TOKEN_FILE_SUFFIX)) {
+                  String tokenFile = potentialTokenFile;
+                  String tokenDirectory = filePathToken;
+
+                  TokenWrapper tokenWrapper =
+                      (TokenWrapper)
+                          pakFile.getContent(campaignVersion, removeLeadingSlash(tokenFile));
+                  Token token = tokenWrapper.token;
+                  checkIDs(guids, token, tokenFile);
+                  List<MacroFileWrapper> tokenMacroFiles = tokenWrapper.macroFiles;
+                  zone.putToken(token);
+
+                  // check for macros defined in token file
+                  List<String> definedTokenMacroFiles = new LinkedList<>();
+                  List<MacroButtonProperties> macroPropertiesList = new LinkedList<>();
+                  for (MacroFileWrapper tokenMacroFileWrapper : tokenMacroFiles) {
+                    String macroFile = removeLeadingSlash(tokenMacroFileWrapper.macroFile);
+                    String macroContentFile = changeFileEndingTo(macroFile, MTSCRIPT_FILE_SUFFIX);
+                    // make sure file was not removed
+                    if (pakFile.hasFile(macroFile)) {
+                      MacroButtonProperties macroButtonProperties =
+                          (MacroButtonProperties) pakFile.getContent(campaignVersion, macroFile);
+                      loadMacroContentFile(
+                          pakFile, campaignVersion, macroContentFile, macroButtonProperties);
+                      macroButtonProperties.setIndex(tokenMacroFileWrapper.index);
+                      macroButtonProperties.setSaveLocation(tokenMacroFileWrapper.saveLocation);
+                      checkIDs(guids, macroButtonProperties, macroFile);
+                      macroPropertiesList.add(macroButtonProperties);
+                      definedTokenMacroFiles.add(macroFile);
+                    } else {
+                      // just ignore non found file and show message
+                      MapTool.addLocalMessage(
+                          I18N.getText("PersistenceUtil.warn.fileNotFound", macroContentFile));
+                    }
+                  }
+
+                  // check dynamically for macro files that are under token directory but
+                  // not defined in token
+                  for (String potentialTokenMacroFile : pakFile.getPaths()) {
+                    String fileNameTokenMacro = getFileName(potentialFile);
+                    String filePathTokenMacro = getPath(potentialFile);
+                    if (filePathTokenMacro.startsWith(
+                            joinFilePaths(tokenDirectory, MACROS_DIRECTORY))
+                        && fileNameTokenMacro.startsWith(MACRO_FILE_PREFIX)
+                        && fileNameTokenMacro.endsWith(MACRO_FILE_SUFFIX)
+                        && !definedTokenMacroFiles.contains(potentialTokenMacroFile)) {
+                      String macroFile = removeLeadingSlash(potentialTokenMacroFile);
+                      String macroContentFile = changeFileEndingTo(macroFile, MTSCRIPT_FILE_SUFFIX);
+                      MacroButtonProperties macroButtonProperties =
+                          (MacroButtonProperties) pakFile.getContent(campaignVersion, macroFile);
+                      loadMacroContentFile(
+                          pakFile, campaignVersion, macroContentFile, macroButtonProperties);
+                      checkIDs(guids, macroButtonProperties, macroFile);
+                      macroPropertiesList.add(macroButtonProperties);
+                    }
+                  }
+
+                  token.replaceMacroList(macroPropertiesList);
+                  zone.fixZOrder();
+                }
+              }
+            }
+          }
+
+          Campaign campaign =
+              new Campaign(
+                  campaignWrapper.id,
+                  campaignProperties,
+                  campaignWrapper.exportSettings,
+                  campaignWrapper.exportLocation,
+                  campaignWrapper.hasUsedFogToolbar,
+                  campaignWrapper.macroButtonLastIndex,
+                  macroButtonPropertiesList,
+                  zones);
+          persistedCampaign.campaign = campaign;
+          persistedCampaign.mapToolVersion = campaignWrapper.mapToolVersion;
+          persistedCampaign.currentZoneId = campaignWrapper.currentZoneId;
+          //          persistedCampaign = (PersistedCampaign) pakFile.getContent(campaignVersion,
+          // PackedFile.CONTENT_FILE);
+        }
       } catch (ConversionException ce) {
         // Ignore the exception and check for "campaign == null" below...
         MapTool.showError("PersistenceUtil.error.campaignVersion", ce);
@@ -503,6 +1051,162 @@ public class PersistenceUtil {
 
     if (persistedCampaign == null) {
       MapTool.showWarning("PersistenceUtil.warn.campaignNotLoaded");
+    }
+    return persistedCampaign;
+  }
+
+  private static String getPath(String fileName) {
+    if (fileName == null || !fileName.contains("/")) {
+      return "/";
+    }
+
+    return fileName.substring(0, fileName.lastIndexOf("/") + 1);
+  }
+
+  private static String getFileName(String fileNameWithPath) {
+    if (fileNameWithPath == null || !fileNameWithPath.contains("/")) {
+      return fileNameWithPath;
+    }
+
+    return fileNameWithPath.substring(fileNameWithPath.lastIndexOf("/") + 1);
+  }
+
+  private static void loadMacroContentFile(
+      PackedFile pakFile,
+      String campaignVersion,
+      String macroContentFile,
+      MacroButtonProperties macroButtonProperties)
+      throws IOException {
+    if (pakFile.hasFile(macroContentFile)) {
+      String content = pakFile.getContentAsString(campaignVersion, macroContentFile);
+      macroButtonProperties.setCommand(content);
+    } else {
+      // just ignore non found file and show message
+      macroButtonProperties.setCommand("");
+      MapTool.addLocalMessage(I18N.getText("PersistenceUtil.warn.fileNotFound", macroContentFile));
+    }
+  }
+
+  private static void showIdWarning(
+      String fileName, String originalFileName, String id, String newId) {
+    if (id == null) {
+      MapTool.addLocalMessage(I18N.getText("PersistenceUtil.warn.noID", fileName, newId));
+    } else {
+      MapTool.addLocalMessage(
+          I18N.getText("PersistenceUtil.warn.duplicateID", fileName, originalFileName, id, newId));
+    }
+  }
+
+  private static void showIdWarning(String fileName, String originalFileName, GUID id, GUID newId) {
+    String idAsString = (id == null) ? null : id.toString();
+    String newIdAsString = (newId == null) ? null : newId.toString();
+    showIdWarning(fileName, originalFileName, idAsString, newIdAsString);
+  }
+
+  /**
+   * This checks if the ID might be a duplicate or not even set. If that is the case it generates a
+   * new ID.
+   *
+   * @param ids
+   * @param macroButtonProperties
+   * @param fileName
+   */
+  private static void checkIDs(
+      Map<String, String> ids, MacroButtonProperties macroButtonProperties, String fileName) {
+    String id = macroButtonProperties.getMacroUUID();
+    while (id == null || ids.containsKey(id)) {
+      String newId = macroButtonProperties.resetMacroUUID();
+      if (id == null) {
+        showIdWarning(fileName, null, id, newId);
+      } else {
+        showIdWarning(fileName, ids.get(id), id, newId);
+      }
+      id = newId;
+    }
+    ids.put(id, fileName);
+  }
+
+  /**
+   * This checks if the ID might be a duplicate or not even set. If that is the case it generates a
+   * new ID.
+   *
+   * @param ids
+   * @param macroButtonProperties
+   * @param fileName
+   */
+  private static void checkIDs(Map<String, String> ids, Zone zone, String fileName) {
+    GUID id = zone.getId();
+    while (id == null || ids.containsKey(id.toString())) {
+      GUID newId = zone.resetId();
+      if (id == null) {
+        showIdWarning(fileName, null, id, newId);
+      } else {
+        showIdWarning(fileName, ids.get(id.toString()), id, newId);
+      }
+      id = newId;
+    }
+    ids.put(id.toString(), fileName);
+  }
+
+  /**
+   * This checks if the ID might be a duplicate or not even set. If that is the case it generates a
+   * new ID.
+   *
+   * @param ids
+   * @param macroButtonProperties
+   * @param fileName
+   */
+  private static void checkIDs(Map<String, String> ids, Token token, String fileName) {
+    GUID id = token.getId();
+    while (id == null || ids.containsKey(id.toString())) {
+      GUID newId = token.resetId();
+      if (id == null) {
+        showIdWarning(fileName, null, id, newId);
+      } else {
+        showIdWarning(fileName, ids.get(id.toString()), id, newId);
+      }
+      id = newId;
+    }
+    ids.put(id.toString(), fileName);
+  }
+
+  public static PersistedCampaign loadLegacyCampaign(File campaignFile) {
+    HessianInput his = null;
+    PersistedCampaign persistedCampaign = null;
+    try {
+      InputStream is = new BufferedInputStream(new FileInputStream(campaignFile));
+      his = new HessianInput(is);
+      persistedCampaign = (PersistedCampaign) his.readObject(null);
+
+      for (MD5Key key : persistedCampaign.assetMap.keySet()) {
+        Asset asset = persistedCampaign.assetMap.get(key);
+        if (!AssetManager.hasAsset(key)) AssetManager.putAsset(asset);
+        if (!MapTool.isHostingServer() && !MapTool.isPersonalServer()) {
+          // If we are remotely installing this campaign, we'll need to
+          // send the image data to the server
+          MapTool.serverCommand().putAsset(asset);
+        }
+      }
+      // Do some sanity work on the campaign
+      // This specifically handles the case when the zone mappings
+      // are out of sync in the save file
+      Campaign campaign = persistedCampaign.campaign;
+      Set<Zone> zoneSet = new HashSet<Zone>(campaign.getZones());
+      campaign.removeAllZones();
+      for (Zone zone : zoneSet) {
+        campaign.putZone(zone);
+      }
+    } catch (FileNotFoundException fnfe) {
+      if (log.isInfoEnabled()) log.info("Campaign file not found -- this can't happen?!", fnfe);
+      persistedCampaign = null;
+    } catch (IOException ioe) {
+      if (log.isInfoEnabled()) log.info("Campaign is not in legacy Hessian format either.", ioe);
+      persistedCampaign = null;
+    } finally {
+      try {
+        his.close();
+      } catch (Exception e) {
+      }
     }
     return persistedCampaign;
   }
@@ -580,7 +1284,7 @@ public class PersistenceUtil {
       String progVersion = (String) pakFile.getProperty(PROP_VERSION);
       if (!versionCheck(progVersion)) return null;
 
-      token = (Token) pakFile.getContent(progVersion);
+      token = (Token) pakFile.getContent(progVersion, PackedFile.CONTENT_FILE);
       loadAssets(token.getAllImageAssets(), pakFile);
     } catch (ConversionException ce) {
       MapTool.showError("PersistenceUtil.error.tokenVersion", ce);
@@ -868,7 +1572,7 @@ public class PersistenceUtil {
       if (!versionCheck(progVersion)) return null;
       CampaignProperties props = null;
       try {
-        props = (CampaignProperties) pakFile.getContent();
+        props = (CampaignProperties) pakFile.getContent(PackedFile.CONTENT_FILE);
         loadAssets(props.getAllImageAssets(), pakFile);
       } catch (ConversionException ce) {
         MapTool.showError(I18N.getText("PersistenceUtil.error.campaignPropertiesVersion"), ce);
@@ -938,7 +1642,7 @@ public class PersistenceUtil {
       String progVersion = (String) pakFile.getProperty(PROP_VERSION);
       if (!versionCheck(progVersion)) return null;
 
-      return asMacro(pakFile.getContent());
+      return asMacro(pakFile.getContent(PackedFile.CONTENT_FILE));
     } catch (IOException e) {
       return loadLegacyMacro(file);
     }
@@ -1034,7 +1738,7 @@ public class PersistenceUtil {
         String progVersion = (String) pakFile.getProperty(PROP_VERSION);
         if (!versionCheck(progVersion)) return null;
 
-        macroButtonSet = asMacroSet(pakFile.getContent());
+        macroButtonSet = asMacroSet(pakFile.getContent(PackedFile.CONTENT_FILE));
       } catch (ConversionException ce) {
         MapTool.showError("PersistenceUtil.error.macrosetVersion", ce);
       }
@@ -1090,7 +1794,7 @@ public class PersistenceUtil {
         String progVersion = (String) pakFile.getProperty(PROP_VERSION);
         if (!versionCheck(progVersion)) return null;
 
-        LookupTable lookupTable = (LookupTable) pakFile.getContent();
+        LookupTable lookupTable = (LookupTable) pakFile.getContent(PackedFile.CONTENT_FILE);
         loadAssets(lookupTable.getAllAssetIds(), pakFile);
         return lookupTable;
       } catch (ConversionException ce) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1502,7 +1502,7 @@ experiments.listTitle   = Experimental Features (use at own risk).
 # Filename extension descriptions
 # (These should be more consistent. Maybe in 1.4. Sigh.)
 file.ext.cmpgn    = MapTool Campaign
-file.ext.cmpgnDirectory = MapTool Campaign Directory
+file.ext.cmpgnDirectory=(Experimental) MapTool Campaign Directory
 file.ext.mtmacro  = MapTool Macro
 file.ext.mtmacset = MapTool Macro Set
 file.ext.mtprops  = MapTool Campaign Properties

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -685,6 +685,9 @@ PreferencesDialog.themeChangeWarningTitle         = Theme Change.
 Preferences.combo.themes.filter.all               = All
 Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
+PersistenceUtil.warn.duplicateID                = Dupicate ID "{2}" found in "{0}", already mentioned in "{1}". Regenerated new ID: "{3}".
+PersistenceUtil.warn.fileNotFound               = Ignoring file "{0}" as it cannot be found.
+PersistenceUtil.warn.noID                       = No ID found in file "{0}", regenerated new ID: "{1}".
 
 ServerDialog.error.port                = You must enter a numeric port.
 ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
@@ -1499,6 +1502,7 @@ experiments.listTitle   = Experimental Features (use at own risk).
 # Filename extension descriptions
 # (These should be more consistent. Maybe in 1.4. Sigh.)
 file.ext.cmpgn    = MapTool Campaign
+file.ext.cmpgnDirectory = MapTool Campaign Directory
 file.ext.mtmacro  = MapTool Macro
 file.ext.mtmacset = MapTool Macro Set
 file.ext.mtprops  = MapTool Campaign Properties
@@ -2135,7 +2139,7 @@ msg.title.importProperties                    = Import Properties
 msg.title.loadAssetTree                       = Load Asset Tree
 msg.title.loadCampaign                        = Load Campaign
 msg.autosave.wait                             = Waiting up to {0} seconds for autosave to finish...
-# I'm trying to add some consistency to the property names.  So... 
+# I'm trying to add some consistency to the property names.  So...
 # "msg.title.*" are strings used as the titles of dialogs and frames
 # created by the application.
 msg.title.loadMap                             = Load Map


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #102

### Description of the Change
Since #102 is still a wanted feature I brought the campaign-dir branch up to date.

I made sure that one can only save as a directory and load from it if the file filter was selected. 
The name of the filter contains "(Experimental)" so users should be warned.

I only merged an made it work. So lets all look over this and decide if we want this merged,
if we want changes, or if we scrap it and delete the branch and close the issue.

### Possible Drawbacks
Saving and loading doesn't work any more.

### Release Notes
- added experimental feature to store campaigns as a directory instead of a file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/maptool/3801)
<!-- Reviewable:end -->
