### PR TITLE
Remove extra vision transform that is no longer needed in VisibilityInspector

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityInspector.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityInspector.java
@@ -147,7 +147,6 @@ public class VisibilityInspector extends JPanel {
             pitVblTree);
 
     final var obstructedVision = new Area(unobstructedVision);
-    obstructedVision.transform(AffineTransform.getTranslateInstance(point.getX(), point.getY()));
 
     g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .5f));
     if (vision != null) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Relates to #3747, fixes a bug in PR #3813

### Description of the Change

With the recent change to `FogUtil.calculateVisibility()` no longer transforming the vision areas, `VisibilityInspector` was not correctly updated to handle those changes. The obstructed vision was still being transformed after calling `FogUtil.calculateVisibility()` despite being created from an area that was already transformed.

### Possible Drawbacks

None. Applies to the VisibilityInspector not part of MapTool proper.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3820)
<!-- Reviewable:end -->
