### PR TITLE
Ensure PackedFile is always closed and remove PackedFile.finalize()

### DIFF
--- a/src/main/java/net/rptools/lib/io/PackedFile.java
+++ b/src/main/java/net/rptools/lib/io/PackedFile.java
@@ -753,11 +753,6 @@ public class PackedFile implements AutoCloseable {
     dirty = !file.exists();
   }
 
-  @Override
-  protected void finalize() throws Throwable {
-    close();
-  }
-
   protected File getExplodedFile(String path) {
     return new File(tmpFile, path);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/assetpanel/ImageFileImagePanelModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/assetpanel/ImageFileImagePanelModel.java
@@ -133,8 +133,7 @@ public class ImageFileImagePanelModel implements ImagePanelModel {
     if (!Token.isTokenFile(fileList.get(index).getName())) {
       return null;
     }
-    try {
-      PackedFile pakFile = new PackedFile(fileList.get(index));
+    try (PackedFile pakFile = new PackedFile(fileList.get(index))) {
       Object isHeroLab = pakFile.getProperty(PersistenceUtil.HERO_LAB);
       if (isHeroLab != null && (boolean) isHeroLab) {
         return new Image[] {herolabDecorationImage};

--- a/src/test/java/net/rptools/maptool/client/swing/preference/net/rptools/lib/io/PackedFileTest.java
+++ b/src/test/java/net/rptools/maptool/client/swing/preference/net/rptools/lib/io/PackedFileTest.java
@@ -33,9 +33,10 @@ public class PackedFileTest {
   @Test
   public void emptySave(@TempDir File tempDir) throws IOException {
     File f = new File(tempDir, PACKED_TEST_FILE);
-    PackedFile pf = new PackedFile(f);
-    pf.save();
-    assertTrue(f.exists());
+    try (PackedFile pf = new PackedFile(f)) {
+      pf.save();
+      assertTrue(f.exists());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Identify the Bug or Feature request

Implements #3948

### Description of the Change

Almost all `PackedFile` instances are wrapped in a try-with-resources to ensure they are always closed. The one exception (`PersistenceUtils.saveCampaign()`) had logic around `.close()`, so I left that in its `finally` block instead of trying to rework it into try-with-resources.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4226)
<!-- Reviewable:end -->
