### PR TITLE
Make XStream more agreeable, and other fixes

### DIFF
--- a/src/main/java/net/rptools/lib/FileUtil.java
+++ b/src/main/java/net/rptools/lib/FileUtil.java
@@ -42,7 +42,9 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
+import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.model.AStarCellPointConverter;
+import net.rptools.maptool.model.ShapeType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -508,6 +510,8 @@ public class FileUtil {
     XStream.setupDefaultSecurity(xStream);
     xStream.allowTypesByWildcard(new String[] {"net.rptools.**", "java.awt.**", "sun.awt.**"});
     xStream.registerConverter(new AStarCellPointConverter());
+    xStream.addImmutableType(ShapeType.class, true);
+    xStream.addImmutableType(BarTokenOverlay.Side.class, true);
     return xStream;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -209,6 +209,7 @@ public class MapTool {
     } else {
       msg = I18N.getText(msgKey) + "<br/>" + t.toString();
     }
+    msg = msg.replace("\n", "<br/>");
     return msg;
   }
 

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -1094,6 +1094,9 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     if (toolTip == null) {
       toolTip = "";
     }
+    if (saveLocation == null) {
+      saveLocation = "";
+    }
     return this;
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -23,6 +23,7 @@ import java.awt.geom.Area;
 import java.awt.geom.GeneralPath;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
@@ -33,7 +34,7 @@ import net.rptools.maptool.server.proto.drawing.LineSegmentDrawableDto;
  */
 public class LineSegment extends AbstractDrawing {
   private final List<Point> points = new ArrayList<Point>();
-  private Float width;
+  private @Nonnull Float width;
   private boolean squareCap;
   private transient int lastPointCount = -1;
   private transient Rectangle cachedBounds;
@@ -48,6 +49,15 @@ public class LineSegment extends AbstractDrawing {
     super(id);
     this.width = width;
     this.squareCap = squareCap;
+  }
+
+  @SuppressWarnings("ConstantValue")
+  private Object readResolve() {
+    if (width == null) {
+      width = 2.f;
+    }
+
+    return this;
   }
 
   /**
@@ -95,17 +105,12 @@ public class LineSegment extends AbstractDrawing {
       }
       gp.lineTo(point.x, point.y);
     }
-    BasicStroke stroke =
-        new BasicStroke(width != null ? width : 2, getStrokeCap(), getStrokeJoin());
+    BasicStroke stroke = new BasicStroke(width, getStrokeCap(), getStrokeJoin());
     return new Area(stroke.createStrokedShape(gp));
   }
 
   @Override
   protected void draw(Graphics2D g) {
-    if (width == null) {
-      // Handle legacy values
-      area = null; // reset, build with new value
-    }
     width = ((BasicStroke) g.getStroke()).getLineWidth();
     squareCap = ((BasicStroke) g.getStroke()).getEndCap() == BasicStroke.CAP_SQUARE;
     Area area = getArea();
@@ -144,7 +149,7 @@ public class LineSegment extends AbstractDrawing {
     return bounds;
   }
 
-  public Float getWidth() {
+  public float getWidth() {
     return width;
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4066

### Description of the Change

The enum `ShapeType` is now considered referencable by XStream. This allows it to load campaigns that contain references to a `ShapeType` while still not writing them out anymore. The same was done to `BarTokenOverlay.Side` to load other campaigns.

On the way, a few other problems were found and fixed:
- Error dialogs weren't keeping newlines, making XStream messages _very_ wide.
- `MacroButtonProperties.saveLocation` was forgotten in `readResolve()` in #4052, causing some NPEs
- `LineSegment.width` was nullable, and `toDto()` was not accounting for that. It is no longer nullable, as `readResolve()` handles it.


### Possible Drawbacks

Higher memory usage according to the [XStream docs](https://x-stream.github.io/faq.html#Serialization_referencing_immutable_types).

### Documentation Notes

N/A

### Release Notes

- Improved backwards compatibility with campaigns from the 1.13b50 era, allowing more of them to be loaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4067)
<!-- Reviewable:end -->
