### PR TITLE
Upgrade to FlatLaf version 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -366,11 +366,11 @@ dependencies {
     implementation 'com.thoughtworks.xstream:xstream:1.4.19'
 
     // themes
-    implementation 'com.formdev:flatlaf:2.4'
-    implementation 'com.formdev:flatlaf-intellij-themes:2.4'
-    implementation 'com.formdev:flatlaf-extras:2.4'
+    implementation 'com.formdev:flatlaf:3.1'
+    implementation 'com.formdev:flatlaf-intellij-themes:3.1'
+    implementation 'com.formdev:flatlaf-extras:3.1'
     implementation 'com.formdev:svgSalamander:1.1.3'
-    implementation 'com.formdev:flatlaf-jide-oss:2.4'
+    implementation 'com.formdev:flatlaf-jide-oss:3.1'
 
     // JS support for macros
     implementation group: 'org.graalvm.js', name: 'js', version: '21.2.0'

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/TokenPanelTreeCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/TokenPanelTreeCellRenderer.java
@@ -108,6 +108,10 @@ public class TokenPanelTreeCellRenderer extends DefaultTreeCellRenderer {
 
   @Override
   public Icon getLeafIcon() {
-    return new ImageIcon(image);
+    if (image != null) {
+      return new ImageIcon(image);
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION


### Identify the Bug or Feature request
resolves #3943 

### Description of the Change
Updates to latest version of FlatLaf


### Possible Drawbacks
There are bound to be tweaks we have to make to MapTool based on the update, after all MT is an old code base with some very dusty corners.

### Release Notes
- Update to FlatLaf 3.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3944)
<!-- Reviewable:end -->
