### PR TITLE
Added multiple gridTypes for SquareGrid

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/gridtool/AdjustGridControlPanelView.form
+++ b/src/main/java/net/rptools/maptool/client/tool/gridtool/AdjustGridControlPanelView.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.rptools.maptool.client.tool.gridtool.AdjustGridControlPanelView">
-  <grid id="241de" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="241de" binding="mainPanel" layout-manager="GridLayoutManager" row-count="9" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="308" height="258"/>
+      <xy x="10" y="10" width="351" height="318"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -18,7 +18,7 @@
       </component>
       <component id="4491d" class="javax.swing.JSpinner">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="gridSize"/>
@@ -36,7 +36,7 @@
       </component>
       <component id="fc376" class="javax.swing.JTextField">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="6"/>
@@ -54,7 +54,7 @@
       </component>
       <component id="cbe69" class="javax.swing.JTextField">
         <constraints>
-          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="6"/>
@@ -89,7 +89,7 @@
       </component>
       <component id="e83dd" class="javax.swing.JSlider">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="4" vsize-policy="2" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <majorTickSpacing value="20"/>
@@ -98,7 +98,7 @@
       </component>
       <component id="3c06e" class="javax.swing.JButton">
         <constraints>
-          <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="Close"/>
@@ -108,22 +108,46 @@
       </component>
       <vspacer id="9fd">
         <constraints>
-          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="2" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <hspacer id="47d6b">
         <constraints>
-          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="2" row-span="1" col-span="2" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
       <component id="6cd53" class="javax.swing.JTextField">
         <constraints>
-          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="6"/>
           <name value="offsetY"/>
           <text value=""/>
+        </properties>
+      </component>
+      <component id="1ed06" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Grid type"/>
+        </properties>
+      </component>
+      <component id="3f6fb" class="javax.swing.JComboBox">
+        <constraints>
+          <grid row="7" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <background color="-12236470"/>
+          <editable value="false"/>
+          <enabled value="true"/>
+          <model>
+            <item value="Line"/>
+            <item value="Dash"/>
+            <item value="Intersection"/>
+          </model>
+          <name value="GridSelectorBox"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
@@ -16,14 +16,7 @@ package net.rptools.maptool.client.tool.gridtool;
 
 import java.awt.Color;
 import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseWheelEvent;
