### PR TITLE
Refactor ZoneView to keep lighting consistent

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/IlluminationModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/IlluminationModel.java
@@ -1,0 +1,101 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Light;
+import net.rptools.maptool.model.LightSource;
+
+/**
+ * Manages the light sources and illuminations of a zone, for a given set of illumniator parameters.
+ *
+ * <p>This needs to be kept in sync with the associated {@code Zone} in order for the results to
+ * make sense
+ *
+ * <p>No caching is done here, this is purely a data structure.
+ */
+public class IlluminationModel {
+  /**
+   * Associates a LitArea stored in an Illuminator with the Light that it was created for.
+   *
+   * <p>This is used to represent normal lights, personal lights, and day light. In the case of
+   * daylight, lightInfo will be null since it doesn't originate from an actual light, and should
+   * never be rendered.
+   *
+   * @param litArea
+   * @param lightInfo
+   */
+  public record ContributedLight(Illuminator.LitArea litArea, LightInfo lightInfo) {}
+
+  /**
+   * Combines a LightSource and a Light for easy referencing in ContributedLight.
+   *
+   * @param lightSource
+   * @param light
+   */
+  public record LightInfo(LightSource lightSource, Light light) {}
+
+  /**
+   * The data structure for calculating lit areas according to lumens. Lit areas can be added and
+   * removed from this structure.
+   */
+  private final Illuminator illuminator = new Illuminator();
+
+  /**
+   * The list of all non-personal lights contributing to the the illuminator.
+   *
+   * <p>This is used to associate the LitAreas added to the Illuminator with the original lighting
+   * parameters that created it. We can use this information to generate DrawableLights for
+   * rendering.
+   */
+  private final Map<GUID, List<ContributedLight>> contributedLightsByToken = new HashMap<>();
+
+  public void removeToken(GUID tokenId) {
+    final var contributions =
+        Objects.requireNonNullElse(
+            contributedLightsByToken.remove(tokenId), Collections.<ContributedLight>emptyList());
+    // Remove each contribution from the illuminator as well.
+    for (final var contributedLight : contributions) {
+      illuminator.remove(contributedLight.litArea());
+    }
+  }
+
+  public boolean hasToken(GUID tokenId) {
+    return contributedLightsByToken.containsKey(tokenId);
+  }
+
+  public void addToken(GUID tokenId, List<ContributedLight> contributions) {
+    for (final var contribution : contributions) {
+      illuminator.add(contribution.litArea());
+      contributedLightsByToken.computeIfAbsent(tokenId, id -> new ArrayList<>()).add(contribution);
+    }
+  }
+
+  public Stream<ContributedLight> getContributions() {
+    return contributedLightsByToken.values().stream().flatMap(Collection::stream);
+  }
+
+  public Illumination getIllumination() {
+    return illuminator.getIllumination();
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -618,8 +618,7 @@ public class ZoneRenderer extends JComponent
   /**
    * Remove the token from: {@link #tokenLocationCache}, {@link #flipImageMap}, {@link
    * #flipIsoImageMap}, {@link #labelRenderingCache}. Set the {@link #visibleScreenArea}, {@link
-   * #tokenStackMap}, {@link #drawableLights}, {@link #drawableAuras} to null. Flush the token from
-   * the zoneView.
+   * #tokenStackMap} to null. Flush the token from {@link #zoneView}.
    *
    * @param token the token to flush
    */
@@ -638,9 +637,6 @@ public class ZoneRenderer extends JComponent
 
     // This could also be smarter
     tokenStackMap = null;
-
-    drawableLights = null;
-    drawableAuras = null;
 
     zoneView.flush(token);
   }
@@ -668,20 +664,13 @@ public class ZoneRenderer extends JComponent
     flushDrawableRenderer();
     flipImageMap.clear();
     flipIsoImageMap.clear();
-    drawableLights = null;
-    drawableAuras = null;
     zoneView.flushFog();
 
     isLoaded = false;
   }
 
