### PR TITLE
Fix path for Images.GRID_BORDER_ISOMETRIC

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
@@ -235,7 +235,7 @@ public class RessourceManager {
           put(Images.DECORATION_RPTOK, IMAGE_DIR + "rptokIcon.png");
           put(Images.EMPTY, IMAGE_DIR + "empty.png");
           put(Images.GRID_BORDER_HEX, IMAGE_DIR + "hexBorder.png");
-          put(Images.GRID_BORDER_ISOMETRIC, IMAGE_DIR + "hexBorder.png");
+          put(Images.GRID_BORDER_ISOMETRIC, IMAGE_DIR + "isoBorder.png");
           put(Images.GRID_BORDER_SQUARE, IMAGE_DIR + "whiteBorder.png");
           put(Images.GRID_BORDER_SQUARE_RED, IMAGE_DIR + "grid-square-red.png");
           put(Images.HEROLABS_PORTRAIT, IMAGE_DIR + "powered_by_hero_lab_small.png");


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4077

### Description of the Change

The wrong image was being loaded when highlighting iso cells in paths. This has been fixed to use `isoBorder.png`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where iso cells were highlight as hex cells.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4079)
<!-- Reviewable:end -->
