### PR TITLE
Fill the lumens overlay properly

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -1509,15 +1509,16 @@ public class ZoneRenderer extends JComponent
       timer.stop("renderLumensOverlay:allocateBuffer");
 
       Graphics2D newG = lumensOverlay.createGraphics();
-      newG.setComposite(AlphaComposite.SrcOver.derive(overlayOpacity));
-      SwingUtil.useAntiAliasing(newG);
-
       // At night, show any uncovered areas as dark. In daylight, show them as light (clear).
+      newG.setComposite(AlphaComposite.Src.derive(overlayOpacity));
       newG.setPaint(
           zone.getVisionType() == Zone.VisionType.NIGHT
               ? new Color(0.f, 0.f, 0.f, 1.f)
               : new Color(0.f, 0.f, 0.f, 0.f));
       newG.fillRect(0, 0, lumensOverlay.getWidth(), lumensOverlay.getHeight());
+
+      newG.setComposite(AlphaComposite.SrcOver.derive(overlayOpacity));
+      SwingUtil.useAntiAliasing(newG);
 
       if (clipStyle != null && visibleScreenArea != null) {
         timer.start("renderLumensOverlay:setClip");


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes a missed case in PR #4003.

### Description of the Change

We removed the logic to clear images returned from `BufferedImagePool` because all the uses of it already either cleared the image or rendered to it completely.

While the lumens overlay also filled the buffer before rendering, it mistakenly did that with `SrcOver`, meaning the existing contents of the buffer were being mixed with the fill color. This has now been changed so that it instead uses `Src` to overwrite the buffer contents.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A (only exists in develop)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4045)
<!-- Reviewable:end -->
