### PR TITLE
Fix players not being able to toggle the lumens overlay or environmental lights

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1525,7 +1525,7 @@ public class AppActions {
 
   /** This is the menu option turns the lumens overlay on and off. */
   public static final Action TOGGLE_LUMENS_OVERLAY =
-      new ZoneAdminClientAction() {
+      new ZoneClientAction() {
         {
           init("action.showLumensOverlay");
         }
@@ -1544,7 +1544,7 @@ public class AppActions {
 
   /** This is the menu option turns the lumens overlay on and off. */
   public static final Action TOGGLE_SHOW_LIGHTS =
-      new ZoneAdminClientAction() {
+      new ZoneClientAction() {
         {
           init("action.showLights");
         }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -494,6 +494,7 @@ public class Zone {
     mapAsset = zone.mapAsset;
     fogPaint = zone.fogPaint;
     visionType = zone.visionType;
+    lightingStyle = zone.lightingStyle;
 
     undo = new UndoPerZone(this); // Undo/redo manager isn't copied
     setName(zone.getName());


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4033

### Description of the Change

The actions associated with these View menu items were inadvertently made "admin" actions, so players could not toggle the options. This has now been fixed.

I also happened across another bug where the lighting style was not being copied between `Zone` instances. This caused all maps to revert to the Overlaid style after starting a server.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where players could not toggle the lumens overlay or lights in the View menu.
- Fixed a bug where map lighting styles would all revert to Overlaid after starting a server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4040)
<!-- Reviewable:end -->
