### PR TITLE
Fix maximum number of parameters for setTokenLayoutProps()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -57,7 +57,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
   private TokenPropertyFunctions() {
     super(
         0,
-        4,
+        5,
         "getPropertyNames",
         "getAllPropertyNames",
         "getPropertyNamesRaw",


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3900

### Description of the Change

Since `setTokenLayoutProps()` can take 5 parameters, the max parameters declared for `TokenPropertyFunctions` needs to be at least 5 instead of 4.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where `setTokenLayoutProps()` would not accept a fifth parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3901)
<!-- Reviewable:end -->
