### PR TITLE
Stop the gradle daemon after the build task during verification

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Build with Gradle
         uses: GabrielBB/xvfb-action@v1.0
         with: 
-          run: ./gradlew build
+          run: ./gradlew build --no-daemon


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4260

### Description of the Change

This just adds the `--no-daemon` flag to gradle when executing the `build` task. This way the lock files are released and windows will allow `tar` to do its job and the cache to be built.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4261)
<!-- Reviewable:end -->
