### PR TITLE
Move selection logic into a dedicated model

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -38,6 +38,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -230,9 +231,7 @@ public class AppActions {
             }
             // Move to chosen token
             if (chosenOne != null) {
-              renderer.clearSelectedTokens();
-              renderer.centerOn(chosenOne);
-              renderer.updateAfterSelection();
+              renderer.centerOnAndSetSelected(chosenOne);
             }
           }
         }
@@ -938,8 +937,10 @@ public class AppActions {
     }
     if (!tokensToRemove.isEmpty()) {
       MapTool.serverCommand().removeTokens(zone.getId(), tokensToRemove);
-      MapTool.getFrame().getCurrentZoneRenderer().clearSelectedTokens();
-      MapTool.getFrame().getCurrentZoneRenderer().updateAfterSelection();
+      MapTool.getFrame()
+          .getCurrentZoneRenderer()
+          .getSelectionModel()
+          .replaceSelection(Collections.emptyList());
       if (copy) {
         keepIdsOnPaste = true; // pasted tokens should have same ids as cut ones
       }

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -317,7 +317,7 @@ public class ClientMessageHandler implements MessageHandler {
               msg.getSelectedTokensList().stream().map(GUID::valueOf).collect(Collectors.toSet());
 
           var renderer = MapTool.getFrame().getZoneRenderer(zoneGUID);
-          renderer.addMoveSelectionSet(playerId, keyToken, selectedSet, true);
+          renderer.addMoveSelectionSet(playerId, keyToken, selectedSet);
         });
   }
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -110,8 +110,6 @@ public class PointerTool extends DefaultTool {
 
   private String currentPointerName;
 
-  private final Stack<Set<GUID>> savedTokenSelectionSet = new Stack<>();
-
   public PointerTool() {
     htmlRenderer.setBackground(new Color(0, 0, 0, 200));
     htmlRenderer.setForeground(Color.black);
@@ -206,14 +204,7 @@ public class PointerTool extends DefaultTool {
     return "tool.pointer.tooltip";
   }
 
-  public void startTokenDrag(Token keyToken, Set<GUID> selectedTokens) {
-    savedTokenSelectionSet.push(new HashSet<>(renderer.getSelectedTokenSet()));
-    renderer.clearSelectedTokens();
-    renderer.selectTokens(selectedTokens);
-    startTokenDrag(keyToken);
-  }
-
-  public void startTokenDrag(Token keyToken) {
+  public void startTokenDrag(Token keyToken, Set<GUID> tokens) {
     tokenBeingDragged = keyToken;
 
     Player p = MapTool.getPlayer();
@@ -225,16 +216,13 @@ public class PointerTool extends DefaultTool {
     }
 
     renderer.addMoveSelectionSet(
-        p.getName(),
-        tokenBeingDragged.getId(),
-        renderer.getOwnedTokens(renderer.getSelectedTokenSet()),
-        false);
+        p.getName(), tokenBeingDragged.getId(), renderer.getOwnedTokens(tokens));
     MapTool.serverCommand()
         .startTokenMove(
             p.getName(),
             renderer.getZone().getId(),
             tokenBeingDragged.getId(),
-            renderer.getOwnedTokens(renderer.getSelectedTokenSet()));
+            renderer.getOwnedTokens(tokens));
 
     isDraggingToken = true;
   }
@@ -249,10 +237,6 @@ public class PointerTool extends DefaultTool {
     dragOffsetY = 0;
 
     exposeFoW(null);
-    if (!savedTokenSelectionSet.isEmpty()) {
-      renderer.clearSelectedTokens();
-      renderer.selectTokens(savedTokenSelectionSet.pop());
-    }
   }
 
   /**
@@ -367,17 +351,19 @@ public class PointerTool extends DefaultTool {
       if (token == null || !AppUtil.playerOwns(token)) {
         return;
       }
-      renderer.clearSelectedTokens();
-      boolean selected = renderer.selectToken(token.getId());
-      renderer.updateAfterSelection();
 
-      if (selected) {
+      final var selectionModel = renderer.getSelectionModel();
+      final var wasNotAlreadySelected = !selectionModel.isSelected(token.getId());
+      // Only this token should be selected going forward.
+      renderer.getSelectionModel().replaceSelection(Collections.singletonList(token.getId()));
+
+      if (wasNotAlreadySelected) {
         Tool tool = MapTool.getFrame().getToolbox().getSelectedTool();
         if (!(tool instanceof PointerTool)) {
           return;
         }
         tokenUnderMouse = token;
-        ((PointerTool) tool).startTokenDrag(token);
+        ((PointerTool) tool).startTokenDrag(token, Collections.singleton(token.getId()));
       }
     }
 
@@ -489,9 +475,8 @@ public class PointerTool extends DefaultTool {
       List<Token> tokenList = renderer.getTokenStackAt(mouseX, mouseY);
       if (tokenList != null) {
         // Stack
-        renderer.clearSelectedTokens();
+        renderer.getSelectionModel().replaceSelection(Collections.emptyList());
         showTokenStackPopup(tokenList, e.getX(), e.getY());
-        renderer.updateAfterSelection();
       } else {
         // Single
         Token token = renderer.getTokenAt(e.getX(), e.getY());
@@ -506,24 +491,23 @@ public class PointerTool extends DefaultTool {
     }
     // SELECTION
     Token token = renderer.getTokenAt(e.getX(), e.getY());
+    final var selectionModel = renderer.getSelectionModel();
     if (token != null && !isDraggingToken && SwingUtilities.isLeftMouseButton(e)) {
       // Don't select if it's already being moved by someone
       isNewTokenSelected = false;
       if (!renderer.isTokenMoving(token)) {
+        final var isSelected = selectionModel.isSelected(token.getId());
         if (SwingUtil.isShiftDown(e)) {
           // if shift, we invert the selection of the token
-          if (renderer.getSelectedTokenSet().contains(token.getId())) {
-            renderer.deselectToken(token.getId());
+          if (isSelected) {
+            selectionModel.removeTokensFromSelection(Collections.singletonList(token.getId()));
           } else {
-            renderer.selectToken(token.getId());
+            selectionModel.addTokensToSelection(Collections.singletonList(token.getId()));
           }
-          renderer.updateAfterSelection();
-        } else if (!renderer.getSelectedTokenSet().contains(token.getId())) {
+        } else if (!isSelected) {
           // if not shift and click on non-selected token, switch selection to the token
           isNewTokenSelected = true;
-          renderer.clearSelectedTokens();
-          renderer.selectToken(token.getId());
-          renderer.updateAfterSelection();
+          selectionModel.replaceSelection(Collections.singletonList(token.getId()));
         }
         // ZonePoint dragged to
         ZonePoint pos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
@@ -592,15 +576,16 @@ public class PointerTool extends DefaultTool {
           repaint();
         }
         // SELECTION BOUND BOX
+        final var selectionModel = renderer.getSelectionModel();
         if (isDrawingSelectionBox) {
           isDrawingSelectionBox = false;
 
+          final var tokens = renderer.getTokenIdsInBounds(selectionBoundBox);
           if (!SwingUtil.isShiftDown(e)) {
-            renderer.clearSelectedTokens();
+            selectionModel.replaceSelection(tokens);
+          } else {
+            selectionModel.addTokensToSelection(tokens);
           }
-          renderer.selectTokens(selectionBoundBox);
-          renderer.updateAfterSelection();
-
           selectionBoundBox = null;
           return;
         }
@@ -610,13 +595,14 @@ public class PointerTool extends DefaultTool {
           stopTokenDrag();
         } else {
           // IF SELECTING MULTIPLE, SELECT SINGLE TOKEN
-          if (SwingUtilities.isLeftMouseButton(e) && !SwingUtil.isShiftDown(e)) {
+          if (!SwingUtil.isShiftDown(e)) {
             Token token = renderer.getTokenAt(e.getX(), e.getY());
-            // Only if it isn't already being moved
-            if (renderer.isSubsetSelected(token) && !renderer.isTokenMoving(token)) {
-              renderer.clearSelectedTokens();
-              renderer.selectToken(token.getId());
-              renderer.updateAfterSelection();
+            // Mouse down already selected the token. Now let's enforce it being the only one.
+            // ... but only if it isn't being moved at the same time.
+            if (token != null
+                && selectionModel.isSelected(token.getId())
+                && !renderer.isTokenMoving(token)) {
+              selectionModel.replaceSelection(Collections.singletonList(token.getId()));
             }
           }
         }
@@ -638,37 +624,29 @@ public class PointerTool extends DefaultTool {
 
     // POPUP MENU
     if (SwingUtilities.isRightMouseButton(e) && !isDraggingToken && !isDraggingMap()) {
-      if (tokenUnderMouse != null
-          && !renderer.getSelectedTokenSet().contains(tokenUnderMouse.getId())) {
+      final var selectionModel = renderer.getSelectionModel();
+      if (tokenUnderMouse != null && !selectionModel.isSelected(tokenUnderMouse.getId())) {
         if (!SwingUtil.isShiftDown(e)) {
-          renderer.clearSelectedTokens();
+          selectionModel.replaceSelection(Collections.singletonList(tokenUnderMouse.getId()));
+        } else {
+          selectionModel.addTokensToSelection(Collections.singletonList(tokenUnderMouse.getId()));
         }
-        renderer.selectToken(tokenUnderMouse.getId());
-        renderer.updateAfterSelection();
         isNewTokenSelected = false;
       }
-      if (tokenUnderMouse != null && !renderer.getSelectedTokenSet().isEmpty()) {
+      final var selectedTokens = renderer.getSelectedTokenSet();
+      if (tokenUnderMouse != null && !selectedTokens.isEmpty()) {
         if (tokenUnderMouse.isStamp()) {
-          new StampPopupMenu(
-                  renderer.getSelectedTokenSet(), e.getX(), e.getY(), renderer, tokenUnderMouse)
+          new StampPopupMenu(selectedTokens, e.getX(), e.getY(), renderer, tokenUnderMouse)
               .showPopup(renderer);
         } else if (AppUtil.playerOwns(tokenUnderMouse)) {
-          // FIXME Every once in awhile we get a report on the forum of the following
-          // exception:
-          // java.awt.IllegalComponentStateException: component must be showing on the
-          // screen to
+          // FIXME Every once in awhile we get a report on the forum of the following exception:
+          // java.awt.IllegalComponentStateException: component must be showing on the screen to
           // determine its location
-          // It's thrown as a result of the showPopup() call on the next line. For the
-          // life of me, I
-          // can't figure out why the
-          // "renderer" component might not be "showing on the screen"??? Maybe it has
-          // something to
-          // do with a dual-monitor
-          // configuration? Or a monitor added after Java was started and then MT dragged
-          // to that
-          // monitor?
-          new TokenPopupMenu(
-                  renderer.getSelectedTokenSet(), e.getX(), e.getY(), renderer, tokenUnderMouse)
+          // It's thrown as a result of the showPopup() call on the next line. For the life of me, I
+          // can't figure out why the "renderer" component might not be "showing on the screen"???
+          // Maybe it has something to do with a dual-monitor configuration? Or a monitor added
+          // after Java was started and then MT dragged to that monitor?
+          new TokenPopupMenu(selectedTokens, e.getX(), e.getY(), renderer, tokenUnderMouse)
               .showPopup(renderer);
         }
         return;
@@ -830,10 +808,10 @@ public class PointerTool extends DefaultTool {
       if (!isDraggingToken && renderer.isTokenMoving(tokenUnderMouse)) {
         return;
       }
-      if (isNewTokenSelected && !renderer.isOnlyTokenSelected(tokenUnderMouse)) {
-        renderer.clearSelectedTokens();
-        renderer.selectToken(tokenUnderMouse.getId());
-        renderer.updateAfterSelection();
+      if (isNewTokenSelected) {
+        renderer
+            .getSelectionModel()
+            .replaceSelection(Collections.singletonList(tokenUnderMouse.getId()));
       }
       isNewTokenSelected = false;
 
@@ -855,7 +833,7 @@ public class PointerTool extends DefaultTool {
             }
           }
         }
-        startTokenDrag(tokenUnderMouse);
+        startTokenDrag(tokenUnderMouse, selectedTokenSet);
         isDraggingToken = true;
         if (AppPreferences.getHideMousePointerWhileDragging()) SwingUtil.hidePointer(renderer);
       }
@@ -1403,7 +1381,7 @@ public class PointerTool extends DefaultTool {
       // Note these are zone space coordinates
       dragStartX = keyToken.getX();
       dragStartY = keyToken.getY();
-      startTokenDrag(keyToken);
+      startTokenDrag(keyToken, selectedTokenSet);
     }
     if (!isMovingWithKeys) {
       dragOffsetX = 0;

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1220,11 +1220,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
               if (row instanceof Token && e.getClickCount() == 2) {
                 Token token = (Token) row;
-                getCurrentZoneRenderer().clearSelectedTokens();
-                // Pick an appropriate tool
-                // Jamz: why not just call .centerOn(Token token), now we have one place to fix...
-                getCurrentZoneRenderer().centerOn(token);
-                getCurrentZoneRenderer().updateAfterSelection();
+                getCurrentZoneRenderer().centerOnAndSetSelected(token);
               }
             }
             if (SwingUtilities.isRightMouseButton(e)) {

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -18,6 +18,7 @@ import com.google.common.eventbus.Subscribe;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.events.ZoneActivated;
 import net.rptools.maptool.client.events.ZoneDeactivated;
+import net.rptools.maptool.client.ui.zone.SelectionModel;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
@@ -198,6 +199,15 @@ public class HTMLFrameFactory {
     public Listener() {
       new MapToolEventBus().getMainEventBus().register(this);
       currentZone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+    }
+
+    @Subscribe
+    private void onSelectionChanged(SelectionModel.SelectionChanged event) {
+      if (event.zone() != currentZone) {
+        return;
+      }
+
+      selectedListChanged();
     }
 
     @Subscribe

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
@@ -28,6 +28,7 @@ import net.rptools.maptool.client.ui.MapToolFrame;
 import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
+import net.rptools.maptool.client.ui.zone.SelectionModel;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
@@ -152,6 +153,11 @@ public class ImpersonatePanel extends AbstractMacroPanel {
     if (!currentlyImpersonating || getToken() == null) {
       reset();
     }
+  }
+
+  @Subscribe
+  private void onSelectionChanged(SelectionModel.SelectionChanged event) {
+    reset();
   }
 
   @Subscribe

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/MenuButtonsPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/MenuButtonsPanel.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui.macrobuttons.panels;
 import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.Collections;
 import javax.swing.*;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.theme.Icons;
@@ -47,8 +48,10 @@ public class MenuButtonsPanel extends JToolBar {
             ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
             // Check if there is a map. Fix #1605
             if (zr != null) {
-              zr.selectTokens(new Rectangle(zr.getX(), zr.getY(), zr.getWidth(), zr.getHeight()));
-              zr.updateAfterSelection();
+              final var tokens =
+                  zr.getTokenIdsInBounds(
+                      new Rectangle(zr.getX(), zr.getY(), zr.getWidth(), zr.getHeight()));
+              zr.getSelectionModel().replaceSelection(tokens);
             }
           }
         });
@@ -65,8 +68,7 @@ public class MenuButtonsPanel extends JToolBar {
           public void mouseReleased(MouseEvent event) {
             ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
             if (renderer != null) {
-              renderer.clearSelectedTokens();
-              renderer.updateAfterSelection();
+              renderer.getSelectionModel().replaceSelection(Collections.emptyList());
             }
           }
         });
@@ -83,7 +85,7 @@ public class MenuButtonsPanel extends JToolBar {
           public void mouseReleased(MouseEvent event) {
             ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
             if (zr != null) {
-              zr.undoSelectToken();
+              zr.getSelectionModel().undoSelection(zr.getActiveLayer());
             }
           }
         });

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
@@ -25,6 +25,7 @@ import net.rptools.maptool.client.ui.MapToolFrame;
 import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
+import net.rptools.maptool.client.ui.zone.SelectionModel;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
@@ -112,6 +113,11 @@ public class SelectionPanel extends AbstractMacroPanel {
       if (log.isDebugEnabled()) log.debug(results);
     }
     new MapToolEventBus().getMainEventBus().register(this);
+  }
+
+  @Subscribe
+  private void onSelectionChanged(SelectionModel.SelectionChanged event) {
+    reset();
   }
 
   @Subscribe

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -872,9 +872,7 @@ public class InitiativePanel extends JPanel
                   return;
                 }
 
-                renderer.clearSelectedTokens();
-                renderer.centerOn(token);
-                renderer.updateAfterSelection();
+                renderer.centerOnAndSetSelected(token);
                 renderer.maybeForcePlayersView();
               }
             });

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.ui.tokenpanel;
 
 import java.awt.event.ActionEvent;
+import java.util.Collections;
 import java.util.Set;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -199,10 +200,10 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
         @Override
         public void actionPerformed(ActionEvent e) {
           Token token = tokenInitiativeUnderMouse.getToken();
-          getRenderer().centerOn(new ZonePoint(token.getX(), token.getY()));
-          getRenderer().clearSelectedTokens();
-          getRenderer().selectToken(token.getId());
-          getRenderer().updateAfterSelection();
+          final var renderer = getRenderer();
+          final var selectionModel = renderer.getSelectionModel();
+          renderer.centerOn(new ZonePoint(token.getX(), token.getY()));
+          selectionModel.replaceSelection(Collections.singletonList(token.getId()));
         }
       };
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/SelectionModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/SelectionModel.java
@@ -1,0 +1,226 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.rptools.maptool.client.AppUtil;
+import net.rptools.maptool.events.MapToolEventBus;
+import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
+
+/** Models the current and historical selections for a ZoneRenderer. */
+public class SelectionModel {
+  public record SelectionChanged(Zone zone) {}
+
+  /** The zone in which the selections are made. */
+  private final Zone zone;
+  /** The current selection. */
+  private final Set<GUID> currentSelection = new HashSet<>();
+  /** A stack of previous selections that can be restored. */
+  private final List<Set<GUID>> selectionHistory = new ArrayList<>();
+  /** How long {@link #selectionHistory} can get before old entries are forgotten. */
+  private int maxHistoryLength = 20;
+
+  /** @param zone The zone in which selections will be managed. */
+  public SelectionModel(Zone zone) {
+    this.zone = zone;
+  }
+
+  /**
+   * Adds the selection into the history so that it can be restored in the future.
+   *
+   * <p>In order to avoid storing empty and redundant history, the current selection will only be
+   * added to the history if it is not empty and if not equal to the previous item in the history.
+   */
+  private void pushCurrentSelectionIntoHistory() {
+    // don't add empty selections to history
+    if (currentSelection.size() == 0) {
+      return;
+    }
+    // Don't add history if nothing has changed.
+    if (!selectionHistory.isEmpty() && currentSelection.equals(selectionHistory.get(0))) {
+      return;
+    }
+
+    Set<GUID> history = new HashSet<>(currentSelection);
+    selectionHistory.add(0, history);
+
+    // limit the history to a certain size
+    if (selectionHistory.size() > maxHistoryLength) {
+      selectionHistory.subList(maxHistoryLength, selectionHistory.size() - 1).clear();
+    }
+  }
+
+  /** Fire a SelectionChanged event. */
+  private void selectionChanged() {
+    new MapToolEventBus().getMainEventBus().post(new SelectionChanged(zone));
+  }
+
+  /**
+   * Get the IDs of the selected tokens.
+   *
+   * <p>Note: no validation is done to ensure that the token IDs are still valid. It is up to the
+   * caller to do that as needed.
+   *
+   * @return The IDs of all tokens that are current selected.
+   */
+  public Set<GUID> getSelectedTokenIds() {
+    return Collections.unmodifiableSet(currentSelection);
+  }
+
+  /**
+   * Check if any tokens are selected.
+   *
+   * @return {@code true} if there is some selected token, otherwise {@code false}.
+   */
+  public boolean isAnyTokenSelected() {
+    return !currentSelection.isEmpty();
+  }
+
+  /**
+   * Check if a token is selected.
+   *
+   * @param tokenId The ID of the token to check.
+   * @return {@code true} if the token is selected, otherwise {@code false}.
+   */
+  public boolean isSelected(GUID tokenId) {
+    return currentSelection.contains(tokenId);
+  }
+
+  /**
+   * Check whether a token is eligible to be selected.
+   *
+   * <p>A token is only eligible for selection if:
+   *
+   * <ol>
+   *   <li>It exists.
+   *   <li>The token belongs to the zone that this model is for.
+   *   <li>The token is either visible or owned by the current player.
+   * </ol>
+   *
+   * @param tokenGuid The ID of the token to check.
+   * @return {@code true} if the token is allowed to be selected, otherwise {@code false}.
+   */
+  private boolean isSelectable(GUID tokenGuid) {
+    if (tokenGuid == null) {
+      return false; // doesn't exist
+    }
+    final var token = zone.getToken(tokenGuid);
+    if (token == null) {
+      return false; // doesn't exist
+    }
+    if (!zone.isTokenVisible(token)) {
+      return AppUtil.playerOwns(token); // can't own or see
+    }
+    return true;
+  }
+
+  /**
+   * Saves the current selection to the history, and replaces the selection.
+   *
+   * <p>Among {@code tokens}, only selectable tokens will be added.
+   *
+   * @param tokens The IDs of the tokens to make selected.
+   */
+  public void replaceSelection(Collection<GUID> tokens) {
+    pushCurrentSelectionIntoHistory();
+
+    currentSelection.clear();
+    for (GUID tokenGUID : tokens) {
+      if (!isSelectable(tokenGUID)) {
+        continue;
+      }
+      currentSelection.add(tokenGUID);
+    }
+
+    selectionChanged();
+  }
+
+  /**
+   * Saves the current selection to the history, and adds tokens to the selection.
+   *
+   * <p>Among {@code tokens}, only selectable tokens will be added.
+   *
+   * @param tokens The IDs of the tokens to add to the selection.
+   */
+  public void addTokensToSelection(Collection<GUID> tokens) {
+    pushCurrentSelectionIntoHistory();
+
+    boolean anyAdded = false;
+    for (GUID tokenGUID : tokens) {
+      if (!isSelectable(tokenGUID)) {
+        continue;
+      }
+      currentSelection.add(tokenGUID);
+      anyAdded = true;
+    }
+    if (anyAdded) {
+      selectionChanged();
+    }
+  }
+
+  /**
+   * Saves the current selection to the history, and removes tokens from the selection.
+   *
+   * @param tokens The IDs of the tokens to remove from the selection.
+   */
+  public void removeTokensFromSelection(Collection<GUID> tokens) {
+    pushCurrentSelectionIntoHistory();
+    final var changed = currentSelection.removeAll(tokens);
+    if (changed) {
+      selectionChanged();
+    }
+  }
+
+  /**
+   * Discard the current selection and replace it with a previous one from the history.
+   *
+   * <p>The selection will be restored to the most recent non-empty item in the history. Emptiness
+   * is considered after discarding any tokens that do not exist or are no longer on the active
+   * layer.
+   *
+   * @param activeLayer The current layer. Tokens not on this layer will not be part of the restored
+   *     selection.
+   */
+  public void undoSelection(Zone.Layer activeLayer) {
+    currentSelection.clear();
+    while (!selectionHistory.isEmpty()) {
+      currentSelection.addAll(selectionHistory.remove(0));
+
+      // The user may have deleted some of the tokens that are contained in the selection history.
+      // There could also be tokens in another than the current layer which we don't want to go back
+      // to. Find them and filter them otherwise the selection will have orphaned GUIDs.
+      for (final var guid : currentSelection) {
+        final var token = zone.getToken(guid);
+        if (token == null || token.getLayer() != activeLayer) {
+          currentSelection.remove(guid);
+        }
+      }
+
+      // It may be that all tokens weren't available anymore. If so, go further back in the history
+      // in the hopes of not landing on an empty result.
+      if (!currentSelection.isEmpty()) {
+        break;
+      }
+    }
+
+    selectionChanged();
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -52,7 +52,6 @@ import net.rptools.maptool.client.tool.drawing.OvalExposeTool;
 import net.rptools.maptool.client.tool.drawing.PolygonExposeTool;
 import net.rptools.maptool.client.tool.drawing.RectangleExposeTool;
 import net.rptools.maptool.client.ui.Scale;
-import net.rptools.maptool.client.ui.htmlframe.HTMLFrameFactory;
 import net.rptools.maptool.client.ui.theme.Borders;
 import net.rptools.maptool.client.ui.theme.Images;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
@@ -106,6 +105,8 @@ public class ZoneRenderer extends JComponent
 
   /** The ZoneView constructed from the zone. */
   private final ZoneView zoneView;
+  /** Manages the selected tokens on the zone. */
+  private final SelectionModel selectionModel;
 
   private Scale zoneScale;
   private final DrawableRenderer backgroundDrawableRenderer = new PartitionedDrawableRenderer();
@@ -115,15 +116,9 @@ public class ZoneRenderer extends JComponent
   private final List<ZoneOverlay> overlayList = new ArrayList<ZoneOverlay>();
   private final Map<Zone.Layer, List<TokenLocation>> tokenLocationMap =
       new HashMap<Zone.Layer, List<TokenLocation>>();
-  private Set<GUID> selectedTokenSet = new LinkedHashSet<GUID>();
-  private boolean keepSelectedTokenSet = false;
-  private final List<Set<GUID>> selectedTokenSetHistory = new ArrayList<Set<GUID>>();
   private final List<LabelLocation> labelLocationList = new LinkedList<LabelLocation>();
   private Map<Token, Set<Token>> tokenStackMap;
   private final Map<GUID, SelectionSet> selectionSetMap = new HashMap<GUID, SelectionSet>();
-  // private final Map<Token, TokenLocation> tokenLocationCache = Collections.synchronizedMap(new
-  // HashMap<Token,
-  // TokenLocation>());
   private final Map<Token, TokenLocation> tokenLocationCache = new HashMap<Token, TokenLocation>();
   private final List<TokenLocation> markerLocationList = new ArrayList<TokenLocation>();
   private GeneralPath facingArrow;
@@ -189,6 +184,7 @@ public class ZoneRenderer extends JComponent
     setFocusable(true);
     setZoneScale(new Scale());
     zoneView = new ZoneView(zone);
+    selectionModel = new SelectionModel(zone);
 
     // add(MapTool.getFrame().getFxPanel(), PositionalLayout.Position.NW);
 
@@ -249,7 +245,7 @@ public class ZoneRenderer extends JComponent
    *
    * @param token the token to center on
    */
-  public void centerOn(Token token) {
+  public void centerOnAndSetSelected(Token token) {
     if (token == null) {
       return;
     }
@@ -260,7 +256,7 @@ public class ZoneRenderer extends JComponent
         .getToolbox()
         .setSelectedTool(token.isToken() ? PointerTool.class : StampTool.class);
 
-    selectToken(token.getId());
+    selectionModel.replaceSelection(Collections.singletonList(token.getId()));
     requestFocusInWindow();
   }
 
@@ -270,25 +266,6 @@ public class ZoneRenderer extends JComponent
 
   public boolean isPathShowing(Token token) {
     return showPathList.contains(token);
-  }
-
-  public void clearShowPaths() {
-    showPathList.clear();
-    // [PNICHOLS04] This call is unnecessary, because we are in a method that is
-    // only called once (from clearSelectedTokens), and the caller requires a
-    // repaint after we return.
-    // repaintDebouncer.dispatch();
-  }
-
-  /**
-   * Resets the token panels, fire onTokenSelection, repaints. The impersonation panel is only reset
-   * if no token is currently impersonated.
-   */
-  public void updateAfterSelection() {
-    MapTool.getFrame().getSelectionPanel().reset();
-    MapTool.getFrame().getImpersonatePanel().resetIfNotImpersonating();
-    HTMLFrameFactory.selectedListChanged();
-    repaintDebouncer.dispatch();
   }
 
   public Scale getZoneScale() {
@@ -341,14 +318,8 @@ public class ZoneRenderer extends JComponent
     return false;
   }
 
-  public void addMoveSelectionSet(
-      String playerId, GUID keyToken, Set<GUID> tokenList, boolean clearLocalSelected) {
+  public void addMoveSelectionSet(String playerId, GUID keyToken, Set<GUID> tokenList) {
     // I'm not supposed to be moving a token when someone else is already moving it
-    if (clearLocalSelected) {
-      for (GUID guid : tokenList) {
-        selectedTokenSet.remove(guid);
-      }
-    }
     selectionSetMap.put(keyToken, new SelectionSet(playerId, keyToken, tokenList));
     repaintDebouncer.dispatch(); // Jamz: Seems to have no affect?
   }
@@ -679,6 +650,10 @@ public class ZoneRenderer extends JComponent
     return zoneView;
   }
 
+  public SelectionModel getSelectionModel() {
+    return selectionModel;
+  }
+
   /** Clear internal caches and backbuffers */
   public void flush() {
     if (zone.getBackgroundPaint() instanceof DrawableTexturePaint) {
@@ -908,7 +883,7 @@ public class ZoneRenderer extends JComponent
    */
   public PlayerView getPlayerView(Player.Role role, boolean selected) {
     List<Token> selectedTokens = null;
-    if (selected && getSelectedTokenSet() != null && !getSelectedTokenSet().isEmpty()) {
+    if (selected && selectionModel.isAnyTokenSelected()) {
       selectedTokens = getSelectedTokensList();
       selectedTokens.removeIf(token -> !token.getHasSight() || !AppUtil.playerOwns(token));
     }
@@ -2827,13 +2802,7 @@ public class ZoneRenderer extends JComponent
    */
   public void setActiveLayer(Zone.Layer layer) {
     activeLayer = layer;
-
-    if (!keepSelectedTokenSet && !selectedTokenSet.isEmpty()) {
-      selectedTokenSet.clear();
-      updateAfterSelection();
-    }
-    keepSelectedTokenSet = false; // Always reset it back, temp boolean only
-
+    selectionModel.replaceSelection(Collections.emptyList());
     repaintDebouncer.dispatch();
   }
 
@@ -3487,6 +3456,12 @@ public class ZoneRenderer extends JComponent
     }
     timer.start("tokenlist-12");
     boolean useIF = MapTool.getServerPolicy().isUseIndividualFOW();
+
+    final var movingTokens = new HashSet<GUID>();
+    for (final var selectionSet : selectionSetMap.values()) {
+      movingTokens.addAll(selectionSet.getTokens());
+    }
+
     // Selection and labels
     for (Token token : tokenPostProcessing) {
       TokenLocation location = tokenLocationCache.get(token);
@@ -3502,7 +3477,9 @@ public class ZoneRenderer extends JComponent
       }
       Rectangle footprintBounds = token.getBounds(zone);
 
-      boolean isSelected = selectedTokenSet.contains(token.getId());
+      // Count moving tokens as "selected" so that a border is drawn around them.
+      boolean isSelected =
+          selectionModel.isSelected(token.getId()) || movingTokens.contains(token.getId());
       if (isSelected) {
         ScreenPoint sp = ScreenPoint.fromZonePoint(this, footprintBounds.x, footprintBounds.y);
         double width = footprintBounds.width * getScale();
@@ -3731,11 +3708,7 @@ public class ZoneRenderer extends JComponent
   }
 
   public Set<GUID> getSelectedTokenSet() {
-    return selectedTokenSet;
-  }
-
-  public void setKeepSelectedTokenSet(boolean keep) {
-    this.keepSelectedTokenSet = keep;
+    return selectionModel.getSelectedTokenIds();
   }
 
   /**
@@ -3759,16 +3732,17 @@ public class ZoneRenderer extends JComponent
   }
 
   /**
-   * A convenience method to get selected tokens ordered by name
+   * A convenience method to get selected tokens that actually exist.
    *
    * @return List of tokens
    */
   public List<Token> getSelectedTokensList() {
     List<Token> tokenList = new ArrayList<Token>();
 
-    for (GUID g : selectedTokenSet) {
-      if (zone.getToken(g) != null) {
-        tokenList.add(zone.getToken(g));
+    for (GUID g : selectionModel.getSelectedTokenIds()) {
+      final var token = zone.getToken(g);
+      if (token != null) {
+        tokenList.add(token);
       }
     }
     // Commented out to preserve selection order
@@ -3798,159 +3772,35 @@ public class ZoneRenderer extends JComponent
   }
 
   /**
-   * Removes a token from the selected set.
-   *
-   * @param tokenGUID the token to remove from the selection
-   */
-  public void deselectToken(GUID tokenGUID) {
-    addToSelectionHistory(selectedTokenSet);
-    selectedTokenSet.remove(tokenGUID);
-    // flushFog = true; // could call flushFog() but also clears visibleScreenArea and I don't know
-    // if we want
-    // that...
-  }
-
-  /**
-   * Adds a token from the selected set, if token is selectable.
-   *
-   * @param tokenGUID the token to add to the selection
-   * @return false if nothing was done because the token wasn't selectable, true otherwise
-   */
-  public boolean selectToken(GUID tokenGUID) {
-    if (!isTokenSelectable(tokenGUID)) {
-      return false;
-    }
-    addToSelectionHistory(selectedTokenSet);
-    selectedTokenSet.add(tokenGUID);
-    return true;
-  }
-
-  /**
-   * Add tokens to the selection.
-   *
-   * @param tokens the collection of tokens to add
-   */
-  public void selectTokens(Collection<GUID> tokens) {
-    for (GUID tokenGUID : tokens) {
-      if (!isTokenSelectable(tokenGUID)) {
-        continue;
-      }
-      selectedTokenSet.add(tokenGUID);
-    }
-    addToSelectionHistory(selectedTokenSet);
-  }
-
-  /**
    * Selects the tokens inside a selection rectangle.
    *
    * @param rect the selection rectangle
    */
-  public void selectTokens(Rectangle rect) {
-    List<GUID> selectedList = new LinkedList<GUID>();
+  public List<GUID> getTokenIdsInBounds(Rectangle rect) {
+    final var tokens = new ArrayList<GUID>();
     for (TokenLocation location : getTokenLocations(getActiveLayer())) {
       if (rect.intersects(location.bounds.getBounds())) {
-        selectedList.add(location.token.getId());
+        tokens.add(location.token.getId());
       }
     }
-    selectTokens(selectedList);
-  }
-
-  /** Clears the set of selected tokens. */
-  public void clearSelectedTokens() {
-    addToSelectionHistory(selectedTokenSet);
-    clearShowPaths();
-    selectedTokenSet.clear();
-  }
-
-  /**
-   * Returns true if the given token is the only one selected, and the selection is valid.
-   *
-   * @param token the token
-   * @return true if the selectedTokenSet size is 1 and contains the token, false otherwise
-   */
-  public boolean isOnlyTokenSelected(Token token) {
-    return selectedTokenSet.size() == 1
-        && token != null
-        && selectedTokenSet.contains(token.getId())
-        && isTokenSelectable(token.getId());
-  }
-
-  /**
-   * Returns true if the given token is selected, there is more than one token selected, and the
-   * token can be selected.
-   *
-   * @param token the token
-   * @return true if the selectedTokenSet size is greater than 1 and contains the token, false
-   *     otherwise
-   */
-  public boolean isSubsetSelected(Token token) {
-    return selectedTokenSet.size() > 1
-        && token != null
-        && selectedTokenSet.contains(token.getId())
-        && isTokenSelectable(token.getId());
-  }
-
-  /**
-   * Reverts the token selection. If the previous selection is empty, keeps reverting until it is
-   * non-empty. Fires onTokenSelection events.
-   */
-  public void undoSelectToken() {
-
-    while (selectedTokenSetHistory.size() > 0) {
-
-      selectedTokenSet = selectedTokenSetHistory.remove(0);
-
-      // user may have deleted some of the tokens that are contained in the selection history.
-      // There could also be tokens in another than the current layer which we don't want to go
-      // back to.
-      // find them and filter them otherwise the selectionSet will have orphaned GUIDs and
-      // they will cause NPE
-      Set<GUID> invalidTokenSet = new HashSet<GUID>();
-      for (GUID guid : selectedTokenSet) {
-        Token token = zone.getToken(guid);
-        if (token == null || token.getLayer() != getActiveLayer()) {
-          invalidTokenSet.add(guid);
-        }
-      }
-      selectedTokenSet.removeAll(invalidTokenSet);
-
-      if (!selectedTokenSet.isEmpty()) break;
-    }
-    // TODO: if selection history is empty, notify the selection panel to
-    // disable the undo button.
-    updateAfterSelection();
-  }
-
-  private void addToSelectionHistory(Set<GUID> selectionSet) {
-    // don't add empty selections to history
-    if (selectionSet.size() == 0) {
-      return;
-    }
-    Set<GUID> history = new HashSet<GUID>(selectionSet);
-    selectedTokenSetHistory.add(0, history);
-
-    // limit the history to a certain size
-    if (selectedTokenSetHistory.size() > 20) {
-      selectedTokenSetHistory.subList(20, selectedTokenSetHistory.size() - 1).clear();
-    }
+    return tokens;
   }
 
   public void cycleSelectedToken(int direction) {
     List<Token> visibleTokens = getTokensOnScreen();
-    Set<GUID> selectedTokenSet = getSelectedTokenSet();
     int newSelection = 0;
 
     if (visibleTokens.size() == 0) {
       return;
     }
-    if (selectedTokenSet.size() > 0) {
+    if (selectionModel.isAnyTokenSelected()) {
       // Find the first selected token on the screen
       for (int i = 0; i < visibleTokens.size(); i++) {
         Token token = visibleTokens.get(i);
         if (!isTokenSelectable(token.getId())) {
           continue;
         }
-        if (getSelectedTokenSet().contains(token.getId())) {
+        if (selectionModel.isSelected(token.getId())) {
           newSelection = i;
           break;
         }
@@ -3966,26 +3816,8 @@ public class ZoneRenderer extends JComponent
     }
 
     // Make the selection
-    clearSelectedTokens();
-    selectToken(visibleTokens.get(newSelection).getId());
-    updateAfterSelection();
-  }
-
-  /**
-   * Convenience function to check if a player owns all the tokens in the selection set
-   *
-   * @return true if every token in selectedTokenSet is owned by the player
-   */
-  public boolean playerOwnsAllSelected() {
-    if (selectedTokenSet.isEmpty()) {
-      return false;
-    }
-    for (GUID tokenGUID : selectedTokenSet) {
-      if (!AppUtil.playerOwns(zone.getToken(tokenGUID))) {
-        return false;
-      }
-    }
-    return true;
+    selectionModel.replaceSelection(
+        Collections.singletonList(visibleTokens.get(newSelection).getId()));
   }
 
   public Area getTokenBounds(Token token) {
@@ -4684,8 +4516,7 @@ public class ZoneRenderer extends JComponent
       selectThese.add(token.getId());
     }
     // For convenience, select them
-    clearSelectedTokens();
-    selectTokens(selectThese);
+    selectionModel.replaceSelection(selectThese);
 
     if (!isGM) {
       String msg = I18N.getText("Token.dropped.byPlayer", zone.getName(), MapTool.getPlayer());
@@ -4700,7 +4531,6 @@ public class ZoneRenderer extends JComponent
     AppActions.copyTokens(tokens);
     AppActions.updateActions();
     requestFocusInWindow();
-    updateAfterSelection();
   }
 
   /**
@@ -4773,6 +4603,16 @@ public class ZoneRenderer extends JComponent
    */
   @Override
   public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+  @Subscribe
+  private void onSelectionChanged(SelectionModel.SelectionChanged event) {
+    if (event.zone() != zone) {
+      return;
+    }
+
+    showPathList.clear();
+    repaintDebouncer.dispatch();
+  }
 
   @Subscribe
   private void onTokensAdded(TokensAdded event) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3759

### Description of the Change

The primary motivation here is fixing the linked bug. There was also another bug discovered in the meantime where selection history was not being saved at the right times, resulting in both missing and duplicated entries in the history.

Secondary to that, I took the opportunity to clean up `ZoneRenderer` with regards to selection. The current selection and selection history are now managed by the `SelectionModel` class (there is one per `ZoneRenderer`). In addition to querying the current selection, `SelectionModel` also provides these bulk operations:
- `replaceSelection()`: deselect all tokens and then select the provided tokens.
- `addTokensToSelection()`: keep the current selection and add more tokens to it.
- `removeTokensFromSelection()`: keep the current selection but deselect the provided tokens.
- `undoSelection()`: revert selection to a previous state.

These operations guarantee that history is modified consistently. They also communicate selection changes via a new `SelectionChanged` event sent through the event bus.

The new event means we no longer need `ZoneRenderer.updateAfterSelection()`, which needed to be called in ~30 places to keep the selection panel, impersonation panel and HTML views up-to-date. Instead this is now done automatically with each of the components being directly notified of the selection change.

### Possible Drawbacks

As usual, it's possible I messed up somewhere that I didn't test.

### Documentation Notes

N/A, just a minor bug fix.

### Release Notes

- Fixed a bug where client selections were being cleared when other clients moved tokens.
- Fixed a bug where the selection undo history included redundant entries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3866)
<!-- Reviewable:end -->
