### PR TITLE
Replace string comparisons with OverlayType enum in Token States

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,9 @@ dependencies {
     // commandline parsing
     implementation 'commons-cli:commons-cli:1.4'
 
+    // needed for preference dialog at runtime
+    implementation 'commons-beanutils:commons-beanutils:1.9.4'
+
     // RPTool Libs
     // default ressources (token, textures etc.)
     implementation 'com.github.RPTools:maptool-resources:1.6.0'

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -475,7 +475,9 @@ public class TokenStatesController
     String text = formPanel.getTextComponent(IMAGE).getText();
     var overlayType = OverlayType.values()[formPanel.getComboBox(TYPE).getSelectedIndex()];
     boolean hasImage =
-            !(overlayType == OverlayType.CornerImage || overlayType == OverlayType.GridImage || overlayType == OverlayType.Image)
+        !(overlayType == OverlayType.CornerImage
+                || overlayType == OverlayType.GridImage
+                || overlayType == OverlayType.Image)
             || text != null && (text = text.trim()).length() != 0;
     text = formPanel.getTextComponent(NAME).getText();
     boolean hasName = text != null && (text = text.trim()).length() != 0;
@@ -721,7 +723,9 @@ public class TokenStatesController
     // Check for overlays that don't use width
     BooleanTokenOverlay to = null;
     if (overlay == OverlayType.Dot) {
-      to = new ColorDotTokenOverlay(name, color, Quadrant.values()[formPanel.getComboBox(CORNER).getSelectedIndex()]);
+      to =
+          new ColorDotTokenOverlay(
+              name, color, Quadrant.values()[formPanel.getComboBox(CORNER).getSelectedIndex()]);
     } else if (overlay == OverlayType.Shaded) {
       to = new ShadedTokenOverlay(name, color);
     } // endif
@@ -783,7 +787,11 @@ public class TokenStatesController
         if (overlay == OverlayType.Image) {
           to = new ImageTokenOverlay(name, assetId);
         } else if (overlay == OverlayType.CornerImage) {
-          to = new CornerImageTokenOverlay(name, assetId, Quadrant.values()[formPanel.getComboBox(CORNER).getSelectedIndex()]);
+          to =
+              new CornerImageTokenOverlay(
+                  name,
+                  assetId,
+                  Quadrant.values()[formPanel.getComboBox(CORNER).getSelectedIndex()]);
         } else if (overlay == OverlayType.GridImage) {
           to = new FlowImageTokenOverlay(name, assetId, grid);
         } // endif

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -215,6 +215,25 @@ public class TokenStatesController
     {true, false, false, true, false, false}, // Flow Square
   };
 
+  private enum OverlayType {
+    Image,
+    CornerImage,
+    GridImage,
+    Dot,
+    GridDot,
+    Circle,
+    Shaded,
+    X,
+    Cross,
+    Diamond,
+    GridDiamond,
+    Yield,
+    GridYield,
+    Triangle,
+    GridTriangle,
+    GridSquare
+  }
+  // the order needs to match the OverlayType enum
   private static final List<String> types =
       List.of(
           "CampaignPropertiesDialog.combo.states.type.image",
@@ -234,6 +253,7 @@ public class TokenStatesController
           "CampaignPropertiesDialog.combo.states.type.gridTriangle",
           "CampaignPropertiesDialog.combo.states.type.gridSquare");
 
