### PR TITLE
fix for html notes being copied to new token dialog text area

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -209,11 +209,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     // ICON
     getTokenIconPanel().setImageId(token.getImageAssetId());
 
-    // NOTES
-    getGMNotesEditor().setText(token.getGMNotes());
+    // NOTES, GM NOTES. Due to the way things happen on different gui threads, the type must be set
+    // before the text
+    // otherwise the wrong values can get populated when the tab change listener fires.
     getGMNotesEditor().setTextType(token.getGmNotesType());
-    getPlayerNotesEditor().setText(token.getNotes());
+    getGMNotesEditor().setText(token.getGMNotes());
     getPlayerNotesEditor().setTextType(token.getNotesType());
+    getPlayerNotesEditor().setText(token.getNotes());
 
     // TYPE
     getTypeCombo().setSelectedItem(token.getType());


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #4039


### Description of the Change
The HTML version of notes is being set in the JavaFX thread whilst changing the tab (and subsequent change event happens in the Swing thread) as the update to HTML control is run via `Platform.runLater()` its likely that the HTML control will contain stale content at the time of the change event, which is copied into the non-HTML notes. 

This change makes sure that the type is set (and therefore will change tab if required) before the notes are updated, which ensures that the information in them is the current and correct values.

I am not enamoured with the solution as it's working around rather than fixing a bug but it works and I think is acceptable for now.

### Possible Drawbacks

Hopefully none, other than its still possible to recreate the bug if adding code dealing with a new way to edit notes.

### Documentation Notes
Fix the bug where clicking cancel on a token while displaying the HTML token notes could copy that value into the next token if it did not have HTML note type.

### Release Notes
- Fix the bug where clicking cancel on a token while displaying the HTML token notes could copy that value into the next token if it did not have HTML note type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4055)
<!-- Reviewable:end -->
