### PR TITLE
Allow mapped integers to be mapped back to integral BigDecimals

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ExecFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExecFunction.java
@@ -31,11 +31,15 @@ import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.Function;
 import net.rptools.parser.function.ParameterException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ExecFunction extends AbstractFunction {
 
   /** Singleton instance of the ExecFunction class. */
   private static final ExecFunction instance = new ExecFunction();
+
+  private static final Logger log = LogManager.getLogger(ExecFunction.class);
 
   /** Object used for various operations on {@link JsonArray}s. */
   private JsonArrayFunctions jsonArrayFunctions =
@@ -204,7 +208,8 @@ public class ExecFunction extends AbstractFunction {
     MapTool.getParser().enterTrustedContext(functionName, "execFunction");
     try {
       function.evaluate(parser, new MapToolVariableResolver(null), functionName, execArgs);
-    } catch (ParserException ignored) {
+    } catch (ParserException pe) {
+      log.error("execFunction failed:", pe);
     }
     MapTool.getParser().exitContext();
   }

--- a/src/main/java/net/rptools/maptool/server/Mapper.java
+++ b/src/main/java/net/rptools/maptool/server/Mapper.java
@@ -293,7 +293,8 @@ public class Mapper {
         return dto.getStringVal();
       }
       case DOUBLE_VAL -> {
-        return BigDecimal.valueOf(dto.getDoubleVal());
+        final var stripped = BigDecimal.valueOf(dto.getDoubleVal()).stripTrailingZeros();
+        return stripped.setScale(Math.max(0, stripped.scale()));
       }
       case JSON_VAL -> {
         return new JsonParser().parse(dto.getJsonVal());


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3895

### Description of the Change

The root of the problem is that when we send `execFunction` parameters to clients, each parameter is represented as a `ScriptTypeDto` which supports doubles strings and JSON values. Numbers (represented as `BigDecimal`) are represented as doubles regardless of whether they are integral or not. When the client receives the parameters, the doubles are converted back to `BigDecimal`, but integral values still keep their fractional part and thus the string representation can't be parsed as integers.

This PR changes the client side conversion to remove zero fractional parts that might exist in the `BigDecimal` on the client side. This guarantees the string representation can be parsed by functions like `Integer.valueOf()`. Note that this change only applies to parameters of `execFunction()`.

I've also added logging for when the callee of `execFunction` fails, so that similar issues in the future can be more easily diagnosed. 

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where `execFunction()` could not run `playStream()` on clients if two or more parameters were passed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3965)
<!-- Reviewable:end -->