+  // the order needs to match the AbstractTemplate.Quadrant enum
   private static final List<String> corners =
       List.of(
           "CampaignPropertiesDialog.combo.states.corner.topRight",
@@ -453,8 +473,9 @@ public class TokenStatesController
   @Override
   public void changedUpdate(DocumentEvent e) {
     String text = formPanel.getTextComponent(IMAGE).getText();
+    var overlayType = OverlayType.values()[formPanel.getComboBox(TYPE).getSelectedIndex()];
     boolean hasImage =
-        !((String) formPanel.getComboBox(TYPE).getSelectedItem()).contains("Image")
+            !(overlayType == OverlayType.CornerImage || overlayType == OverlayType.GridImage || overlayType == OverlayType.Image)
             || text != null && (text = text.trim()).length() != 0;
     text = formPanel.getTextComponent(NAME).getText();
     boolean hasName = text != null && (text = text.trim()).length() != 0;
@@ -517,62 +538,62 @@ public class TokenStatesController
       formPanel.getCheckBox(SHOW_OTHERS).setSelected(s.isShowOthers());
 
       // Get most of the colors and all of the widths from the XTokenOverlay
-      int type = -1;
+      OverlayType type = OverlayType.Image;
       if (s instanceof XTokenOverlay) {
-        type = 7;
+        type = OverlayType.X;
         formPanel.getSpinner(WIDTH).setValue(((XTokenOverlay) s).getWidth());
         ((ColorWell) formPanel.getComponent(COLOR)).setColor(((XTokenOverlay) s).getColor());
       } // endif
 
       // Get the the flow grid for most components from FlowColorDotTokenOverlay
       if (s instanceof FlowColorDotTokenOverlay) {
-        type = 4;
+        type = OverlayType.GridDot;
         int size = ((FlowColorDotTokenOverlay) s).getGrid();
         formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
       } // endif
 
       // Handle the
       if (s instanceof CornerImageTokenOverlay) {
-        type = 1;
+        type = OverlayType.CornerImage;
         formPanel
             .getComboBox(CORNER)
             .setSelectedIndex(((CornerImageTokenOverlay) s).getCorner().ordinal());
       } else if (s instanceof FlowImageTokenOverlay) {
-        type = 2;
+        type = OverlayType.GridImage;
         int size = ((FlowImageTokenOverlay) s).getGrid(); // Still need grid size
         formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
       } else if (s instanceof ImageTokenOverlay) {
-        type = 0;
+        type = OverlayType.Image;
       } else if (s instanceof ColorDotTokenOverlay) {
-        type = 3;
+        type = OverlayType.Dot;
         formPanel
             .getComboBox(CORNER)
             .setSelectedIndex(((ColorDotTokenOverlay) s).getCorner().ordinal());
       } else if (s instanceof OTokenOverlay) {
-        type = 5;
+        type = OverlayType.Circle;
       } else if (s instanceof ShadedTokenOverlay) {
-        type = 6;
+        type = OverlayType.Shaded;
         ((ColorWell) formPanel.getComponent(COLOR)).setColor(((ShadedTokenOverlay) s).getColor());
       } else if (s instanceof CrossTokenOverlay) {
-        type = 8;
+        type = OverlayType.Cross;
       } else if (s instanceof DiamondTokenOverlay) {
-        type = 9;
+        type = OverlayType.Diamond;
       } else if (s instanceof FlowDiamondTokenOverlay) {
-        type = 10;
+        type = OverlayType.GridDiamond;
       } else if (s instanceof YieldTokenOverlay) {
-        type = 11;
+        type = OverlayType.Yield;
       } else if (s instanceof FlowYieldTokenOverlay) {
-        type = 12;
+        type = OverlayType.GridYield;
       } else if (s instanceof TriangleTokenOverlay) {
-        type = 13;
+        type = OverlayType.Triangle;
       } else if (s instanceof FlowTriangleTokenOverlay) {
-        type = 14;
+        type = OverlayType.GridTriangle;
       } else if (s instanceof FlowColorSquareTokenOverlay) {
-        type = 15;
+        type = OverlayType.GridSquare;
       } // endif
 
       // Set the type and change components
-      formPanel.getComboBox(TYPE).setSelectedIndex(type);
+      formPanel.getComboBox(TYPE).setSelectedIndex(type.ordinal());
       enableDataComponents();
     }
   }
@@ -690,7 +711,7 @@ public class TokenStatesController
     String name = formPanel.getTextComponent(NAME).getText();
     String group = formPanel.getTextComponent(GROUP).getText();
     boolean mouseover = formPanel.getCheckBox(MOUSEOVER).isSelected();
-    String overlay = ((String) formPanel.getComboBox(TYPE).getSelectedItem());
+    var overlay = OverlayType.values()[formPanel.getComboBox(TYPE).getSelectedIndex()];
     int opacity = getSpinner(OPACITY, "opacity", formPanel);
     int index = getSpinner(INDEX, "index", formPanel);
     boolean showGM = formPanel.getCheckBox(SHOW_GM).isSelected();
@@ -699,10 +720,9 @@ public class TokenStatesController
 
     // Check for overlays that don't use width
     BooleanTokenOverlay to = null;
