### PR TITLE
Add support for map IDs in macro functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -23,7 +23,6 @@ import java.util.List;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
-import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -208,24 +207,6 @@ public class DrawingFunctions extends AbstractFunction {
     else if ("OBJECT".equalsIgnoreCase(layer)) return Layer.OBJECT;
     else if ("BACKGROUND".equalsIgnoreCase(layer)) return Layer.BACKGROUND;
     return Layer.TOKEN;
-  }
-
-  /**
-   * Find the map/zone for a given map name
-   *
-   * @param functionName String Name of the calling function.
-   * @param mapName String Name of the searched for map.
-   * @return ZoneRenderer The map/zone.
-   * @throws ParserException if the map is not found
-   */
-  protected ZoneRenderer getNamedMap(String functionName, String mapName) throws ParserException {
-    for (ZoneRenderer zr : MapTool.getFrame().getZoneRenderers()) {
-      if (mapName.equals(zr.getZone().getName())) {
-        return zr;
-      }
-    }
-    throw new ParserException(
-        I18N.getText("macro.function.moveTokenMap.unknownMap", functionName, mapName));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingGetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingGetterFunctions.java
@@ -61,7 +61,7 @@ public class DrawingGetterFunctions extends DrawingFunctions {
     FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
     String mapName = parameters.get(0).toString();
     String id = parameters.get(1).toString();
-    Zone map = getNamedMap(functionName, mapName).getZone();
+    Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
     GUID guid = getGUID(functionName, id);
     if ("getDrawingLayer".equalsIgnoreCase(functionName)) {
       return getDrawable(functionName, map, guid).getLayer().name();

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
@@ -64,7 +64,7 @@ public class DrawingMiscFunctions extends DrawingFunctions {
     checkTrusted(functionName);
     String mapName = parameters.get(0).toString();
     String drawing = parameters.get(1).toString();
-    Zone map = getNamedMap(functionName, mapName).getZone();
+    Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
     if ("movedOverDrawing".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
       String jsonPath = parameters.get(2).toString();

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
@@ -54,7 +54,7 @@ public class DrawingSetterFunctions extends DrawingFunctions {
     FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
     String mapName = parameters.get(0).toString();
     String id = parameters.get(1).toString();
-    Zone map = getNamedMap(functionName, mapName).getZone();
+    Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
     GUID guid = getGUID(functionName, id);
     if ("setDrawingLayer".equalsIgnoreCase(functionName)) {
       Layer layer = getLayer(parameters.get(2).toString());

--- a/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
@@ -872,21 +872,35 @@ public class FindTokenFunctions extends AbstractFunction {
    * Finds the specified token.
    *
    * @param identifier the identifier of the token (name, GM name, or GUID).
-   * @param zoneName the name of the zone. If null, check current zone.
+   * @param zoneNameOrId the name or ID of the zone. If null, check current zone.
    * @return the token, or null if none found.
    */
-  public static Token findToken(String identifier, String zoneName) {
+  public static Token findToken(String identifier, String zoneNameOrId) {
     if (identifier == null) {
       return null;
     }
-    if (zoneName == null || zoneName.length() == 0) {
+    if (zoneNameOrId == null || zoneNameOrId.length() == 0) {
       ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
       return zr == null ? null : zr.getZone().resolveToken(identifier);
     } else {
+      if (!GUID.isNotGUID(zoneNameOrId)) {
+        try {
+          final var zr = MapTool.getFrame().getZoneRenderer(GUID.valueOf(zoneNameOrId));
+          if (zr != null) {
+            Token token = zr.getZone().resolveToken(identifier);
+            if (token != null) {
+              return token;
+            }
+          }
+        } catch (InvalidGUIDException ignored) {
+          // Wasn't a GUID after all. Fall back to looking up by name.
+        }
+      }
+
       List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
       for (ZoneRenderer zr : zrenderers) {
         Zone zone = zr.getZone();
-        if (zone.getName().equalsIgnoreCase(zoneName)) {
+        if (zone.getName().equalsIgnoreCase(zoneNameOrId)) {
           Token token = zone.resolveToken(identifier);
           if (token != null) {
             return token;

--- a/src/main/java/net/rptools/maptool/client/functions/FogOfWarFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FogOfWarFunctions.java
@@ -28,6 +28,7 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
@@ -75,17 +76,7 @@ public class FogOfWarFunctions extends AbstractFunction {
               parameters.size()));
     }
 
-    ZoneRenderer zoneRenderer;
-    if (parameters.size() >= 1) {
-      String mapName = parameters.get(0).toString();
-      zoneRenderer = MapTool.getFrame().getZoneRenderer(mapName);
-      if (zoneRenderer == null) {
-        throw new ParserException(
-            I18N.getText("macro.function.moveTokenMap.unknownMap", functionName, mapName));
-      }
-    } else {
-      zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
-    }
+    final var zoneRenderer = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 0);
 
     /*
      * String empty = exposePCOnlyArea(optional String mapName)

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.client.functions;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.awt.*;
 import java.awt.geom.Point2D;
@@ -22,6 +21,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
@@ -31,6 +31,7 @@ import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.client.walker.astar.AStarSquareEuclideanWalker;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.CellPoint;
+import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
@@ -65,6 +66,7 @@ public class TokenLocationFunctions extends AbstractFunction {
         "getTokenY",
         "getTokenDrawOrder",
         "getTokenMap",
+        "getTokenMapIDs",
         "getDistance",
         "moveToken",
         "goto",
@@ -111,10 +113,18 @@ public class TokenLocationFunctions extends AbstractFunction {
       return BigDecimal.valueOf(token.getZOrder());
     }
     if (functionName.equalsIgnoreCase("getTokenMap")) {
-      FunctionUtil.checkNumberParam("getDistance", parameters, 1, 2);
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       String identifier = parameters.get(0).toString();
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
-      return getTokenMap(identifier, delim);
+      final var zoneNames = getTokenZones(identifier).map(Zone::getName).toList();
+      return FunctionUtil.delimitedResult(delim, zoneNames);
+    }
+    if (functionName.equalsIgnoreCase("getTokenMapIDs")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
+      String identifier = parameters.get(0).toString();
+      String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
+      final var zoneNames = getTokenZones(identifier).map(Zone::getId).map(GUID::toString).toList();
+      return FunctionUtil.delimitedResult(delim, zoneNames);
     }
     if (functionName.equalsIgnoreCase("getDistance")) {
       FunctionUtil.checkNumberParam("getDistance", parameters, 1, 4);
@@ -166,19 +176,9 @@ public class TokenLocationFunctions extends AbstractFunction {
     } else {
       tokens.add((String) tokenString);
     }
-    Zone zone = null;
-    List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
-    for (ZoneRenderer zr : zrenderers) {
-      Zone z = zr.getZone();
-      if (z.getName().equalsIgnoreCase(map)) {
-        zone = z;
-        break;
-      }
-    }
-    if (zone == null) {
-      throw new ParserException(
-          I18N.getText("macro.function.moveTokenMap.unknownMap", functionName, map));
-    }
+
+    final var zone = FunctionUtil.getZoneRenderer(functionName, map).getZone();
+
     Zone toZone;
     Zone fromZone;
 
@@ -606,32 +606,14 @@ public class TokenLocationFunctions extends AbstractFunction {
   }
 
   /**
-   * Returns a list of maps containing the token.
+   * Returns the zones containing the identified token.
    *
    * @param identifier the identifier of the token.
-   * @param delim the delimiter of the returned list.
-   * @return the list of maps containing the token.
+   * @return all zones containing the token.
    */
-  private Object getTokenMap(String identifier, String delim) {
-    List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
-    List<String> mapList = new ArrayList<>();
-
-    for (final ZoneRenderer zr : zrenderers) {
-      Zone zone = zr.getZone();
-      Token token = zone.resolveToken(identifier);
-      if (token != null) {
-        mapList.add(zr.getZone().getName());
-      }
-    }
-
-    if ("json".equalsIgnoreCase(delim)) {
-      JsonArray jsonArray = new JsonArray();
-      for (String map : mapList) {
-        jsonArray.add(map);
-      }
-      return jsonArray;
-    } else {
-      return String.join(delim, mapList);
-    }
+  private Stream<Zone> getTokenZones(String identifier) {
+    return MapTool.getFrame().getZoneRenderers().stream()
+        .map(ZoneRenderer::getZone)
+        .filter(zone -> zone.resolveToken(identifier) != null);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -307,10 +307,13 @@ public class getInfoFunction extends AbstractFunction {
         "initiative owner permissions",
         FunctionUtil.getDecimalForBoolean(cp.isInitiativeOwnerPermissions()));
 
+    JsonArray zoneIds = new JsonArray();
     JsonObject zinfo = new JsonObject();
     for (Zone z : c.getZones()) {
+      zoneIds.add(z.getId().toString());
       zinfo.addProperty(z.getName(), z.getId().toString());
     }
+    cinfo.add("zoneIDs", zoneIds);
     cinfo.add("zones", zinfo);
 
     JsonArray tinfo = new JsonArray();


### PR DESCRIPTION
### Identify the Bug or Feature request

Implements #3852

### Description of the Change

All map functions that accept a map name or display name now accept a map ID if it makes sense. Many other functions should also support map IDs now, though this was done by modifying common functionality and I have not exhaustively checked which are all affected (not all functions use common functionality to find maps).

The following new functions have been added to return map IDs similar to the existing functions that return map names:
- `getCurrentMapID()`
- `getAllMapIDs([delim])`
- `getMapIDs(mapName, [delim])`
- `getVisibleMapIDs([delim])`
- `getTokenMapIDs(name/ID, [delim])`

Finally, a list of zone IDs has been added to the result of `getInfo("campaign")`, under the `"zoneIDs"` key 

### Possible Drawbacks

In the edge case that someone has a map named with the GUID of another map, the lookup behaviour will be changed.

### Documentation Notes

What follows is documentation for the new functions. Many existing functions will also need updating in the Wiki to add IDs to the set of possible parameters.

#### getCurrentMapID

Returns the unique ID of the current map.

**Usage**
```
getCurrentMapID()
```

#### getAllMapIDs

> Note: This function can only be used in a [Trusted Macro](https://wiki.rptools.info/index.php/Trusted_Macro)

Returns the IDs of all maps in the campaign as either a String List of a JSON Array

**Usage**
```
getAllMapIDs()
getAllMapIDs(delim)
```
**Parameters**
- `delim` The delimiter to use for a String List. If the value is `json`, then a JSON Array is returned.

#### getMapIDs

Returns the IDs of all maps with the given name.

**Usage**
```
getMapIDs(name)
getMapIDs(name, delim)
```
**Parameters**
- `name` The name of the map to find
- `delim` The delimiter to use for a String List. If the value is `json`, then a JSON Array is returned.

#### getVisibleMapIDs

Returns the IDs of all visible maps in the campaign as either a String List of a JSON Array

**Usage**
```
getVisibleMapIDs()
getVisibleMapIDs(delim)
```
**Parameters**
- `delim` The delimiter to use for a String List. If the value is `json`, then a JSON Array is returned.

#### getTokenMapIDs

Gets the list of map(s) where a token resides. The list is returned either as a string list, or as a JSON Array.

**Usage**
```
getTokenMapIDs(name/ID)
getTokenMapIDs(name/ID, delim)
```
**Parameters**
- `name/ID` Either the name of the token or the ID.
- `delim` The delimiter used in the string list returned, defaults to `","`. If set to `json`, then a JSON array is returned.

### Release Notes

- Map macro functions and many other macro functions now support map IDs as parameters.
- Added functions `getCurrentMapID()`, `getAllMapIDs([delim])`, `getMapIDs(mapName, [delim])`, `getVisibleMapIDs([delim])`, `getTokenMapIDs(name/ID, [delim])`
- Add list of map IDs under the `"zoneIDs"` key of `getInfo("campaign")`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4127)
<!-- Reviewable:end -->
