### PR TITLE
Fix google-java-format invocation

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: "17"
       - uses: axel-op/googlejavaformat-action@v3
         with:
-          args: "--dry-run --skip-sorting-imports --replace"
+          args: "--dry-run --skip-sorting-imports"
   build:
     name: ${{ matrix.os }} w/JDK ${{ matrix.java }}
     runs-on:  ${{ matrix.os }}


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3848

### Description of the Change

The `--replace` flags has been removed so that there is no longer a conflict with `--dry-run`.

I would have liked to also add `--set-exit-if-changed` so that the build would fail on formatting violations, but the google-java-format requirements differ from the spotless requirements, so we can't have both at the moment.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3849)
<!-- Reviewable:end -->
