### PR TITLE
Fall back to the map name when the display name is equal or set empty

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -14,8 +14,6 @@
  */
 package net.rptools.maptool.client.functions;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
@@ -65,76 +63,34 @@ public class MapFunctions extends AbstractFunction {
       ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
       if (currentZR == null) {
         throw new ParserException(I18N.getText("macro.function.map.none", functionName));
-      } else {
-        return currentZR.getZone().getName();
       }
+      return currentZR.getZone().getName();
+
     } else if (functionName.equalsIgnoreCase("getMapDisplayName")) {
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
-      if (parameters.size() == 0) {
-        ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
-        if (currentZR == null) {
-          throw new ParserException(I18N.getText("macro.function.map.none", functionName));
-        } else {
-          return currentZR.getZone().getPlayerAlias();
-        }
-      } else {
-        List<ZoneRenderer> rendererList =
-            new LinkedList<ZoneRenderer>(
-                MapTool.getFrame().getZoneRenderers()); // copied from ZoneSelectionPopup
-        String searchMap = parameters.get(0).toString();
-        String foundMap = null;
-        for (int i = 0; i < rendererList.size(); i++) {
-          if (rendererList.get(i).getZone().getName().equals(searchMap)) {
-            foundMap = rendererList.get(i).getZone().getPlayerAlias();
-            break;
-          }
-        }
-        if (foundMap == null) {
-          throw new ParserException(I18N.getText("macro.function.map.notFound", functionName));
-        } else {
-          return foundMap;
-        }
-      }
+      final var zr = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 0);
+      return zr.getZone().getPlayerAlias();
+
     } else if (functionName.equalsIgnoreCase("setCurrentMap")) {
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       String mapName = parameters.get(0).toString();
-      ZoneRenderer zr = getNamedMap(functionName, mapName);
+      final var zr = FunctionUtil.getZoneRenderer(functionName, mapName);
       MapTool.getFrame().setCurrentZoneRenderer(zr);
       return mapName;
+
     } else if ("getMapVisible".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
-      if (parameters.size() > 0) {
-        String mapName = parameters.get(0).toString();
-        return getNamedMap(functionName, mapName).getZone().isVisible()
-            ? BigDecimal.ONE
-            : BigDecimal.ZERO;
-      } else {
-        // Return the visibility of the current map/zone
-        ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
-        if (currentZR == null) {
-          throw new ParserException(I18N.getText("macro.function.map.none", functionName));
-        } else {
-          return currentZR.getZone().isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
-        }
-      }
+      final var zr = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 0);
+      return zr.getZone().isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
+
     } else if ("setMapVisible".equalsIgnoreCase(functionName)) {
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       boolean visible = FunctionUtil.getBooleanValue(parameters.get(0).toString());
-      Zone zone;
-      if (parameters.size() > 1) {
-        String mapName = parameters.get(1).toString();
-        zone = getNamedMap(functionName, mapName).getZone();
-      } else {
-        ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
-        if (currentZR == null) {
-          throw new ParserException(I18N.getText("macro.function.map.none", functionName));
-        } else {
-          zone = currentZR.getZone();
-        }
-      }
+      final var zr = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 1);
+      final var zone = zr.getZone();
       // Set the zone and return the visibility of the current map/zone
       zone.setVisible(visible);
       MapTool.serverCommand().setZoneVisibility(zone.getId(), zone.isVisible());
