### PR TITLE
Properly sequence response logic for HTML5 XMLHttpResponse to avoid races

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/MTXMLHttpRequest.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/MTXMLHttpRequest.java
@@ -14,24 +14,24 @@
  */
 package net.rptools.maptool.client.ui.htmlframe;
 
-import java.awt.*;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import javafx.scene.web.*;
-import javax.swing.*;
 import net.rptools.maptool.model.library.url.*;
 import net.rptools.maptool.util.threads.ThreadExecutionHelper;
 import netscape.javascript.*;
-import org.w3c.dom.*;
-import org.w3c.dom.html.*;
 
 public class MTXMLHttpRequest {
   // The javascript counterpart to this request.
-  private JSObject ctx = null;
+  private final JSObject ctx;
 
   // Used for resolving relative resources.
-  private String href;
+  private final String href;
+
+  private final HashMap<String, String> requestHeaders;
+
+  // Private state for the response side
+  private final HashMap<String, String> responseHeaders;
 
   // Private state for the request side
   private String uri = null;
@@ -43,10 +43,6 @@ public class MTXMLHttpRequest {
   private String responseType = "text";
   private int readyState = 0;
   private String status = null;
-  private HashMap<String, String> requestHeaders = null;
-
-  // Private state for the response side
-  private HashMap<String, String> responseHeaders = null;
 
   private static boolean warned = false;
 
@@ -84,7 +80,7 @@ public class MTXMLHttpRequest {
     this.async = async;
     this.user = user;
     this.psw = psw;
-    readyState = 1;
+    this.readyState = 1;
     this.readyStateChanged();
     if (!async && !warned) {
       this.ctx.call("_warnAsync");
@@ -202,7 +198,7 @@ public class MTXMLHttpRequest {
       _uri = new URI(this.href).resolve(this.uri);
     } catch (Exception e) {
       readyState = 0;
-      CompletableFuture c = new CompletableFuture<String>();
+      var c = new CompletableFuture<String>();
       c.complete(e.getMessage());
       return c;
     }

--- a/src/main/resources/net/rptools/maptool/client/html5/javascript/XMLHttpRequest.js
+++ b/src/main/resources/net/rptools/maptool/client/html5/javascript/XMLHttpRequest.js
@@ -20,6 +20,9 @@ class XMLHttpRequest {
 
     get statusText() {
 	let s = this._req.getStatus();
+	if (s == null || s.length == 0) {
+		return 0;
+	}
 	return s.substring(s.indexOf(' ') + 1);
     }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4179

### Description of the Change

Alongisde some cleanup, this changes the return of `RequestHandler.processRequest()` for `macro://` URIs so that the returned future is not completed until the response headers are read back from the macro variables. This avoids an accidental race between the `RequestHandler.processRequest()` logic and the logic in `MTXMLHttpRequest.send()` that pulls the status code from the headers. There is also a small change to handle the edge case that no status line is set when reading `statusText`.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a rare ConcurrentModificationException in the HTML5 fetch API

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4197)
<!-- Reviewable:end -->
