### PR TITLE
Remove a stray call to FunctionUtil.getZoneRenderer()

### DIFF
--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -189,7 +189,7 @@ public class FunctionUtil {
       throw new ParserException(I18N.getText(KEY_UNKNOWN_MAP, functionName, map));
     }
 
-    return getZoneRenderer(functionName, map);
+    return zoneRenderer;
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Fix a mistake in PR #3861 (for #3857)

### Description of the Change

I somehow inserted a stray call to `FunctionUtil.getZoneRenderer()` in `FunctionUtil.getZoneRendererFromParam()`, rather than returning `zoneRenderer`. This PR fixes that to return what we already have.


### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3881)
<!-- Reviewable:end -->
