### PR TITLE
Fire TokensAdded / ZoneAdded when handling PutZoneMsg

### DIFF
--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -36,7 +36,9 @@ import net.rptools.maptool.model.Zone.VisionType;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawnElement;
 import net.rptools.maptool.model.drawing.Pen;
+import net.rptools.maptool.model.zones.TokensAdded;
 import net.rptools.maptool.model.zones.TokensRemoved;
+import net.rptools.maptool.model.zones.ZoneAdded;
 import net.rptools.maptool.model.zones.ZoneRemoved;
 import net.rptools.maptool.server.proto.*;
 import net.rptools.maptool.transfer.AssetProducer;
@@ -461,8 +463,8 @@ public class ServerMessageHandler implements MessageHandler {
     server.getCampaign().putZone(zone);
 
     // Now we have fire off adding the tokens in the zone
-    new MapToolEventBus().getMainEventBus().post(new TokensRemoved(zone, zone.getTokens()));
-    new MapToolEventBus().getMainEventBus().post(new ZoneRemoved(zone));
+    new MapToolEventBus().getMainEventBus().post(new ZoneAdded(zone));
+    new MapToolEventBus().getMainEventBus().post(new TokensAdded(zone, zone.getTokens()));
   }
 
   private void handle(PutLabelMsg msg) {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement
* Fill out the template below. Any pull request that does not include enough information to be reviewed in timely manner will result in a request for you to update the pull request 
  and possibly closure of the pull request if it is not provided after this request.
* After you create the pull request, all status checks must pass before a maintainer will review your contribution. 


### Identify the Bug or Feature request

Fixes #3908


### Description of the Change

This fixes an error introduced in PR #3749. In `ServerMessageHandler`, we were firing `TokensRemoved` / `ZoneRemoved` where `TokensAdded`/`ZoneAdded` is expected. The analogous logic in `ClientMessageHandler` had this correct already.

In particular this was causing Lib:tokens to be removed from the library manager in cases such as cell type changes.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A (fixes a new bug)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3912)
<!-- Reviewable:end -->
