### PR TITLE
Add a createMap() macro function

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1136,15 +1136,24 @@ public class MapTool {
   }
 
   public static void addZone(Zone zone, boolean changeZone) {
+    Zone zoneToRemove = null;
     if (getCampaign().getZones().size() == 1) {
       // Remove the default map
       Zone singleZone = getCampaign().getZones().get(0);
       if (ZoneFactory.DEFAULT_MAP_NAME.equals(singleZone.getName()) && singleZone.isEmpty()) {
-        removeZone(singleZone);
+        zoneToRemove = singleZone;
       }
     }
     getCampaign().putZone(zone);
     serverCommand().putZone(zone);
+
+    // Now that clients know about the new zone, we can delete the single empty zone. Otherwise
+    // clients would not have anything to switch to, and they would get all confused.
+    if (zoneToRemove != null) {
+      removeZone(zoneToRemove);
+      changeZone = true;
+    }
+
     new MapToolEventBus().getMainEventBus().post(new ZoneAdded(zone));
     // Now we have fire off adding the tokens in the zone
     new MapToolEventBus().getMainEventBus().post(new TokensAdded(zone, zone.getTokens()));

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -20,9 +20,7 @@ import java.awt.Point;
 import java.awt.geom.PathIterator;
 import java.math.BigDecimal;
 import java.util.List;
-import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -221,23 +219,6 @@ public class DrawingFunctions extends AbstractFunction {
    */
   protected Pen getPen(String functionName, Zone map, GUID guid) throws ParserException {
     return getDrawnElement(functionName, map, guid).getPen();
-  }
-
-  /**
-   * Parses a string into either a Color Paint or Texture Paint.
-   *
-   * @param paint String containing the paint description.
-   * @return Pen DrawableTexturePaint or DrawableColorPaint.
-   */
-  protected DrawablePaint paintFromString(String paint) {
-    if (paint.toLowerCase().startsWith("asset://")) {
-      String id = paint.substring(8);
-      return new DrawableTexturePaint(new MD5Key(id));
-    } else if (paint.length() == 32) {
-      return new DrawableTexturePaint(new MD5Key(paint));
-    } else {
-      return new DrawableColorPaint(MapToolUtil.getColor(paint));
-    }
   }
 
   protected String paintToString(DrawablePaint drawablePaint) {

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
@@ -74,7 +74,7 @@ public class DrawingSetterFunctions extends DrawingFunctions {
         getPen(functionName, map, guid).setForegroundMode(Pen.MODE_TRANSPARENT);
       else {
         getPen(functionName, map, guid).setForegroundMode(Pen.MODE_SOLID);
-        getPen(functionName, map, guid).setPaint(paintFromString(paint));
+        getPen(functionName, map, guid).setPaint(FunctionUtil.getPaintFromString(paint));
       }
       return "";
     } else if ("setFillColor".equalsIgnoreCase(functionName)) {
@@ -83,7 +83,7 @@ public class DrawingSetterFunctions extends DrawingFunctions {
         getPen(functionName, map, guid).setBackgroundMode(Pen.MODE_TRANSPARENT);
       else {
         getPen(functionName, map, guid).setBackgroundMode(Pen.MODE_SOLID);
-        getPen(functionName, map, guid).setBackgroundPaint(paintFromString(paint));
+        getPen(functionName, map, guid).setBackgroundPaint(FunctionUtil.getPaintFromString(paint));
       }
       return "";
     } else if ("setDrawingEraser".equalsIgnoreCase(functionName)) {

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -173,7 +173,7 @@ public class LookupTableFunction extends AbstractFunction {
       String value = params.get(3).toString();
       MD5Key asset = null;
       if (params.size() > 4) {
-        asset = getAssetFromString(params.get(4).toString());
+        asset = FunctionUtil.getAssetKeyFromString(params.get(4).toString());
       }
       LookupTable lookupTable = getMaptoolTable(name, function);
       lookupTable.addEntry(Integer.parseInt(min), Integer.parseInt(max), value, asset);
@@ -208,7 +208,7 @@ public class LookupTableFunction extends AbstractFunction {
       String lookups = params.get(2).toString();
       MD5Key asset = null;
       if (params.size() > 3) {
-        asset = getAssetFromString(params.get(3).toString());
+        asset = FunctionUtil.getAssetKeyFromString(params.get(3).toString());
       }
       LookupTable lookupTable = new LookupTable();
       lookupTable.setName(name);
@@ -244,7 +244,7 @@ public class LookupTableFunction extends AbstractFunction {
       checkTrusted(function);
       FunctionUtil.checkNumberParam("setTableImage", params, 2, 2);
       String name = params.get(0).toString();
-      MD5Key asset = getAssetFromString(params.get(1).toString());
+      MD5Key asset = FunctionUtil.getAssetKeyFromString(params.get(1).toString());
       LookupTable lookupTable = getMaptoolTable(name, function);
       lookupTable.setTableImage(asset);
       MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
@@ -272,7 +272,7 @@ public class LookupTableFunction extends AbstractFunction {
       String result = params.get(2).toString();
       MD5Key imageId = null;
       if (params.size() == 4) {
-        imageId = getAssetFromString(params.get(3).toString());
+        imageId = FunctionUtil.getAssetKeyFromString(params.get(3).toString());
       }
       LookupTable lookupTable = getMaptoolTable(name, function);
       LookupEntry entry = lookupTable.getLookup(roll);
@@ -507,25 +507,5 @@ public class LookupTableFunction extends AbstractFunction {
               "macro.function.LookupTableFunctions.unknownTable", functionName, tableName));
     }
     return lookupTable;
-  }
-
-  /**
-   * Provide more consistent handling of assets. Allow assets to be passed as 32 digit numbers or
-   * "asset://" urls.
-   *
-   * @param assetString String containing either an asset ID or asset URL.
-   * @return MD5Key asset id or null
-   */
-  private MD5Key getAssetFromString(String assetString) {
-    if (assetString.isEmpty()) {
-      return null;
-    }
-
-    if (assetString.toLowerCase().startsWith("asset://")) {
-      String id = assetString.substring(8);
-      return new MD5Key(id);
-    } else {
-      return new MD5Key(assetString);
-    }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -14,15 +14,24 @@
  */
 package net.rptools.maptool.client.functions;
 
+import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.InvalidGUIDException;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.ZoneFactory;
+import net.rptools.maptool.model.drawing.DrawablePaint;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -52,6 +61,7 @@ public class MapFunctions extends AbstractFunction {
         "setMapName",
         "setMapDisplayName",
         "copyMap",
+        "createMap",
         "getMapName",
         "setMapSelectButton");
   }
@@ -167,6 +177,126 @@ public class MapFunctions extends AbstractFunction {
       MapTool.serverCommand().putZone(newMap);
       return newMap.getName();
 
+    } else if ("createMap".equalsIgnoreCase(functionName)) {
+      FunctionUtil.blockUntrustedMacro(functionName);
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
+      String mapName = parameters.get(0).toString();
+      JsonObject config =
+          parameters.size() < 2
+              ? new JsonObject()
+              : FunctionUtil.paramAsJsonObject(functionName, parameters, 1);
+
+      final var newMap = ZoneFactory.createZone();
+      newMap.setName(mapName);
+
+      if (config.has("display name")) {
+        newMap.setPlayerAlias(config.getAsJsonPrimitive("display name").getAsString());
+      }
+      if (config.has("player visible")) {
+        final var visible = config.getAsJsonPrimitive("player visible").getAsBoolean();
+        newMap.setVisible(visible);
+      }
+      if (config.has("vision type")) {
+        newMap.setVisionType(
+            Zone.VisionType.valueOf(
+                config.getAsJsonPrimitive("vision type").getAsString().toUpperCase()));
+      }
+      if (config.has("vision distance")) {
+        newMap.setTokenVisionDistance(config.getAsJsonPrimitive("vision distance").getAsInt());
+      }
+      if (config.has("lighting style")) {
+        newMap.setLightingStyle(
+            Zone.LightingStyle.valueOf(
+                config.getAsJsonPrimitive("lighting style").getAsString().toUpperCase()));
+      }
+      if (config.has("has fog")) {
+        final var hasFog = config.getAsJsonPrimitive("has fog").getAsBoolean();
+        newMap.setHasFog(hasFog);
+      }
+      if (config.has("ai rounding")) {
+        final var aiRounding =
+            Zone.AStarRoundingOptions.valueOf(
+                config.getAsJsonPrimitive("ai rounding").getAsString().toUpperCase());
+        newMap.setAStarRounding(aiRounding);
+      }
+
+      {
+        final var gridConfig =
+            config.has("grid") ? config.getAsJsonObject("grid") : new JsonObject();
+
+        final var gridType =
+            gridConfig.has("type")
+                ? gridConfig.getAsJsonPrimitive("type").getAsString()
+                : AppPreferences.getDefaultGridType();
+        final var grid =
+            GridFactory.createGrid(
+                gridType, AppPreferences.getFaceEdge(), AppPreferences.getFaceVertex());
+
+        final var gridColor =
+            gridConfig.has("color")
+                ? MapToolUtil.getColor(gridConfig.getAsJsonPrimitive("color").getAsString())
+                : AppPreferences.getDefaultGridColor();
+        newMap.setGridColor(gridColor.getRGB());
+
+        final var gridUnitsPerCell =
+            gridConfig.has("units per cell")
+                ? gridConfig.getAsJsonPrimitive("units per cell").getAsDouble()
+                : AppPreferences.getDefaultUnitsPerCell();
+        newMap.setUnitsPerCell(gridUnitsPerCell);
+
+        final var gridSize =
+            gridConfig.has("size")
+                ? gridConfig.getAsJsonPrimitive("size").getAsInt()
+                : AppPreferences.getDefaultGridSize();
+        grid.setSize(gridSize);
+
+        final var gridOffsetX =
+            gridConfig.has("x offset") ? gridConfig.getAsJsonPrimitive("x offset").getAsInt() : 0;
+        final var gridOffsetY =
+            gridConfig.has("y offset") ? gridConfig.getAsJsonPrimitive("y offset").getAsInt() : 0;
+        grid.setOffset(gridOffsetX, gridOffsetY);
+
+        newMap.setGrid(grid);
+      }
+
+      // The background and fog paints can either be an asset:// URL or a color.
+      final Map<String, Consumer<DrawablePaint>> mapPaints =
+          Map.of(
+              "background paint", newMap::setBackgroundPaint,
+              "fog paint", newMap::setFogPaint);
+      for (final var entry : mapPaints.entrySet()) {
+        final var property = entry.getKey();
+        if (!config.has(property)) {
+          continue;
+        }
+
+        final var paint =
+            FunctionUtil.getPaintFromString(config.getAsJsonPrimitive(property).getAsString());
+        MapToolUtil.uploadTexture(paint);
+        entry.getValue().accept(paint);
+      }
+
+      if (config.has("map asset")) {
+        final var mapAssetId = config.getAsJsonPrimitive("map asset").getAsString();
+        final var mapAssetKey = FunctionUtil.getAssetKeyFromString(mapAssetId);
+        if (mapAssetKey == null) {
+          throw new ParserException(
+              I18N.getText("macro.function.map.invalidAsset", functionName, mapAssetId));
+        }
+
+        final var mapAsset = AssetManager.getAsset(mapAssetKey);
+        if (mapAsset != null) {
+          AssetManager.putAsset(mapAsset);
+          if (!MapTool.isHostingServer()) {
+            MapTool.serverCommand().putAsset(mapAsset);
+          }
+        }
+
+        newMap.setMapAsset(mapAssetKey);
+      }
+
+      MapTool.addZone(newMap, false);
+      return newMap.getId();
     } else if ("getVisibleMapIDs".equalsIgnoreCase(functionName)
         || "getAllMapIDs".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);
@@ -186,7 +316,6 @@ public class MapFunctions extends AbstractFunction {
       }
 
       return FunctionUtil.delimitedResult(delim, mapIds);
-
     } else if ("getVisibleMapNames".equalsIgnoreCase(functionName)
         || "getAllMapNames".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 1);

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -44,6 +44,8 @@ import net.rptools.maptool.model.LookupTable;
 import net.rptools.maptool.model.SightType;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
+import net.rptools.maptool.model.drawing.DrawableTexturePaint;
 import net.rptools.maptool.server.ServerPolicy;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.MapToolSysInfoProvider;
@@ -139,11 +141,12 @@ public class getInfoFunction extends AbstractFunction {
     String visionType = zone.getVisionType().name();
     minfo.addProperty("vision type", visionType);
     minfo.addProperty("vision distance", zone.getTokenVisionDistance());
+    minfo.addProperty("lighting style", zone.getLightingStyle().name());
+    minfo.addProperty("has fog", zone.hasFog());
+    minfo.addProperty("ai rounding", zone.getAStarRounding().name());
 
     JsonObject ginfo = new JsonObject();
-
     Grid grid = zone.getGrid();
-
     ginfo.addProperty("type", GridFactory.getGridType(grid));
     ginfo.addProperty("color", String.format("%h", zone.getGridColor()));
     ginfo.addProperty("units per cell", zone.getUnitsPerCell());
@@ -155,8 +158,33 @@ public class getInfoFunction extends AbstractFunction {
     ginfo.addProperty("x offset", zone.getGrid().getOffsetX());
     ginfo.addProperty("y offset", zone.getGrid().getOffsetY());
     ginfo.addProperty("second dimension", grid.getSecondDimension());
-
     minfo.add("grid", ginfo);
+
+    {
+      final var backgroundPaint = zone.getBackgroundPaint();
+      String background = null;
+      if (backgroundPaint instanceof DrawableColorPaint dcp) {
+        background = String.format("#%h", zone.getGridColor());
+      } else if (backgroundPaint instanceof DrawableTexturePaint dtp) {
+        background = "asset://" + dtp.getAssetId().toString();
+      }
+      minfo.addProperty("background paint", background);
+    }
+    {
+      final var fogPaint = zone.getFogPaint();
+      String fog = null;
+      if (fogPaint instanceof DrawableColorPaint dcp) {
+        fog = String.format("#%h", zone.getGridColor());
+      } else if (fogPaint instanceof DrawableTexturePaint dtp) {
+        fog = "asset://" + dtp.getAssetId().toString();
+      }
+      minfo.addProperty("fog paint", fog);
+    }
+    {
+      final var mapAsset = zone.getMapAssetId();
+      minfo.addProperty("map asset", mapAsset == null ? null : "asset://" + mapAsset.toString());
+    }
+
     return minfo;
   }
 

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
@@ -509,6 +510,25 @@ public class FunctionUtil {
     } else {
       return new DrawableColorPaint(MapToolUtil.getColor(paint));
     }
+  }
+
+  /**
+   * Parses a string as an asset URL.
+   *
+   * @param assetUrlOrId String containing the asset ID or asset URL.
+   * @return The MD5 key present in {@code assetUrlOrId}, or null.
+   */
+  public static @Nullable MD5Key getAssetKeyFromString(String assetUrlOrId) {
+    final String id;
+    if (assetUrlOrId.toLowerCase().startsWith("asset://")) {
+      id = assetUrlOrId.substring("asset://".length());
+    } else if (assetUrlOrId.length() == 32) {
+      id = assetUrlOrId;
+    } else {
+      return null;
+    }
+
+    return new MD5Key(id);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -21,7 +21,9 @@ import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
 import java.util.List;
 import javax.annotation.Nonnull;
+import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.FindTokenFunctions;
 import net.rptools.maptool.client.functions.StringFunctions;
@@ -31,6 +33,9 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.InvalidGUIDException;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
+import net.rptools.maptool.model.drawing.DrawablePaint;
+import net.rptools.maptool.model.drawing.DrawableTexturePaint;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.Function;
@@ -488,6 +493,24 @@ public class FunctionUtil {
   public static BigDecimal getDecimalForBoolean(boolean b) {
     return b ? BigDecimal.ONE : BigDecimal.ZERO;
   }
+
+  /**
+   * Parses a string into either a Color Paint or Texture Paint.
+   *
+   * @param paint String containing the paint description.
+   * @return Pen DrawableTexturePaint or DrawableColorPaint.
+   */
+  public static DrawablePaint getPaintFromString(String paint) {
+    if (paint.toLowerCase().startsWith("asset://")) {
+      String id = paint.substring("asset://".length());
+      return new DrawableTexturePaint(new MD5Key(id));
+    } else if (paint.length() == 32) {
+      return new DrawableTexturePaint(new MD5Key(paint));
+    } else {
+      return new DrawableColorPaint(MapToolUtil.getColor(paint));
+    }
+  }
+
   /**
    * Throw an exception if the macro isn't trusted.
    *

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1858,6 +1858,7 @@ macro.function.macroLink.unknown                   = Unknown
 macro.function.map.none                            = {0}: function requires a current map, but none is present.
 # {0} is the function name
 macro.function.map.notFound                        = {0}: indicated map in first parameter not found.
+macro.function.map.invalidAsset                    = {0}: "{1}" is not a valid asset ID or URL
 # {0} is the function name
 macro.function.moveTokenMap.alreadyThere           = Can not use "{0}" to move tokens to a map that they are already on!
 # {0} is the token name/id, {1} is the map it's moved to.


### PR DESCRIPTION
### Identify the Bug or Feature request

Implements #3505

### Description of the Change

First up there is some supporting refactoring to bring paint string parsing and asset ID/URL parsing into `FunctionUtil`. `DrawingFunctions` and its children, and `LookupTableFunction` now use these common methods instead of using their own. These will also be used by `createMap()`.

Second is a tweak to `MapTool.addZone()` to fix an edge case I encountered while testing `createMap()`. In the case that we replace the default map, there were two undesirable effects of how we did the replacement:
1. On the client adding the map, the new map would not be set as current, leaving the client on no map. Otherwise things work fine, the client just has to be manually switched to the new map before they can see anything.
2. On a connected client receiving the new map, an NPE could result. Since we delete the default map first, then send the new map, there is a short time where the client has no maps at all.

The behaviour is now changed so that we add the new map first, then delete the default map. We also always force a map change on the originating client if adding the map results in deleting the default map.

Third is a change to `getInfo("map")` / `getInfo("zone")` to include more information via new keys. The new keys hold info that will be useful when calling `createMap()`, so I wanted easy access to these values. The new keys are:
- `"lighting style"`
- `"has fog"`
- `"ai rounding"`
- `"background paint"`
- `"fog paint"`
- `"map asset"`

Finally is the main change: `createMap()`. This trusted macro function builds brand new maps given only a name and some options. This will allow add-ons and other macros to create new maps from nothing, which can then be populated using existing macros, e.g., `createToken()`, etc. The `createMap()` function supports every option in the **Map Properties** dialog, and also every meaningful property returned by `getInfo("map")` (inlcuding the newly added ones). I aimed for alignment between `createMap()` keys and `getInfo("map")` keys to make it easier to build a configuration object for use with `createMap()`. The documentation notes below detail the exact set of keys that are supported in the configuration.

### Possible Drawbacks

Should be none

### Documentation Notes

#### createMap

**Usage**
```
createMap(name)
createMap(name, config)
```
**Parameters**
- `name` The name of the new map.
- `config` A JSON object of options to apply to the new map.

**config parameter**
`config` is a JSON Object that can contain any of the following fields. Field names are case-sensitive, and all fields are optional:
- `display name`: defaults to none
- `player visible`: defaults to user preferences
- `vision type`: defaults to user preferences
- `vision distance`: defaults to user preferences
- `lighting style`: defaults to `"OVERTOP"`
- `background paint`: defaults to built-in Grass
- `fog paint`: defaults to black
- `has fog`: defaults to user preferences (TODO Implement it)
- `map asset`: defaults to none
- `grid`: JSON object, see below

The `grid` value is another JSON object, with these optional keys:
- `type`: defaults to user preferences
- `color`: defaults to user preferences
- `units per cell`: defaults to user preferences
- `size`: defaults to user preferences
- `x offset`: defaults to 0
- `y offset`: defaults to 0

**Examples**

```
[h: vNewMapId = createMap("New Map", json.set("{}",
        "display name", "Display Name",
        "player visible", json.true,
        "vision type", "NIGHT",
        "vision distance", 600,
        "lighting style", "OVERTOP",
        "has fog", json.true,
        "ai rounding", "CELL_UNIT",
        "grid", json.set("{}",
                "type", "Square",
                "color", "#FF0000",
                "units per cell", 20,
                "size", 200,
                "x offset", 7,
                "y offset", 11
        ),
        "background paint", "asset://da1712226dac0f02c4a9a57ab772856b",
        "fog paint", "asset://d3e430bd9f1e380ec749c42e060f015b",
        "map asset", "asset://014aaa10a10b5ddcbbe006f3c22188c2"
))]
```


### Release Notes

- Fixed a NullPointerException that could result when creating a new map in a blank campaign with connected clients.
- Added the following keys to the result of `getInfo("map")`/`getInfo("zone")`: `"lighting style"`, `"has fog"`, `"ai rounding"`, `"background paint"`, `"fog paint"`, `"map asset"`
- Added `createMap(name, [config])` function to create new maps with configurable options.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4128)
<!-- Reviewable:end -->
