### PR TITLE
Add lighting style to the ZoneDto

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2300,6 +2300,7 @@ public class Zone {
     zone.playerAlias = dto.hasPlayerAlias() ? dto.getPlayerAlias().getValue() : null;
     zone.isVisible = dto.getIsVisible();
     zone.visionType = VisionType.valueOf(dto.getVisionType().name());
+    zone.lightingStyle = LightingStyle.valueOf(dto.getLightingStyle().name());
     zone.tokenSelection = TokenSelection.valueOf(dto.getTokenSelection().name());
     zone.height = dto.getHeight();
     zone.width = dto.getWidth();
@@ -2369,6 +2370,7 @@ public class Zone {
     }
     dto.setIsVisible(isVisible);
     dto.setVisionType(ZoneDto.VisionTypeDto.valueOf(visionType.name()));
+    dto.setLightingStyle(ZoneDto.LightingStyleDto.valueOf(lightingStyle.name()));
     dto.setTokenSelection(ZoneDto.TokenSelectionDto.valueOf(tokenSelection.name()));
     dto.setHeight(height);
     dto.setWidth(width);

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -490,6 +490,10 @@ message ZoneDto {
     DAY = 1;
     NIGHT = 2;
   }
+  enum LightingStyleDto {
+      ENVIRONMENTAL = 0;
+      OVERTOP = 1;
+  }
   enum AStarRoundingOptionsDto {
     NONE = 0;
     CELL_UNIT = 1;
@@ -529,9 +533,10 @@ message ZoneDto {
   google.protobuf.StringValue player_alias = 32;
   bool is_visible = 33;
   VisionTypeDto vision_type = 34;
-  TokenSelectionDto token_selection = 35;
-  int32 height = 36;
-  int32 width = 37;
+  LightingStyleDto lighting_style = 35;
+  TokenSelectionDto token_selection = 36;
+  int32 height = 37;
+  int32 width = 38;
 }
 
 message InitiativeListDto {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3982

### Description of the Change

The lighting style was not added to the protobuf DTO when it was implemented. This PR adds it to the DTO, and adds the logic for reading and writing the new field.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3983)
<!-- Reviewable:end -->
