### PR TITLE
Fix double title bars with grouped floating frames

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui;
 import com.google.common.eventbus.Subscribe;
 import com.jidesoft.docking.DefaultDockableHolder;
 import com.jidesoft.docking.DockableFrame;
+import com.jidesoft.docking.DockingManager;
 import java.awt.*;
 import java.awt.event.*;
 import java.awt.image.BufferedImage;
@@ -71,6 +72,7 @@ import net.rptools.maptool.client.ui.assetpanel.AssetDirectory;
 import net.rptools.maptool.client.ui.assetpanel.AssetPanel;
 import net.rptools.maptool.client.ui.commandpanel.CommandPanel;
 import net.rptools.maptool.client.ui.connections.ClientConnectionPanel;
+import net.rptools.maptool.client.ui.docking.MapToolDockingManager;
 import net.rptools.maptool.client.ui.drawpanel.DrawPanelPopupMenu;
 import net.rptools.maptool.client.ui.drawpanel.DrawPanelTreeCellRenderer;
 import net.rptools.maptool.client.ui.drawpanel.DrawPanelTreeModel;
@@ -617,6 +619,11 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   public DockableFrame getFrame(MTFrame frame) {
     return frameMap.get(frame);
+  }
+
+  @Override
+  protected DockingManager createDockingManager(Container container) {
+    return new MapToolDockingManager(this, container);
   }
 
   private void initializeFrames() {

--- a/src/main/java/net/rptools/maptool/client/ui/docking/MapToolDockingManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/docking/MapToolDockingManager.java
@@ -1,0 +1,51 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.docking;
+
+import com.jidesoft.docking.DefaultDockingManager;
+import com.jidesoft.docking.DialogFloatingContainer;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Window;
+import javax.swing.RootPaneContainer;
+
+/**
+ * Custom docking manager that creates custom floating containers.
+ *
+ * <p>This is how to use {@link SingleTitleBarDialogFloatingContainer} instead of the default
+ * implementation.
+ */
+public class MapToolDockingManager extends DefaultDockingManager {
+  public MapToolDockingManager(RootPaneContainer rootPaneContainer, Container container) {
+    super(rootPaneContainer, container);
+  }
+
+  @Override
+  protected DialogFloatingContainer createDialogFloatingContainer(
+      InternalEventManager internalEventManager, Window window) {
+    if (window instanceof Dialog dialog) {
+      return new SingleTitleBarDialogFloatingContainer(this, internalEventManager, dialog);
+    }
+
+    if (window instanceof Frame frame) {
+      return new SingleTitleBarDialogFloatingContainer(this, internalEventManager, frame);
+    }
+
+    throw new UnsupportedOperationException(
+        "JIDE Docking Framework doesn't support floating frames if rootPaneContainer is "
+            + (window == null ? "null" : window.getClass().getName()));
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/docking/SingleTitleBarDialogFloatingContainer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/docking/SingleTitleBarDialogFloatingContainer.java
@@ -1,0 +1,71 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.docking;
+
+import com.jidesoft.docking.DialogFloatingContainer;
+import com.jidesoft.docking.DockingManager;
+import com.jidesoft.docking.DockingUtils;
+import com.jidesoft.plaf.UIDefaultsLookup;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.HeadlessException;
+import javax.swing.JRootPane;
+
+/**
+ * Container implementation that only decorates the root pane and not the dialog itself.
+ *
+ * <p>The default implementation ({@link com.jidesoft.docking.DialogFloatingContainer}) always
+ * decorates both the dialog and the root pane when decorations are requested, resulting in
+ * redundant title bars for docked floating frames.
+ */
+public class SingleTitleBarDialogFloatingContainer extends DialogFloatingContainer {
+  public SingleTitleBarDialogFloatingContainer(
+      DockingManager dockingManager, FloatingContainerManager floatingContainerManager, Frame frame)
+      throws HeadlessException {
+    super(dockingManager, floatingContainerManager, frame);
+  }
+
+  public SingleTitleBarDialogFloatingContainer(
+      DockingManager dockingManager,
+      FloatingContainerManager floatingContainerManager,
+      Dialog dialog)
+      throws HeadlessException {
+    super(dockingManager, floatingContainerManager, dialog);
+  }
+
+  @Override
+  public void updateUndecorated() {
+    this.setVisible(false); // So we can change the decorations.
+
+    this.setUndecorated(true);
+
+    final var dockingManager = this.getDockingManager();
+    final var contentPane = this.getContentPane();
+    if (DockingUtils.shouldUseDecoratedFloatingContainer(dockingManager, contentPane)) {
+      this.getRootPane().setWindowDecorationStyle(JRootPane.PLAIN_DIALOG);
+    } else {
+      this.getRootPane().setWindowDecorationStyle(JRootPane.NONE);
+    }
+    this.setBorder(UIDefaultsLookup.getBorder("Resizable.resizeBorder"));
+
+    this.updateBorders();
+
+    if (!this.getDockingManager().getMainContainer().isShowing()) {
+      return;
+    }
+
+    this.setVisible(true);
+  }
+}


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #2455

### Description of the Change

This is a workaround for some strange JIDE behaviour for floating frames that are docked together. The containing dialog was being decorated (via `this.setUndecorated(false)`), _and_ its root pane was being decorated as a dialog (via `this.getRootPane().setWindowDecorationStyle(JRootPane.PLAIN_DIALOG)`), resulting in two separate title bars.

The new behaviour is found in the `SingleTitleBarDialogFloatingContainer` class which overrides the `updateUndecorated()` method responsible for setting the decorations on these dialogs. It always sets the dialog itself as undecorated and will set the root pane as decorated when decorations are needed.

I could just as well have done the opposite (decorate the dialog itself, not the root pane), but I preferred these aesthetics and also liked that the docked frames would be a distinguished from "normal" dialogs. For reference, this is what it would have looked like (compare with images further below):
![image](https://github.com/RPTools/maptool/assets/7492219/a6650471-4de7-4f1a-a34a-b496f7aed4c6)

### Possible Drawbacks

There is some inconsistency with decorations on different systems, so it's possible this particular solution could run afoul of some system's expectations.

### Documentation Notes

Prior to MT 1.14.0, docking floating frames together would result in multiple title bars:
![image](https://github.com/RPTools/maptool/assets/7492219/f4222aa2-191b-4097-9e27-fdd63c52ba66)

Now that no longer happens, so docking just has the one title bar:
![image](https://github.com/RPTools/maptool/assets/7492219/14ef13a1-88c2-48f4-ac25-5c5da471718d)

### Release Notes

- Fixed a bug where docking floating frames together would create a dialog with multiple title bars.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4264)
<!-- Reviewable:end -->
