### PR TITLE
Uses the proper function name in the error messages

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
@@ -354,20 +354,18 @@ public class Topology_Functions extends AbstractFunction {
       if (token == null) {
         throw new ParserException(
             I18N.getText(
-                "macro.function.general.unknownToken",
-                "getTokenVBL",
-                parameters.get(0).toString()));
+                "macro.function.general.unknownToken", functionName, parameters.get(0).toString()));
       }
     } else if (parameters.size() == 0) {
       MapToolVariableResolver res = (MapToolVariableResolver) resolver;
       token = res.getTokenInContext();
       if (token == null) {
         throw new ParserException(
-            I18N.getText("macro.function.general.noImpersonated", "getTokenVBL"));
+            I18N.getText("macro.function.general.noImpersonated", functionName));
       }
     } else {
       throw new ParserException(
-          I18N.getText("macro.function.general.tooManyParam", "getTokenVBL", 1, parameters.size()));
+          I18N.getText("macro.function.general.tooManyParam", functionName, 1, parameters.size()));
     }
 
     JsonArray allShapes = new JsonArray();
@@ -437,7 +435,7 @@ public class Topology_Functions extends AbstractFunction {
     }
     if (token == null) {
       throw new ParserException(
-          I18N.getText("macro.function.general.noImpersonated", "getTokenVBL"));
+          I18N.getText("macro.function.general.noImpersonated", functionName));
     }
 
     Area tokenTopology = new Area();
@@ -525,9 +523,7 @@ public class Topology_Functions extends AbstractFunction {
       if (token == null) {
         throw new ParserException(
             I18N.getText(
-                "macro.function.general.unknownToken",
-                "getTokenVBL",
-                parameters.get(0).toString()));
+                "macro.function.general.unknownToken", functionName, parameters.get(0).toString()));
       }
     } else {
       MapToolVariableResolver res = (MapToolVariableResolver) resolver;


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3883

### Description of the Change

"getTokenVBL" was used in a number of places where `functionName` was required.

### Possible Drawbacks

None that I can see

### Documentation Notes

The following sample code executed in the chat:

```
[r: transferVBL('[]', 1, 'not a token')]
```

now produces:


![correct_transfer_vbl](https://user-images.githubusercontent.com/1532349/231290513-2e0518aa-a509-49b1-b115-3da7e0936ec1.jpg)

### Release Notes

* fixes function name being wrong in error messages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3916)
<!-- Reviewable:end -->
