### PR TITLE
Save and load server preferences

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
@@ -280,7 +280,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 prefex.exportSubtree(outStream);
                 outStream.close();
               } catch (IOException | BackingStoreException | IllegalStateException prefserr) {
-                MapTool.showError("Error while Exporting, please try again.");
+                MapTool.showError("ServerDialog.error.xmlExport");
               }
             });
   }
@@ -348,7 +348,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 getMovementMetric().setSelectedItem(prefs.getMovementMetric());
                 getUseWebRTCCheckBox().setEnabled(getRPToolsAlias().getText().length() > 0);
               } catch (IOException | InvalidPreferencesFormatException prefserr) {
-                MapTool.showError("Error while Importing, please try again.");
+                MapTool.showError("ServerDialog.error.xmlImport");
               }
             });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
@@ -280,7 +280,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 prefex.exportSubtree(outStream);
                 outStream.close();
               } catch (IOException | BackingStoreException | IllegalStateException prefserr) {
-                  MapTool.showError("Error while Exporting, please try again.");
+                MapTool.showError("Error while Exporting, please try again.");
               }
             });
   }
@@ -348,7 +348,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 getMovementMetric().setSelectedItem(prefs.getMovementMetric());
                 getUseWebRTCCheckBox().setEnabled(getRPToolsAlias().getText().length() > 0);
               } catch (IOException | InvalidPreferencesFormatException prefserr) {
-                  MapTool.showError("Error while Importing, please try again.");
+                MapTool.showError("Error while Importing, please try again.");
               }
             });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
@@ -261,12 +261,26 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
               }
               try {
                 commit();
+                prefs.setRole((Player.Role) getRoleCombo().getSelectedItem());
+                prefs.setMovementMetric((WalkerMetric) movementMetricCombo.getSelectedItem());
+                prefs.setAutoRevealOnMovement(autoRevealOnMovement.isSelected());
+                prefs.setUsePasswordFile(usePasswordFile.isSelected());
+                prefs.setUseEasyConnect(useEasyConnect.isSelected());
+                prefs.setMapSelectUIHidden(hideMapSelectUI.isSelected());
+                prefs.setLockTokenEditOnStart(lockTokenEditOnStartup.isSelected());
+                prefs.setLockPlayerMovementOnStart(lockPlayerMoveOnStartup.isSelected());
+                prefs.setPlayerLibraryLock(lockPlayerLibrary.isSelected());
+                JCheckBox useWebRTCCheckBox = getUseWebRTCCheckBox();
+                prefs.setKeyUseWebrtc(
+                    useWebRTCCheckBox.isEnabled() && useWebRTCCheckBox.isSelected());
+                prefs.setUseToolTipsForUnformattedRolls(getUseTooltipForRolls().isSelected());
+                prefs.setUseTooltips(getUseTooltipForRolls().isSelected());
                 FileOutputStream outStream = new FileOutputStream(file_name, false);
                 Preferences prefex = prefs.getPrefs();
                 prefex.exportSubtree(outStream);
                 outStream.close();
               } catch (IOException | BackingStoreException | IllegalStateException prefserr) {
-
+                  MapTool.showError("Error while Exporting, please try again.");
               }
             });
   }
@@ -295,8 +309,46 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 inStream.close();
                 unbind();
                 bind(prefs);
