### PR TITLE
Add buttons to the add-on dialog to easily copy MT Theme and MT Stat Sheet Theme CSS to the clipboard

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppConstants.java
+++ b/src/main/java/net/rptools/maptool/client/AppConstants.java
@@ -90,4 +90,7 @@ public class AppConstants {
   /** CSS used for MT Stat Sheet Theme support */
   public static final String MT_THEME_STAT_SHEET_CSS =
       "lib://net.rptools.maptool/css/mt-stat-sheet.css";
+
+  /** Namespace for built in add-ons. This is used to determine if an add-on is built in or not. */
+  public static final String MT_BUILTIN_ADD_ON_NAMESPACE = "net.rptools.maptool";
 }

--- a/src/main/java/net/rptools/maptool/client/AppConstants.java
+++ b/src/main/java/net/rptools/maptool/client/AppConstants.java
@@ -83,4 +83,11 @@ public class AppConstants {
    */
   public static final String INTERNAL_MAP_UNDER_POINTER_HTML_OVERLAY_NAME =
       INTERNAL_FRAME_PREFIX + "Internal Map Under Pointer Overlay";
+
+  /** CSS used for MT Theme support */
+  public static final String MT_THEME_CSS = "lib://net.rptools.maptool/css/mt-theme.css";
+
+  /** CSS used for MT Stat Sheet Theme support */
+  public static final String MT_THEME_STAT_SHEET_CSS =
+      "lib://net.rptools.maptool/css/mt-stat-sheet.css";
 }

--- a/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.form
@@ -249,7 +249,7 @@
                   </splitpane>
                 </children>
               </grid>
-              <grid id="78150" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="78150" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="library.dialog.development.label"/>
@@ -257,6 +257,24 @@
                 <properties/>
                 <border type="none"/>
                 <children>
+                  <hspacer id="28b4a">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
+                  <vspacer id="61f72">
+                    <constraints>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </vspacer>
+                  <component id="fde58" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="library.dialog.copy.title"/>
+                    </properties>
+                  </component>
                   <component id="456e5" class="javax.swing.JButton" binding="copyThemeCSS">
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -265,16 +283,6 @@
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="library.dialog.copyMTThemeCSS"/>
                     </properties>
                   </component>
-                  <hspacer id="28b4a">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                  </hspacer>
-                  <vspacer id="61f72">
-                    <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                  </vspacer>
                   <component id="35630" class="javax.swing.JButton" binding="copyStatSheetThemeButton" default-binding="true">
                     <constraints>
                       <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>

--- a/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.form
@@ -249,14 +249,41 @@
                   </splitpane>
                 </children>
               </grid>
-              <grid id="78150" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="78150" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="library.dialog.development.label"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
-                <children/>
+                <children>
+                  <component id="456e5" class="javax.swing.JButton" binding="copyThemeCSS">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="library.dialog.copyMTThemeCSS"/>
+                    </properties>
+                  </component>
+                  <hspacer id="28b4a">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
+                  <vspacer id="61f72">
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </vspacer>
+                  <component id="35630" class="javax.swing.JButton" binding="copyStatSheetThemeButton" default-binding="true">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="library.dialog.copyMTStatSheetTheme"/>
+                    </properties>
+                  </component>
+                </children>
               </grid>
             </children>
           </tabbedpane>

--- a/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.java
@@ -14,6 +14,8 @@
  */
 package net.rptools.maptool.client.ui.addon;
 
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -21,6 +23,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import javax.swing.JButton;
@@ -34,6 +37,7 @@ import javax.swing.JTable;
 import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 import net.rptools.maptool.client.AppActions.MapPreviewFileChooser;
+import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.JLabelHyperLinkListener;
 import net.rptools.maptool.client.ui.ViewAssetDialog;
@@ -63,6 +67,8 @@ public class AddOnLibrariesDialogView extends JDialog {
   private JLabel addOnLicenseLabel;
   private JButton viewReadMeFileButton;
   private JButton viewLicenseFileButton;
+  private JButton copyThemeCSS;
+  private JButton copyStatSheetThemeButton;
 
   private LibraryInfo selectedAddOn;
 
@@ -160,6 +166,44 @@ public class AddOnLibrariesDialogView extends JDialog {
             buttonAdd.setEnabled(false);
             buttonRemove.setEnabled(false);
           }
+        });
+
+    copyThemeCSS.addActionListener(
+        e -> {
+          new LibraryManager()
+              .getLibrary(AppConstants.MT_BUILTIN_ADD_ON_NAMESPACE)
+              .ifPresent(
+                  library -> {
+                    URI uri = URI.create(AppConstants.MT_THEME_CSS);
+                    String themeCss = null;
+                    try {
+                      themeCss = library.readAsString(uri.toURL()).get();
+                    } catch (InterruptedException | ExecutionException | IOException ex) {
+                      throw new RuntimeException(ex);
+                    }
+                    Toolkit.getDefaultToolkit()
+                        .getSystemClipboard()
+                        .setContents(new StringSelection(themeCss), null);
+                  });
+        });
+
+    copyStatSheetThemeButton.addActionListener(
+        e -> {
+          new LibraryManager()
+              .getLibrary(AppConstants.MT_BUILTIN_ADD_ON_NAMESPACE)
+              .ifPresent(
+                  library -> {
+                    URI uri = URI.create(AppConstants.MT_THEME_STAT_SHEET_CSS);
+                    String themeCss = null;
+                    try {
+                      themeCss = library.readAsString(uri.toURL()).get();
+                    } catch (InterruptedException | ExecutionException | IOException ex) {
+                      throw new RuntimeException(ex);
+                    }
+                    Toolkit.getDefaultToolkit()
+                        .getSystemClipboard()
+                        .setContents(new StringSelection(themeCss), null);
+                  });
         });
   }
 

