### PR TITLE
Work around the JavaFX NPE bug causing HTML5 listeners to not be called

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -49,7 +49,6 @@ import netscape.javascript.JSObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.*;
-import org.w3c.dom.events.EventListener;
 import org.w3c.dom.events.EventTarget;
 import org.w3c.dom.html.*;
 
@@ -78,11 +77,6 @@ public class HTMLWebViewManager {
 
   /** The bridge from Javascript to Java. */
   private final JavaBridge bridge;
-
-  // Event listener for the href macro link clicks.
-  private final EventListener listenerA = this::fixHref;
-  // Event listener for form submission.
-  private final EventListener listenerSubmit = this::getDataAndSubmit;
 
   /** Represents a bridge from Javascript to Java. */
   public class JavaBridge {
@@ -152,11 +146,11 @@ public class HTMLWebViewManager {
         if (addedNode instanceof EventTarget) {
           EventTarget target = (EventTarget) addedNode;
           if (addedNode instanceof HTMLAnchorElement || addedNode instanceof HTMLAreaElement) {
-            target.addEventListener("click", listenerA, true);
+            target.addEventListener("click", HTMLWebViewManager.this::fixHref, true);
           } else if (target instanceof HTMLFormElement) {
-            target.addEventListener("submit", listenerSubmit, true);
+            target.addEventListener("submit", HTMLWebViewManager.this::getDataAndSubmit, true);
           } else if (target instanceof HTMLInputElement || target instanceof HTMLButtonElement) {
-            target.addEventListener("click", listenerSubmit, true);
+            target.addEventListener("click", HTMLWebViewManager.this::getDataAndSubmit, true);
           }
         }
 
@@ -167,34 +161,34 @@ public class HTMLWebViewManager {
         nodeList = addedNode.getElementsByTagName("a");
         for (int i = 0; i < nodeList.getLength(); i++) {
           EventTarget node = (EventTarget) nodeList.item(i);
-          node.addEventListener("click", listenerA, true);
+          node.addEventListener("click", HTMLWebViewManager.this::fixHref, true);
         }
 
         // Add event handlers for hyperlinks for maps.
         nodeList = addedNode.getElementsByTagName("area");
         for (int i = 0; i < nodeList.getLength(); i++) {
           EventTarget node = (EventTarget) nodeList.item(i);
-          node.addEventListener("click", listenerA, true);
+          node.addEventListener("click", HTMLWebViewManager.this::fixHref, true);
         }
 
         // Set the "submit" handler to get the data on submission not based on buttons
         nodeList = addedNode.getElementsByTagName("form");
         for (int i = 0; i < nodeList.getLength(); i++) {
           EventTarget target = (EventTarget) nodeList.item(i);
-          target.addEventListener("submit", listenerSubmit, true);
+          target.addEventListener("submit", HTMLWebViewManager.this::getDataAndSubmit, true);
         }
 
         // Set the "submit" handler to get the data on submission based on input
         nodeList = addedNode.getElementsByTagName("input");
         for (int i = 0; i < nodeList.getLength(); i++) {
           EventTarget target = (EventTarget) nodeList.item(i);
-          target.addEventListener("click", listenerSubmit, true);
+          target.addEventListener("click", HTMLWebViewManager.this::getDataAndSubmit, true);
         }
         // Set the "submit" handler to get the data on submission based on button
         nodeList = addedNode.getElementsByTagName("button");
         for (int i = 0; i < nodeList.getLength(); i++) {
           EventTarget target = (EventTarget) nodeList.item(i);
-          target.addEventListener("click", listenerSubmit, true);
+          target.addEventListener("click", HTMLWebViewManager.this::getDataAndSubmit, true);
         }
       }
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Should fix #4048

### Description of the Change

There is a bug in JavaFX 19 & 20 where using the same `EventListener` instance across different pages with the same WebView will result in an internal NPE that prevents the `EventListener` from being called. This change works around that by always provided a new instance (via method reference) when registering the handler.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4259)
<!-- Reviewable:end -->
