### PR TITLE
Fix repeated macro buttons in selection panel

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
@@ -186,7 +186,10 @@ public abstract class AbstractMacroPanel extends JPanel implements Scrollable, M
 
   @Subscribe
   void onZoneActivated(ZoneActivated event) {
-    reset();
+    SwingUtilities.invokeLater(
+        () -> {
+          reset();
+        });
   }
 
   public static void clearHotkeys(AbstractMacroPanel panel) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/ImpersonatePanel.java
@@ -157,27 +157,42 @@ public class ImpersonatePanel extends AbstractMacroPanel {
 
   @Subscribe
   private void onSelectionChanged(SelectionModel.SelectionChanged event) {
-    reset();
+    SwingUtilities.invokeLater(
+        () -> {
+          reset();
+        });
   }
 
   @Subscribe
   private void onTokenMacroChanged(TokenMacroChanged event) {
-    resetIfAnyImpersonated(Collections.singletonList(event.token()));
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfAnyImpersonated(Collections.singletonList(event.token()));
+        });
   }
 
   @Subscribe
   private void onTokenPanelChanged(TokenPanelChanged event) {
-    resetIfAnyImpersonated(Collections.singletonList(event.token()));
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfAnyImpersonated(Collections.singletonList(event.token()));
+        });
   }
 
   @Subscribe
   private void onTokensRemoved(TokensRemoved event) {
-    resetIfAnyImpersonated(event.tokens());
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfAnyImpersonated(event.tokens());
+        });
   }
 
   @Subscribe
   private void onTokensEdited(TokenEdited event) {
-    resetIfAnyImpersonated(Collections.singletonList(event.token()));
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfAnyImpersonated(Collections.singletonList(event.token()));
+        });
   }
 
   private void resetIfAnyImpersonated(List<Token> tokens) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/SelectionPanel.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui.macrobuttons.panels;
 import com.google.common.eventbus.Subscribe;
 import com.jidesoft.docking.DockableFrame;
 import java.util.*;
+import javax.swing.SwingUtilities;
 import net.rptools.lib.CodeTimer;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.AppUtil;
@@ -112,32 +113,46 @@ public class SelectionPanel extends AbstractMacroPanel {
       MapTool.getProfilingNoteFrame().addText(results);
       if (log.isDebugEnabled()) log.debug(results);
     }
-    new MapToolEventBus().getMainEventBus().register(this);
   }
 
   @Subscribe
   private void onSelectionChanged(SelectionModel.SelectionChanged event) {
-    reset();
+    SwingUtilities.invokeLater(
+        () -> {
+          reset();
+        });
   }
 
   @Subscribe
   private void onTokenMacroChanged(TokenMacroChanged event) {
-    resetIfSelected(Collections.singletonList(event.token()));
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfSelected(Collections.singletonList(event.token()));
+        });
   }
 
   @Subscribe
   private void onTokenPanelChanged(TokenPanelChanged event) {
-    resetIfSelected(Collections.singletonList(event.token()));
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfSelected(Collections.singletonList(event.token()));
+        });
   }
 
   @Subscribe
   private void onTokensRemoved(TokensRemoved event) {
-    resetIfSelected(event.tokens());
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfSelected(event.tokens());
+        });
   }
 
   @Subscribe
   private void onTokenEdited(TokenEdited event) {
-    resetIfSelected(Collections.singletonList(event.token()));
+    SwingUtilities.invokeLater(
+        () -> {
+          resetIfSelected(Collections.singletonList(event.token()));
+        });
   }
 
   private void resetIfSelected(List<Token> tokenList) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3977

### Description of the Change

Some of the events that `SelectionPanel` handles are fired off the Swing thread, resulting in unexpected code flow. This PR changes those event handlers to run on the Swing thread, and does the same for the other macro panels.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where macro buttons would be added to the selection panel twice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3978)
<!-- Reviewable:end -->
