### PR TITLE
Fixes #3259

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -407,6 +407,7 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'		// https://mvnrepository.com/artifact/com.google.code.gson/gson
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
     // For mocking features during unit tests

--- a/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroLinkFunction.java
@@ -18,17 +18,19 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import java.awt.EventQueue;
+import java.awt.*;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
-import net.rptools.maptool.client.functions.exceptions.*;
+import net.rptools.maptool.client.functions.exceptions.AbortFunctionException;
+import net.rptools.maptool.client.functions.exceptions.AssertFunctionException;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.ui.commandpanel.CommandPanel;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
@@ -64,8 +66,18 @@ public class MacroLinkFunction extends AbstractFunction {
   /** Singleton instance of the MacroLinkFunction class. */
   private static final MacroLinkFunction instance = new MacroLinkFunction();
 
-  private static final Pattern AUTOEXEC_PATTERN =
-      Pattern.compile("([^:]*)://([^/]*)/([^/]*)/([^?]*)(?:\\?(.*))?");
+  /** Moving all the patterns together to ensure that we don't forget any */
+  static final Pattern AUTOEXEC_PATTERN =
+      Pattern.compile("([^:]*)://(.*)/([^/]*)/([^?]*)(?:\\?(.*))?");
+
+  static final Pattern TOOLTIP_PATTERN =
+      Pattern.compile("([^:]*)://(.*)/([^/]*)/([^?]*)(?:\\?(.*))?");
+  /** Pattern to distinguish a link (group 1) from its data (group 2). */
+  public static final Pattern LINK_DATA_PATTERN =
+      Pattern.compile("((?s)[^:]*://.*/[^/]*/[^?]*\\?)(.*)?");
+
+  static final Pattern MACROLINK_PATTERN =
+      Pattern.compile("(?s)([^:]*)://(.*)/([^/]*)/([^?]*)(?:\\?(.*))?");
 
   /**
    * Gets and instance of the MacroLinkFunction class.
@@ -278,10 +290,6 @@ public class MacroLinkFunction extends AbstractFunction {
     return args.toString();
   }
 
-  /** Pattern to distinguish a link (group 1) from its data (group 2). */
-  public static final Pattern LINK_DATA_PATTERN =
-      Pattern.compile("((?s)[^:]*://[^/]*/[^/]*/[^?]*\\?)(.*)?");
-
   /**
    * Returns the link data as a json element.
    *
@@ -300,9 +308,6 @@ public class MacroLinkFunction extends AbstractFunction {
       return JSONMacroFunctions.getInstance().asJsonElement(decodedLinkData);
     }
   }
-
-  private static final Pattern TOOLTIP_PATTERN =
-      Pattern.compile("([^:]*)://([^/]*)/([^/]*)/([^?]*)(?:\\?(.*))?");
 
   /**
    * Gets a string that describes the macro link.
@@ -376,9 +381,6 @@ public class MacroLinkFunction extends AbstractFunction {
     runMacroLink(link, false);
   }
 
-  private static final Pattern macroLink =
-      Pattern.compile("(?s)([^:]*)://([^/]*)/([^/]*)/([^?]*)(?:\\?(.*))?");
-
   /**
    * Runs the macro specified by the link.
    *
@@ -390,7 +392,7 @@ public class MacroLinkFunction extends AbstractFunction {
     if (link == null || link.length() == 0) {
       return;
     }
-    Matcher m = macroLink.matcher(link);
+    Matcher m = MACROLINK_PATTERN.matcher(link);
 
     if (m.matches() && m.group(1).equalsIgnoreCase("macro")) {
       OutputTo outputTo;

--- a/src/main/resources/net/rptools/maptool/client/functions/linkDataCases.csv
+++ b/src/main/resources/net/rptools/maptool/client/functions/linkDataCases.csv
@@ -1,0 +1,5 @@
+caseName,macro,link,data
+no slashes in macro name,macro://jukebox_playAllClient@lib:bizland5e/all/Impersonated?281_Escape_from_Shadow.mp3,macro://jukebox_playAllClient@lib:bizland5e/all/Impersonated?,281_Escape_from_Shadow.mp3
+slashes in macro name,macro://jukebox/playAllClient@lib:bizland5e/all/Impersonated?281_Escape_from_Shadow.mp3,macro://jukebox/playAllClient@lib:bizland5e/all/Impersonated?,281_Escape_from_Shadow.mp3
+spaces before the protocol, macro://macroName@lib:token/all/Impersonated?val,macro://macroName@lib:token/all/Impersonated?,val
+minimal match,:////?,:////?,""

--- a/src/main/resources/net/rptools/maptool/client/functions/macroURLCases.csv
+++ b/src/main/resources/net/rptools/maptool/client/functions/macroURLCases.csv
@@ -1,0 +1,5 @@
+caseName,macroLink,protocol,macroName,who,targets,val
+no slashes in macro name,macro://jukebox_playAllClient@lib:bizland5e/all/Impersonated?281_Escape_from_Shadow.mp3,macro,jukebox_playAllClient@lib:bizland5e,all,Impersonated,281_Escape_from_Shadow.mp3
+slashes in macro name,macro://jukebox/playAllClient@lib:bizland5e/all/Impersonated?281_Escape_from_Shadow.mp3,macro,jukebox/playAllClient@lib:bizland5e,all,Impersonated,281_Escape_from_Shadow.mp3
+spaces before the protocol, macro://macroName@lib:token/all/Impersonated?val,macro,macroName@lib:token,all,Impersonated,val
+minimal match,:////,"","","","",

--- a/src/test/java/net/rptools/maptool/client/functions/MacroLinkFunctionTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/MacroLinkFunctionTest.java
@@ -1,0 +1,112 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvFileSource;
+
+class MacroLinkFunctionTest {
+
+  @ParameterizedTest(name = "{index} - {0} is properly parsed")
+  @CsvFileSource(
+      resources = "/net/rptools/maptool/client/functions/macroURLCases.csv",
+      numLinesToSkip = 1)
+  void testMacroLinkPattern(
+      String caseName,
+      String macroLink,
+      String protocol,
+      String macroName,
+      String who,
+      String target,
+      String val) {
+    Pattern macroLinkPattern = MacroLinkFunction.MACROLINK_PATTERN;
+
+    Matcher matcher = macroLinkPattern.matcher(macroLink);
+
+    assertTrue(matcher.matches());
+    assertEquals(protocol, matcher.group(1));
+    assertEquals(macroName, matcher.group(2));
+    assertEquals(who, matcher.group(3));
+    assertEquals(target, matcher.group(4));
+    assertEquals(val, matcher.group(5));
+  }
+
+  @ParameterizedTest(name = "{index} - {0} is properly parsed")
+  @CsvFileSource(
+      resources = "/net/rptools/maptool/client/functions/macroURLCases.csv",
+      numLinesToSkip = 1)
+  void testAutoExecPattern(
+      String caseName,
+      String macroLink,
+      String protocol,
+      String macroName,
+      String who,
+      String target,
+      String val) {
+    Pattern autoexecPattern = MacroLinkFunction.AUTOEXEC_PATTERN;
+
+    Matcher matcher = autoexecPattern.matcher(macroLink);
+
+    assertTrue(matcher.matches());
+    assertEquals(protocol, matcher.group(1));
+    assertEquals(macroName, matcher.group(2));
+    assertEquals(who, matcher.group(3));
+    assertEquals(target, matcher.group(4));
+    assertEquals(val, matcher.group(5));
+  }
+
+  @ParameterizedTest(name = "{index} - {0} is properly parsed")
+  @CsvFileSource(
+      resources = "/net/rptools/maptool/client/functions/macroURLCases.csv",
+      numLinesToSkip = 1)
+  void testTooltipPattern(
+      String caseName,
+      String macroLink,
+      String protocol,
+      String macroName,
+      String who,
+      String target,
+      String val) {
+    Pattern tooltipPattern = MacroLinkFunction.TOOLTIP_PATTERN;
+
+    Matcher matcher = tooltipPattern.matcher(macroLink);
+
+    assertTrue(matcher.matches());
+    assertEquals(protocol, matcher.group(1));
+    assertEquals(macroName, matcher.group(2));
+    assertEquals(who, matcher.group(3));
+    assertEquals(target, matcher.group(4));
+    assertEquals(val, matcher.group(5));
+  }
+
+  @ParameterizedTest(name = "{index} - {0} is properly parsed")
+  @CsvFileSource(
+      resources = "/net/rptools/maptool/client/functions/linkDataCases.csv",
+      numLinesToSkip = 1)
+  void testLinkDataPattern(String caseName, String macro, String macroLink, String macroData) {
+    Pattern linkDataPattern = MacroLinkFunction.LINK_DATA_PATTERN;
+
+    Matcher matcher = linkDataPattern.matcher(macro);
+
+    assertTrue(matcher.matches());
+    assertEquals(macroLink, matcher.group(1));
+    assertEquals(macroData, matcher.group(2));
+  }
+}


### PR DESCRIPTION
Changed all the regular expression related to MacroLinkFunction class to directly match the longest possible path in the macro path.

### Identify the Bug or Feature request
Fixes #3259


### Description of the Change

The regular expressions used to parse the macro links didn't cope with the possibility to have forward slashes (`/`) in the name of the macro. With the adds-on this is now a possibility, so I am extending the macro to match as much as possible in the macro URL to include also the folder names.

I have added some test cases to test for possible cases. The tests are driven by a couple of CSV files, so if more test cases are needed, it should be easy to add them.

### Possible Drawbacks

There could be other parts of the code which rely on the fact that there are no slashes in the macro name; while I tried to check all the patterns which could be relevant, it's entirely possible that I missed some.

### Documentation Notes
N/A

### Release Notes

- Fixed a limitation in add-ons which prevented macros to be in subfolders when used as macro links

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3860)
<!-- Reviewable:end -->
