### PR TITLE
htmlize notes from previous MT versions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -2035,8 +2035,13 @@ public class PointerTool extends DefaultTool {
     var notes = marker.getNotes();
     var gmNotes = marker.getGMNotes();
 
-    boolean showGMNotes = MapTool.getPlayer().isGM() && !StringUtil.isEmpty(gmNotes);
-    boolean showNotes = !StringUtil.isEmpty(notes);
+    var notesWithoutTags =
+        Optional.ofNullable(notes).map(s -> s.replaceAll("<[^>]*>", "")).orElse(null);
+    var gmNotesWithoutTags =
+        Optional.ofNullable(gmNotes).map(s -> s.replaceAll("<[^>]*>", "")).orElse(null);
+
+    boolean showGMNotes = MapTool.getPlayer().isGM() && !StringUtil.isEmpty(gmNotesWithoutTags);
+    boolean showNotes = !StringUtil.isEmpty(notesWithoutTags);
 
     StringBuilder builder = new StringBuilder();
 
@@ -2053,9 +2058,6 @@ public class PointerTool extends DefaultTool {
       builder.append("</span></b><br>");
     }
     if (showNotes) {
-      if (!notes.startsWith("<html")) {
-        notes = notes.replaceAll("\n", "<br>");
-      }
       if (showGMNotes) {
         notes = notes.replaceAll("</html>", "");
         notes = notes.replaceAll("</body>", "");
@@ -2071,9 +2073,6 @@ public class PointerTool extends DefaultTool {
         builder.append("<b><span class='title'>GM Notes</span></b><br>");
         gmNotes = gmNotes.replaceAll("<html[^>]*>", "");
         gmNotes = gmNotes.replaceAll("<body[^>]*>", "");
-      }
-      if (!gmNotes.startsWith("<html")) {
-        gmNotes = gmNotes.replaceAll("\n", "<br>");
       }
       builder.append(gmNotes);
     }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -609,7 +609,7 @@ public class Token implements Cloneable {
 
   public String getGMNotes() {
     if (MapTool.getPlayer().isGM() || MapTool.getParser().isMacroTrusted()) {
-      return gmNotes;
+      return toHtml(gmNotes);
     } else {
       return "";
     }
@@ -2048,7 +2048,22 @@ public class Token implements Cloneable {
 
   /** @return Getter for notes */
   public String getNotes() {
-    return notes;
+    return toHtml(notes);
+  }
+
+  /** convert string to html */
+  private String toHtml(String input) {
+    if (input != null && !input.startsWith("<html")) {
+      input = input.replaceAll("\n\n", "<p>");
+      input = input.replaceAll("\n", "\n<br>\n");
+      return "<html dir=\"ltr\">\n"
+          + " <head></head>\n"
+          + " <body contenteditable=\"true\">\n"
+          + input
+          + " </body>\n"
+          + "</html>";
+    }
+    return input;
   }
 
   /** @param aNotes Setter for notes */


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #3814


### Description of the Change
Replaces plain text notes from tokens with html versions to keep linebreaks.
Don't interpret empty html as content to display in hovernote.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3859)
<!-- Reviewable:end -->
