### PR TITLE
Fix for MapTool Freeze when using an asset that can't be found on macro button

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -760,9 +760,9 @@ public class ClientMessageHandler implements MessageHandler {
   }
 
   private void handle(PutAssetMsg msg) {
+    AssetManager.putAsset(Asset.fromDto(msg.getAsset()));
     EventQueue.invokeLater(
         () -> {
-          AssetManager.putAsset(Asset.fromDto(msg.getAsset()));
           MapTool.getFrame().getCurrentZoneRenderer().flushDrawableRenderer();
           MapTool.getFrame().refresh();
         });


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4163

### Description of the Change
Changed the client handler put asset call so that the adding of the asset to the asset manager occurs on the current thread rather than a deferred Swing thread. As the memory cache is thread safe, this is fine, and it avoids the issue where Swing is blocking waiting for an image which currently locks up MapTool.


### Possible Drawbacks

Should be none

### Documentation Notes
Missing assets used in macro buttons OR <img> tags in chat or frame/dialog should no longer cause MapTool to lock up.

### Release Notes
- Missing assets used in macro buttons OR <img> tags in chat or frame/dialog should no longer cause MapTool to lock up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4182)
<!-- Reviewable:end -->
