### PR TITLE
new functions - getMapVision(), setMapVision("off/day/night")

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -63,7 +63,9 @@ public class MapFunctions extends AbstractFunction {
         "copyMap",
         "createMap",
         "getMapName",
-        "setMapSelectButton");
+        "setMapSelectButton",
+        "getMapVision",
+        "setMapVision");
   }
 
   public static MapFunctions getInstance() {
@@ -397,6 +399,29 @@ public class MapFunctions extends AbstractFunction {
       return (MapTool.getFrame().getToolbarPanel().getMapselect().isVisible()
           ? BigDecimal.ONE
           : BigDecimal.ZERO);
+    } else if ("setMapVision".equalsIgnoreCase(functionName)) {
+      FunctionUtil.blockUntrustedMacro(functionName);
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
+      Zone currentZR = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+      if (parameters.get(0).toString().equalsIgnoreCase("off")) {
+        MapTool.serverCommand().setVisionType(currentZR.getId(), Zone.VisionType.OFF);
+      } else if (parameters.get(0).toString().equalsIgnoreCase("day")) {
+        MapTool.serverCommand().setVisionType(currentZR.getId(), Zone.VisionType.DAY);
+      } else if (parameters.get(0).toString().equalsIgnoreCase("night")) {
+        MapTool.serverCommand().setVisionType(currentZR.getId(), Zone.VisionType.NIGHT);
+      }
+      /*  else if (!parameters.get(0).toString().isBlank()) {
+        throw new ParameterException(
+            I18N.getText("macro.function.general.argumentTypeInvalid", functionName));
+      }  */
+      if (currentZR == null) {
+        throw new ParserException(I18N.getText("macro.function.map.none", functionName));
+      }
+      return "";
+    } else if ("getMapVision".equalsIgnoreCase(functionName)) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 0);
+      ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
+      return currentZR.getZone().getVisionType().toString();
     }
 
     throw new ParserException(I18N.getText("macro.function.general.unknownFunction", functionName));


### PR DESCRIPTION
Requested feature

It was requested here: https://discord.com/channels/296230822262865920/296657960720007169/950558437991911475 

### Description of the Change
Two must be trusted functions
`getMapVision()` will return the current Map Vision setting
`setMapVision("off,day,night")` will set the Map Vision setting for the current map

### Possible Drawbacks
I'm not aware of any drawbacks, risks, or introduced issues

### Release Notes
Examples:
- `[getMapVision()]`
Will return `off` or `day` or `night`

- `[setMapVision("day")]`
Will set map vision to `day`
- `[setMapVision("off")]`
Will set map vision to `off`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4276)
<!-- Reviewable:end -->
