### PR TITLE
When copying a campaign, keep the campaign and zone IDs

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -167,6 +167,7 @@ public class Campaign {
    * @param campaign The campaign to copy from.
    */
   public Campaign(Campaign campaign) {
+    id = campaign.getId();
     name = campaign.getName();
 
     /*

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -444,6 +444,10 @@ public class Zone {
    * @param keepIds Should the token ids stay the same.
    */
   public Zone(Zone zone, boolean keepIds) {
+    if (keepIds) {
+      this.id = zone.getId();
+    }
+
     backgroundPaint = zone.backgroundPaint;
     mapAsset = zone.mapAsset;
     fogPaint = zone.fogPaint;


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3781

### Description of the Change

Copying `Campaign` objects (e.g., by starting a server) will now copy the campaign ID and each zone's ID. The `Zone` constructor conditionally copies the ID based on the existing `keepIds` parameter.

Explicit copy actions will still result in new maps being given new IDs.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

- Fixed an issue where map and campaign IDs would change whenever a server is started.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3847)
<!-- Reviewable:end -->
