### PR TITLE
Add move up / move down buttons for token properties

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -104,6 +104,14 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     return (JButton) getComponent("typeDeleteButton");
   }
 
+  public JButton getPropertyMoveUpButton() {
+    return (JButton) getComponent("propertyMoveUpButton");
+  }
+
+  public JButton getPropertyMoveDownButton() {
+    return (JButton) getComponent("propertyMoveDownButton");
+  }
+
   public JButton getPropertyAddButton() {
     return (JButton) getComponent("propertyAddButton");
   }
@@ -219,6 +227,40 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     button.setEnabled(false);
   }
 
+  public void initPropertyMoveUpButton() {
+    var button = getPropertyMoveUpButton();
+    button.addActionListener(
+        l -> {
+          var selectedRow = getTokenPropertiesTable().getSelectedRow();
+          if (selectedRow <= 0) {
+            return;
+          }
+
+          var model = getTokenPropertiesTableModel();
+          model.movePropertyUp(selectedRow);
+          --selectedRow;
+          getTokenPropertiesTable().setRowSelectionInterval(selectedRow, selectedRow);
+        });
+    button.setEnabled(false);
+  }
+
+  public void initPropertyMoveDownButton() {
+    var button = getPropertyMoveDownButton();
+    button.addActionListener(
+        l -> {
+          var selectedRow = getTokenPropertiesTable().getSelectedRow();
+          if (selectedRow < 0 || selectedRow >= getTokenPropertiesTable().getRowCount() - 1) {
+            return;
+          }
+
+          var model = getTokenPropertiesTableModel();
+          model.movePropertyDown(selectedRow);
+          ++selectedRow;
+          getTokenPropertiesTable().setRowSelectionInterval(selectedRow, selectedRow);
+        });
+    button.setEnabled(false);
+  }
+
   public void initPropertyAddButton() {
     var button = getPropertyAddButton();
     button.addActionListener(
@@ -256,8 +298,17 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
                 return;
               }
 
-              var button = getPropertyDeleteButton();
-              button.setEnabled(getTokenPropertiesTable().getSelectedRow() >= 0);
+              var deleteButton = getPropertyDeleteButton();
+              deleteButton.setEnabled(getTokenPropertiesTable().getSelectedRow() >= 0);
+
+              var moveUpButton = getPropertyMoveUpButton();
+              moveUpButton.setEnabled(getTokenPropertiesTable().getSelectedRow() > 0);
+
+              var moveDownButton = getPropertyMoveDownButton();
+              // Note: this works even if selection is empty (getSelectedRow() == -1).
+              moveDownButton.setEnabled(
+                  getTokenPropertiesTable().getSelectedRow()
+                      < getTokenPropertiesTable().getRowCount() - 1);
             });
     propertyTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     propertyTable.getColumnModel().getColumn(0).setPreferredWidth(80);

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanelView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanelView.form
@@ -162,6 +162,37 @@
           <text resource-bundle="net/rptools/maptool/language/i18n" key="TokenPropertiesPanel.label.statSheet"/>
         </properties>
       </component>
+      <grid id="8e1f5" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="2" column="6" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="5" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="b0c00" class="javax.swing.JButton">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="MovePropertyUp"/>
+              <name value="propertyMoveUpButton"/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="Button.up"/>
+            </properties>
+          </component>
+          <component id="f04b7" class="javax.swing.JButton">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="MovePropertyDown"/>
+              <name value="propertyMoveDownButton"/>
+              <selected value="false"/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="Button.down"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
 </form>

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesTableModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesTableModel.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.ui.campaignproperties;
 
 import java.io.Serial;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,6 +175,28 @@ public class TokenPropertiesTableModel extends AbstractTableModel {
     var properties = tokenTypeMap.get(tokenType);
     properties.remove(selectedRow);
     fireTableRowsDeleted(selectedRow, selectedRow);
+  }
+
+  public void movePropertyUp(int selectedRow) {
+    var properties = tokenTypeMap.get(tokenType);
+    if (selectedRow <= 0 || selectedRow >= properties.size()) {
+      // Either already at the top or a nonsense index.
+      throw new ArrayIndexOutOfBoundsException(selectedRow);
+    }
+
+    Collections.swap(properties, selectedRow - 1, selectedRow);
+    fireTableRowsUpdated(selectedRow - 1, selectedRow);
+  }
+
+  public void movePropertyDown(int selectedRow) {
+    var properties = tokenTypeMap.get(tokenType);
+    if (selectedRow < 0 || selectedRow >= properties.size() - 1) {
+      // Either already at the bottom or a nonsense index.
+      throw new ArrayIndexOutOfBoundsException(selectedRow);
+    }
+
+    Collections.swap(properties, selectedRow, selectedRow + 1);
+    fireTableRowsUpdated(selectedRow, selectedRow + 1);
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #3149

### Description of the Change

Adds a "Move Up" and a "Move Down" button to the Token Properties panel. These buttons are enabled whenever a token property is selected, and just move the row up or down. Behaviour is like the equivalent buttons for the State panel.

### Possible Drawbacks

Should be none. Haven't really thought these changes through though.

### Documentation Notes

To add to #4084:

The "Move Up" and "Move Down" buttons can be used to reorder the token properties:
![image](https://github.com/RPTools/maptool/assets/7492219/e01c239b-54dd-48bb-98e8-4909515f43f4)

### Release Notes

- Add "Move Up" / "Move Down" buttons for reordering token properties.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4271)
<!-- Reviewable:end -->
