### PR TITLE
Fix json.* constants to keep a GSON representation

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -290,9 +290,10 @@ public class MapToolVariableResolver implements VariableResolver {
 
     Object value;
 
-    if (result instanceof JsonArray) {
-      value = result;
-    } else if (result instanceof JsonObject) {
+    if (result instanceof JsonArray
+        || result instanceof JsonObject
+        || result instanceof JsonNull
+        || (result instanceof JsonPrimitive primitive && primitive.isBoolean())) {
       value = result;
     } else if (result instanceof BigDecimal) {
       value = result;


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4161

### Description of the Change

When looking up a variable (including constants), we preserve `JsonArray` and `JsonObject` values rather than converting them strings. The same functionality is now extended to `JsonNull` and boolean `JsonPrimitive`.

I could have altered the checks to a single `JsonElement`, but I'm not confident whether changing other primitive JSON values (numbers) could cause issues. So instead I have chosen to be more precise and only accomodate the needs of `json.null`, `json.true`, and `json.false`, leaving the behaviour of JSON numbers to be unchanged.

No other changes have been made to functions or MTScript-JSON conversion, notably:
- `json.get()` and similar functions will still convert returned `null`, `true`, or `false` to the MTScript strings `"null"`, `"true"`, and `"false"`.
- MTScript strings `"null"`, `"true"`, `"false"` will not be converted to JSON `null`, `true`, or `false` when used in places that JSON is expected.

### Possible Drawbacks

Anyone relying on `json.*` constants being strings will need to update their code.

### Documentation Notes

I believe the wiki should already match the new behaviour, but just in case:

- **json.null** Constant representing a null value in json.
- **json.true** Constant representing a true value in json.
- **json.false** Constant representing a false value in json.

### Release Notes

- Fixed `json.null`, `json.true`, and `json.false` so that they are real JSON values rather than strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4247)
<!-- Reviewable:end -->
