### PR TITLE
Attempt to fix overlay flicker

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
@@ -69,8 +69,6 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
 
   /** The RGB value for a fully invisible color (alpha = 0). */
   private static final int COLOR_INVISIBLE = new Color(0, 0, 0, 0).getRGB();
-  /** The RGB value for a nearly invisible color (alpha = 1). */
-  private static final int COLOR_VISIBLE = new Color(128, 128, 128, 1).getRGB();
 
   /** The ZOrder of the overlay. */
   private int zOrder;
@@ -131,8 +129,9 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
 
   @Override
   public void updateContents(final String html, boolean scrollReset) {
-    // Sets the background to be barely visible. Workaround to fix #1976.
-    setPageBackgroundColor(COLOR_VISIBLE);
+    // If we don't set the background to invisible here, we might see a white flash for overlays
+    // whose content is slow to load.
+    setPageBackgroundColor(COLOR_INVISIBLE);
     macroCallbacks.clear();
     super.updateContents(html, scrollReset);
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Attempts to fix #4241

### Description of the Change

There was a workaround introducedd for #1976 where we set the overlay page background to something not-quite-transparent, otherwise the overlay contents might not be cleared. Unfortunately this appears to be the cause of the flickering that overlays are known to have. This PR removes the workaround and always sets the page to have a transparent background.

It is necessary to set the page background to invisible in `updateContents()` rather than just leaving it up to `handlePage()`.  I found that if a stat sheet has content that takes a bit to load (e.g., Rev's "Anim" stat sheet), the overlay would render as pure white for a moment before transitioning to transaprent.


### Possible Drawbacks

- Issue #1976 may be system-dependent and could show up again if it wasn't fixed in JavaFX.

### Documentation Notes

- N/A

### Release Notes

- Fixed the flickering that sometimes happens when opening overlays and stat sheets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4246)
<!-- Reviewable:end -->