@@ -143,41 +99,45 @@ public class MapFunctions extends AbstractFunction {
       return zone.isVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
 
     } else if ("setMapName".equalsIgnoreCase(functionName)) {
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
       String oldMapName = parameters.get(0).toString();
       String newMapName = parameters.get(1).toString();
-      Zone zone = getNamedMap(functionName, oldMapName).getZone();
+      Zone zone = FunctionUtil.getZoneRenderer(functionName, oldMapName).getZone();
       zone.setName(newMapName);
       MapTool.serverCommand().renameZone(zone.getId(), newMapName);
-      if (zone == MapTool.getFrame().getCurrentZoneRenderer().getZone())
+      if (zone == MapTool.getFrame().getCurrentZoneRenderer().getZone()) {
         MapTool.getFrame().setCurrentZoneRenderer(MapTool.getFrame().getCurrentZoneRenderer());
+      }
       return zone.getName();
 
     } else if ("setMapDisplayName".equalsIgnoreCase(functionName)) {
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
       String mapName = parameters.get(0).toString();
       String newMapDisplayName = parameters.get(1).toString();
-      Zone zone = getNamedMap(functionName, mapName).getZone();
-      String oldName;
-      oldName = zone.getPlayerAlias();
+      Zone zone = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
+      String oldName = zone.getPlayerAlias();
       zone.setPlayerAlias(newMapDisplayName);
-      if (oldName.equals(newMapDisplayName)) return zone.getPlayerAlias();
+      if (oldName.equals(newMapDisplayName)) {
+        return zone.getPlayerAlias();
+      }
       MapTool.serverCommand().changeZoneDispName(zone.getId(), newMapDisplayName);
-      if (zone == MapTool.getFrame().getCurrentZoneRenderer().getZone())
+      if (zone == MapTool.getFrame().getCurrentZoneRenderer().getZone()) {
         MapTool.getFrame().setCurrentZoneRenderer(MapTool.getFrame().getCurrentZoneRenderer());
-      if (oldName.equals(zone.getPlayerAlias()))
+      }
+      if (oldName.equals(zone.getPlayerAlias())) {
         throw new ParserException(
             I18N.getText("macro.function.map.duplicateDisplay", functionName));
+      }
       return zone.getPlayerAlias();
 
     } else if ("copyMap".equalsIgnoreCase(functionName)) {
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
       String oldName = parameters.get(0).toString();
       String newName = parameters.get(1).toString();
-      Zone oldMap = getNamedMap(functionName, oldName).getZone();
+      Zone oldMap = FunctionUtil.getZoneRenderer(functionName, oldName).getZone();
       Zone newMap = new Zone(oldMap);
       newMap.setName(newName);
       MapTool.addZone(newMap, false);
@@ -189,97 +149,65 @@ public class MapFunctions extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
       boolean allMaps = functionName.equalsIgnoreCase("getAllMapNames");
 
-      if (allMaps) checkTrusted(functionName);
+      if (allMaps) {
+        FunctionUtil.blockUntrustedMacro(functionName);
+      }
 
-      List<String> mapNames = new LinkedList<String>();
+      List<String> mapNames = new LinkedList<>();
       for (ZoneRenderer zr : MapTool.getFrame().getZoneRenderers()) {
         if (allMaps || zr.getZone().isVisible()) {
           mapNames.add(zr.getZone().getName());
         }
       }
+
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : ",";
-      if ("json".equals(delim)) {
-        JsonArray jarr = new JsonArray();
-        mapNames.forEach(m -> jarr.add(new JsonPrimitive(m)));
-        return jarr;
-      } else {
-        return StringFunctions.getInstance().join(mapNames, delim);
-      }
+      return FunctionUtil.delimitedResult(delim, mapNames);
 
     } else if ("getVisibleMapDisplayNames".equalsIgnoreCase(functionName)
         || "getAllMapDisplayNames".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
       boolean allMaps = functionName.equalsIgnoreCase("getAllMapDisplayNames");
 
-      if (allMaps) checkTrusted(functionName);
+      if (allMaps) {
+        FunctionUtil.blockUntrustedMacro(functionName);
+      }
 
-      List<String> mapNames = new LinkedList<String>();
+      List<String> mapNames = new LinkedList<>();
       for (ZoneRenderer zr : MapTool.getFrame().getZoneRenderers()) {
         if (allMaps || zr.getZone().isVisible()) {
           mapNames.add(zr.getZone().getPlayerAlias());
         }
       }
+
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : ",";
-      if ("json".equals(delim)) {
-        JsonArray jarr = new JsonArray();
-        mapNames.forEach(m -> jarr.add(new JsonPrimitive(m)));
-        return jarr;
-      } else {
-        return StringFunctions.getInstance().join(mapNames, delim);
-      }
+      return FunctionUtil.delimitedResult(delim, mapNames);
+
     } else if ("getMapName".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
-      String dispName = parameters.get(0).toString();
-      checkTrusted(functionName);
+      String displayName = parameters.get(0).toString();
+      FunctionUtil.blockUntrustedMacro(functionName);
 
       for (ZoneRenderer zr : MapTool.getFrame().getZoneRenderers()) {
-        if (zr.getZone().getPlayerAlias().equals(dispName)) {
+        if (zr.getZone().getPlayerAlias().equals(displayName)) {
           return zr.getZone().getName();
         }
       }
       throw new ParserException(I18N.getText("macro.function.map.notFound", functionName));
+
     } else if ("setMapSelectButton".equalsIgnoreCase(functionName)) {
       // this is kind of a map function? :)
-      checkTrusted(functionName);
+      FunctionUtil.blockUntrustedMacro(functionName);
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       boolean vis = !parameters.get(0).toString().equals("0");
-      if (MapTool.getFrame().getFullsZoneButton() != null)
+      if (MapTool.getFrame().getFullsZoneButton() != null) {
         MapTool.getFrame().getFullsZoneButton().setVisible(vis);
+      }
       MapTool.getFrame().getToolbarPanel().getMapselect().setVisible(vis);
       return (MapTool.getFrame().getToolbarPanel().getMapselect().isVisible()
           ? BigDecimal.ONE
           : BigDecimal.ZERO);
     }
+
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));
-  }
-
-  /**
-   * Find the map/zone for a given map name
-   *
-   * @param functionName String Name of the calling function.
-   * @param mapName String Name of the searched for map.
-   * @return ZoneRenderer The map/zone.
-   * @throws ParserException if the map is not found
-   */
-  private ZoneRenderer getNamedMap(final String functionName, final String mapName)
-      throws ParserException {
-    ZoneRenderer zr = MapTool.getFrame().getZoneRenderer(mapName);
-
-    if (zr != null) return zr;
-
-    throw new ParserException(
-        I18N.getText("macro.function.moveTokenMap.unknownMap", functionName, mapName));
-  }
-
-  /**
-   * Checks whether or not the function is trusted
-   *
-   * @param functionName Name of the macro function
-   * @throws ParserException Returns trust error message and function name
-   */
-  private void checkTrusted(String functionName) throws ParserException {
-    if (!MapTool.getParser().isMacroTrusted()) {
-      throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
-    }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -123,7 +123,7 @@ public class getInfoFunction extends AbstractFunction {
     }
 
     minfo.addProperty("name", zone.getName());
-    minfo.addProperty("display name", zone.getPlayerAlias());
+    minfo.addProperty("display name", zone.getDisplayName());
     minfo.addProperty("image x scale", zone.getImageScaleX());
     minfo.addProperty("image y scale", zone.getImageScaleY());
     minfo.addProperty("player visible", zone.isVisible() ? 1 : 0);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -1985,7 +1985,7 @@ public class ZoneRenderer extends JComponent
     loadingProgress =
         String.format(
             " Loading Map '%s' - %d/%d Loaded %d/%d Cached",
-            zone.getPlayerAlias(), downloadCount, assetSet.size(), cacheCount, assetSet.size());
+            zone.getDisplayName(), downloadCount, assetSet.size(), cacheCount, assetSet.size());
     isLoaded = loaded;
     if (isLoaded) {
       // Notify the token tree that it should update


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3857

### Description of the Change

Now that player aliases can internally be `null` (e.g., when upgrading a campaign, or when the user sets the display name to the same as the regular name), a few macro functions started returning `null` or generating NPEs. These functions now fallback to the map name when a player alias is not set:
- `getMapDisplayName()`
- `getMapName()`
- `getAllMapDisplayNames()`
- `getVisibleMapDisplayNames()`
- `getInfo("map")`

The loading banner will also now show the map name rather than `'null'` if no player alias is set.

The new method `Zone.getDisplayName()` is used to consistently get the player-visible name of a map, whether that is the player alias or the map name.

### Possible Drawbacks

Should be none 

### Documentation Notes

None (restores 1.12.2 behaviour)

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3861)
<!-- Reviewable:end -->
