### PR TITLE
ignore path not found exception on json.path.put to retain compatability

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -18,6 +18,7 @@ import com.google.gson.*;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 import java.math.BigDecimal;
@@ -886,7 +887,12 @@ public class JSONMacroFunctions extends AbstractFunction {
   private JsonElement jsonPathPut(JsonElement json, String path, String key, Object info) {
     Object value = asJsonElement(info);
 
-    return JsonPath.using(jaywayConfig).parse(shallowCopy(json)).put(path, key, value).json();
+    try {
+      return JsonPath.using(jaywayConfig).parse(shallowCopy(json)).put(path, key, value).json();
+    } catch (PathNotFoundException ex) {
+      // Return original json, this is to preserve backwards compatability pre library update
+      return json;
+    }
   }
 
   /**


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #4123

### Description of the Change
The upgrade of json path library introduced an incompatibility for json path put, previously a put with a path that didn't exist ignored the put silently, now it throws an exception. This change captures the exception and returns the original object to preserve MTScript compatibility


### Possible Drawbacks

Should be none


### Documentation Notes
Fix json path put issue introduced by library upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4280)
<!-- Reviewable:end -->
