### PR TITLE
Stop rendering clear lights

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
@@ -39,7 +39,6 @@ public class StatSheetListener {
    */
   @Subscribe
   public void onHoverEnter(TokenHoverEnter event) {
-    System.out.println("TokenHoverListener.onHoverEnter");
     if (AppPreferences.getShowStatSheet()
         && AppPreferences.getShowStatSheetModifier() == event.shiftDown()) {
       var ssManager = new StatSheetManager();
@@ -69,7 +68,6 @@ public class StatSheetListener {
    */
   @Subscribe
   public void onHoverExit(TokenHoverExit event) {
-    System.out.println("TokenHoverListener.onHoverLeave");
     MapTool.getFrame().showControlPanel();
     if (statSheet != null) {
       statSheet.clearContent();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/DrawableLight.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/DrawableLight.java
@@ -15,26 +15,27 @@
 package net.rptools.maptool.client.ui.zone;
 
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.drawing.DrawablePaint;
 
 public class DrawableLight {
 
-  private DrawablePaint paint;
-  private Area area;
+  private @Nonnull DrawablePaint paint;
+  private @Nonnull Area area;
   private int lumens;
 
-  public DrawableLight(DrawablePaint paint, Area area, int lumens) {
+  public DrawableLight(@Nonnull DrawablePaint paint, @Nonnull Area area, int lumens) {
     super();
     this.paint = paint;
     this.area = area;
     this.lumens = lumens;
   }
 
-  public DrawablePaint getPaint() {
+  public @Nonnull DrawablePaint getPaint() {
     return paint;
   }
 
-  public Area getArea() {
+  public @Nonnull Area getArea() {
     return area;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/Illumination.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/Illumination.java
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
  *   <li>The obscured lumens levels. For each light area in the basic structure, subtract out any
  *       stronger darknesses, and for each darkness subtract out any stronger lights. The result is
  *       the obscured lit areas arranged by lumens level.
- *   <li>The complete visible area. This is the union of the light areas after the process in (1).
+ *   <li>The complete lit area. This is the union of the light areas after the process in (1).
  *   <li>The disjoint obscured lumens levels. Starting from (1), we can additionally subtract strong
  *       light from weak light and strong darkness from weak darkness so that any given point is
  *       represented only in the strongest lumens level.
@@ -105,7 +105,15 @@ public final class Illumination {
    * <p>This is derived from {@link #obscuredLumensLevels} by unioning all light areas and leaving
    * out all darkness areas.
    */
-  private Area visibleArea = null;
+  private Area litArea = null;
+
+  /**
+   * The complete darkened area.
+   *
+   * <p>This is derived from {@link #obscuredLumensLevels} by unioning all darkness areas and
+   * leaving out all light areas.
+   */
+  private Area darkenedArea = null;
 
   // endregion
 
@@ -113,8 +121,8 @@ public final class Illumination {
    * Create a new {@code Illumination} from a set of base lumens levels.
    *
    * <p>The {@code lumensLevels} should contain the complete areas that <emp>could</emp> be covered
-   * covered by each level of lumens. Obscurement (darkness competing with light) should not already
-   * be calculated, as the {@code Illumination} will handle this.
+   * by each level of lumens. Obscurement (darkness competing with light) should not already be
+   * calculated, as the {@code Illumination} will handle this.
    *
    * @param lumensLevels The base areas covered by each level of lumens.
    */
@@ -210,18 +218,36 @@ public final class Illumination {
    * Get the total lit area from all lumens levels.
    *
    * <p>After subtracting stronger darkness from weaker lights, the resulting lights are unioned
-   * into a single visible area.
+   * into a single area.
    *
    * @return The lit area.
    */
-  public @Nonnull Area getVisibleArea() {
-    if (visibleArea == null) {
+  public @Nonnull Area getLitArea() {
+    if (litArea == null) {
       final var result = new Area();
       getObscuredLumensLevels().forEach(level -> result.add(level.lightArea()));
-      visibleArea = result;
+      litArea = result;
     }
 
-    return new Area(visibleArea);
+    return new Area(litArea);
+  }
+
+  /**
+   * Get the total dark area from all lumens levels.
+   *
+   * <p>After subtracting stronger lights from weaker darkness, the resulting darknesses are unioned
+   * into a single area.
+   *
+   * @return The darkened area.
+   */
+  public @Nonnull Area getDarkenedArea() {
+    if (darkenedArea == null) {
+      final var result = new Area();
+      getObscuredLumensLevels().forEach(level -> result.add(level.darknessArea()));
+      darkenedArea = result;
+    }
+
+    return new Area(darkenedArea);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/zone/IlluminationModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/IlluminationModel.java
@@ -27,7 +27,7 @@ import net.rptools.maptool.model.Light;
 import net.rptools.maptool.model.LightSource;
 
 /**
- * Manages the light sources and illuminations of a zone, for a given set of illumniator parameters.
+ * Manages the light sources and illuminations of a zone, for a given set of illuminator parameters.
  *
  * <p>This needs to be kept in sync with the associated {@code Zone} in order for the results to
  * make sense

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -1427,7 +1427,6 @@ public class ZoneRenderer extends JComponent
           overlayBlending,
           view.isGMView() ? null : LightOverlayClipStyle.CLIP_TO_VISIBLE_AREA,
           drawableLights,
-          Color.black,
           overlayFillColor);
       timer.stop("renderLights:renderLightOverlay");
     }
@@ -1463,7 +1462,6 @@ public class ZoneRenderer extends JComponent
         AlphaComposite.SrcOver,
         view.isGMView() ? null : LightOverlayClipStyle.CLIP_TO_VISIBLE_AREA,
         drawableAuras,
-        new Color(255, 255, 255, 150),
         new Color(0, 0, 0, 0));
     timer.stop("renderAuras:renderAuraOverlay");
   }
@@ -1580,7 +1578,6 @@ public class ZoneRenderer extends JComponent
    * @param clipStyle How to clip the overlay relative to the visible area. Set to null for no extra
    *     clipping.
    * @param lights The lights that will be rendered and blended.
-   * @param defaultPaint A default paint for lights without a paint.
    */
   private void renderLightOverlay(
       Graphics2D g,
@@ -1588,7 +1585,6 @@ public class ZoneRenderer extends JComponent
       Composite overlayBlending,
       @Nullable LightOverlayClipStyle clipStyle,
       Collection<DrawableLight> lights,
-      Paint defaultPaint,
       Paint backgroundFill) {
     if (lights.isEmpty()) {
       // No point spending resources accomplishing nothing.
@@ -1631,8 +1627,7 @@ public class ZoneRenderer extends JComponent
       // Draw lights onto the buffer image so the map doesn't affect how they blend
       timer.start("renderLightOverlay:drawLights");
       for (var light : lights) {
-        var paint = light.getPaint() != null ? light.getPaint().getPaint() : defaultPaint;
-        newG.setPaint(paint);
+        newG.setPaint(light.getPaint().getPaint());
         timer.start("renderLightOverlay:fillLight");
         newG.fill(light.getArea());
         timer.stop("renderLightOverlay:fillLight");

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.swing.*;
@@ -1109,7 +1110,7 @@ public class ZoneRenderer extends JComponent
       timer.stop("ZoneRenderer-getVisibleArea");
 
       timer.start("createTransformedArea");
-      if (a != null && !a.isEmpty()) {
+      if (!a.isEmpty()) {
         visibleScreenArea = a.createTransformedArea(af);
       }
       timer.stop("createTransformedArea");
@@ -1120,7 +1121,7 @@ public class ZoneRenderer extends JComponent
     {
       // renderMoveSelectionSet() requires exposedFogArea to be properly set
       exposedFogArea = new Area(zone.getExposedArea());
-      if (exposedFogArea != null && zone.hasFog()) {
+      if (zone.hasFog()) {
         if (visibleScreenArea != null && !visibleScreenArea.isEmpty()) {
           exposedFogArea.intersect(visibleScreenArea);
         } else {
@@ -1864,10 +1865,10 @@ public class ZoneRenderer extends JComponent
   }
 
   private void renderFogArea(
-      final Graphics2D buffG, final PlayerView view, Area softFog, Area visibleArea) {
+      final Graphics2D buffG, final PlayerView view, Area softFog, @Nonnull Area visibleArea) {
     if (zoneView.isUsingVision()) {
       buffG.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC));
-      if (visibleArea != null && !visibleArea.isEmpty()) {
+      if (!visibleArea.isEmpty()) {
         buffG.setColor(new Color(0, 0, 0, AppPreferences.getFogOverlayOpacity()));
 
         // Fill in the exposed area
@@ -1889,9 +1890,10 @@ public class ZoneRenderer extends JComponent
     }
   }
 
-  private void renderFogOutline(final Graphics2D buffG, PlayerView view, Area visibleArea) {
+  private void renderFogOutline(
+      final Graphics2D buffG, PlayerView view, @Nonnull Area visibleArea) {
     // If there is no visible area, there is no outline that needs rendering.
-    if (zoneView.isUsingVision() && visibleArea != null && !visibleArea.isEmpty()) {
+    if (zoneView.isUsingVision() && !visibleArea.isEmpty()) {
       // Transform the area (not G2D) because we want the drawn line to remain thin.
       AffineTransform af = new AffineTransform();
       af.translate(zoneScale.getOffsetX(), zoneScale.getOffsetY());

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -189,7 +189,7 @@ public class ZoneView {
    * @param view the PlayerView
    * @return the visible area
    */
-  public Area getVisibleArea(PlayerView view) {
+  public @Nonnull Area getVisibleArea(PlayerView view) {
     return visibleAreaMap.computeIfAbsent(
         view,
         view2 -> {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -756,6 +756,12 @@ public class ZoneView {
                           return null;
                         }
 
+                        // Lights without a colour are "clear" and should not be rendered.
+                        var paint = laud.lightInfo().light().getPaint();
+                        if (paint == null) {
+                          return null;
+                        }
+
                         // Make sure each drawable light is restricted to the area it covers,
                         // accounting for darkness effects.
                         final var obscuredArea = new Area(laud.litArea().area());
@@ -770,10 +776,7 @@ public class ZoneView {
                             isDarkness
                                 ? lumensLevel.get().darknessArea()
                                 : lumensLevel.get().lightArea());
-                        return new DrawableLight(
-                            laud.lightInfo().light().getPaint(),
-                            obscuredArea,
-                            laud.litArea().lumens());
+                        return new DrawableLight(paint, obscuredArea, laud.litArea().lumens());
                       })
                   .filter(Objects::nonNull)
                   .toList();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -520,7 +520,7 @@ public class ZoneView {
     return personalLights;
   }
 
-  private Illumination getIllumination(PlayerView view) {
+  public Illumination getIllumination(PlayerView view) {
     var illumination = illuminationsPerView.get(view);
     if (illumination == null) {
       // Not yet calculated. Do so now.
@@ -750,6 +750,12 @@ public class ZoneView {
                   .filter(laud -> laud.lightInfo() != null)
                   .map(
                       (ContributedLight laud) -> {
+                        var isDarkness = laud.litArea().lumens() < 0;
+                        if (isDarkness && !view.isGMView()) {
+                          // Non-GM players do not render the light aspect of darkness.
+                          return null;
+                        }
+
                         // Make sure each drawable light is restricted to the area it covers,
                         // accounting for darkness effects.
                         final var obscuredArea = new Area(laud.litArea().area());
@@ -761,7 +767,7 @@ public class ZoneView {
                         }
 
                         obscuredArea.intersect(
-                            laud.litArea().lumens() < 0
+                            isDarkness
                                 ? lumensLevel.get().darknessArea()
                                 : lumensLevel.get().lightArea());
                         return new DrawableLight(

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -625,14 +625,14 @@ public class ZoneView {
     // perspective.
     final var singleTokenView = new PlayerView(view.getRole(), Collections.singletonList(token));
     final var illumination = getIllumination(singleTokenView);
-    final var visibleArea = illumination.getVisibleArea();
-    visibleArea.intersect(tokenVisibleArea);
+    final var litArea = illumination.getLitArea();
+    litArea.intersect(tokenVisibleArea);
 
-    tokenVisionCache.put(token.getId(), visibleArea);
+    tokenVisionCache.put(token.getId(), litArea);
 
     // log.info("getVisibleArea: \t\t" + stopwatch);
 
-    return visibleArea;
+    return litArea;
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4213

### Description of the Change

The primary change is to avoid building `DrawableLight` objects for clear lights (lights with a `null` paint).

This required changes to how player darkness is rendered as we can no longer rely on each darkness being represented as `DrawableLight`s (darkness can be clear just like lights). So instead we now find the entire darkened area from the `ZoneView` and render that as black without needing to know about the individual darkness sources.

For a performance win, we also now avoid rendering the colour aspect of darkness when the player is not a GM, since only GMs can see them anyways.

Some minor edits made along the way were:
- Removing some System.out.println() calls that were spamming my console logs.
- Removing some redundant `null` checks in `ZoneRenderer` regarding the visible area.

### Possible Drawbacks

Anyone with a clear light may have gotten used to the 1.13 behaviour of treating it as black. Can be worked around by explicitly defining the light as black.

### Documentation Notes

Lights will be rendered a clear if no colour is given, e.g., `Transparent 20: scale circle 20+100`

### Release Notes

- Fixed a bug where clear lights were being rendered like black lights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4225)
<!-- Reviewable:end -->
