### PR TITLE
Fix array predicates in JSON path filters

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -77,9 +77,6 @@ public class JSONMacroFunctions extends AbstractFunction {
   private static final Configuration jaywayConfig =
       Configuration.builder().jsonProvider(new GsonJsonProvider()).build();
 
-  /** The parser used to parse Json strings into an internal representation. */
-  private static final JsonParser jsonParser = new JsonParser();
-
   /** Creates a new <code>JSONMacroFunctions</code> object. */
   private JSONMacroFunctions() {
     super(
@@ -123,7 +120,7 @@ public class JSONMacroFunctions extends AbstractFunction {
         "json.rolls",
         "json.objrolls");
 
-    typeConversion = new JsonMTSTypeConversion(jsonParser);
+    typeConversion = new JsonMTSTypeConversion();
     jsonArrayFunctions = new JsonArrayFunctions(typeConversion);
     jsonObjectFunctions = new JsonObjectFunctions(typeConversion);
   }

--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -19,6 +19,7 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,8 +75,15 @@ public class JSONMacroFunctions extends AbstractFunction {
   private static final JSONMacroFunctions instance = new JSONMacroFunctions();
 
   /** Configuration object for JSONPath. */
-  private static final Configuration jaywayConfig =
-      Configuration.builder().jsonProvider(new GsonJsonProvider()).build();
+  private static final Configuration jaywayConfig;
+
+  static {
+    jaywayConfig =
+        Configuration.builder()
+            .jsonProvider(new GsonJsonProvider())
+            .mappingProvider(new GsonMappingProvider())
+            .build();
+  }
 
   /** Creates a new <code>JSONMacroFunctions</code> object. */
   private JSONMacroFunctions() {

--- a/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversion.java
@@ -23,20 +23,11 @@ import java.math.BigDecimal;
 /** Class used to convert between json and MT Script types. */
 class JsonMTSTypeConversion {
 
-  /** parser used to parse strings into {@link JsonElement} */
-  private final JsonParser parser;
-
   /** An empty <code>String</code> as a {@link JsonPrimitive}. */
   public static final JsonPrimitive EMPTY_STRING_ELEMENT = new JsonPrimitive("");
 
-  /**
-   * Creates a new <code>JsonMTSTypeConversion</code> object.
-   *
-   * @param parser The json parser which will be used to convert a string into json.
-   */
-  JsonMTSTypeConversion(JsonParser parser) {
-    this.parser = parser;
-  }
+  /** Creates a new <code>JsonMTSTypeConversion</code> object. */
+  JsonMTSTypeConversion() {}
 
   /**
    * Returns a valid MTScript type for the given object.

--- a/src/main/java/net/rptools/maptool/server/Mapper.java
+++ b/src/main/java/net/rptools/maptool/server/Mapper.java
@@ -297,7 +297,7 @@ public class Mapper {
         return stripped.setScale(Math.max(0, stripped.scale()));
       }
       case JSON_VAL -> {
-        return new JsonParser().parse(dto.getJsonVal());
+        return JsonParser.parseString(dto.getJsonVal());
       }
       default -> {
         log.warn("Unexpected type case:" + dto.getTypeCase());

--- a/src/test/java/net/rptools/maptool/client/functions/json/JsonArrayFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JsonArrayFunctionsTest.java
@@ -42,15 +42,14 @@ class JsonArrayFunctionsTest {
 
   @BeforeEach
   void setup() {
-    JsonParser jsonParser = new JsonParser();
-    JsonMTSTypeConversion typeConversion = new JsonMTSTypeConversion(jsonParser);
+    JsonMTSTypeConversion typeConversion = new JsonMTSTypeConversion();
     random = new Random(System.currentTimeMillis());
 
     jsonArrayFunctions = new JsonArrayFunctions(typeConversion);
 
-    jsonArray1 = jsonParser.parse(jsonArrString1).getAsJsonArray();
-    jsonArray2 = jsonParser.parse(jsonArrString2).getAsJsonArray();
-    jsonArray3 = jsonParser.parse(jsonArrString3).getAsJsonArray();
+    jsonArray1 = JsonParser.parseString(jsonArrString1).getAsJsonArray();
+    jsonArray2 = JsonParser.parseString(jsonArrString2).getAsJsonArray();
+    jsonArray3 = JsonParser.parseString(jsonArrString3).getAsJsonArray();
 
     jsonEmpty = new JsonArray();
   }

--- a/src/test/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversionTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JsonMTSTypeConversionTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
 import java.util.Random;
@@ -34,8 +33,7 @@ class JsonMTSTypeConversionTest {
 
   @BeforeEach
   void setup() {
-    JsonParser jsonParser = new JsonParser();
-    typeConversion = new JsonMTSTypeConversion(jsonParser);
+    typeConversion = new JsonMTSTypeConversion();
     random = new Random(System.currentTimeMillis());
   }
 

--- a/src/test/java/net/rptools/maptool/client/functions/json/JsonObjectFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JsonObjectFunctionsTest.java
@@ -46,15 +46,14 @@ class JsonObjectFunctionsTest {
 
   @BeforeEach
   void setup() {
-    JsonParser jsonParser = new JsonParser();
-    JsonMTSTypeConversion typeConversion = new JsonMTSTypeConversion(jsonParser);
+    JsonMTSTypeConversion typeConversion = new JsonMTSTypeConversion();
     random = new Random(System.currentTimeMillis());
 
     jsonObjectFunctions = new JsonObjectFunctions(typeConversion);
 
-    jsonObject1 = jsonParser.parse(jsonObjString1).getAsJsonObject();
-    jsonObject2 = jsonParser.parse(jsonObjString2).getAsJsonObject();
-    jsonObject3 = jsonParser.parse(jsonObjString3).getAsJsonObject();
+    jsonObject1 = JsonParser.parseString(jsonObjString1).getAsJsonObject();
+    jsonObject2 = JsonParser.parseString(jsonObjString2).getAsJsonObject();
+    jsonObject3 = JsonParser.parseString(jsonObjString3).getAsJsonObject();
 
     jsonEmpty = new JsonObject();
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3358

### Description of the Change

We now use GSON as the mapping provider in addition to the JSON provider when using JsonPath. This allows array values to be built by JsonPath, where before it was unable to instantiate `List`.

The only remaining non-GSON representation is JSONSmart, used by JsonPath to parse literals in the path expression. This is hardcoded, and unfortunately results in some inconsistencies noted below.

I also included some cleanup to eliminate `JsonParser` instances, as those are deprecated and we don't need them anyways.

### Possible Drawbacks

There will no doubt be some confusion over the exact behaviour of array predicates. Most predicates should just work as expected (e.g., `anyof`, equality between numbers, etc), but specifically equality checks on numeric arrays are a problematic case that I don't think we can just fix. Such predicates will require the integral literals to be written with a decimal point so that JSONSmart treats them as doubles to match what the GSON mapping provider produces for the other operand. Using integers, the predicate will never match.

### Documentation Notes

Given this data set:
```
[h: data = json.append("[]",
	json.set("{}","key",1,"array",json.append("",2,3)),
	json.set("{}","key",2,"array",json.append("",1,2,3))
)]
```

The following expressions will work to filter an array:
```
[r: json.path.read(data, "\$[?(@.array == [2.0, 3.0])]")]
[r: json.path.read(data, "\$[?(@.key in [2,3])]")]
[r: json.path.read(data, "\$[?(@.key == 1)]")]
[r: json.path.read(data, "\$[?(@.key == 1.0)]")]
[r: json.path.read(data, "\$[?(@.array anyof [2,3])]")]
[r: json.path.read(data, "\$[?(@.array anyof [2.0,3.0])]")]
```

But this one will not match any elements since the integers inside the array are not considered equal to the floats used internally for the array being matched:
```
[r: json.path.read(data, "\$[?(@.array == [2, 3])]")]
```

### Release Notes

- Fixed `json.path` functions so that array predicates can be used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4199)
<!-- Reviewable:end -->
