### PR TITLE
#4207 #4206 Changed the ConnectionInfoDialog to show active interface…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialog.java
@@ -107,13 +107,19 @@ public class ConnectionInfoDialog extends JDialog {
     if (name == null) {
       name = "---";
     }
+
     String localv4Address = "Unknown";
-    String localv6Address = "Unknown";
     try {
       localv4Address = getIPAddress(false);
+    } catch (IOException e) { // UnknownHost | Socket
+      log.warn("Can't resolve our own IPv4 address!?", e);
+    }
+
+    String localv6Address = "Unknown";
+    try {
       localv6Address = getIPAddress(true);
     } catch (IOException e) { // UnknownHost | Socket
-      log.warn("Can't resolve our own IP address!?", e);
+      log.warn("Can't resolve our own IPv6 address!?", e);
     }
 
     String port =

--- a/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialog.java
@@ -84,7 +84,7 @@ public class ConnectionInfoDialog extends JDialog {
    * @param server the server instance for the connection dialog
    */
   public ConnectionInfoDialog(MapToolServer server) {
-    // super(MapTool.getFrame(), I18N.getText("ConnectionInfoDialog.title"), true);
+    super(MapTool.getFrame(), I18N.getText("ConnectionInfoDialog.title"), true);
     setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     setSize(275, 275);
 

--- a/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialog.java
@@ -20,6 +20,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.concurrent.Callable;
@@ -62,6 +63,12 @@ public class ConnectionInfoDialog extends JDialog {
           if (inetAddress.isLoopbackAddress()
               || inetAddress.isLinkLocalAddress()
               || inetAddress.isMulticastAddress()) {
+            continue;
+          }
+
+          try {
+            InetAddress rptools = InetAddress.getByName("www.rptools.net");
+          } catch (UnknownHostException e) {
             continue;
           }
 

--- a/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialogView.form
@@ -32,7 +32,7 @@
         </constraints>
         <properties>
           <font name="SansSerif" size="11" style="1"/>
-          <text resource-bundle="net/rptools/maptool/language/i18n" key="ConnectionInfoDialog.address.external"/>
+          <text resource-bundle="net/rptools/maptool/language/i18n" key="ConnectionInfoDialog.address.local"/>
         </properties>
       </component>
       <component id="3c360" class="javax.swing.JLabel">

--- a/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/connectioninfodialog/ConnectionInfoDialogView.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.rptools.maptool.client.ui.connectioninfodialog.ConnectionInfoDialogView">
-  <grid id="f0bbd" binding="mainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="f0bbd" binding="mainPanel" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
       <xy x="10" y="10" width="207" height="211"/>
@@ -17,7 +17,7 @@
           <text resource-bundle="net/rptools/maptool/language/i18n" key="Label.name"/>
         </properties>
       </component>
-      <component id="12eb5" class="javax.swing.JLabel">
+      <component id="12eb6" class="javax.swing.JLabel">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -26,7 +26,7 @@
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ConnectionInfoDialog.address.local"/>
         </properties>
       </component>
-      <component id="3c360" class="javax.swing.JLabel">
+      <component id="12eb5" class="javax.swing.JLabel">
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -35,9 +35,18 @@
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ConnectionInfoDialog.address.external"/>
         </properties>
       </component>
-      <component id="d0010" class="javax.swing.JLabel">
+      <component id="3c360" class="javax.swing.JLabel">
         <constraints>
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <font name="SansSerif" size="11" style="1"/>
+          <text resource-bundle="net/rptools/maptool/language/i18n" key="ConnectionInfoDialog.address.external"/>
+        </properties>
+      </component>
+      <component id="d0010" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font name="SansSerif" size="11" style="1"/>
@@ -67,13 +76,26 @@
           <text value="name"/>
         </properties>
       </component>
-      <component id="4188" class="javax.swing.JTextField">
+      <component id="4189" class="javax.swing.JTextField">
         <constraints>
           <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <editable value="false"/>
-          <name value="localAddress"/>
+          <name value="localv4Address"/>
+          <opaque value="false"/>
+          <selectionEnd value="12"/>
+          <selectionStart value="12"/>
+          <text value="localAddress"/>
+        </properties>
+      </component>
+      <component id="4188" class="javax.swing.JTextField">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <editable value="false"/>
+          <name value="localv6Address"/>
           <opaque value="false"/>
           <selectionEnd value="12"/>
           <selectionStart value="12"/>
@@ -82,7 +104,7 @@
       </component>
       <component id="96cea" class="javax.swing.JTextField">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <editable value="false"/>
@@ -95,7 +117,7 @@
       </component>
       <component id="a928c" class="javax.swing.JTextField">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <editable value="false"/>
@@ -108,7 +130,7 @@
       </component>
       <component id="74e0b" class="javax.swing.JButton">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="OK"/>


### PR DESCRIPTION
… and IPv6 Address

### Identify the Bug or Feature request
fixes #4206
resolves #4207


### Description of the Change
Added a method that differentiates between the active and non active network interfaces and is able to return the IPv6 Address. Then I added a field to the ConnectionInfoDialog and differnetiated between IPv4 and IPv6, so that the dialog is now able to output both IPs at the same time if applicable.

### Possible Drawbacks
Positive side-effect is that if you get a native IPv6 Address and configure that in your router to be passed through the firewall the IPv6 Address shown in the ConnectionInfoDialog should be the one that could by used by others to connect to your game via IPv6 when using the direct connection tab. There shouldn't be negative impacts. 

### Documentation Notes
The InfoDialog is self-explanatory in my opinion. 

### Release Notes
- ConnectionInfoDialog shows active interface information for IPv4 and IPv6 if available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4208)
<!-- Reviewable:end -->