-  /**
-   * Set the {@link #drawableLights} and {@link #drawableAuras} to null, flush the zoneView, and
-   * repaint.
-   */
+  /** Flush the {@link #zoneView} and repaint. */
   public void flushLight() {
-    drawableLights = null;
-    drawableAuras = null;
     zoneView.flush();
     repaintDebouncer.dispatch();
   }
@@ -1045,12 +1034,10 @@ public class ZoneRenderer extends JComponent
   }
 
   /**
-   * This method clears {@link #drawableLights}, {@link #drawableAuras}, {@link #visibleScreenArea},
-   * and {@link #lastView}. It also flushes the {@link #zoneView}.
+   * This method clears {@link #visibleScreenArea} and {@link #lastView}. It also flushes the {@link
+   * #zoneView}.
    */
   public void invalidateCurrentViewCache() {
-    drawableLights = null;
-    drawableAuras = null;
     visibleScreenArea = null;
     lastView = null;
   }
@@ -1423,12 +1410,8 @@ public class ZoneRenderer extends JComponent
   private void renderLights(Graphics2D g, PlayerView view) {
     // Collect and organize lights
     timer.start("renderLights:getLights");
-    if (drawableLights == null) {
-      timer.start("renderLights:populateCache");
-      drawableLights = new ArrayList<>(zoneView.getDrawableLights(view));
-      timer.stop("renderLights:populateCache");
-    }
-    timer.start("renderLights:filterLights");
+    final var drawableLights = zoneView.getDrawableLights(view);
+    timer.stop("renderLights:getLights");
 
     if (AppState.isShowLights()) {
       // Lighting enabled.
@@ -1482,14 +1465,8 @@ public class ZoneRenderer extends JComponent
     }
   }
 
-  /** Caches the lights to be drawn as returned ZoneView. */
-  private List<DrawableLight> drawableLights;
-  /** Holds the auras from lightSourceMap after they have been combined. */
-  private List<DrawableLight> drawableAuras;
-
   /**
-   * Get the list of auras from lightSourceMap, combine them, store them in drawableAuras, and draw
-   * them.
+   * Render the auras.
    *
    * @param g the Graphics2D object.
    * @param view the player view.
@@ -1497,9 +1474,7 @@ public class ZoneRenderer extends JComponent
   private void renderAuras(Graphics2D g, PlayerView view) {
     // Setup
     timer.start("renderAuras:getAuras");
-    if (drawableAuras == null) {
-      drawableAuras = new ArrayList<>(zoneView.getDrawableAuras());
-    }
+    final var drawableAuras = zoneView.getDrawableAuras();
     timer.stop("renderAuras:getAuras");
 
     timer.start("renderAuras:renderAuraOverlay");


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3905

### Description of the Change

`ZoneView.illuminators` and `ZoneView.contributedLightsByToken` have been moved into a new `IlluminationModel` that tracks a single `Illuminator` and set of token contributions. `ZoneView.getIlluminationModel(IlluminationKey)` returns such a model and ensures that it is up-to-date and contains all necessary light sources. This replaces `ZoneView.getUpToDateIlluminator()` which has subtle interactions with the state of token contributions.

We no longer have `ZoneView.illuminationCache` as it just caches a relatively lightweight intermediate result. We still cache full illumination results via `ZoneView.illuminationsPerView`.

`ZoneRenderer` no longer caches drawable lights and auras because it's possible for it to get out-of-sync with the underlying `ZoneView`. Instead, `ZoneView` caches `DrawableLight` on a per-view basis, and `DrawableAuras` generally. These are kept in sync by invalidating them at the same time as the caches from which they are calculated.

Since `ZoneView`'s flushing methods can be called off the Swing thread, we now delegate the flushing to the Swing thread. The rest of the ZoneView still expects to run on the Swing thread. We can do this now that we have `IlluminationModel` to keep the contributions and illuminators in-sync, and now that `DrawableLight`s and `DrawableAura`s are cached in ZoneView and we don't have to worry about any potentially delays in `ZoneView` flushing relative to the `ZoneRenderer`.

### Possible Drawbacks

Possibility of exposing other multithreading issues.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3952)
<!-- Reviewable:end -->
