### PR TITLE
Fix for character sheet not being copied with token copy

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -498,6 +498,7 @@ public class Token implements Cloneable {
     terrainModifiersIgnored.addAll(token.terrainModifiersIgnored);
     speechName = token.speechName != null ? token.speechName : "";
     allowURIAccess = token.allowURIAccess;
+    statSheet = token.statSheet;
   }
 
   public Token() {}


### PR DESCRIPTION

### Identify the Bug or Feature request
fixes #4240


### Description of the Change
The statsheet value was not being set in the copy constructor. This will fix hotkey cut and paste as well as copyToken() function.


### Possible Drawbacks
Should be none

### Documentation Notes
Fix bug where stat sheet was not getting copied for a token when copy and pasting or using copyToken() macro.

### Release Notes
- Fix bug where stat sheet was not getting copied for a token when copy and pasting or using copyToken() macro.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4242)
<!-- Reviewable:end -->