-    if (overlay.equals("Dot")) {
-      String cornerName = ((String) formPanel.getComboBox(CORNER).getSelectedItem());
-      to = new ColorDotTokenOverlay(name, color, Quadrant.valueOf(cornerName));
-    } else if (overlay.equals("Shaded")) {
+    if (overlay == OverlayType.Dot) {
+      to = new ColorDotTokenOverlay(name, color, Quadrant.values()[formPanel.getComboBox(CORNER).getSelectedIndex()]);
+    } else if (overlay == OverlayType.Shaded) {
       to = new ShadedTokenOverlay(name, color);
     } // endif
 
@@ -711,19 +731,19 @@ public class TokenStatesController
     if (to == null) {
       String sGrid = (String) formPanel.getSpinner(FLOW_GRID).getValue();
       grid = Integer.parseInt(sGrid.substring(0, 1));
-      if (overlay.equals("Grid Dot")) {
+      if (overlay == OverlayType.GridDot) {
         to = new FlowColorDotTokenOverlay(name, color, grid);
       }
-      if (overlay.equals("Grid Square")) {
+      if (overlay == OverlayType.GridSquare) {
         to = new FlowColorSquareTokenOverlay(name, color, grid);
       }
-      if (overlay.equals("Grid Triangle")) {
+      if (overlay == OverlayType.GridTriangle) {
         to = new FlowTriangleTokenOverlay(name, color, grid);
       }
-      if (overlay.equals("Grid Diamond")) {
+      if (overlay == OverlayType.GridDiamond) {
         to = new FlowDiamondTokenOverlay(name, color, grid);
       }
-      if (overlay.equals("Grid Yield")) {
+      if (overlay == OverlayType.GridYield) {
         to = new FlowYieldTokenOverlay(name, color, grid);
       } // endif
     } // endif
@@ -731,17 +751,17 @@ public class TokenStatesController
     // Handle all of the overlays with width
     if (to == null) {
       int width = getSpinner(WIDTH, "width", formPanel);
-      if (overlay.equals("Circle")) {
+      if (overlay == OverlayType.Circle) {
         to = new OTokenOverlay(name, color, width);
-      } else if (overlay.equals("X")) {
+      } else if (overlay == OverlayType.X) {
         to = new XTokenOverlay(name, color, width);
-      } else if (overlay.equals("Cross")) {
+      } else if (overlay == OverlayType.Cross) {
         to = new CrossTokenOverlay(name, color, width);
-      } else if (overlay.equals("Diamond")) {
+      } else if (overlay == OverlayType.Diamond) {
         to = new DiamondTokenOverlay(name, color, width);
-      } else if (overlay.equals("Yield")) {
+      } else if (overlay == OverlayType.Yield) {
         to = new YieldTokenOverlay(name, color, width);
-      } else if (overlay.equals("Triangle")) {
+      } else if (overlay == OverlayType.Triangle) {
         to = new TriangleTokenOverlay(name, color, width);
       } // endif
     } // endif
@@ -760,12 +780,11 @@ public class TokenStatesController
 
       // Create all of the image overlays
       if (assetId != null) {
-        if (overlay.equals("Image")) {
+        if (overlay == OverlayType.Image) {
           to = new ImageTokenOverlay(name, assetId);
-        } else if (overlay.equals("Corner Image")) {
-          String cornerName = ((String) formPanel.getComboBox(CORNER).getSelectedItem());
-          to = new CornerImageTokenOverlay(name, assetId, Quadrant.valueOf(cornerName));
-        } else if (overlay.equals("Grid Image")) {
+        } else if (overlay == OverlayType.CornerImage) {
+          to = new CornerImageTokenOverlay(name, assetId, Quadrant.values()[formPanel.getComboBox(CORNER).getSelectedIndex()]);
+        } else if (overlay == OverlayType.GridImage) {
           to = new FlowImageTokenOverlay(name, assetId, grid);
         } // endif
       } // endif


### PR DESCRIPTION
### Identify the Bug or Feature request
Fix #3844


### Description of the Change
Replace string comparison with a proper OverlayType enum. 


### Release Notes

- Fixed Bug that made it impossible to change state definions in languages other than en.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3846)
<!-- Reviewable:end -->
