### PR TITLE
Jmr3366 - FR #1386 to allow opacity to be set at 0

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -884,7 +884,7 @@
                 </constraints>
                 <properties>
                   <majorTickSpacing value="10"/>
-                  <minimum value="5"/>
+                  <minimum value="0"/>
                   <minorTickSpacing value="5"/>
                   <name value="tokenOpacitySlider"/>
                   <orientation value="1"/>

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.java
@@ -453,7 +453,7 @@ public class TokenPropertiesDialog {
         panel11.add(spacer8, new GridConstraints(0, 9, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
         final JSlider slider1 = new JSlider();
         slider1.setMajorTickSpacing(10);
-        slider1.setMinimum(5);
+        slider1.setMinimum(0);
         slider1.setMinorTickSpacing(5);
         slider1.setName("tokenOpacitySlider");
         slider1.setOrientation(1);

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -674,7 +674,7 @@ public class Token implements Cloneable {
   }
 
   public float getTokenOpacity() {
-    if (tokenOpacity <= 0.0f) {
+    if (tokenOpacity < 0.0f) {
       tokenOpacity = 1.0f;
     }
 
@@ -701,8 +701,8 @@ public class Token implements Cloneable {
     if (alpha > 1.0f) {
       alpha = 1.0f;
     }
-    if (alpha <= 0.0f) {
-      alpha = 0.05f;
+    if (alpha < 0.0f) {
+      alpha = 0.0f;
     }
 
     tokenOpacity = alpha;

--- a/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
+++ b/src/main/resources/net/rptools/maptool/client/ui/forms/tokenPropertiesDialog.xml
@@ -4981,7 +4981,7 @@
                                    <at name="width">29</at>
                                    <at name="majorTickSpacing">20</at>
                                    <at name="minorTickSpacing">5</at>
-                                   <at name="minimum">5</at>
+                                   <at name="minimum">0</at>
                                    <at name="value">100</at>
                                    <at name="height">109</at>
                                   </object>


### PR DESCRIPTION
### Identify the Bug or Feature request
#1386  
### Description of the Change
Allows for token opacity to be set at zero through the dialog or through `setTokenOpacity()`

### Possible Drawbacks
Tokens can be made invisible and would only be seen through Map Explorer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3921)
<!-- Reviewable:end -->
