### PR TITLE
Adds the tooltip for Initiative button in Full Screen Mode

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1721,6 +1721,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
         });
 
     initiativeButton.setBorder(btn.getBorder());
+    initiativeButton.setToolTipText(I18N.getText("tools.initiative.tooltip"));
     fullScreenToolPanel.add(initiativeButton);
 
     // set buttons to uniform size

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1583,6 +1583,7 @@ initiative.menu.remove          = Remove
 initiative.menu.resume          = Resume
 initiative.menu.setState        = Set Initiative...
 
+
 layer.token      = Token
 layer.gm         = Hidden
 layer.object     = Object
@@ -2496,6 +2497,7 @@ tools.token.fow.npc.tooltip = Show FoW for NPC Tokens you explicitly own or are 
 tools.token.fow.pc.tooltip  = Show FoW for PC Tokens you explicitly own or are owned by all.
 tools.topo.tooltip          = Vision Blocking Layer (VBL) Tools
 tools.zoneselector.tooltip  = Select Map
+tools.initiative.tooltip    = Initiative Tools
 
 undefinedmacro.unknownCommand = Unknown command: "{0}".  Try <b>/help</b> for a list of commands.
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3806

### Description of the Change

This adds the missing tooltip from the Initiative button in full screen mode.

### Possible Drawbacks

N/A (?)

### Documentation Notes

N/A

### Release Notes

- adds missing tooltip from the Initiative button in fullscreen mode

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3910)
<!-- Reviewable:end -->