+                getRoleCombo().setSelectedItem(prefs.getRole());
+                useIndividualFOW.setEnabled(prefs.getUseIndividualViews());
+                if (!useIndividualViews.isSelected()) {
+                  useIndividualFOW.setSelected(false);
+                  useIndividualFOW.setEnabled(false);
+                } else {
+                  useIndividualFOW.setEnabled(true);
+                }
+                autoRevealOnMovement.setEnabled(prefs.getPlayersCanRevealVision());
+                if (!playersCanRevealVision.isSelected()) {
+                  autoRevealOnMovement.setSelected(false);
+                  autoRevealOnMovement.setEnabled(false);
+                } else {
+                  autoRevealOnMovement.setEnabled(true);
+                }
+                boolean usePf = usePasswordFile.isSelected();
+                boolean useEC = useEasyConnect.isSelected();
+                playerPassword.setEnabled(!usePf);
+                gmPassword.setEnabled(!usePf);
+                usePasswordFile.setEnabled(!useEC);
+                boolean passwordFile = usePasswordFile.isSelected();
+                playerPassword.setEnabled(!passwordFile);
+                gmPassword.setEnabled(!passwordFile);
+                boolean easyConnect = useEasyConnect.isSelected();
+                if (easyConnect) {
+                  usePasswordFile.setSelected(true);
+                  usePasswordFile.setEnabled(false);
+                } else {
+                  usePasswordFile.setEnabled(true);
+                }
+                hideMapSelectUI.setSelected(prefs.getMapSelectUIHidden());
+                lockTokenEditOnStartup.setSelected(prefs.getLockTokenEditOnStart());
+                lockPlayerMoveOnStartup.setSelected(prefs.getLockPlayerMovementOnStart());
+                lockPlayerLibrary.setSelected(prefs.getPlayerLibraryLock());
+                getUseTooltipForRolls().setSelected(prefs.getUseTooltips());
+                prefs.setUseToolTipsForUnformattedRolls(getUseTooltipForRolls().isSelected());
+                getMovementMetric().setSelectedItem(prefs.getMovementMetric());
+                getUseWebRTCCheckBox().setEnabled(getRPToolsAlias().getText().length() > 0);
               } catch (IOException | InvalidPreferencesFormatException prefserr) {
-
+                  MapTool.showError("Error while Importing, please try again.");
               }
             });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
@@ -14,14 +14,23 @@
  */
 package net.rptools.maptool.client.ui.startserverdialog;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.text.DecimalFormat;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.InvalidPreferencesFormatException;
+import java.util.prefs.Preferences;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
 import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.AbeillePanel;
@@ -192,6 +201,14 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
     return (JTextField) getComponent("@username");
   }
 
+  public JButton getexportButton() {
+    return (JButton) getComponent("exportButton");
+  }
+
+  public JButton getimportButton() {
+    return (JButton) getComponent("importButton");
+  }
+
   public JButton getOKButton() {
     return (JButton) getComponent("okButton");
   }
