### PR TITLE
Fix for lights not updating after token move

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -760,9 +760,12 @@ public class ClientMessageHandler implements MessageHandler {
   }
 
   private void handle(PutAssetMsg msg) {
-    AssetManager.putAsset(Asset.fromDto(msg.getAsset()));
-    MapTool.getFrame().getCurrentZoneRenderer().flushDrawableRenderer();
-    MapTool.getFrame().refresh();
+    EventQueue.invokeLater(
+        () -> {
+          AssetManager.putAsset(Asset.fromDto(msg.getAsset()));
+          MapTool.getFrame().getCurrentZoneRenderer().flushDrawableRenderer();
+          MapTool.getFrame().refresh();
+        });
   }
 
   private void handle(PlayerDisconnectedMsg msg) {
@@ -979,14 +982,17 @@ public class ClientMessageHandler implements MessageHandler {
   }
 
   private void handle(AddTopologyMsg addTopologyMsg) {
-    var zoneGUID = GUID.valueOf(addTopologyMsg.getZoneGuid());
-    var area = Mapper.map(addTopologyMsg.getArea());
-    var topologyType = Zone.TopologyType.valueOf(addTopologyMsg.getType().name());
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(addTopologyMsg.getZoneGuid());
+          var area = Mapper.map(addTopologyMsg.getArea());
+          var topologyType = Zone.TopologyType.valueOf(addTopologyMsg.getType().name());
 
-    var zone = MapTool.getCampaign().getZone(zoneGUID);
-    zone.addTopology(area, topologyType);
+          var zone = MapTool.getCampaign().getZone(zoneGUID);
+          zone.addTopology(area, topologyType);
 
-    MapTool.getFrame().getZoneRenderer(zoneGUID).repaint();
+          MapTool.getFrame().getZoneRenderer(zoneGUID).repaint();
+        });
   }
 
   private void handle(BootPlayerMsg bootPlayerMsg) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.swing.SwingUtilities;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.Illumination.LumensLevel;
