### PR TITLE
Fix errors caused by auras inside solid VBL

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.lib.CodeTimer;
 import net.rptools.lib.GeometryUtil;
@@ -74,7 +75,7 @@ public class FogUtil {
    * @param topology the VBL topology.
    * @return the visible area.
    */
-  public static Area calculateVisibility(
+  public static @Nonnull Area calculateVisibility(
       Point origin, Area vision, AreaTree topology, AreaTree hillVbl, AreaTree pitVbl) {
     // We could use the vision envelope instead, but vision geometry tends to be pretty simple.
     final var visionGeometry = PreparedGeometryFactory.prepare(GeometryUtil.toJts(vision));
@@ -98,7 +99,7 @@ public class FogUtil {
       final var isVisionCompletelyBlocked = consumer.apply(accumulator);
       if (!isVisionCompletelyBlocked) {
         // Vision has been completely blocked by this topology. Short circuit.
-        return null;
+        return new Area();
       }
 
       final var visibleArea =

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -333,7 +333,7 @@ public class ZoneView {
             getTopologyTree(Zone.TopologyType.WALL_VBL),
             getTopologyTree(Zone.TopologyType.HILL_VBL),
             getTopologyTree(Zone.TopologyType.PIT_VBL));
-    if (lightSourceVisibleArea == null) {
+    if (lightSourceVisibleArea.isEmpty()) {
       // Nothing illuminated for this source.
       return Collections.emptyList();
     }
@@ -591,8 +591,6 @@ public class ZoneView {
               getTopologyTree(Zone.TopologyType.WALL_VBL),
               getTopologyTree(Zone.TopologyType.HILL_VBL),
               getTopologyTree(Zone.TopologyType.PIT_VBL));
-      // Can be null if no visibility.
-      tokenVisibleArea = Objects.requireNonNullElse(tokenVisibleArea, new Area());
       tokenVisibleAreaCache.put(token.getId(), tokenVisibleArea);
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityInspector.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityInspector.java
@@ -149,7 +149,7 @@ public class VisibilityInspector extends JPanel {
     final var obstructedVision = new Area(unobstructedVision);
 
     g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .5f));
-    if (vision != null) {
+    {
       obstructedVision.subtract(vision);
       g2d.setColor(Color.red);
       g2d.fill(vision);


### PR DESCRIPTION
### Identify the Bug or Feature request

#4203

### Description of the Change

The cause of the error was that `FogUtil.calculateVisibility()` returns `null` when visibility is completely blocked by VBL Rather than add additional `null` checks to avoid the NPE, I've instead changed the result of `FogUtil.calculateVisibility()` to never be `null`. All callers already had to treat this case the same as an empty area (since that is what it signals), and can still take optimized code paths by checking if the area is empty rather than `null`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where auras inside solid VBL would generate repeated errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4204)
<!-- Reviewable:end -->
