### PR TITLE
Update build to use 20.0.1 for packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ runtime {
                     '--win-upgrade-uuid', winUpgradeUUID
             ]
             targetPlatform('win') {
-                jdkHome = jdkDownload('https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-debugimage_x64_windows_hotspot_20_36.zip');
+                jdkHome = jdkDownload('https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.1%2B9/OpenJDK20U-jdk_x64_windows_hotspot_20.0.1_9.zip');
             }
         }
 
@@ -269,7 +269,7 @@ runtime {
                     '--mac-package-name', project.name + developerRelease
             ]
             targetPlatform('mac') {
-                jdkHome = jdkDownload('https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jdk_x64_mac_hotspot_20_36.tar.gz');
+                jdkHome = jdkDownload('https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.1%2B9/OpenJDK20U-jdk_x64_mac_hotspot_20.0.1_9.tar.gz');
                 jvmArgs += [ '-Xdock:name=' + project.name + developerRelease ]
             }
         }
@@ -295,7 +295,7 @@ runtime {
                 ]
             }
             targetPlatform('linux') {
-                jdkHome = jdkDownload('https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jre_x64_linux_hotspot_20_36.tar.gz');
+                jdkHome = jdkDownload('https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.1%2B9/OpenJDK20U-jdk_x64_linux_hotspot_20.0.1_9.tar.gz');
             }
         }
     }


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #4124

### Description of the Change
The Temurin 20.0.0 build of Java has been taken down for Windows/Linux and replaced with 20.0.1, this updates the build to use that version for packaging.


### Possible Drawbacks

Should be none

### Documentation Notes
Update build to package Java 20.0.1

### Release Notes
- Update build to package Java 20.0.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4125)
<!-- Reviewable:end -->
