### PR TITLE
Feature addon metadata

### DIFF
--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
@@ -209,7 +209,7 @@ public class AddOnLibraryImporter {
         Asset asset =
             Type.fromMediaType(mediaType)
                 .getFactory()
-                .apply(namespace + "/" + METADATA_DIR + path, bytes);
+                .apply(namespace + "/" + path, bytes);
         addAsset(asset);
         pathAssetMap.put(path, Pair.with(asset.getMD5Key(), asset.getType()));
       }

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
@@ -59,6 +59,9 @@ public class AddOnLibraryImporter {
   /** The name of the file with the stat sheets. */
   public static final String STATS_SHEET_FILE = "stat_sheets.json";
 
+  /** The directory where metadata from the root dir of the zip directory is copied to. */
+  public static final String METADATA_DIR = "metadata/";
+
   /**
    * Returns the {@link FileFilter} for add on library files.
    *
@@ -176,6 +179,9 @@ public class AddOnLibraryImporter {
             .merge(new InputStreamReader(zip.getInputStream(statSheetEntry)), statSheetsBuilder);
       }
 
+      // Copy Metadata
+      addMetaData(builder.getNamespace(), zip, pathAssetMap);
+
       var addOnLib = builder.build();
       byte[] data = Files.readAllBytes(file.toPath());
       var asset = Type.MTLIB.getFactory().apply(addOnLib.getNamespace(), data);
@@ -188,6 +194,25 @@ public class AddOnLibraryImporter {
           eventPropBuilder.build(),
           statSheetsBuilder.build(),
           pathAssetMap);
+    }
+  }
+
+  private void addMetaData(
+      String namespace, ZipFile zip, Map<String, Pair<MD5Key, Type>> pathAssetMap)
+      throws IOException {
+    var entries = zip.stream().filter(e -> !e.getName().contains("/")).toList();
+    for (var entry : entries) {
+      String path = METADATA_DIR + entry.getName();
+      try (InputStream inputStream = zip.getInputStream(entry)) {
+        byte[] bytes = inputStream.readAllBytes();
+        MediaType mediaType = Asset.getMediaType(entry.getName(), bytes);
+        Asset asset =
+            Type.fromMediaType(mediaType)
+                .getFactory()
+                .apply(namespace + "/" + METADATA_DIR + path, bytes);
+        addAsset(asset);
+        pathAssetMap.put(path, Pair.with(asset.getMD5Key(), asset.getType()));
+      }
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryImporter.java
@@ -207,9 +207,7 @@ public class AddOnLibraryImporter {
         byte[] bytes = inputStream.readAllBytes();
         MediaType mediaType = Asset.getMediaType(entry.getName(), bytes);
         Asset asset =
-            Type.fromMediaType(mediaType)
-                .getFactory()
-                .apply(namespace + "/" + path, bytes);
+            Type.fromMediaType(mediaType).getFactory().apply(namespace + "/" + path, bytes);
         addAsset(asset);
         pathAssetMap.put(path, Pair.with(asset.getMD5Key(), asset.getType()));
       }


### PR DESCRIPTION


### Identify the Bug or Feature request
resolves #4166


### Description of the Change
Any files in the root of the mtlib zip file also get entries in the metadata/ directory


### Possible Drawbacks

If someone has a metadata/ directory already that contains the same filename it will be overwritten


### Documentation Notes
Files at the top level of the .mtlib zip file will be available lib://<namespace>/metadata/<filename>


### Release Notes
- Files at the top level of the .mtlib zip file will be available lib://<namespace>/metadata/<filename>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4167)
<!-- Reviewable:end -->
