### PR TITLE
Update actions in GitHub build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
         java: [ '20' ]
+        distribution: ['temurin']
       fail-fast: false
     steps:
       #       ____          _  __     __   ___        ____                __
@@ -29,7 +30,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Cache Gradle
       uses: actions/cache@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,14 @@ jobs:
       #   /_____/ \__,_//_//_/ \__,_/   \____/\/  /_/     \__,_/ \___//_/|_| \__,_/ \__, / \___/
       #                                                                            /____/
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
     - name: Cache Gradle
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       # Cache only seems to work on ubuntu right now...
       if: matrix.os == 'ubuntu-latest'
       with:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: "20"
       - name: spotlessCheck
         run: ./gradlew spotlessCheck

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: ${{ matrix.java }}
+          distribution: ${{ matrix.distribution }}
       - name: Cache Gradle
         uses: actions/cache@v3
         with:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: "20"
       - name: spotlessCheck
@@ -41,13 +41,13 @@ jobs:
       fail-fast: false
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
       - name: Cache Gradle
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -39,6 +39,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
         java: [ '20' ]
+        distribution: [ 'temurin']
       fail-fast: false
     steps:
       - name: Git checkout
@@ -47,6 +48,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.java }}
       - name: Cache Gradle
         uses: actions/cache@v3
         with:


### PR DESCRIPTION

### Identify the Bug or Feature request
closes #3930


### Description of the Change
Update actions to later versions as node 12 actions are deprecated.
The cache action in particular was a worry as it was using deprecated functionality that would stop working come first of June 😱 

### Possible Drawbacks
Possibly will require further tweaks.

### Documentation Notes
Update actions to later versions as node 12 actions are deprecated

### Release Notes
- Update actions to later versions as node 12 actions are deprecated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3947)
<!-- Reviewable:end -->
