### PR TITLE
Add ability to set Token Images, Portraits, and Handouts from addon assets (include copy/create token)

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenCopyDeleteFunctions.java
@@ -33,6 +33,7 @@ import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.TokenFootprint;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
+import net.rptools.maptool.util.AssetResolver;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -119,6 +120,10 @@ public class TokenCopyDeleteFunctions extends AbstractFunction {
       throw new ParserException(I18N.getText("macro.function.tokenCopyDelete.noImage"));
     }
     String tokenImage = vals.get("tokenImage").getAsString();
+    var asset = new AssetResolver().getAssetKey(tokenImage);
+    if (asset.isPresent()) {
+      tokenImage = asset.get().toString();
+    }
 
     Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
     List<Token> allTokens = zone.getTokens();

--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -18,8 +18,6 @@ import com.google.gson.JsonObject;
 import java.awt.Image;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
@@ -27,6 +25,7 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.util.AssetResolver;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.parser.Parser;
@@ -38,8 +37,6 @@ public class TokenImage extends AbstractFunction {
 
   /** Singleton instance. */
   private static final TokenImage instance = new TokenImage();
-
-  private static final Pattern assetRE = Pattern.compile("asset://([^-]+)");
 
   enum imageType {
     TOKEN_IMAGE(0),
@@ -260,12 +257,8 @@ public class TokenImage extends AbstractFunction {
    * @throws ParserException if assetName not found or assetName doesn't
    */
   public static MD5Key getMD5Key(String assetName, String functionName) throws ParserException {
-    Matcher m = assetRE.matcher(assetName);
-
-    String assetId;
-    if (m.matches()) {
-      assetId = m.group(1);
-    } else if (assetName.toLowerCase().startsWith("image:")) {
+    String assetId = null;
+    if (assetName.toLowerCase().startsWith("image:")) {
       Token imageToken = findImageToken(assetName, functionName);
       if (imageToken == null) {
         throw new ParserException(
@@ -273,10 +266,17 @@ public class TokenImage extends AbstractFunction {
       }
       assetId = imageToken.getImageAssetId().toString();
     } else {
+      var assetKey = new AssetResolver().getAssetKey(assetName);
+      if (assetKey.isPresent()) {
+        assetId = assetKey.get().toString();
+      }
+    }
+    if (assetId == null) {
       throw new ParserException(
           I18N.getText("macro.function.general.argumentTypeInvalid", functionName, 1, assetName));
+    } else {
+      return new MD5Key(assetId);
     }
-    return new MD5Key(assetId);
   }
 
   private static void setImage(Token token, String assetName) throws ParserException {

--- a/src/main/java/net/rptools/maptool/model/library/Library.java
+++ b/src/main/java/net/rptools/maptool/model/library/Library.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.Token;
@@ -47,6 +48,23 @@ public interface Library {
    * @throws IOException if there is an io error reading the location.
    */
   CompletableFuture<Boolean> locationExists(URL location) throws IOException;
+
+  /**
+   * Checks to see if the specified location is an Asset.
+   *
+   * @param location the location to check.
+   * @return {@code true} if the location is an asset, otherwise {@code false}.
+   */
+  CompletableFuture<Boolean> isAsset(URL location);
+
+  /**
+   * Returns the asset at the specified location. This will only return a value if {@link
+   * #isAsset(URL)} returns {@code true}.
+   *
+   * @param location the location to get the asset for.
+   * @return the asset at the specified location.
+   */
+  CompletableFuture<Optional<MD5Key>> getAssetKey(URL location);
 
   /**
    * Reads the location as a string.

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
@@ -440,6 +440,20 @@ public class AddOnLibrary implements Library {
   }
 
   @Override
+  public CompletableFuture<Boolean> isAsset(URL location) {
+    return CompletableFuture.completedFuture(getURILocation(location) != null);
+  }
+
+  @Override
+  public CompletableFuture<Optional<MD5Key>> getAssetKey(URL location) {
+    var AssetInfo = getURILocation(location);
+    if (AssetInfo == null) {
+      return CompletableFuture.completedFuture(Optional.empty());
+    }
+    return CompletableFuture.completedFuture(Optional.of(AssetInfo.getValue0()));
+  }
+
+  @Override
   public CompletableFuture<String> readAsString(URL location) throws IOException {
     if (allowsUriAccess) {
       var values = getURILocation(location);

--- a/src/main/java/net/rptools/maptool/model/library/builtin/MapToolBuiltInLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/MapToolBuiltInLibrary.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
@@ -107,6 +108,16 @@ public class MapToolBuiltInLibrary implements BuiltInLibrary {
   public CompletableFuture<Boolean> locationExists(URL location) throws IOException {
     var key = location.getPath().replaceFirst("^/", "");
     return CompletableFuture.completedFuture(resourcesMap.containsKey(key));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> isAsset(URL location) {
+    return CompletableFuture.completedFuture(false);
+  }
+
+  @Override
+  public CompletableFuture<Optional<MD5Key>> getAssetKey(URL location) {
+    return CompletableFuture.completedFuture(Optional.empty());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.language.I18N;
@@ -180,6 +181,16 @@ class LibraryToken implements Library {
                 return getProperty(loc.location()) != null ? Boolean.TRUE : Boolean.FALSE;
               }
             });
+  }
+
+  @Override
+  public CompletableFuture<Boolean> isAsset(URL location) {
+    return CompletableFuture.completedFuture(Boolean.FALSE);
+  }
+
+  @Override
+  public CompletableFuture<Optional<MD5Key>> getAssetKey(URL location) {
+    return CompletableFuture.completedFuture(Optional.empty());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/util/AssetResolver.java
+++ b/src/main/java/net/rptools/maptool/util/AssetResolver.java
@@ -25,17 +25,14 @@ import net.rptools.maptool.model.library.Library;
 import net.rptools.maptool.model.library.LibraryManager;
 
 /**
- * Utility Class to aid in resolving asset keys for images.
- * It will resolve the asset key for the following:
- * lib:// URI
- * asset:// URI
- * image:token
- * MD5 hash (as String)
+ * Utility Class to aid in resolving asset keys for images. It will resolve the asset key for the
+ * following: lib:// URI asset:// URI image:token MD5 hash (as String)
  */
 public class AssetResolver {
 
   /**
    * Returns the asset key for the specified URL.
+   *
    * @param url the URL to get the asset key for.
    * @return the MD5key of the asset at the specified URL.
    */
@@ -57,12 +54,8 @@ public class AssetResolver {
   }
 
   /**
-   * Returns the asset key for the specified location.
-   * Locations can be:
-   * lib:// URI
-   * asset:// URI
-   * image:token
-   * MD5 hash (as String)
+   * Returns the asset key for the specified location. Locations can be: lib:// URI asset:// URI
+   * image:token MD5 hash (as String)
    *
    * @param location the location to get the asset key for.
    * @return the MD5key of the asset at the specified location.
@@ -83,6 +76,7 @@ public class AssetResolver {
 
   /**
    * Returns the asset key for the specified URI.
+   *
    * @param uri the URI to get the asset key for.
    * @return the MD5key of the asset at the specified URI.
    */

--- a/src/main/java/net/rptools/maptool/util/AssetResolver.java
+++ b/src/main/java/net/rptools/maptool/util/AssetResolver.java
@@ -1,0 +1,96 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.util;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import net.rptools.lib.MD5Key;
+import net.rptools.maptool.model.library.Library;
+import net.rptools.maptool.model.library.LibraryManager;
+
+/**
+ * Utility Class to aid in resolving asset keys for images.
+ * It will resolve the asset key for the following:
+ * lib:// URI
+ * asset:// URI
+ * image:token
+ * MD5 hash (as String)
+ */
+public class AssetResolver {
+
+  /**
+   * Returns the asset key for the specified URL.
+   * @param url the URL to get the asset key for.
+   * @return the MD5key of the asset at the specified URL.
+   */
+  public Optional<MD5Key> getAssetKey(URL url) {
+    Optional<Library> lib = null;
+    try {
+      lib = new LibraryManager().getLibrary(url).get();
+      if (lib.isPresent()) {
+        var asset = lib.get().getAssetKey(url).get();
+        if (asset.isPresent()) {
+          String key = asset.get().toString();
+          return Optional.of(new MD5Key(key));
+        }
+      }
+    } catch (InterruptedException | ExecutionException e) {
+      return Optional.empty();
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the asset key for the specified location.
+   * Locations can be:
+   * lib:// URI
+   * asset:// URI
+   * image:token
+   * MD5 hash (as String)
+   *
+   * @param location the location to get the asset key for.
+   * @return the MD5key of the asset at the specified location.
+   */
+  public Optional<MD5Key> getAssetKey(String location) {
+    if (location.startsWith("asset://")) {
+      return getAssetKey(location.substring(8));
+    } else if (location.toLowerCase().startsWith("lib:")) {
+      try {
+        return getAssetKey(new URI(location));
+      } catch (URISyntaxException e) {
+        return Optional.empty();
+      }
+    } else {
+      return Optional.of(new MD5Key(location));
+    }
+  }
+
+  /**
+   * Returns the asset key for the specified URI.
+   * @param uri the URI to get the asset key for.
+   * @return the MD5key of the asset at the specified URI.
+   */
+  public Optional<MD5Key> getAssetKey(URI uri) {
+    try {
+      return getAssetKey(uri.toURL());
+    } catch (MalformedURLException e) {
+      return Optional.empty();
+    }
+  }
+}


### PR DESCRIPTION

### Identify the Bug or Feature request
Resolves #4183


### Description of the Change
Added a utility class to resolve assets from different locations and the ability to retrieve the asset key from add ons.
Modified the following macro functions to use this new resolver
* createToken()
* copyToken()
* setTokenImage()
* setTokenPortrait()
* setTokenHandout()


### Possible Drawbacks
Should be none

### Documentation Notes
The following macro functions can now use lib:// URIs for assets
* createToken()
* copyToken()
* setTokenImage()
* setTokenPortrait()
* setTokenHandout()

the URIs already work with <img> tags so can be used in dialog, frame, chat, and macro buttons. This means they should hopefully be useable everywhere now.

### Release Notes
- Added ability to specify assets for macro functions from lib:// URIs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4192)
<!-- Reviewable:end -->