+import java.awt.event.*;
 import java.util.Map;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -59,6 +52,8 @@ public class GridTool extends DefaultTool {
   private final JSlider zoomSlider;
   private final JTextField gridSecondDimension;
   private final JLabel gridSecondDimensionLabel;
+  private final JComboBox<String> gridTypeSelector;
+
   private final AbeillePanel controlPanel;
 
   private int lastZoomIndex;
@@ -90,6 +85,10 @@ public class GridTool extends DefaultTool {
 
     colorWell = (ColorWell) controlPanel.getComponent("colorWell");
     colorWell.addActionListener(e -> copyControlPanelToGrid());
+
+    gridTypeSelector = (JComboBox<String>) controlPanel.getComponent("GridSelectorBox");
+    gridTypeSelector.addFocusListener(new UpdateGridListener());
+
 
     JButton closeButton = (JButton) controlPanel.getComponent("closeButton");
     closeButton.addActionListener(
@@ -140,6 +139,7 @@ public class GridTool extends DefaultTool {
     gridOffsetXTextField.setText(Integer.toString(grid.getOffsetX()));
     gridOffsetYTextField.setText(Integer.toString(grid.getOffsetY()));
     colorWell.setColor(new Color(zone.getGridColor()));
+    gridTypeSelector.setSelectedItem(grid.getGridType());
     // Setting the size must be done last as it triggers a ChangeEvent
     // which causes copyControlPanelToGrid() to be called.
     gridSizeSpinner.setValue(grid.getSize());
@@ -175,6 +175,7 @@ public class GridTool extends DefaultTool {
     grid.setOffset(getInt(gridOffsetXTextField, 0), getInt(gridOffsetYTextField, 0));
     zone.setGridColor(colorWell.getColor().getRGB());
     grid.setSize(Math.max((Integer) gridSizeSpinner.getValue(), Grid.MIN_GRID_SIZE));
+    grid.setGridType(getString(gridTypeSelector, "Line"));
   }
 
   @Override
@@ -204,6 +205,14 @@ public class GridTool extends DefaultTool {
       return value.length() > 0 ? Double.parseDouble(value.trim()) : defaultValue;
     } catch (NumberFormatException e) {
       return 0;
+    }
+  }
+
+  private String getString(JComboBox<String> component, String defaultValue) {
+    try {
+      return component.getSelectedItem().toString();
+    } catch (NullPointerException e) {
+      return defaultValue;
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -71,6 +71,12 @@ public abstract class Grid implements Cloneable {
   protected static final Logger log = LogManager.getLogger();
   protected static final int CIRCLE_SEGMENTS = 60;
 
+  public static final String LINE_GRID = "Line";
+
+  public static final String DASH_GRID = "Dash";
+
+  public static final String INTERSECT_GRID = "Intersection";
+
   private static final Dimension NO_DIM = new Dimension();
   private static final DirectionCalculator calculator = new DirectionCalculator();
   private static Map<Integer, Area> gridShapeCache = new ConcurrentHashMap<>();
@@ -80,6 +86,8 @@ public abstract class Grid implements Cloneable {
   private int size;
   private Zone zone;
   private Area cellShape;
+
+  private String gridType;
 
   public Grid() {
     setSize(AppPreferences.getDefaultGridSize());
@@ -293,6 +301,10 @@ public abstract class Grid implements Cloneable {
     fireGridChanged();
   }
 
+  public void setGridType(String gridType) {
+    this.gridType = gridType;
+  }
+
   /**
    * @return The x component of the grid's offset.
    */
@@ -305,6 +317,10 @@ public abstract class Grid implements Cloneable {
    */
   public int getOffsetY() {
     return offsetY;
+  }
+
+  public String getGridType() {
+    return gridType;
   }
 
   public ZoneWalker createZoneWalker() {

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -14,12 +14,7 @@
  */
 package net.rptools.maptool.model;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
@@ -329,27 +324,75 @@ public class SquareGrid extends Grid {
 
     int startCol = (int) ((int) (bounds.x / gridSize) * gridSize);
     int startRow = (int) ((int) (bounds.y / gridSize) * gridSize);
+    String currentGridType = getGridType();
+    float[] dashArray = {4f, 2f};
 
     for (double row = startRow; row < bounds.y + bounds.height + gridSize; row += gridSize) {
-      if (AppState.getGridSize() == 1) {
-        g.drawLine(bounds.x, (int) (row + offY), bounds.x + bounds.width, (int) (row + offY));
+      if (currentGridType == LINE_GRID) {
+        if (AppState.getGridSize() == 1) {
+          g.drawLine(bounds.x, (int) (row + offY), bounds.x + bounds.width, (int) (row + offY));
+        } else {
+          g.fillRect(
+              bounds.x,
+              (int) (row + offY - (AppState.getGridSize() / 2)),
+              bounds.width,
+              AppState.getGridSize());
+        }
+      } else if (currentGridType == DASH_GRID) {
+        g.setStroke(
+            new BasicStroke(
+                AppState.getGridSize(),
+                BasicStroke.CAP_BUTT,
+                BasicStroke.JOIN_ROUND,
+                0,
+                dashArray,
+                0));
+        if (AppState.getGridSize() == 1) {
+          g.drawLine(bounds.x, (int) (row + offY), bounds.x + bounds.width, (int) (row + offY));
+        } else {
+          g.drawLine(
+              bounds.x,
+              (int) (row + offY - (AppState.getGridSize() / 2)),
+              bounds.x + bounds.width,
+              (int) (row + offY - (AppState.getGridSize() / 2)));
+        }
       } else {
-        g.fillRect(
-            bounds.x,
-            (int) (row + offY - (AppState.getGridSize() / 2)),
-            bounds.width,
-            AppState.getGridSize());
+        if (AppState.getGridSize() == 1) {
+          g.drawLine(bounds.x, (int) (row + offY), bounds.x + bounds.width, (int) (row + offY));
+        } else {
+          g.drawLine(bounds.x, (int) (row + offY), bounds.x + bounds.width, (int) (row + offY));
+        }
       }
     }
     for (double col = startCol; col < bounds.x + bounds.width + gridSize; col += gridSize) {
-      if (AppState.getGridSize() == 1) {
-        g.drawLine((int) (col + offX), bounds.y, (int) (col + offX), bounds.y + bounds.height);
+      if (currentGridType == LINE_GRID) {
+        if (AppState.getGridSize() == 1) {
+          g.drawLine((int) (col + offX), bounds.y, (int) (col + offX), bounds.y + bounds.height);
+        } else {
+          g.fillRect(
+              (int) (col + offX - (AppState.getGridSize() / 2)),
+              bounds.y,
+              AppState.getGridSize(),
+              bounds.height);
+        }
+      } else if (currentGridType == DASH_GRID) {
+        if (AppState.getGridSize() == 1) {
+          g.drawLine((int) (col + offX), bounds.y, (int) (col + offX), bounds.y + bounds.height);
+        } else {
+          // Draw the dashed line
+          g.drawLine(
+              (int) (col + offX - (AppState.getGridSize() / 2)),
+              bounds.y,
+              (int) (col + offX - (AppState.getGridSize() / 2)),
+              bounds.y + bounds.height);
+        }
+
       } else {
-        g.fillRect(
-            (int) (col + offX - (AppState.getGridSize() / 2)),
-            bounds.y,
-            AppState.getGridSize(),
-            bounds.height);
+        if (AppState.getGridSize() == 1) {
+          g.drawLine((int) (col + offX), bounds.y, (int) (col + offX), bounds.y + bounds.height);
+        } else {
+          g.drawLine((int) (col + offX), bounds.y, (int) (col + offX), bounds.y + bounds.height);
+        }
       }
     }
   }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement


### Identify the Bug or Feature request
Resolves  #3840 


### Description of the Change

I added an extra item to the adjustGridControlPanelView.form to select a grid type. using a getGridtype in the squareGrid.draw the correct grid type should be displayed 

### Possible Drawbacks

given the extra steps the draw function has to do there may be a slight performance hit


### Documentation Notes
added additional grid type support for square grid 


### Release Notes

added additional grid type support for square grid

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4105)
<!-- Reviewable:end -->
