### PR TITLE
Fix for visible area being confused with illuminated area

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -844,11 +844,11 @@ public class ZoneView {
       return;
     }
     // Cache it
-    final var illumination = getIllumination(view);
-    // We _could_ instead union up all the individual token's areas, but we already have the same
-    // result via the view's illumination.
+    final var visibleArea = new Area();
+    getTokensForView(view).map(token -> this.getVisibleArea(token, view)).forEach(visibleArea::add);
+
     VisibleAreaMeta meta = new VisibleAreaMeta();
-    meta.visibleArea = illumination.getVisibleArea();
+    meta.visibleArea = visibleArea;
     visibleAreaMap.put(view, meta);
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4043

### Description of the Change

Change `ZoneView.getVisibleArea(PlayerView)` to return token vision restricted to illuminated areas rather than returning the entire illuminated area for the view.

I also put in some simplifications for things that bother me, i.e., the fact that `calculateVisibleArea()` is a separate method, and that `VisibleAreaMeta` does nothing but transparently wrap an `Area`.

### Possible Drawbacks

Should be none.

### Documentation Notes

None

### Release Notes

- Fixed a bug where some rendering was not restricted to token vision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4044)
<!-- Reviewable:end -->
