### PR TITLE
Adjust pasted token offset by the destination grid

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1051,8 +1051,9 @@ public class AppActions {
     // Only cut if some tokens are selected. Don't want to accidentally
     // lose what might already be in the clipboard.
     if (!tokenList.isEmpty()) {
-      if (tokenCopySet != null)
+      if (tokenCopySet != null) {
         tokenCopySet.clear(); // Just to help out the garbage collector a little bit
+      }
 
       Token topLeft = tokenList.get(0);
       tokenCopySet = new HashSet<Token>();
@@ -1191,8 +1192,7 @@ public class AppActions {
                     token.getX() + gridCopiedFrom.getOffsetX(),
                     token.getY() + gridCopiedFrom.getOffsetY()));
         ZonePoint zp = grid.convert(cp);
-        tokenOffset =
-            new ZonePoint(zp.x - gridCopiedFrom.getOffsetX(), zp.y - gridCopiedFrom.getOffsetY());
+        tokenOffset = new ZonePoint(zp.x - grid.getOffsetX(), zp.y - grid.getOffsetY());
       } else {
         // For gridless sources, gridless destinations, or tokens that are not SnapToGrid: just use
         // the pixel offsets


### PR DESCRIPTION
### Identify the Bug or Feature request

Should hopefully fix #2260 for good.

### Description of the Change

Fixed a case of adjusting for the wrong grid when pasting tokens. In this case we needed to adjust for the destination grid, but were adjusting for the source grid.

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where tokens were being pasted in the wrong cell when the grid was adjusted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3870)
<!-- Reviewable:end -->
