### PR TITLE
Fix for NPE reading old campaigns

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2347,6 +2347,10 @@ public class Zone {
 
   public ZoneDto toDto() {
     var dto = ZoneDto.newBuilder();
+    dto.setName(name);
+    if (playerAlias != null) {
+      dto.setPlayerAlias(StringValue.of(playerAlias));
+    }
     dto.setCreationTime(creationTime);
     dto.setId(id.toString());
     dto.setGrid(grid.toDto());
@@ -2396,10 +2400,6 @@ public class Zone {
     dto.setBoardPosition(Mapper.map(boardPosition));
     dto.setDrawBoard(drawBoard);
     dto.setBoardChanged(boardChanged);
-    dto.setName(name);
-    if (playerAlias != null) {
-      dto.setPlayerAlias(StringValue.of(playerAlias));
-    }
     dto.setIsVisible(isVisible);
     dto.setVisionType(ZoneDto.VisionTypeDto.valueOf(visionType.name()));
     dto.setLightingStyle(ZoneDto.LightingStyleDto.valueOf(lightingStyle.name()));

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -211,7 +211,9 @@ public interface Drawable {
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        drawable.setQuadrant(AbstractTemplate.Quadrant.valueOf(dto.getQuadrant()));
+        if (!dto.getQuadrant().isEmpty()) {
+          drawable.setQuadrant(AbstractTemplate.Quadrant.valueOf(dto.getQuadrant()));
+        }
         drawable.setMouseSlopeGreater(dto.getMouseSlopeGreater());
         var pathVertex = dto.getPathVertex();
         drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -486,10 +486,14 @@ public class LineTemplate extends AbstractTemplate {
         .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto())
-        .setQuadrant(getQuadrant().name())
         .setMouseSlopeGreater(isMouseSlopeGreater())
-        .setPathVertex(getPathVertex().toDto())
         .setDoubleWide(isDoubleWide());
+    if (getPathVertex() != null) {
+      dto.setPathVertex(getPathVertex().toDto());
+    }
+    if (getQuadrant() != null) {
+      dto.setQuadrant(getQuadrant().name());
+    }
 
     if (getName() != null) dto.setName(StringValue.of(getName()));
 


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #4095 

### Description of the Change
Fixes the NPE on loading old campaigns where there is no quadrant for dodgy drawings/templates.
I have also moved setting of name and playerAlias in Zone.toDto() to the top of the method as it makes debugging these kinds of issues a lot easier.


### Possible Drawbacks
These campaigns will now load, but there may be cases where dodgy drawings/templates did not appear on the map pre 1.12 but do now. But this is vastly more preferable than the campaign not being able to load at all

### Documentation Notes
- Fix for problems loading old campaigns that would previously not be able to be loaded.

### Release Notes
- Fix for problems loading old campaigns that would previously not be able to be loaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4096)
<!-- Reviewable:end -->
