### PR TITLE
Clear Legacy Statsheet when moving between tokens

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -728,6 +728,7 @@ public class PointerTool extends DefaultTool {
                     SwingUtil.isControlDown(keysDown)));
       }
     } else if (tokenUnderMouse != oldTokenUnderMouse) {
+      statSheet = null;
       if (oldTokenUnderMouse != null) {
         new MapToolEventBus()
             .getMainEventBus()


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #4150


### Description of the Change
The legacy stat sheet is now cleared if the mouse moves from one token to another, this was not required prior to the new stat sheet change as there was no chance of having 2 different methods for rendering the statsheet.


### Possible Drawbacks

Should be all upside

### Documentation Notes
The legacy stat sheet is now cleared if the mouse moves from one token to another, this was not required prior to the new stat sheet change as there was no chance of having 2 different methods for rendering the statsheet.


### Release Notes
- Clear legacy stat sheet when moving mouse directly from hovering over one token to another

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4177)
<!-- Reviewable:end -->
