### PR TITLE
Fix old tokens being given zero opacity when added to a campaign

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -38,6 +38,7 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -291,7 +292,7 @@ public class Token implements Cloneable {
   private transient Color visionOverlayColor;
 
   // Jamz: allow token alpha channel modification
-  private float tokenOpacity = 1.0f;
+  private @Nonnull Float tokenOpacity = 1.0f;
 
   private String speechName = "";
 
@@ -673,31 +674,17 @@ public class Token implements Cloneable {
     return haloColor;
   }
 
+  /** @return The token opacity, in the range [0.0f, 1.0f]. */
   public float getTokenOpacity() {
-    if (tokenOpacity < 0.0f) {
-      tokenOpacity = 1.0f;
-    }
-
     return tokenOpacity;
   }
 
   /**
-   * Set the token opacity from a string trimmed to [0.05f, 1.0f]
-   *
-   * @param alpha the String of the opacity value.
-   * @return the float of the opacity
-   */
-  public float setTokenOpacity(String alpha) {
-    return setTokenOpacity(Float.parseFloat(alpha));
-  }
-
-  /**
-   * Set the token opacity from a float trimmed to [0.05f, 1.0f]
+   * Set the token opacity from a float trimmed to [0.0f, 1.0f]
    *
    * @param alpha the float of the opacity.
-   * @return the float of the opacity trimmed.
    */
-  public float setTokenOpacity(float alpha) {
+  public void setTokenOpacity(float alpha) {
     if (alpha > 1.0f) {
       alpha = 1.0f;
     }
@@ -706,8 +693,6 @@ public class Token implements Cloneable {
     }
 
     tokenOpacity = alpha;
-
-    return tokenOpacity;
   }
 
   /**
@@ -2520,6 +2505,12 @@ public class Token implements Cloneable {
       gmNotesType = SyntaxConstants.SYNTAX_STYLE_NONE;
     }
 
+    // Pre 1.13
+    if (tokenOpacity == null) {
+      tokenOpacity = 1.f;
+    }
+    tokenOpacity = Math.max(0.f, Math.min(tokenOpacity, 1.f));
+
     return this;
   }
 
@@ -2720,7 +2711,7 @@ public class Token implements Cloneable {
         setIsAlwaysVisible(parameters.get(0).getBoolValue());
         break;
       case setTokenOpacity:
-        setTokenOpacity(parameters.get(0).getStringValue());
+        setTokenOpacity(Float.parseFloat(parameters.get(0).getStringValue()));
         break;
       case setTerrainModifier:
         setTerrainModifier(parameters.get(0).getDoubleValue());


### PR DESCRIPTION
### Identify the Bug or Feature request

#3986

### Description of the Change

It used to be that `Token.tokenOpacity` would use the default value of `0` when an old token was loaded that didn't have the field. This would be modified into `1` so that the token would be opaque instead of transparent.

Now that we support real zero opacity, we need another default value so that we distinguish it. The field is now a `Float` instead of a `float` so that `null` is now the default, and a value of `0` can be relied on as meaning fully transparent. `readResolve()` is also now responsible for fixing up the opacity rather than leaving that for the getter.

Some cleanup is also included as `getTokenOpacity()` now longer needs to range-check the value, and we don't need a separate and public-facing `setTokenOpacity()` for string values.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/3987)
<!-- Reviewable:end -->
