### PR TITLE
Fix map background dialog width

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/PaintChooser.java
+++ b/src/main/java/net/rptools/maptool/client/swing/PaintChooser.java
@@ -31,7 +31,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.colorchooser.AbstractColorChooserPanel;
 import net.rptools.maptool.language.I18N;
 
-@SuppressWarnings("serial")
 public class PaintChooser extends JPanel {
 
   private final JColorChooser swatchColorChooser;

--- a/src/main/java/net/rptools/maptool/client/ui/TextureChooserPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/TextureChooserPanel.java
@@ -18,7 +18,6 @@ import java.awt.GridLayout;
 import javax.swing.JComponent;
 import javax.swing.JSplitPane;
 import net.rptools.maptool.client.swing.AbstractPaintChooserPanel;
-import net.rptools.maptool.client.swing.ImagePanel;
 import net.rptools.maptool.client.swing.PaintChooser;
 import net.rptools.maptool.client.ui.assetpanel.AssetPanel;
 import net.rptools.maptool.client.ui.assetpanel.AssetPanelModel;
@@ -28,7 +27,6 @@ import net.rptools.maptool.model.Asset;
 public class TextureChooserPanel extends AbstractPaintChooserPanel {
 
   private PaintChooser paintChooser;
-  private ImagePanel imagePanel;
 
   public TextureChooserPanel(PaintChooser paintChooser, AssetPanelModel model) {
     this(paintChooser, model, "textureChooser");
@@ -60,7 +58,7 @@ public class TextureChooserPanel extends AbstractPaintChooserPanel {
 
           paintChooser.setPaint(new AssetPaint(asset));
         });
-    assetPanel.setThumbSize(100);
+    assetPanel.setThumbSize(50);
 
     return assetPanel;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/AssetPanel.java
@@ -141,6 +141,7 @@ public class AssetPanel extends JComponent {
     imagePanel.setShowCaptions(true);
     imagePanel.setSelectionMode(SelectionMode.SINGLE);
     imagePanel.setFont(new Font("Helvetica", 0, 10)); // XXX Overrides TinyLAF?
+    imagePanel.setVisibleRowCount(2);
 
     imagePanel.addMouseWheelListener(
         e -> {
@@ -183,8 +184,8 @@ public class AssetPanel extends JComponent {
     imagePanelProgressBar.setVisible(false);
 
     panel.add(BorderLayout.NORTH, createFilterPanel());
-    panel.add(BorderLayout.NORTH, createFilterPanel());
     panel.add(BorderLayout.WEST, getThumbnailPreviewSlider());
+
     panel.add(BorderLayout.CENTER, new JScrollPane(imagePanel));
     panel.add(BorderLayout.SOUTH, imagePanelProgressBar);
 

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
@@ -192,7 +192,6 @@ public class MapPropertiesDialog extends JDialog {
     TextureChooserPanel textureChooserPanel =
         new TextureChooserPanel(paintChooser, model, "mapPropertiesTextureChooser");
     paintChooser.addPaintChooser(textureChooserPanel);
-    paintChooser.setPreferredSize(new Dimension(450, 400));
     mapSelectorDialog = new MapSelectorDialog();
     getRootPane().setDefaultButton(getOKButton());
   }
@@ -423,6 +422,7 @@ public class MapPropertiesDialog extends JDialog {
     getMapButton()
         .addActionListener(
             e -> {
+              mapSelectorDialog.pack();
               Asset asset = mapSelectorDialog.chooseAsset();
               if (asset == null) {
                 return;
@@ -584,7 +584,6 @@ public class MapPropertiesDialog extends JDialog {
       add(BorderLayout.CENTER, createImageExplorerPanel());
       add(BorderLayout.SOUTH, createButtonBar());
       this.setTitle(I18N.getText("MapPropertiesDialog.label.image"));
-      setSize(500, 400);
     }
 
     @Override


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3684. and fixes #755, #1157 some more.

### Description of the Change

The main thing to change was to stop hardcoding a preferred size for the `PaintChooser` in the **Choose Background** / **Chose Fog** dialogs. This fixed the width of those dialogs, though the height of the dialogs suddenly became very large. The culprit there is the scrollable `ImagePanel` setting its preferred _viewport_ size based on the number of rows it expects, which can be very many. I've solved this by taking a cue from `JList` : `ImagePanel` now has a configurable "visible row count" that is used to determine the preferred viewport height separately from the preferred height.

The **Select Map Image** dialog also had a hardcoded size that is now removed.

***

It became clear while working on this that both #755 and #1157 still existed, and I've included fixes for them as they are related. The problem was two discrepancies between `ImagePanel.getPreferredSize()` and `ImagePanel.paintComponent()`:
- for #755, the problem is that `paintComponent()` sometimes renders one fewer columns than it should. Fewer columns means more rows, which causes the render to go beyond what `getPreferredSize()` was expecting vertically. Since `getPreferredSize()` is used in decide whether scrolling is need, this resulted in the apparenty issue of scrolling not being enabled when it should be.
- for #1157, `paintComponent()` incorrectly calculated its vertical step by omitting the caption padding. All other height calculations included it, in particular `getPreferredSize()`. This caused the rendered height to be far less than the preferred height when there are many rows of thumbnails. As a result, scrolling was allowed to go far beyond the end of the thumbnail list.

The solution to both of these was to bring `getPreferredSize()` and `paintComponent()` more in line with each other in terms of layout. There are new methods for consistently calculating the real estate needed for a thumbnail (`getItemWidth()`, `getItemHeight()`), and a new method for calculating how many columns there should be (`calculateItemsPerRow()`). `paintComponent()` no longer does line wrapping, but instead calculates the current row and column using the above methods, making it consistent with `getPreferredSize()`.

### Possible Drawbacks

The sizing changes might not be optimized for different screen configurations.

### Documentation Notes

N/A, bugfix

### Release Notes

- Fixed a bug where the **Select Background** and **Select Fog** dialogs were too small for their contents.
- Fixed a bug where the **Library** and other windows would sometimes not allow scrolling even when the images overflowed.
- Fixed a bug where the **Library** and other windows with lots of images would allow scrolling well past the end of the images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3869)
<!-- Reviewable:end -->