@@ -777,29 +776,23 @@ public class ZoneView {
    * explicit flush should go away or at least be reduced.
    */
   public void flush() {
-    SwingUtilities.invokeLater(
-        () -> {
-          // Recalculate everything.
-          illuminationModels.clear();
+    // Recalculate everything.
+    illuminationModels.clear();
 
-          contributedPersonalLightsByToken.clear();
-          tokenVisibleAreaCache.clear();
+    contributedPersonalLightsByToken.clear();
+    tokenVisibleAreaCache.clear();
 
-          tokenVisionCachePerView.clear();
-          illuminationsPerView.clear();
-          exposedAreaMap.clear();
-          visibleAreaMap.clear();
+    tokenVisionCachePerView.clear();
+    illuminationsPerView.clear();
+    exposedAreaMap.clear();
+    visibleAreaMap.clear();
 
-          drawableLights.clear();
-          drawableAuras = null;
-        });
+    drawableLights.clear();
+    drawableAuras = null;
   }
 
   public void flushFog() {
-    SwingUtilities.invokeLater(
-        () -> {
-          exposedAreaMap.clear();
-        });
+    exposedAreaMap.clear();
   }
 
   /**
@@ -810,38 +803,35 @@ public class ZoneView {
    * @param token the token to flush.
    */
   public void flush(Token token) {
-    SwingUtilities.invokeLater(
-        () -> {
-          for (final var cache : tokenVisionCachePerView.values()) {
-            cache.remove(token.getId());
-          }
-          tokenVisibleAreaCache.remove(token.getId());
+    for (final var cache : tokenVisionCachePerView.values()) {
+      cache.remove(token.getId());
+    }
+    tokenVisibleAreaCache.remove(token.getId());
 
-          // TODO Split logic for light and sight, since the sight portion is entirely duplicated.
-          final var modelsWithToken =
-              illuminationModels.values().stream()
-                  .filter(model -> model.hasToken(token.getId()))
-                  .toList();
-          if (!modelsWithToken.isEmpty() || token.hasLightSources()) {
-            modelsWithToken.forEach(model -> model.removeToken(token.getId()));
-            contributedPersonalLightsByToken.remove(token.getId());
-            tokenVisionCachePerView.clear();
-            illuminationsPerView.clear();
-            exposedAreaMap.clear();
-            visibleAreaMap.clear();
-            // TODO Could we instead only clear those views that include the token?
-            drawableLights.clear();
-            drawableAuras = null;
-          } else if (token.getHasSight()) {
-            contributedPersonalLightsByToken.remove(token.getId());
-            // TODO Could we instead only clear those views that include the token?
-            illuminationsPerView.clear();
-            exposedAreaMap.clear();
-            visibleAreaMap.clear();
-            drawableLights.clear();
-            drawableAuras = null;
-          }
-        });
+    // TODO Split logic for light and sight, since the sight portion is entirely duplicated.
+    final var modelsWithToken =
+        illuminationModels.values().stream()
+            .filter(model -> model.hasToken(token.getId()))
+            .toList();
+    if (!modelsWithToken.isEmpty() || token.hasLightSources()) {
+      modelsWithToken.forEach(model -> model.removeToken(token.getId()));
+      contributedPersonalLightsByToken.remove(token.getId());
+      tokenVisionCachePerView.clear();
+      illuminationsPerView.clear();
+      exposedAreaMap.clear();
+      visibleAreaMap.clear();
+      // TODO Could we instead only clear those views that include the token?
+      drawableLights.clear();
+      drawableAuras = null;
+    } else if (token.getHasSight()) {
+      contributedPersonalLightsByToken.remove(token.getId());
+      // TODO Could we instead only clear those views that include the token?
+      illuminationsPerView.clear();
+      exposedAreaMap.clear();
+      visibleAreaMap.clear();
+      drawableLights.clear();
+      drawableAuras = null;
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.server;
 
 import static net.rptools.maptool.server.proto.Message.MessageTypeCase.HEARTBEAT_MSG;
 
+import java.awt.EventQueue;
 import java.awt.geom.Area;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +58,6 @@ import org.apache.tika.utils.ExceptionUtils;
  */
 public class ServerMessageHandler implements MessageHandler {
   private final MapToolServer server;
-  private final Object MUTEX = new Object();
   private static final Logger log = LogManager.getLogger(ServerMessageHandler.class);
 
   public ServerMessageHandler(MapToolServer server) {
@@ -265,68 +265,91 @@ public class ServerMessageHandler implements MessageHandler {
   }
 
   private void handle(UpdateExposedAreaMetaMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    zone.setExposedAreaMetaData(
-        msg.hasTokenGuid() ? GUID.valueOf(msg.getTokenGuid().getValue()) : null,
-        new ExposedAreaMetaData(Mapper.map(msg.getArea()))); // update the server
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          zone.setExposedAreaMetaData(
+              msg.hasTokenGuid() ? GUID.valueOf(msg.getTokenGuid().getValue()) : null,
+              new ExposedAreaMetaData(Mapper.map(msg.getArea()))); // update the server
+        });
   }
 
   private void handle(UpdateGmMacrosMsg msg) {
-    var campaignMacros =
-        msg.getMacrosList().stream()
-            .map(MacroButtonProperties::fromDto)
-            .collect(Collectors.toList());
-    MapTool.getCampaign().setGmMacroButtonPropertiesArray(campaignMacros);
-    server.getCampaign().setGmMacroButtonPropertiesArray(campaignMacros);
+    EventQueue.invokeLater(
+        () -> {
+          var campaignMacros =
+              msg.getMacrosList().stream()
+                  .map(MacroButtonProperties::fromDto)
+                  .collect(Collectors.toList());
+          MapTool.getCampaign().setGmMacroButtonPropertiesArray(campaignMacros);
+          server.getCampaign().setGmMacroButtonPropertiesArray(campaignMacros);
+        });
   }
 
   private void handle(UpdateCampaignMacrosMsg msg) {
-    var campaignMacros =
-        msg.getMacrosList().stream()
-            .map(MacroButtonProperties::fromDto)
-            .collect(Collectors.toList());
-    MapTool.getCampaign().setMacroButtonPropertiesArray(campaignMacros);
-    server.getCampaign().setMacroButtonPropertiesArray(campaignMacros);
+    EventQueue.invokeLater(
+        () -> {
+          var campaignMacros =
+              msg.getMacrosList().stream()
+                  .map(MacroButtonProperties::fromDto)
+                  .collect(Collectors.toList());
+          MapTool.getCampaign().setMacroButtonPropertiesArray(campaignMacros);
+          server.getCampaign().setMacroButtonPropertiesArray(campaignMacros);
+        });
   }
 
   private void handle(UpdateTokenInitiativeMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    var tokenId = GUID.valueOf(msg.getTokenGuid());
-    InitiativeList list = zone.getInitiativeList();
-    TokenInitiative ti = list.getTokenInitiative(msg.getIndex());
-    if (!ti.getId().equals(tokenId)) {
-      // Index doesn't point to same token, try to find it
-      Token token = zone.getToken(tokenId);
-      List<Integer> tokenIndex = list.indexOf(token);
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          var tokenId = GUID.valueOf(msg.getTokenGuid());
+          InitiativeList list = zone.getInitiativeList();
+          TokenInitiative ti = list.getTokenInitiative(msg.getIndex());
+          if (!ti.getId().equals(tokenId)) {
+            // Index doesn't point to same token, try to find it
+            Token token = zone.getToken(tokenId);
+            List<Integer> tokenIndex = list.indexOf(token);
 
-      // If token in list more than one time, punt
-      if (tokenIndex.size() != 1) return;
-      ti = list.getTokenInitiative(tokenIndex.get(0));
-    } // endif
-    ti.update(msg.getIsHolding(), msg.hasState() ? msg.getState().getValue() : null);
+            // If token in list more than one time, punt
+            if (tokenIndex.size() != 1) return;
+            ti = list.getTokenInitiative(tokenIndex.get(0));
+          } // endif
+          ti.update(msg.getIsHolding(), msg.hasState() ? msg.getState().getValue() : null);
+        });
   }
 
   private void handle(UpdateInitiativeMsg msg) {
-    if (msg.hasList()) {
-      var list = InitiativeList.fromDto(msg.getList());
-      if (list.getZone() == null) return;
-      Zone zone = server.getCampaign().getZone(list.getZone().getId());
-      zone.setInitiativeList(list);
-    } else if (msg.hasOwnerPermission()) {
-      MapTool.getFrame()
-          .getInitiativePanel()
-          .setOwnerPermissions(msg.getOwnerPermission().getValue());
-    }
+    EventQueue.invokeLater(
+        () -> {
+          if (msg.hasList()) {
+            var list = InitiativeList.fromDto(msg.getList());
+            if (list.getZone() == null) return;
+            Zone zone = server.getCampaign().getZone(list.getZone().getId());
+            zone.setInitiativeList(list);
+          } else if (msg.hasOwnerPermission()) {
+            MapTool.getFrame()
+                .getInitiativePanel()
+                .setOwnerPermissions(msg.getOwnerPermission().getValue());
+          }
+        });
   }
 
   private void handle(UpdateCampaignMsg msg) {
-    server.getCampaign().replaceCampaignProperties(CampaignProperties.fromDto(msg.getProperties()));
+    EventQueue.invokeLater(
+        () -> {
+          server
+              .getCampaign()
+              .replaceCampaignProperties(CampaignProperties.fromDto(msg.getProperties()));
+        });
   }
 
   private void handle(SetServerPolicyMsg msg) {
-    server.updateServerPolicy(
-        ServerPolicy.fromDto(msg.getPolicy())); // updates the server policy, fixes #1648
-    MapTool.getFrame().getToolbox().updateTools();
+    EventQueue.invokeLater(
+        () -> {
+          server.updateServerPolicy(
+              ServerPolicy.fromDto(msg.getPolicy())); // updates the server policy, fixes #1648
+          MapTool.getFrame().getToolbox().updateTools();
+        });
   }
 
   private void handle(UndoDrawMsg msg) {
@@ -343,108 +366,160 @@ public class ServerMessageHandler implements MessageHandler {
     // or flushing it entirely in the new zone. We'll save all of this for a separate patch against
     // 1.3 or
     // for 1.4.
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    zone.removeDrawable(GUID.valueOf(msg.getDrawableGuid()));
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          zone.removeDrawable(GUID.valueOf(msg.getDrawableGuid()));
+        });
   }
 
   private void handle(SetZoneVisibilityMsg msg) {
-    server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid())).setVisible(msg.getIsVisible());
+    EventQueue.invokeLater(
+        () -> {
+          server
+              .getCampaign()
+              .getZone(GUID.valueOf(msg.getZoneGuid()))
+              .setVisible(msg.getIsVisible());
+        });
   }
 
   private void handle(UpdateTokenPropertyMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    Token token = zone.getToken(GUID.valueOf(msg.getTokenGuid()));
-    token.updateProperty(
-        zone,
-        Token.Update.valueOf(msg.getProperty().name()),
-        msg.getValuesList()); // update server version of token
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          Token token = zone.getToken(GUID.valueOf(msg.getTokenGuid()));
+          token.updateProperty(
+              zone,
+              Token.Update.valueOf(msg.getProperty().name()),
+              msg.getValuesList()); // update server version of token
+        });
   }
 
   private void handle(UpdateDrawingMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    zone.updateDrawable(DrawnElement.fromDto(msg.getDrawing()), Pen.fromDto(msg.getPen()));
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          zone.updateDrawable(DrawnElement.fromDto(msg.getDrawing()), Pen.fromDto(msg.getPen()));
+        });
   }
 
   private void handle(SetZoneHasFowMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    zone.setHasFog(msg.getHasFow());
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          zone.setHasFog(msg.getHasFow());
+        });
   }
 
   private void handle(SetZoneGridSizeMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    Grid grid = zone.getGrid();
-    grid.setSize(msg.getSize());
-    grid.setOffset(msg.getXOffset(), msg.getYOffset());
-    zone.setGridColor(msg.getColor());
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          Grid grid = zone.getGrid();
+          grid.setSize(msg.getSize());
+          grid.setOffset(msg.getXOffset(), msg.getYOffset());
+          zone.setGridColor(msg.getColor());
+        });
   }
 
   private void handle(SetVisionTypeMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    zone.setVisionType(VisionType.valueOf(msg.getVision().name()));
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          zone.setVisionType(VisionType.valueOf(msg.getVision().name()));
+        });
   }
 
   private void handle(SetFowMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    var area = Mapper.map(msg.getArea());
-    var selectedTokens =
-        msg.getSelectedTokensList().stream().map(GUID::valueOf).collect(Collectors.toSet());
-    zone.setFogArea(area, selectedTokens);
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          var area = Mapper.map(msg.getArea());
+          var selectedTokens =
+              msg.getSelectedTokensList().stream().map(GUID::valueOf).collect(Collectors.toSet());
+          zone.setFogArea(area, selectedTokens);
+        });
   }
 
   private void handle(SetCampaignNameMsg msg) {
-    server.getCampaign().setName(msg.getName());
+    EventQueue.invokeLater(
+        () -> {
+          server.getCampaign().setName(msg.getName());
+        });
   }
 
   private void handle(SetCampaignMsg msg) {
-    server.setCampaign(Campaign.fromDto(msg.getCampaign()));
+    EventQueue.invokeLater(
+        () -> {
+          server.setCampaign(Campaign.fromDto(msg.getCampaign()));
+        });
   }
 
   private void handle(SendTokensToBackMsg msg) {
-    var zoneGuid = GUID.valueOf(msg.getZoneGuid());
-    var tokens = msg.getTokenGuidsList().stream().map(GUID::valueOf).collect(Collectors.toSet());
-    sendTokensToBack(zoneGuid, tokens);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGuid = GUID.valueOf(msg.getZoneGuid());
+          var tokens =
+              msg.getTokenGuidsList().stream().map(GUID::valueOf).collect(Collectors.toSet());
+          sendTokensToBack(zoneGuid, tokens);
+        });
   }
 
   private void handle(RenameZoneMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    var name = msg.getName();
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    if (zone != null) {
-      zone.setName(name);
-    }
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          var name = msg.getName();
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          if (zone != null) {
+            zone.setName(name);
+          }
+        });
   }
 
   private void handle(RemoveZoneMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    var zone = server.getCampaign().getZone(zoneGUID);
-    server.getCampaign().removeZone(zoneGUID);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          var zone = server.getCampaign().getZone(zoneGUID);
+          server.getCampaign().removeZone(zoneGUID);
 
-    // Now we have fire off adding the tokens in the zone
-    new MapToolEventBus().getMainEventBus().post(new TokensRemoved(zone, zone.getTokens()));
-    new MapToolEventBus().getMainEventBus().post(new ZoneRemoved(zone));
+          // Now we have fire off adding the tokens in the zone
+          new MapToolEventBus().getMainEventBus().post(new TokensRemoved(zone, zone.getTokens()));
+          new MapToolEventBus().getMainEventBus().post(new ZoneRemoved(zone));
+        });
   }
 
   private void handle(RemoveTopologyMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    var area = Mapper.map(msg.getArea());
-    var topologyType = Zone.TopologyType.valueOf(msg.getType().name());
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    zone.removeTopology(area, topologyType);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          var area = Mapper.map(msg.getArea());
+          var topologyType = Zone.TopologyType.valueOf(msg.getType().name());
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          zone.removeTopology(area, topologyType);
+        });
   }
 
   private void handle(RemoveTokensMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    var tokenGUIDs =
-        msg.getTokenGuidList().stream().map(GUID::valueOf).collect(Collectors.toList());
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    zone.removeTokens(tokenGUIDs); // remove server tokens
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          var tokenGUIDs =
+              msg.getTokenGuidList().stream().map(GUID::valueOf).collect(Collectors.toList());
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          zone.removeTokens(tokenGUIDs); // remove server tokens
+        });
   }
 
   private void handle(RemoveTokenMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    var tokenGUID = GUID.valueOf(msg.getTokenGuid());
-    var zone = server.getCampaign().getZone(zoneGUID);
-    zone.removeToken(tokenGUID); // remove server tokens
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          var tokenGUID = GUID.valueOf(msg.getTokenGuid());
+          var zone = server.getCampaign().getZone(zoneGUID);
+          zone.removeToken(tokenGUID); // remove server tokens
+        });
   }
 
   private void handle(RemoveLabelMsg msg) {
@@ -459,31 +534,43 @@ public class ServerMessageHandler implements MessageHandler {
   }
 
   private void handle(PutZoneMsg msg) {
-    final var zone = Zone.fromDto(msg.getZone());
-    server.getCampaign().putZone(zone);
+    EventQueue.invokeLater(
+        () -> {
+          final var zone = Zone.fromDto(msg.getZone());
+          server.getCampaign().putZone(zone);
 
-    // Now we have fire off adding the tokens in the zone
-    new MapToolEventBus().getMainEventBus().post(new ZoneAdded(zone));
-    new MapToolEventBus().getMainEventBus().post(new TokensAdded(zone, zone.getTokens()));
+          // Now we have fire off adding the tokens in the zone
+          new MapToolEventBus().getMainEventBus().post(new ZoneAdded(zone));
+          new MapToolEventBus().getMainEventBus().post(new TokensAdded(zone, zone.getTokens()));
+        });
   }
 
   private void handle(PutLabelMsg msg) {
-    Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-    zone.putLabel(Label.fromDto(msg.getLabel()));
+    EventQueue.invokeLater(
+        () -> {
+          Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
+          zone.putLabel(Label.fromDto(msg.getLabel()));
+        });
   }
 
   private void handle(PutAssetMsg msg) {
-    AssetManager.putAsset(Asset.fromDto(msg.getAsset()));
+    EventQueue.invokeLater(
+        () -> {
+          AssetManager.putAsset(Asset.fromDto(msg.getAsset()));
+        });
   }
 
   private void handle(HideFowMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    var area = Mapper.map(msg.getArea());
-    var selectedTokens =
-        msg.getTokenGuidList().stream().map(GUID::valueOf).collect(Collectors.toSet());
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          var area = Mapper.map(msg.getArea());
+          var selectedTokens =
+              msg.getTokenGuidList().stream().map(GUID::valueOf).collect(Collectors.toSet());
 
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    zone.hideArea(area, selectedTokens);
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          zone.hideArea(area, selectedTokens);
+        });
   }
 
   private void handle(String id, GetZoneMsg msg) {
@@ -495,53 +582,74 @@ public class ServerMessageHandler implements MessageHandler {
   }
 
   private void handle(ExposePcAreaMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    ZoneRenderer renderer = MapTool.getFrame().getZoneRenderer(zoneGUID);
-    FogUtil.exposePCArea(renderer);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          ZoneRenderer renderer = MapTool.getFrame().getZoneRenderer(zoneGUID);
+          FogUtil.exposePCArea(renderer);
+        });
   }
 
   private void handle(ExposeFowMsg msg) {
-    var zoneGUID = GUID.valueOf(msg.getZoneGuid());
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    Area area = Mapper.map(msg.getArea());
-    var selectedTokens =
-        msg.getTokenGuidList().stream().map(GUID::valueOf).collect(Collectors.toSet());
-    zone.exposeArea(area, selectedTokens);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(msg.getZoneGuid());
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          Area area = Mapper.map(msg.getArea());
+          var selectedTokens =
+              msg.getTokenGuidList().stream().map(GUID::valueOf).collect(Collectors.toSet());
+          zone.exposeArea(area, selectedTokens);
+        });
   }
 
   private void handle(String clientId, PutTokenMsg putTokenMsg) {
-    var zoneGUID = GUID.valueOf(putTokenMsg.getZoneGuid());
-    var token = Token.fromDto(putTokenMsg.getToken());
-    putToken(clientId, zoneGUID, token);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(putTokenMsg.getZoneGuid());
+          var token = Token.fromDto(putTokenMsg.getToken());
+          putToken(clientId, zoneGUID, token);
+        });
   }
 
   private void handle(String clientId, EditTokenMsg editTokenMsg) {
-    var zoneGUID = GUID.valueOf(editTokenMsg.getZoneGuid());
-    var token = Token.fromDto(editTokenMsg.getToken());
-    putToken(clientId, zoneGUID, token);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(editTokenMsg.getZoneGuid());
+          var token = Token.fromDto(editTokenMsg.getToken());
+          putToken(clientId, zoneGUID, token);
+        });
   }
 
   private void handle(DrawMsg drawMsg) {
-    var zoneGuid = GUID.valueOf(drawMsg.getZoneGuid());
-    var pen = Pen.fromDto(drawMsg.getPen());
-    var drawable = Drawable.fromDto(drawMsg.getDrawable());
-    Zone zone = server.getCampaign().getZone(zoneGuid);
-    zone.addDrawable(new DrawnElement(drawable, pen));
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGuid = GUID.valueOf(drawMsg.getZoneGuid());
+          var pen = Pen.fromDto(drawMsg.getPen());
+          var drawable = Drawable.fromDto(drawMsg.getDrawable());
+          Zone zone = server.getCampaign().getZone(zoneGuid);
+          zone.addDrawable(new DrawnElement(drawable, pen));
+        });
   }
 
   private void handle(ClearExposedAreaMsg clearExposedAreaMsg) {
-    var zoneGUID = GUID.valueOf(clearExposedAreaMsg.getZoneGuid());
-    var globalOnly = clearExposedAreaMsg.getGlobalOnly();
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    zone.clearExposedArea(globalOnly);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(clearExposedAreaMsg.getZoneGuid());
+          var globalOnly = clearExposedAreaMsg.getGlobalOnly();
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          zone.clearExposedArea(globalOnly);
+        });
   }
 
   private void handle(ClearAllDrawingsMsg clearAllDrawingsMsg) {
-    var zoneGUID = GUID.valueOf(clearAllDrawingsMsg.getZoneGuid());
-    var layer = Zone.Layer.valueOf(clearAllDrawingsMsg.getLayer());
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    List<DrawnElement> list = zone.getDrawnElements(layer);
-    zone.clearDrawables(list); // FJE Empties the DrawableUndoManager and empties the list
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(clearAllDrawingsMsg.getZoneGuid());
+          var layer = Zone.Layer.valueOf(clearAllDrawingsMsg.getLayer());
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          List<DrawnElement> list = zone.getDrawnElements(layer);
+          zone.clearDrawables(list); // FJE Empties the DrawableUndoManager and empties the list
+        });
   }
 
   private void handle(ChangeZoneDisplayNameMsg changeZoneDisplayNameMsg, Message msg) {
@@ -556,20 +664,26 @@ public class ServerMessageHandler implements MessageHandler {
   }
 
   private void handle(BringTokensToFrontMsg bringTokensToFrontMsg) {
-    var zoneGuid = GUID.valueOf(bringTokensToFrontMsg.getZoneGuid());
-    var tokenSet =
-        bringTokensToFrontMsg.getTokenGuidsList().stream()
-            .map(GUID::valueOf)
-            .collect(Collectors.toSet());
-    bringTokensToFront(zoneGuid, tokenSet);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGuid = GUID.valueOf(bringTokensToFrontMsg.getZoneGuid());
+          var tokenSet =
+              bringTokensToFrontMsg.getTokenGuidsList().stream()
+                  .map(GUID::valueOf)
+                  .collect(Collectors.toSet());
+          bringTokensToFront(zoneGuid, tokenSet);
+        });
   }
 
   private void handle(AddTopologyMsg addTopologyMsg) {
-    var zoneGUID = GUID.valueOf(addTopologyMsg.getZoneGuid());
-    var area = Mapper.map(addTopologyMsg.getArea());
-    var topologyType = Zone.TopologyType.valueOf(addTopologyMsg.getType().name());
-    Zone zone = server.getCampaign().getZone(zoneGUID);
-    zone.addTopology(area, topologyType);
+    EventQueue.invokeLater(
+        () -> {
+          var zoneGUID = GUID.valueOf(addTopologyMsg.getZoneGuid());
+          var area = Mapper.map(addTopologyMsg.getArea());
+          var topologyType = Zone.TopologyType.valueOf(addTopologyMsg.getType().name());
+          Zone zone = server.getCampaign().getZone(zoneGUID);
+          zone.addTopology(area, topologyType);
+        });
   }
 
   private void handle(BootPlayerMsg bootPlayerMsg) {
@@ -586,33 +700,31 @@ public class ServerMessageHandler implements MessageHandler {
   }
 
   private void bringTokensToFront(GUID zoneGUID, Set<GUID> tokenSet) {
-    synchronized (MUTEX) {
-      Zone zone = server.getCampaign().getZone(zoneGUID);
+    Zone zone = server.getCampaign().getZone(zoneGUID);
 
-      // Get the tokens to update
-      List<Token> tokenList = new ArrayList<>();
-      for (GUID tokenGUID : tokenSet) {
-        Token token = zone.getToken(tokenGUID);
-        if (token != null) {
-          tokenList.add(token);
-        }
+    // Get the tokens to update
+    List<Token> tokenList = new ArrayList<>();
+    for (GUID tokenGUID : tokenSet) {
+      Token token = zone.getToken(tokenGUID);
+      if (token != null) {
+        tokenList.add(token);
       }
-      // Arrange
-      tokenList.sort(Zone.TOKEN_Z_ORDER_COMPARATOR);
-
-      // Update
-      int z = zone.getLargestZOrder() + 1;
-      for (Token token : tokenList) {
-        token.setZOrder(z++);
-      }
-      // Broadcast
-      for (Token token : tokenList) {
-        var putTokenMsg =
-            PutTokenMsg.newBuilder().setZoneGuid(zoneGUID.toString()).setToken(token.toDto());
-        sendToAllClients(Message.newBuilder().setPutTokenMsg(putTokenMsg).build());
-      }
-      zone.sortZOrder(); // update new ZOrder on server zone
     }
+    // Arrange
+    tokenList.sort(Zone.TOKEN_Z_ORDER_COMPARATOR);
+
+    // Update
+    int z = zone.getLargestZOrder() + 1;
+    for (Token token : tokenList) {
+      token.setZOrder(z++);
+    }
+    // Broadcast
+    for (Token token : tokenList) {
+      var putTokenMsg =
+          PutTokenMsg.newBuilder().setZoneGuid(zoneGUID.toString()).setToken(token.toDto());
+      sendToAllClients(Message.newBuilder().setPutTokenMsg(putTokenMsg).build());
+    }
+    zone.sortZOrder(); // update new ZOrder on server zone
   }
 
   private void getAsset(String id, MD5Key assetID) {
@@ -655,14 +767,12 @@ public class ServerMessageHandler implements MessageHandler {
 
     int zOrder = 0;
     boolean newToken = zone.getToken(token.getId()) == null;
-    synchronized (MUTEX) {
-      // Set z-order for new tokens
-      if (newToken) {
-        zOrder = zone.getLargestZOrder() + 1;
-        token.setZOrder(zOrder);
-      }
-      zone.putToken(token);
+    // Set z-order for new tokens
+    if (newToken) {
+      zOrder = zone.getLargestZOrder() + 1;
+      token.setZOrder(zOrder);
     }
+    zone.putToken(token);
     if (newToken) {
       // don't send whole token back to sender, instead just send new ZOrder
       var msg =
@@ -678,32 +788,30 @@ public class ServerMessageHandler implements MessageHandler {
   }
 
   private void sendTokensToBack(GUID zoneGUID, Set<GUID> tokenSet) {
-    synchronized (MUTEX) {
-      Zone zone = server.getCampaign().getZone(zoneGUID);
+    Zone zone = server.getCampaign().getZone(zoneGUID);
 
-      // Get the tokens to update
-      List<Token> tokenList = new ArrayList<>();
-      for (GUID tokenGUID : tokenSet) {
-        Token token = zone.getToken(tokenGUID);
-        if (token != null) {
-          tokenList.add(token);
-        }
+    // Get the tokens to update
+    List<Token> tokenList = new ArrayList<>();
+    for (GUID tokenGUID : tokenSet) {
+      Token token = zone.getToken(tokenGUID);
+      if (token != null) {
+        tokenList.add(token);
       }
-      // Arrange
-      tokenList.sort(Zone.TOKEN_Z_ORDER_COMPARATOR);
-
-      // Update
-      int z = zone.getSmallestZOrder() - 1;
-      for (Token token : tokenList) {
-        token.setZOrder(z--);
-      }
-      // Broadcast
-      for (Token token : tokenList) {
-        var putTokenMsg =
-            PutTokenMsg.newBuilder().setZoneGuid(zoneGUID.toString()).setToken(token.toDto());
-        sendToAllClients(Message.newBuilder().setPutTokenMsg(putTokenMsg).build());
-      }
-      zone.sortZOrder(); // update new ZOrder on server zone
     }
+    // Arrange
+    tokenList.sort(Zone.TOKEN_Z_ORDER_COMPARATOR);
+
+    // Update
+    int z = zone.getSmallestZOrder() - 1;
+    for (Token token : tokenList) {
+      token.setZOrder(z--);
+    }
+    // Broadcast
+    for (Token token : tokenList) {
+      var putTokenMsg =
+          PutTokenMsg.newBuilder().setZoneGuid(zoneGUID.toString()).setToken(token.toDto());
+      sendToAllClients(Message.newBuilder().setPutTokenMsg(putTokenMsg).build());
+    }
+    zone.sortZOrder(); // update new ZOrder on server zone
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3979

### Description of the Change

In PR #3952, I modifed the `ZoneView.flush()` to run on the Swing thread via `SwingUtilites.invokeLater()`. This kept the `ZoneView` consistent with itself, but other components assumed they could update the `ZoneRenderer` immediately after the call to `flush()` was done. By delaying the call using `invokeLater()`, the `ZoneRenderer` would sometime update prior to the `ZoneView` flush being run, causing old state to be rendered until another update.

This PR goes a step further towards guaranteeing that `ZoneView.flush()` is only called on the Swing thread. `ClientMessageHandler` and `ServerMessageHandler` have been updated to run their message handlers on the Swing thread if they are responsible for updating the model or the `ZoneRenderer`. This removes the common cases of the ZoneView being accessed off-thread. With that, we no longer use `SwingUtilities.invokeLater()` inside of the `ZoneView.flush()` methods.

There might still be other places where off-thread access could happen (e.g., app actions run on a background thread). but a complete solution to threading is beyond this PR.


### Possible Drawbacks

Other timing assumptions might be violated somewhere.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3981)
<!-- Reviewable:end -->
