### PR TITLE
Ensure MacroEditorDialog.callback is not null

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
@@ -111,7 +111,7 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
    * @return the MacroEditorDialog.
    */
   public static MacroEditorDialog createMacroButtonDialog() {
-    return new MacroEditorDialog(false, true, null);
+    return new MacroEditorDialog(false, true, s -> {});
   }
 
   /**
@@ -127,7 +127,8 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
     return new MacroEditorDialog(true, false, callback);
   }
 
-  private MacroEditorDialog(boolean isModal, boolean isMacroButton, Consumer<String> callback) {
+  private MacroEditorDialog(
+      boolean isModal, boolean isMacroButton, @Nonnull Consumer<String> callback) {
     super(MapTool.getFrame(), "", true);
     if (!isModal) {
       this.setModalityType(ModalityType.MODELESS);
@@ -740,9 +741,7 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
 
   private void save(boolean closeDialog) {
     if (button == null) {
-      if (callback != null) {
-        callback.accept(getCommandTextArea().getText());
-      }
+      callback.accept(getCommandTextArea().getText());
     } else {
       String hotKey = getHotKeyCombo().getSelectedItem().toString();
       button.getHotKeyManager().assignKeyStroke(hotKey);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4238

### Description of the Change

The field `MacroEditorDialog.callback` was `null` for macro button dialogs, but this case was not checked prior to invoking the callback when canceling. Rather than adding a `null` check in the cancel case, I instead opted to use no-op callbacks instead of `null`, removing the need for any `null` checks on the callback.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4239)
<!-- Reviewable:end -->
