### PR TITLE
Fix Mapper.map(Dimension) to set the width as the X value rather than Y

### DIFF
--- a/src/main/java/net/rptools/maptool/server/Mapper.java
+++ b/src/main/java/net/rptools/maptool/server/Mapper.java
@@ -324,7 +324,7 @@ public class Mapper {
   }
 
   public static IntPointDto map(Dimension d) {
-    return IntPointDto.newBuilder().setY(d.width).setY(d.height).build();
+    return IntPointDto.newBuilder().setX(d.width).setY(d.height).build();
   }
 
   public static BasicStroke map(StrokeDto dto) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3838

### Description of the Change

The implementation of `Mapper.map(Dimension)` was calling `setY()` when `setX()` was intended. This fixes that.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where movement overlays would be drawn at the wrong position.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3839)
<!-- Reviewable:end -->
