### PR TITLE
Fix delete drawing tool to respect the selected layer

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -83,7 +83,7 @@ public abstract class DefaultTool extends Tool
     super.attachTo(renderer);
     this.renderer = renderer;
     selectedLayer = renderer.getActiveLayer();
-    layerSelectionDialog.updateViewList();
+    layerSelectionDialog.setSelectedLayer(selectedLayer);
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -82,6 +82,7 @@ public abstract class DefaultTool extends Tool
   protected void attachTo(ZoneRenderer renderer) {
     super.attachTo(renderer);
     this.renderer = renderer;
+    selectedLayer = renderer.getActiveLayer();
     layerSelectionDialog.updateViewList();
   }
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -139,7 +139,7 @@ public class PointerTool extends DefaultTool {
     }
     htmlRenderer.attach(renderer);
 
-    if (renderer.getActiveLayer() != Zone.Layer.TOKEN) {
+    if (getSelectedLayer() != Zone.Layer.TOKEN) {
       MapTool.getFrame().getToolbox().setSelectedTool(StampTool.class);
     }
   }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
@@ -333,7 +333,7 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
       return;
     }
     if (MapTool.getPlayer().isGM()) {
-      drawable.setLayer(renderer.getActiveLayer());
+      drawable.setLayer(getSelectedLayer());
     } else {
       drawable.setLayer(Layer.TOKEN);
     }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
@@ -33,7 +33,6 @@ import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.GUID;
-import net.rptools.maptool.model.Zone.Layer;
 import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.model.drawing.DrawnElement;
 
@@ -45,8 +44,6 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
   private static final Set<GUID> selectedDrawings = new HashSet<>();
   private static final DrawPanelPopupMenu.DeleteDrawingAction deleteAction =
       new DrawPanelPopupMenu.DeleteDrawingAction(selectedDrawings);
-
-  private static Layer selectedLayer = Layer.TOKEN;
 
   public DeleteDrawingTool() {
     new MapToolEventBus().getMainEventBus().register(this);
@@ -91,7 +88,7 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
 
     if (!multiSelect) selectedDrawings.clear();
 
-    var drawableList = zone.getDrawnElements(selectedLayer);
+    var drawableList = zone.getDrawnElements(getSelectedLayer());
     for (var element : drawableList) {
       var drawable = element.getDrawable();
       var id = drawable.getId();

--- a/src/main/java/net/rptools/maptool/client/tool/layerselectiondialog/LayerSelectionDialog.java
+++ b/src/main/java/net/rptools/maptool/client/tool/layerselectiondialog/LayerSelectionDialog.java
@@ -20,7 +20,6 @@ import javax.swing.DefaultListModel;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.model.Zone;
 
@@ -51,11 +50,6 @@ public class LayerSelectionDialog extends JPanel {
     }
   }
 
-  public void updateViewList() {
-    getLayerList()
-        .setSelectedValue(MapTool.getFrame().getCurrentZoneRenderer().getActiveLayer(), true);
-  }
-
   private JList<Zone.Layer> getLayerList() {
 
     if (list == null) {
@@ -83,7 +77,7 @@ public class LayerSelectionDialog extends JPanel {
   }
 
   public void setSelectedLayer(Zone.Layer layer) {
-    list.setSelectedValue(layer, true);
+    getLayerList().setSelectedValue(layer, true);
   }
 
   public interface LayerSelectionListener {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4258

### Description of the Change

The bug fix is to remove `DeleteDrawingTool`'s `selectedLayer` field (which is never changed from the Token layer), and instead rely on `DefaultTool.getSelectedLayer()` when the layer is needed.

There is also a bit of related refactoring to make `DefaultTool.getSelectedLayer()` the only place we obtain the current layer for drawing tools, and so the `LayerSelectionDialog` also does not have to figure that out itself.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the delete drawing tool only affected drawings on the token layer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4263)
<!-- Reviewable:end -->
