### PR TITLE
Ensure a frame's undocked bounds are not null prior to using them

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -367,11 +367,15 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
           "autohide", FunctionUtil.getDecimalForBoolean(frame.isAutohide()));
       frameProperties.addProperty("height", frame.getHeight());
       frameProperties.addProperty("width", frame.getWidth());
-      // The x & y are screen coordinates.
-      frameProperties.addProperty("undocked_x", dc.getUndockedBounds().getX());
-      frameProperties.addProperty("undocked_y", dc.getUndockedBounds().getY());
-      frameProperties.addProperty("undocked_h", dc.getUndockedBounds().getHeight());
-      frameProperties.addProperty("undocked_w", dc.getUndockedBounds().getWidth());
+      final var undockedBounds = dc.getUndockedBounds();
+      // A frame docked prior to a Restore Layout will lose its undocked bounds, causing NPE here.
+      if (undockedBounds != null) {
+        // The x & y are screen coordinates.
+        frameProperties.addProperty("undocked_x", undockedBounds.getX());
+        frameProperties.addProperty("undocked_y", undockedBounds.getY());
+        frameProperties.addProperty("undocked_h", undockedBounds.getHeight());
+        frameProperties.addProperty("undocked_w", undockedBounds.getWidth());
+      }
       // Many of the Frame/DockContext attributes shown in the JIDE javadocs don't seem to
       // get updated.  Docked height never changes but docked width does and matches Frame
       // width.  AutoHide Height/Width never change.


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3316

### Description of the Change

Prior to adding the undocked x, y, width and height to the result of `getInfo("client")`, we now check that the bounds are not null. If it is null, we do not include these fields in the result.

### Possible Drawbacks

There may be frameworks counting on these fields always being present. This isn't a breaking change since this case has always resulted in a NPE anyways. Still, some updates may be needed.

### Documentation Notes

N/A

### Release Notes

- Fixed an NPE raised by `getInfo("client")` as a result of certain docked frames not having an undocked state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3880)
<!-- Reviewable:end -->
