### PR TITLE
Refactor/3854 spotless for verification

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -20,13 +20,14 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
         with:
           java-version: "17"
-      - uses: axel-op/googlejavaformat-action@v3
-        with:
-          args: "--dry-run --skip-sorting-imports"
+      - name: spotlessCheck
+        run: ./gradlew spotlessCheck
   build:
     name: ${{ matrix.os }} w/JDK ${{ matrix.java }}
     runs-on:  ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 plugins {
     id "application"
     id "org.ajoberstar.grgit" version "4.1.1"
-    id "com.diffplug.spotless" version "5.14.3"
+    id "com.diffplug.spotless" version "6.16.0"
     id 'org.openjfx.javafxplugin' version '0.0.13'
     id 'org.beryx.runtime' version '1.12.7'
     id "com.google.protobuf" version "0.8.19"
@@ -105,7 +105,7 @@ spotless {
         toggleOffOn()
 
         // Now using the Google Java style guide
-        googleJavaFormat()
+        googleJavaFormat("1.11.0")
     }
 
     format 'misc', {


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #3854

### Description of the Change

The googlejavaformat action is removed from the formatting PR verification step in favour of running `spotlessCheck`. If the check fails, the PR verification will fail.

I've also updated the spotless gradle plugin to the current latest version (6.16.0) while leaving the backend version of google-java-format where it was to avoid distracting formatting changes.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3855)
<!-- Reviewable:end -->
