### PR TITLE
Fr 3438

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ZoomFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ZoomFunctions.java
@@ -17,6 +17,8 @@ package net.rptools.maptool.client.functions;
 import com.google.gson.JsonObject;
 import java.awt.Rectangle;
 import java.util.List;
+
+import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.model.CellPoint;
@@ -35,7 +37,7 @@ public class ZoomFunctions extends AbstractFunction {
   private static final String EQUALS = "=";
 
   private ZoomFunctions() {
-    super(0, 6, "getZoom", "setZoom", "getViewArea", "setViewArea", "getViewCenter");
+    super(0, 6, "getZoom", "setZoom", "getViewArea", "setViewArea", "getViewCenter", "setZoomLock");
   }
 
   public static ZoomFunctions getInstance() {
@@ -81,6 +83,12 @@ public class ZoomFunctions extends AbstractFunction {
           args.size() > 0 ? FunctionUtil.paramAsBoolean(functionName, args, 0, true) : true;
       String delim = args.size() > 1 ? args.get(1).toString() : ",";
       return getViewCenter(pixels, delim);
+    }
+    if ("setZoomLock".equalsIgnoreCase(functionName)) {
+      FunctionUtil.checkNumberParam(functionName, args, 1, 1);
+      Boolean zoom = FunctionUtil.paramAsBoolean(functionName, args, 0, true);
+      AppState.setZoomLocked(zoom);
+      return "";
     }
     return null;
   }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement

### Identify the Bug or Feature request
Added setZoomLock(0/1) returns nothing
Added setMoveLock(0/1) returns nothing

Resolves FR #3438

closes #3438
resolves #3438

### Description of the Change
Added two functions noted above

### Possible Drawbacks
Nothing prevents the end-user from manually changing these settings back

Examples:

`setMoveLock(1)`
`setZoomLock(1)`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3937)
<!-- Reviewable:end -->
