### PR TITLE
Un-finalize LightSource.lumens

### DIFF
--- a/src/main/java/net/rptools/maptool/model/LightSource.java
+++ b/src/main/java/net/rptools/maptool/model/LightSource.java
@@ -47,7 +47,7 @@ public class LightSource implements Comparable<LightSource>, Serializable {
 
   // Lumens are now in the individual Lights. This field is only here for backwards compatibility
   // and should not otherwise be used.
-  @Deprecated private final int lumens = Integer.MIN_VALUE;
+  @Deprecated private int lumens = Integer.MIN_VALUE;
 
   /**
    * Constructs a personal light source.


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3902

### Description of the Change

Java's constant propagation was getting cute, preventing our `readResolve()` logic from detecting upgraded light sources. Removing `final` makes JVM respect other values that might be deserialized into the field, allowing `readResolve()` to function properly.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A