### PR TITLE
Enables add/update buttons on state type change

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -14,11 +14,7 @@
  */
 package net.rptools.maptool.client.ui.campaignproperties;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -26,19 +22,10 @@ import java.awt.event.ItemListener;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
+import javax.swing.event.*;
 import javax.swing.filechooser.FileFilter;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppConstants;
@@ -46,30 +33,9 @@ import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.ColorWell;
 import net.rptools.maptool.client.ui.PreviewPanelFileChooser;
-import net.rptools.maptool.client.ui.token.AbstractTokenOverlay;
-import net.rptools.maptool.client.ui.token.BooleanTokenOverlay;
-import net.rptools.maptool.client.ui.token.ColorDotTokenOverlay;
-import net.rptools.maptool.client.ui.token.CornerImageTokenOverlay;
-import net.rptools.maptool.client.ui.token.CrossTokenOverlay;
-import net.rptools.maptool.client.ui.token.DiamondTokenOverlay;
-import net.rptools.maptool.client.ui.token.FlowColorDotTokenOverlay;
-import net.rptools.maptool.client.ui.token.FlowColorSquareTokenOverlay;
-import net.rptools.maptool.client.ui.token.FlowDiamondTokenOverlay;
-import net.rptools.maptool.client.ui.token.FlowImageTokenOverlay;
-import net.rptools.maptool.client.ui.token.FlowTriangleTokenOverlay;
-import net.rptools.maptool.client.ui.token.FlowYieldTokenOverlay;
-import net.rptools.maptool.client.ui.token.ImageTokenOverlay;
-import net.rptools.maptool.client.ui.token.OTokenOverlay;
-import net.rptools.maptool.client.ui.token.ShadedTokenOverlay;
-import net.rptools.maptool.client.ui.token.TriangleTokenOverlay;
-import net.rptools.maptool.client.ui.token.XTokenOverlay;
-import net.rptools.maptool.client.ui.token.YieldTokenOverlay;
+import net.rptools.maptool.client.ui.token.*;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.Asset;
-import net.rptools.maptool.model.AssetManager;
-import net.rptools.maptool.model.Campaign;
-import net.rptools.maptool.model.CampaignProperties;
-import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.drawing.AbstractTemplate.Quadrant;
 import net.rptools.maptool.util.StringUtil;
 
@@ -382,6 +348,7 @@ public class TokenStatesController
       // Change the enabled data components.
     } else if (TYPE.equals(name)) {
       enableDataComponents();
+      changedUpdate(null);
 
       // Update the selected overlay
     } else if (UPDATE.equals(name)) {
@@ -597,6 +564,7 @@ public class TokenStatesController
       // Set the type and change components
       formPanel.getComboBox(TYPE).setSelectedIndex(type.ordinal());
       enableDataComponents();
+      changedUpdate(null);
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #1711

### Description of the Change

The `changeUpdated` method which was responsible for enabling/disabling the Add and Update buttons based on the state of the dialog was not called when the a new value was selected in the Type combo box; as a result, the state of the buttons was changed only when an event like changing the name of the state was triggered.

Also, I renamed a couple of variables to make the logic of enabling/disabling a little clearer.

### Possible Drawbacks

None that I can think of.

### Documentation Notes

N/A

### Release Notes

Enables/disables the add/update buttons when changing the State type in the State dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3875)
<!-- Reviewable:end -->
