### PR TITLE
Fix for gaps in initative list

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -601,7 +601,8 @@ public class Zone {
       }
     }
     // Set the initiative list using the newly create tokens.
-    // We also have to work around old campaign issues where there may be empty positions in the initiative list
+    // We also have to work around old campaign issues where there may be empty positions in the
+    // initiative list
     int newCurrent = -1;
     int oldCurrent = zone.initiativeList.getCurrent();
     if (saveInitiative.length > 0) {

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -601,6 +601,7 @@ public class Zone {
       }
     }
     // Set the initiative list using the newly create tokens.
+    // We also have to work around old campaign issues where there may be empty positions in the initiative list
     int newCurrent = -1;
     int oldCurrent = zone.initiativeList.getCurrent();
     if (saveInitiative.length > 0) {

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -601,18 +601,27 @@ public class Zone {
       }
     }
     // Set the initiative list using the newly create tokens.
+    int newCurrent = -1;
+    int oldCurrent = zone.initiativeList.getCurrent();
     if (saveInitiative.length > 0) {
+      int newInd = 0;
       for (int i = 0; i < saveInitiative.length; i++) {
         Token token = (Token) saveInitiative[i][0];
-        initiativeList.insertToken(i, token);
-        TokenInitiative ti = initiativeList.getTokenInitiative(i);
-        TokenInitiative oldti = (TokenInitiative) saveInitiative[i][1];
-        ti.setHolding(oldti.isHolding());
-        ti.setState(oldti.getState());
+        if (token != null) {
+          initiativeList.insertToken(newInd, token);
+          TokenInitiative ti = initiativeList.getTokenInitiative(newInd);
+          TokenInitiative oldti = (TokenInitiative) saveInitiative[i][1];
+          ti.setHolding(oldti.isHolding());
+          ti.setState(oldti.getState());
+          if (oldCurrent == i) {
+            newCurrent = newInd;
+          }
+          newInd++;
+        }
       }
     }
     initiativeList.setZone(this);
-    initiativeList.setCurrent(zone.initiativeList.getCurrent());
+    initiativeList.setCurrent(newCurrent);
     initiativeList.setRound(zone.initiativeList.getRound());
     initiativeList.setHideNPC(zone.initiativeList.isHideNPC());
 


### PR DESCRIPTION

### Identify the Bug or Feature request
#3310

### Description of the Change
Various scenarios can lead to there being a "gap" in the initiative list. Campaigns that have gaps in the initiative list of one or more maps load successfully but copying the zone during server start results in a null pointer exception, and the server will not start leaving MapTool in an undefined state.

This fix recreates the initiative list without gaps on zone copy.


### Possible Drawbacks
Hopefully none.

### Documentation Notes
Fix issue where server may not start if initiative list has developed gaps.

### Release Notes
- Fix issue where server may not start if initiative list has developed gaps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4074)
<!-- Reviewable:end -->
