### PR TITLE
change compression to zstd.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -459,7 +459,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.0.1-jre'
     // compression of messages between client and server
     implementation 'org.apache.commons:commons-compress:1.22'
-    implementation 'org.tukaani:xz:1.9'
+    implementation 'com.github.luben:zstd-jni:1.5.5-3'
     // intellij forms runtime
     implementation 'com.jetbrains.intellij.java:java-gui-forms-rt:223.7571.182'
     // layout for forms created in code

--- a/src/main/java/net/rptools/clientserver/simple/AbstractConnection.java
+++ b/src/main/java/net/rptools/clientserver/simple/AbstractConnection.java
@@ -26,8 +26,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import net.rptools.clientserver.ActivityListener;
 import net.rptools.clientserver.ActivityListener.Direction;
 import net.rptools.clientserver.ActivityListener.State;
-import org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream;
-import org.apache.commons.compress.compressors.lzma.LZMACompressorOutputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -84,7 +84,7 @@ public abstract class AbstractConnection implements Connection {
   private byte[] compress(byte[] message) {
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream(message.length);
-      OutputStream ios = new LZMACompressorOutputStream(baos);
+      OutputStream ios = new ZstdCompressorOutputStream(baos);
       ios.write(message);
       ios.close();
 
@@ -96,10 +96,9 @@ public abstract class AbstractConnection implements Connection {
   }
 
   private byte[] inflate(byte[] compressedMessage) {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream(compressedMessage.length);
     InputStream bytesIn = new ByteArrayInputStream(compressedMessage);
     try {
-      InputStream ios = new LZMACompressorInputStream(bytesIn);
+      InputStream ios = new ZstdCompressorInputStream(bytesIn);
       var decompressed = ios.readAllBytes();
       ios.close();
       return decompressed;


### PR DESCRIPTION
## Identify the Bug or Feature request ##
-Fixes #4082 for 1.13

## Description of the Change ##
This changes the compression for message from lzma to zstd.
Memory values for my campaign were:
zstd 540 MB
lzma 880 MB
gzip 590 MB
no compression 540 MB

## Possible Drawbacks ##
I couldn't cherry pick the commit so there may be merge conflicts when merging 1.13 into dev.

Release Notes
change compression for messages from lzma to zstd

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4094)
<!-- Reviewable:end -->