@@ -223,6 +240,65 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
   @Override
   protected void preModelBind() {
     Binder.setFormat(getPortTextField(), new DecimalFormat("####"));
+  }
+
+  public void initexportButton() {
+    getexportButton()
+        .addActionListener(
+            e -> {
+              String file_name = "";
+              JFileChooser fileChooser = new JFileChooser();
+              fileChooser.setCurrentDirectory(new File(System.getProperty("user.home")));
+              FileNameExtensionFilter xmlfilter = new FileNameExtensionFilter("XML-Files", "xml");
+              fileChooser.setFileFilter(xmlfilter);
+              fileChooser.setSelectedFile(new File("MaptoolServersettings.xml"));
+              int result = fileChooser.showSaveDialog(this);
+              if (result == JFileChooser.APPROVE_OPTION) {
+                File selectedFile = fileChooser.getSelectedFile();
+                file_name = selectedFile.getAbsolutePath();
+              } else {
+                return;
+              }
+              try {
+                commit();
+                FileOutputStream outStream = new FileOutputStream(file_name, false);
+                Preferences prefex = prefs.getPrefs();
+                prefex.exportSubtree(outStream);
+                outStream.close();
+              } catch (IOException | BackingStoreException | IllegalStateException prefserr) {
+
+              }
+            });
+  }
+
+  public void initimportButton() {
+    getimportButton()
+        .addActionListener(
+            e -> {
+              try {
+                String file_name = "";
+                JFileChooser fileChooser = new JFileChooser();
+                fileChooser.setCurrentDirectory(new File(System.getProperty("user.home")));
+                FileNameExtensionFilter xmlfilter = new FileNameExtensionFilter("XML-Files", "xml");
+                fileChooser.setFileFilter(xmlfilter);
+                fileChooser.setSelectedFile(new File("MaptoolServersettings.xml"));
+                int result = fileChooser.showOpenDialog(this);
+                if (result == JFileChooser.APPROVE_OPTION) {
+                  File selectedFile = fileChooser.getSelectedFile();
+                  file_name = selectedFile.getAbsolutePath();
+                } else {
+                  return;
+                }
+                FileInputStream inStream = new FileInputStream(file_name);
+                Preferences prefim = prefs.getPrefs();
+                prefim.importPreferences(inStream);
+                inStream.close();
+                unbind();
+                bind(prefs);
+              } catch (IOException | InvalidPreferencesFormatException prefserr) {
+
+              }
+            });
   }
 
   public void initOKButton() {

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
@@ -269,4 +269,8 @@ public class StartServerDialogPreferences {
   public void setKeyUseWebrtc(boolean flag) {
     prefs.putBoolean(KEY_USE_WEBRTC, flag);
   }
+
+  public static Preferences getPrefs() {
+    return prefs;
+  }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
@@ -51,6 +51,7 @@ public class StartServerDialogPreferences {
   private static final String KEY_START_LOCKED_TOKEN_EDIT = "lockTokenEditOnStartup";
   private static final String KEY_START_LOCKED_PLAYER_MOVEMENT = "lockPlayerMovementOnStartup";
   private static final String KEY_LOCK_PLAYER_LIBRARY = "lockPlayerLibrary";
+  private static final String KEY_USE_TOOLTIPS = "useTooltips";
 
   private static final String KEY_USE_WEBRTC = "useWebRTC";
 
@@ -187,6 +188,14 @@ public class StartServerDialogPreferences {
 
   public void setUseToolTipsForUnformattedRolls(boolean flag) {
     useToolTipsForUnformattedRolls = flag;
+  }
+
+  public boolean getUseTooltips() {
+    return prefs.getBoolean(KEY_USE_TOOLTIPS, false);
+  }
+
+  public void setUseTooltips(boolean flag) {
+    prefs.putBoolean(KEY_USE_TOOLTIPS, flag);
   }
 
   public WalkerMetric getMovementMetric() {

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogView.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.rptools.maptool.client.ui.startserverdialog.StartServerDialogView">
-  <grid id="67a17" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="67a17" binding="mainPanel" layout-manager="GridLayoutManager" row-count="9" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="573" height="673"/>
+      <xy x="10" y="10" width="1542" height="707"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="5b5f" class="javax.swing.JTextField">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="20"/>
@@ -20,7 +20,7 @@
       </component>
       <component id="407f4" class="javax.swing.JTextField">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="20"/>
@@ -30,7 +30,7 @@
       </component>
       <component id="be82e" class="javax.swing.JLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="username"/>
@@ -39,7 +39,7 @@
       </component>
       <component id="f66e" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ConnectionInfoDialog.port"/>
@@ -47,7 +47,7 @@
       </component>
       <component id="91222" class="javax.swing.JLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.label.password"/>
@@ -55,7 +55,7 @@
       </component>
       <component id="df7b2" class="javax.swing.JComboBox">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="comboBoxChanged"/>
@@ -64,7 +64,7 @@
       </component>
       <component id="25b7e" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.label.alias"/>
@@ -73,7 +73,7 @@
       </component>
       <component id="3688a" class="javax.swing.JTextField">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="20"/>
@@ -84,7 +84,7 @@
       </component>
       <component id="e55f8" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font style="2"/>
@@ -93,7 +93,7 @@
       </component>
       <component id="27ac4" class="javax.swing.JButton">
         <constraints>
-          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="@generateGMPassword"/>
@@ -102,7 +102,7 @@
       </component>
       <component id="40397" class="javax.swing.JButton">
         <constraints>
-          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <name value="@generatePlayerPassword"/>
@@ -111,7 +111,7 @@
       </component>
       <component id="d2d9" class="javax.swing.JLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.label.gmpassword"/>
@@ -120,7 +120,7 @@
       <grid id="fc9cf" layout-manager="GridLayoutManager" row-count="15" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="line" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.options">
@@ -287,7 +287,7 @@
             <properties>
               <actionCommand value="comboBoxChanged"/>
               <name value="movementMetric"/>
-              <toolTipText value ="Determines how MapTool handles movement on the selected grid type."/>
+              <toolTipText value="Determines how MapTool handles movement on the selected grid type."/>
             </properties>
           </component>
           <hspacer id="6c8b3">
@@ -300,7 +300,7 @@
       <grid id="68138" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -345,7 +345,7 @@
       <grid id="67b44" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -375,7 +375,7 @@
       </grid>
       <component id="38cff" class="javax.swing.JCheckBox">
         <constraints>
-          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="Use UPnP"/>
@@ -386,7 +386,7 @@
       </component>
       <component id="72373" class="javax.swing.JCheckBox">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="Use UPnP"/>
@@ -397,7 +397,7 @@
       </component>
       <component id="90bc0" class="javax.swing.JCheckBox">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <actionCommand value="Use UPnP"/>
@@ -408,17 +408,38 @@
       </component>
       <vspacer id="bf87d">
         <constraints>
-          <grid row="6" column="3" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="4" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="f999" class="javax.swing.JTextField">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <columns value="20"/>
           <name value="@username"/>
           <text value=""/>
+        </properties>
+      </component>
+      <component id="5fedb" class="javax.swing.JButton">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <actionCommand value="OK"/>
+          <name value="exportButton"/>
+          <text value="Export to XML"/>
+        </properties>
+      </component>
+      <component id="99124" class="javax.swing.JButton">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <actionCommand value="OK"/>
+          <enabled value="true"/>
+          <name value="importButton"/>
+          <text value="Import from XML"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogView.form
@@ -3,7 +3,7 @@
   <grid id="67a17" binding="mainPanel" layout-manager="GridLayoutManager" row-count="9" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1542" height="707"/>
+      <xy x="10" y="10" width="1825" height="707"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -428,7 +428,7 @@
         <properties>
           <actionCommand value="OK"/>
           <name value="exportButton"/>
-          <text value="Export to XML"/>
+	  <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.button.xmlExport"/>
         </properties>
       </component>
       <component id="99124" class="javax.swing.JButton">
@@ -437,9 +437,8 @@
         </constraints>
         <properties>
           <actionCommand value="OK"/>
-          <enabled value="true"/>
           <name value="importButton"/>
-          <text value="Import from XML"/>
+          <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.button.xmlImport"/>
         </properties>
       </component>
     </children>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -721,6 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
+ServerDialog.error.xmlExport             = Error while Exporting, please try again.
+ServerDialog.error.xmlImport             = Error while Importing, please try again.
 
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Setting Up For Connection Test...
@@ -770,7 +772,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Networking Help
 ServerDialog.generatePassword          = Generate Password
-
+ServerDialog.button.xmlExport          = Export to XML
+ServerDialog.button.xmlImport          = Import from XML
 
 CampaignPropertiesDialog.tab.token     = Token Properties
 CampaignPropertiesDialog.tab.repo      = Repositories

--- a/src/main/resources/net/rptools/maptool/language/i18n_cs.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_cs.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Setting Up For Connection Test...
 ServerDialog.msg.test2                 = Performing connection test.  Success is usually quick; failure often takes longer...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Networking Help
 ServerDialog.generatePassword          = Generate Password
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Token Properties
 CampaignPropertiesDialog.tab.repo      = Repositories
 CampaignPropertiesDialog.tab.sight     = Sight

--- a/src/main/resources/net/rptools/maptool/language/i18n_da.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_da.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = Spilleder adgangskode skal angives.
 ServerDialog.error.passwordMustDiffer  = Spiller og spilleder adgangskode kan ikke være den samme.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Setting Up For Connection Test...
 ServerDialog.msg.test2                 = Performing connection test.  Success is usually quick; failure often takes longer...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Netværkshjælp
 ServerDialog.generatePassword          = Generer adgangskode
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Polet egenskaber
 CampaignPropertiesDialog.tab.repo      = Depoter
 CampaignPropertiesDialog.tab.sight     = Syn

--- a/src/main/resources/net/rptools/maptool/language/i18n_de.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_de.properties
@@ -770,7 +770,7 @@ ServerDialog.option.rolls              = Hilfetexte für [] Würfelwürfe verwen
 ServerDialog.option.rolls.tooltip      = Hilfetexte werden für [ ] Würfelwürfe verwendet, wenn keine Formatoptionen angegeben wurden.
 ServerDialog.button.networkinghelp     = Netzwerkhilfe
 ServerDialog.generatePassword          = Passwort erzeugen
-ServerDialog.button.xmlExport          = Exportieren zu XML
+ServerDialog.button.xmlExport=Exportieren in XML
 ServerDialog.button.xmlImport          = Importieren von XML
 
 CampaignPropertiesDialog.tab.token     = Spielmarkeneigenschaften

--- a/src/main/resources/net/rptools/maptool/language/i18n_de.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_de.properties
@@ -721,6 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Spieler-Passwort muss angegeben werd
 ServerDialog.error.gmPasswordMissing     = SL-Passwort muss angegeben werden.
 ServerDialog.error.passwordMustDiffer  = Spieler- und SL-Passwort dürfen nicht identisch sein.
 ServerDialog.error.serverAlreadyExists = Ein Server mit dem gleichen Namen existiert bereits\!
+ServerDialog.error.xmlExport             = Fehler beim Exportieren, bitte versuche es erneut.
+ServerDialog.error.xmlImport             = Fehler beim Importieren, bitte versuche es erneut.
 
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Einrichten für den Verbindungstest...
@@ -768,7 +770,8 @@ ServerDialog.option.rolls              = Hilfetexte für [] Würfelwürfe verwen
 ServerDialog.option.rolls.tooltip      = Hilfetexte werden für [ ] Würfelwürfe verwendet, wenn keine Formatoptionen angegeben wurden.
 ServerDialog.button.networkinghelp     = Netzwerkhilfe
 ServerDialog.generatePassword          = Passwort erzeugen
-
+ServerDialog.button.xmlExport          = Exportieren zu XML
+ServerDialog.button.xmlImport          = Importieren von XML
 
 CampaignPropertiesDialog.tab.token     = Spielmarkeneigenschaften
 CampaignPropertiesDialog.tab.repo      = Ablagen

--- a/src/main/resources/net/rptools/maptool/language/i18n_es.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_es.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Preparando para prueba de conexión...
 ServerDialog.msg.test2                 = Ejecutando prueba de conexión.  Usualmente el éxito es rápido; un fallo toma más tiempo...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Networking Help
 ServerDialog.generatePassword          = Generate Password
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Token Properties
 CampaignPropertiesDialog.tab.repo      = Repositories
 CampaignPropertiesDialog.tab.sight     = Sight

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Paramétrage du test de connexion...
 ServerDialog.msg.test2                 = Effectuer un test de connexion. Le succès est généralement rapide ; l'échec prend souvent plus de temps...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Utiliser les infobulles pour les lancer
 ServerDialog.option.rolls.tooltip      = Les infobulles seront utilisées pour les lancements [ ] où aucune option de format n'est spécifiée.
 ServerDialog.button.networkinghelp     = Aide réseau
 ServerDialog.generatePassword          = Generate Password
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Propriétés du pion
 CampaignPropertiesDialog.tab.repo      = Dépôts
 CampaignPropertiesDialog.tab.sight     = Vue

--- a/src/main/resources/net/rptools/maptool/language/i18n_it.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_it.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Specificare la Password Giocatore.
 ServerDialog.error.gmPasswordMissing     = Specificare la Password del GM.
 ServerDialog.error.passwordMustDiffer  = Le password Giocatore e GM non possono essere uguali.
 ServerDialog.error.serverAlreadyExists = Esiste già un server con lo stesso nome.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Preparazione per il test della connessione...
 ServerDialog.msg.test2                 = Eseguendo il test della connessione. Il successo di solito è veloce; il fallimento spesso impiega più tempo...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Usa i ToolTip per i tiri fatti con [ ]
 ServerDialog.option.rolls.tooltip      = Verranno utilizzati ToolTip per i tiri fatti con [ ] in cui non sono specificate opzioni di formato.
 ServerDialog.button.networkinghelp     = Aiuto Opzioni di Rete
 ServerDialog.generatePassword          = Genera Password
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Proprietà token
 CampaignPropertiesDialog.tab.repo      = Repository
 CampaignPropertiesDialog.tab.sight     = Vista

--- a/src/main/resources/net/rptools/maptool/language/i18n_ja.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ja.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = プレイヤー用パスワードを
 ServerDialog.error.gmPasswordMissing     = GM用パスワードを指定する必要があります。
 ServerDialog.error.passwordMustDiffer  = プレイヤーとGMのパスワードは異なる必要があります。
 ServerDialog.error.serverAlreadyExists = サーバーには既に同じ名称が存在しています。
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = 接続テストを準備中です...
 ServerDialog.msg.test2                 = 接続テストを実行中。通常、成功時はすぐに終わります。失敗するときは長くかかることが多いです。
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = []ロールにツールチップを使�
 ServerDialog.option.rolls.tooltip      = ツールチップが書式オプション未使用の [ ] ロールで表示されるようになる。
 ServerDialog.button.networkinghelp     = ネットワークのヘルプ
 ServerDialog.generatePassword          = パスワードの自動生成
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = トークン特性値
 CampaignPropertiesDialog.tab.repo      = 配信素材置き場
 CampaignPropertiesDialog.tab.sight     = 視覚

--- a/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Instellen voor een verbindingstest...
 ServerDialog.msg.test2                 = Connectie test uitvoeren. Succes is meestal snel; mislukking duurt vaak langer...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Gebruik ToolTips voor [] Worpen
 ServerDialog.option.rolls.tooltip      = Tool Tips zullen worden gebruikt voor [ ] worpen waar geen formaat opties zijn opgegeven.
 ServerDialog.button.networkinghelp     = Network Hulp
 ServerDialog.generatePassword          = Wachtwoord genereren
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Token Eigenschappen
 CampaignPropertiesDialog.tab.repo      = Repositories
 CampaignPropertiesDialog.tab.sight     = Zicht

--- a/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Należy podać hasło gracza.
 ServerDialog.error.gmPasswordMissing     = Należy podać hasło GM.
 ServerDialog.error.passwordMustDiffer  = Hasła graczy i MG nie mogą być takie same.
 ServerDialog.error.serverAlreadyExists = Serwer o tej samej nazwie już istnieje.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Konfigurowanie testu połączenia...
 ServerDialog.msg.test2                 = Wykonywanie testu połączenia. Powodzenie jest zazwyczaj szybkie; awarie często trwają dłużej...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Użyj dymków dla rzutów []
 ServerDialog.option.rolls.tooltip      = Szczegóły rzutów [ ] będą wyświetlane w dymkach, jeśli nie będzie wybrany inny format.
 ServerDialog.button.networkinghelp     = Pomoc dot. sieci
 ServerDialog.generatePassword          = Wygeneruj hasło
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Cechy żetonów
 CampaignPropertiesDialog.tab.repo      = Repozytoria
 CampaignPropertiesDialog.tab.sight     = Wzrok

--- a/src/main/resources/net/rptools/maptool/language/i18n_pt.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pt.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = A senha do jogador deve ser preenchi
 ServerDialog.error.gmPasswordMissing     = A senha do GM deve ser preenchida.
 ServerDialog.error.passwordMustDiffer  = A senha do jogador e do GM não podem ser a mesma.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Configurando para Teste de Conexão...
 ServerDialog.msg.test2                 = Executando teste de conexão. Sucesso geralmente é rápido; falha frequentemente leva mais tempo...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Networking Help
 ServerDialog.generatePassword          = Gerar Senha
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Propriedades do Token
 CampaignPropertiesDialog.tab.repo      = Repositórios
 CampaignPropertiesDialog.tab.sight     = Visão

--- a/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Проверяем подключение...
 ServerDialog.msg.test2                 = Проводим проверку подключения. Успех обычно быстрый; ошибка часто занимает больше времени...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Networking Help
 ServerDialog.generatePassword          = Generate Password
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Token Properties
 CampaignPropertiesDialog.tab.repo      = Repositories
 CampaignPropertiesDialog.tab.sight     = Sight

--- a/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Spelar- och spelledarlösenord kan inte vara samma.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Inställning för anslutningstest ...
 ServerDialog.msg.test2                 = Utför anslutningstest. Om det lyckas går det nog fort; misslyckande tar ofta längre tid...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Använd verktygstips för []-slag
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Nätverkshjälp
 ServerDialog.generatePassword          = Generera lösenord
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Egenskaper för token
 CampaignPropertiesDialog.tab.repo      = Repositories
 CampaignPropertiesDialog.tab.sight     = Synförmåga

--- a/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = Player and GM Password can not be the same.
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = Перевірка зв'язку...
 ServerDialog.msg.test2                 = Перевірка зв'язку. Успішна проходить швидко; невдала часто вимагає більше часу...
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = Use ToolTips for [] Rolls
 ServerDialog.option.rolls.tooltip      = Tool Tips will be used for [ ] rolls where no format options are specified.
 ServerDialog.button.networkinghelp     = Networking Help
 ServerDialog.generatePassword          = Generate Password
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = Token Properties
 CampaignPropertiesDialog.tab.repo      = Repositories
 CampaignPropertiesDialog.tab.sight     = Sight

--- a/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
@@ -721,7 +721,8 @@ ServerDialog.error.playerPasswordMissing  = Player Password must be provided.
 ServerDialog.error.gmPasswordMissing     = GM Password must be provided.
 ServerDialog.error.passwordMustDiffer  = 玩家密码和GM密码不能相同。
 ServerDialog.error.serverAlreadyExists = A server with the same name already exists.
-
+ServerDialog.error.xmlExport=Error while Exporting, please try again.
+ServerDialog.error.xmlImport=Error while Importing, please try again.
 # The connection test has been disabled so these are not currently used.
 ServerDialog.msg.test1                 = 准备连接测试中...
 ServerDialog.msg.test2                 = 运行连接测试。若成功将快速完成；若失败则通常耗时良久。
@@ -768,8 +769,8 @@ ServerDialog.option.rolls              = 为 [ ] 掷骰启用工具提示
 ServerDialog.option.rolls.tooltip      = 未指定格式选项的 [ ] 掷骰将使用工具提示。
 ServerDialog.button.networkinghelp     = 网络帮助
 ServerDialog.generatePassword          = 生成密码
-
-
+ServerDialog.button.xmlExport=Export to XML
+ServerDialog.button.xmlImport=Import from XML
 CampaignPropertiesDialog.tab.token     = 指示物属性
 CampaignPropertiesDialog.tab.repo      = 资源库
 CampaignPropertiesDialog.tab.sight     = 视线


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #4216


### Description of the Change
I added two buttons on the StartServerDialog to export and import the settings as XML. I also added the translation for them in the i18n-bundle. 


### Possible Drawbacks
* I do not check the XML-File for the correct well formed structure and if it is valid to import.
* I override the selected XML-File without requesting a confirmation from the user, if a file of that name already exists.
* If the export or import fails half way through the process the data model and the view can get out of sync temporarily until the dialog is reopened or one of the operations: export, import or start of the server is reexecuted, but this also happens, if you edit the dialog so it is not a really bad thing.
* To export and import the setup, I programmed a get-Method for the prefs object. I don't know if this is a good way to program it, but it works that way. 
* I did not refractor the dialog in the progress to not depend on XML as Craig suggested.


### Documentation Notes
Export to XML: You can save your actual server configuration into a XML-File. The selected file will be overwritten.
Import from XML: Load a prior exported XML-File with a server configuration into the StartServerDialog.  


### Release Notes
- Export and import server preferences added to StartServerDialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4217)
<!-- Reviewable:end -->
