### PR TITLE
Stop rounding *BL points

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
@@ -1178,10 +1178,6 @@ public class Topology_Functions extends AbstractFunction {
     double[] moveTo = null;
 
     for (double[] currentElement : areaPoints) {
-      // 2 decimals is precise enough, we will deal in .5 pixels mostly.
-      currentElement[1] = Math.floor(currentElement[1] * 100) / 100;
-      currentElement[2] = Math.floor(currentElement[2] * 100) / 100;
-
       // Make the lines
       if (currentElement[0] == PathIterator.SEG_MOVETO) {
         if (defaultPos == null) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3763

### Description of the Change

Closed polygon shapes passed to `setToken*BL()` or `draw*BL()` were reading the point coordinates as integers, ignoring any fractional parts (this did not apply to unclosed "polygons"). This change combines the closed/unclosed cases into one case and reads the coordinates as doubles.

On the `getToken*BL()`/`get*BL()` side, the coordinates of the returned polygon were being truncated after the hundredth place. This truncation is now removed so that the functions returns as values that are as precise as possible.

### Possible Drawbacks

The results of `getToken*BL()`/`get*BL()` will generally be much longer due to the new precision. This could have performance implications in extreme cases, in particular if the results are operated on as strings. The results are also less readable if they need to be inspected by a human.

### Documentation Notes

I don't think it's worth adding documentation as this is just a precision change.

### Release Notes

- Fixed a bug where `setTokenVBL()`, `drawVBL()` and related functions were truncating fractional coordinates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3864)
<!-- Reviewable:end -->
