### PR TITLE
Sends the `START_ASSET_TRANSFER_MSG` through the same channel as the `UPDATE_ASSET_TRANSFER_MSG`

### DIFF
--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -17,7 +17,9 @@ package net.rptools.maptool.server;
 import static net.rptools.maptool.server.proto.Message.MessageTypeCase.HEARTBEAT_MSG;
 
 import java.awt.geom.Area;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import net.rptools.clientserver.simple.MessageHandler;
 import net.rptools.lib.MD5Key;
@@ -26,6 +28,7 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ServerCommandClientImpl;
 import net.rptools.maptool.client.ui.zone.FogUtil;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.common.MapToolConstants;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.InitiativeList.TokenInitiative;
@@ -623,7 +626,10 @@ public class ServerMessageHandler implements MessageHandler {
       var msg = StartAssetTransferMsg.newBuilder().setHeader(producer.getHeader().toDto());
       server
           .getConnection()
-          .sendMessage(id, Message.newBuilder().setStartAssetTransferMsg(msg).build());
+          .sendMessage(
+              id,
+              MapToolConstants.Channel.IMAGE,
+              Message.newBuilder().setStartAssetTransferMsg(msg).build());
       server.addAssetProducer(id, producer);
 
     } catch (IllegalArgumentException iae) {


### PR DESCRIPTION
Fixes #3853

### Identify the Bug or Feature request

As discussed in #3853, sometimes a client can get stuck during the download of a campaign.

### Description of the Change

Following the suggestion from @sauliuskarmanovas, we send the `START_ASSET_TRANSFER_MSG` on the same channel as the `UPDATE_ASSET_TRANSFER_MESSAGE` to prevent that the messages referring to the same asset are received from the client in the wrong order.

### Possible Drawbacks

None foreseen

### Tests done

- opened a campaign with 200+ asset, connected with a client (on the same LAN), the campaign was downloaded successfully

### Documentation Notes

N/A

### Release Notes

- Fixed campaign stuck during download

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3886)
<!-- Reviewable:end -->
