### PR TITLE
Check trusted flag against BigDecimal.ZERO instead of casting to int

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -110,7 +110,7 @@ public class MacroJavaScriptBridge extends AbstractFunction implements DefinesSp
       contextName = (String) args.remove(0);
       boolean makeTrusted = MapTool.getParser().isMacroTrusted();
       if (args.size() > 0) {
-        makeTrusted = ((int) args.remove(0)) > 0;
+        makeTrusted = !BigDecimal.ZERO.equals(args.remove(0));
       }
       JSScriptEngine.registerContext(
           contextName, MapTool.getParser().isMacroTrusted(), makeTrusted);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4151

### Description of the Change

The integral value passed as the `trusted` parameter of `js.createNS()` is represented as a `BigDecimal`, not a value that can be cast to `int`. This PR changes the comparison to check against `BigDecimal.ZERO` as is done in other macro functions.

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Fixed an error when using the two-parameter form of `js.createNS()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4153)
<!-- Reviewable:end -->
