### PR TITLE
Invalid sight is breaking vision

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -437,8 +437,10 @@ public class ZoneView {
     return new ZoneView.IlluminationKey(
         view.isUsingTokenView()
             ? view.getTokens().stream()
+                .filter(Token::getHasSight)
                 .map(Token::getSightType)
                 .map(sightName -> MapTool.getCampaign().getSightType(sightName))
+                .filter(Objects::nonNull)
                 .map(SightType::getMultiplier)
                 .max(Double::compare)
                 .orElse(1.0)


### PR DESCRIPTION
### Identify the Bug or Feature request

#4037

### Description of the Change

There are some situations where a token's sight is not actually a sight defined in the campaign. This is mostly handled by `null` checks, but this was missed when calculating illumination keys. In a similar vein, not all tokens have sight, and this is handled in much the same way as an undefined sight type.

This PR fixes the one place where we don't currently check the validity of the sight type, and where we also don't check if the token has sight: building the illumination key.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed null pointer exception when adding images as tokens to campaigns with a "Normal" sight type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4041)
<!-- Reviewable:end -->
