### PR TITLE
Fix add-on race condition on client

### DIFF
--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
@@ -28,7 +28,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import javax.script.ScriptException;
+import javax.swing.SwingUtilities;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
@@ -50,7 +52,6 @@ import net.rptools.maptool.model.library.data.LibraryData;
 import net.rptools.maptool.model.library.proto.AddOnLibraryDto;
 import net.rptools.maptool.model.library.proto.AddOnLibraryEventsDto;
 import net.rptools.maptool.model.library.proto.MTScriptPropertiesDto;
-import net.rptools.maptool.util.threads.ThreadExecutionHelper;
 import net.rptools.parser.ParserException;
 import org.javatuples.Pair;
 
@@ -546,13 +547,25 @@ public class AddOnLibrary implements Library {
    * @return a CompletableFuture that completes when the function MacroScript function has finished
    */
   private CompletableFuture<Void> callMTSFunction(String name) {
-    return new ThreadExecutionHelper<Void>()
-        .runOnSwingThread(
-            () -> {
-              var resolver = new MapToolVariableResolver(null);
+    if (SwingUtilities.isEventDispatchThread()) {
+      var resolver = new MapToolVariableResolver(null);
+      try {
+        MapTool.getParser().runMacro(resolver, null, name + "@lib:" + namespace, "");
+      } catch (ParserException e) {
+        throw new CompletionException(e);
+      }
+    } else {
+      SwingUtilities.invokeLater(
+          () -> {
+            var resolver = new MapToolVariableResolver(null);
+            try {
               MapTool.getParser().runMacro(resolver, null, name + "@lib:" + namespace, "");
-              return null;
-            });
+            } catch (ParserException e) {
+              throw new CompletionException(e);
+            }
+          });
+    }
+    return CompletableFuture.completedFuture(null);
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #4032 

### Description of the Change
Removed a  race condition in the processing of onInit in add-ons. This race condition would only occur for clients as their add-on import happens on the connection thread. I know the bug report has onFirstInit but the freeze was happening in onInit (clients don't process onFirstInit, its only run first-time add-on is added to the campaign, the removal of onFirstInit causing it to work I guess can be put down to the vagaries of outcomes when it comes to race conditions).


### Possible Drawbacks
There should be none.

### Documentation Notes
Fixes a secnaio where clients connecting to a server with an add-on that has onInit could encounter a MapTool freeze.

### Release Notes
- Fixes a secnaio where clients connecting to a server with an add-on that has onInit could encounter a MapTool freeze.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4038)
<!-- Reviewable:end -->
