### PR TITLE
Handle invalid hex representations of GUIDs

### DIFF
--- a/src/main/java/net/rptools/maptool/model/GUID.java
+++ b/src/main/java/net/rptools/maptool/model/GUID.java
@@ -60,9 +60,16 @@ public class GUID implements Serializable, Comparable<GUID> {
    * @throws InvalidGUIDException if the GUID is invalid
    */
   public GUID(String strGUID) {
-    if (strGUID == null) throw new InvalidGUIDException("GUID is null");
+    if (strGUID == null) {
+      throw new InvalidGUIDException("GUID is null");
+    }
 
-    this.baGUID = HexFormat.of().parseHex(strGUID);
+    try {
+      this.baGUID = HexFormat.of().parseHex(strGUID);
+    } catch (Exception e) {
+      throw new InvalidGUIDException("Invalid format for GUID");
+    }
+
     validateGUID();
   }
 

--- a/src/main/java/net/rptools/maptool/model/GUID.java
+++ b/src/main/java/net/rptools/maptool/model/GUID.java
@@ -43,17 +43,6 @@ public class GUID implements Serializable, Comparable<GUID> {
   }
 
   /**
-   * Creates a new GUID based on the specified GUID value.
-   *
-   * @param baGUID the new GUID
-   * @throws InvalidGUIDException if the GUID is invalid
-   */
-  public GUID(byte[] baGUID) throws InvalidGUIDException {
-    this.baGUID = baGUID;
-    validateGUID();
-  }
-
-  /**
    * Creates a new GUID based on the specified hexadecimal-code string.
    *
    * @param strGUID the guid as a hexadecimal-code string
@@ -82,17 +71,6 @@ public class GUID implements Serializable, Comparable<GUID> {
     if (baGUID == null) throw new InvalidGUIDException("GUID is null");
     if (baGUID.length != GUID_LENGTH)
       throw new InvalidGUIDException("GUID length is invalid: " + baGUID.length);
-  }
-
-  /**
-   * Returns the GUID representation of the {@link byte} array argument.
-   *
-   * @param bits the {@link byte} array of the GUID
-   * @return a new GUID instance
-   */
-  public static GUID valueOf(byte[] bits) {
-    if (bits == null) return null;
-    return new GUID(bits);
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes a bug introduced in PR #4127, for issue #3852

### Description of the Change

The `GUID(String)` constructor is documented to throw an `InvalidGUIDException` when the parameter is not a valid representation of a GUID. However that was not being done when the string is not even a valid hex string. Instead, the `NumberFormatException` thrown by `HexFormat.parseHex()` was allowed to propagate, which was not being handled by the new map ID support.

This PR changes that constructor to obey its contract. The `NumberFormatException` (any `Exception` really) thrown by `HexFormat.parseHes()` is now caught and an `InvalidGUIDException` is thrown in its place.

Also some cleanup: the `byte[]` constructor for `GUID` was unused, so it has been removed.

### Possible Drawbacks

Should be none, unless I overlooked a caller that handles the `NumberFormatException` / `IllegalArgumentException`.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4174)
<!-- Reviewable:end -->
