### PR TITLE
Fix logging issues in 1.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,10 @@ repositories {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.20.0'	// Bridges v1 to v2 for other code in other libs
+    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.7'
+    implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
 
     // Image processing lib
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.8.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core


### PR DESCRIPTION


### Identify the Bug or Feature request

fixes #4028



### Description of the Change
Several of the included libraries use the 1.2 log4j API in a PR earlier this year the 1.2 to 2 bridge was removed from the dependencies. This PR adds them again.


### Possible Drawbacks

Should be none.

### Documentation Notes
Fixes issues with logging.

### Release Notes
-- Fixes issues with logging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4030)
<!-- Reviewable:end -->