--- a/src/main/java/net/rptools/maptool/model/library/builtin/MapToolBuiltInLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/MapToolBuiltInLibrary.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.language.I18N;
@@ -71,31 +72,31 @@ public class MapToolBuiltInLibrary implements BuiltInLibrary {
     }
   }
 
-  private final Map<String, String> cache = new ConcurrentHashMap<>();
+  private static final Map<String, String> cache = new ConcurrentHashMap<>();
 
-  private final String name = "MapTool Built-In Library";
-  private final String namespace = "net.rptools.maptool";
-  private final String version = "1.0.0";
+  private static final String name = "MapTool Built-In Library";
+  private static final String namespace = AppConstants.MT_BUILTIN_ADD_ON_NAMESPACE;
+  private static final String version = "1.0.0";
 
-  private final String website = "https://www.rptools.net";
+  private static final String website = "https://www.rptools.net";
 
-  private final String gitUrl = "https://github.com/RPTools/maptool";
+  private static final String gitUrl = "https://github.com/RPTools/maptool";
 
-  private final String[] authors = new String[] {"RPTools Team"};
+  private static final String[] authors = new String[] {"RPTools Team"};
 
-  private final String license = "AGPLv3";
+  private static final String license = "AGPLv3";
 
-  private final String description = "MapTool Built-In Library";
+  private static final String description = "MapTool Built-In Library";
 
-  private final String shortDescription = "MapTool Built-In Library";
+  private static final String shortDescription = "MapTool Built-In Library";
 
-  private final boolean allowsUriAccess = true;
+  private static final boolean allowsUriAccess = true;
 
-  private final String readMeFile = "";
+  private static final String readMeFile = "";
 
-  private final String licenseFile = "";
+  private static final String licenseFile = "";
 
-  private final String[] tags = new String[] {};
+  private static final String[] tags = new String[] {};
 
   @Override
   public CompletableFuture<String> getVersion() {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2757,8 +2757,11 @@ library.dialog.table.remove       = Remove Library
 library.dialog.table.removeData   = Remove Library and Data
 library.dialog.delete.confirm     = Are you sure you want to remove add-on library {0}?
 library.dialog.deleteData.confirm = Are you sure you want to remove add-on library {0} and all its data?
-library.dialog.copyMTThemeCSS     = Copy CSS Theme to the clipboard
-library.dialog.copyMTStatSheetTheme = Copy Stat Sheet Theme to the clipboard
+library.dialog.copy.title         = <html>The copied CSS is for testing \
+  purposes only.<br/>Within your add-on use<br/>lib://net.rptools.maptool/css/mt-stat-sheet.css \
+  or<br/> lib://net.rptools.maptool/css/mt-theme.css</html>
+library.dialog.copyMTThemeCSS     = Copy CSS Theme to clipbaord
+library.dialog.copyMTStatSheetTheme = Copy Stat Sheet Theme to clipbaord
 
 # Game Data
 data.error.cantConvertTo         = Can''t convert {0} to {1}.

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2757,7 +2757,8 @@ library.dialog.table.remove       = Remove Library
 library.dialog.table.removeData   = Remove Library and Data
 library.dialog.delete.confirm     = Are you sure you want to remove add-on library {0}?
 library.dialog.deleteData.confirm = Are you sure you want to remove add-on library {0} and all its data?
-
+library.dialog.copyMTThemeCSS     = Copy CSS Theme to the clipboard
+library.dialog.copyMTStatSheetTheme = Copy Stat Sheet Theme to the clipboard
 
 # Game Data
 data.error.cantConvertTo         = Can''t convert {0} to {1}.


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #4155

### Description of the Change
Add buttons to the add-on dialog to easily copy MT Theme and MT Stat Sheet Theme CSS to the clipboard

### Possible Drawbacks
Should be none

### Documentation Notes
Add buttons to the add-on dialog to easily copy MT Theme and MT Stat Sheet Theme CSS to the clipboard

### Release Notes
- Add buttons to the add-on dialog to easily copy MT Theme and MT Stat Sheet Theme CSS to the clipboard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4156)
<!-- Reviewable:end -->
