### PR TITLE
Fix for MapTool registry errors in 1.13.0

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1974,6 +1974,7 @@ msg.error.failedAddingDefaultImages           = Could not restore default images
 msg.error.failedAddingDefaultTables           = Could not restore default tables.
 msg.error.failedCannotRegisterServer          = Unable to register your server.
 msg.error.failedConnect                       = Could not connect to server.
+msg.error.fetchingRegistryInformation         = Error fetching server information from registry.
 msg.error.initializeCrypto                    = Failed to initialize Cryptology library.
 msg.error.initializePlayerDatabase            = Failed to initialize Player Database.
 msg.error.failedExportingCampaignRepo         = Could not export campaign repository file.


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #4035 4035

### Description of the Change
The code had been retrieving the body of the response first to check if it was empty and, if not, later on retrieving it again to parse it. This was working in previous versions of okhttp3 but no longer works, and an `IllegalStateException` is thrown. I have modified the code to retrieve the body only once and use that result for the empty check and parsing. 

I have also captured and dealt with all exceptions by displaying an error message dialog and returning from the method correctly to handle it more gracefully (currently, you can end up in a state when you can not continue and have to close MapTool). 


### Possible Drawbacks

There should be none.

### Documentation Notes
Fix problems that can arise when fetching information from the MapTool server registry.

### Release Notes

- Fix problems when fetching information from the MapTool server registry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4036)
<!-- Reviewable:end -->
