### PR TITLE
Include temporary token light sources

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -455,6 +455,13 @@ public class ZoneView {
         illuminationKey, key -> getUpToDateIlluminator(key).getIllumination());
   }
 
+  /**
+   * Add personal lights and daylight for a token, as well as any normal lights if the token is
+   * temporary.
+   *
+   * @param token
+   * @return All extra light contributions to be made for this token.
+   */
   private @Nonnull List<ContributedLight> getPersonalTokenContributions(Token token) {
     if (!token.getHasSight()) {
       return Collections.emptyList();
@@ -475,6 +482,14 @@ public class ZoneView {
         final var contributedLight = ContributedLight.forDaylight(tokenVisibleArea);
         // Treat the entire visible area like a light source of minimal lumens.
         personalLights.add(contributedLight);
+      }
+
+      if (token.hasLightSources()
+          && !lightSourceMap
+              .getOrDefault(LightSource.Type.NORMAL, Collections.emptySet())
+              .contains(token.getId())) {
+        // This accounts for temporary tokens (such as during an Expose Last Path)
+        personalLights.addAll(calculateLitAreas(token, sight.getMultiplier()));
       }
 
       if (sight.hasPersonalLightSource()) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes problem with #3747 added in #3813

### Description of the Change

In PR #3813, some special logic was missed for including light sources for temporary tokens, which are used for the Expose Last Path operation. This PR adds in the equivalent logic for the new lighting.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3830)
<!-- Reviewable:end -->
