### PR TITLE
functions- getMoveLock() - setMoveLock(0/1)

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ServerFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ServerFunctions.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.server.ServerPolicy;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
@@ -28,7 +29,14 @@ public class ServerFunctions extends AbstractFunction {
 
   /** Creates a new {@code PlayerFunctions} object. */
   public ServerFunctions() {
-    super(0, 0, "server.isServer", "server.isHosting", "server.isPersonal");
+    super(
+        0,
+        1,
+        "server.isServer",
+        "server.isHosting",
+        "server.isPersonal",
+        "setMoveLock",
+        "getMoveLock");
   }
 
   @Override
@@ -43,6 +51,24 @@ public class ServerFunctions extends AbstractFunction {
           : BigDecimal.ZERO;
       case "server.ishosting" -> MapTool.isHostingServer() ? BigDecimal.ONE : BigDecimal.ZERO;
       case "server.ispersonal" -> MapTool.isPersonalServer() ? BigDecimal.ONE : BigDecimal.ZERO;
+      case "getmovelock" -> MapTool.getServerPolicy().isMovementLocked();
+      case "setmovelock" -> {
+        if (parameters.size() == 1) {
+          BigDecimal ml = (BigDecimal) parameters.get(0);
+          if (ml.intValue() == 0 || ml.intValue() == 1) {
+            ServerPolicy policy = MapTool.getServerPolicy();
+            policy.setIsMovementLocked(ml.intValue() != 0);
+            MapTool.updateServerPolicy(policy);
+          } else {
+            throw new ParserException(
+                I18N.getText("macro.function.general.argumentTypeInvalid", "setmovelock"));
+          }
+        } else {
+          throw new ParserException(
+              I18N.getText("macro.function.general.argumentTypeInvalid", "setmovelock"));
+        }
+        yield "";
+      }
       default -> throw new ParserException(
           I18N.getText("macro.function.general.unknownFunction", functionName));
     };


### PR DESCRIPTION
### Identify the Bug or Feature request
https://forums.rptools.net/viewtopic.php?t=26911
Discord contains requests from several users

### Description of the Change
Two functions:
`setMoveLock(0/1)` returns nothing.  Mimics the Tool menu -> Lock Player Movement check
`getMoveLock()` returns the current state of the check in true or false

### Possible Drawbacks
End users can still use the hot key or menu to change the state

### Release Notes
Examples:
`[r: setMoveLock(0)]` will uncheck the Lock Player Movement check
`[r: setMoveLock(1)]` will check the Lock Player Movement check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3951)
<!-- Reviewable:end -->
