### PR TITLE
Remove child node enumeration when registering HTML5 event listeners

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -153,43 +153,6 @@ public class HTMLWebViewManager {
             target.addEventListener("click", HTMLWebViewManager.this::getDataAndSubmit, true);
           }
         }
-
-        // Add listeners to the node's descendant as they don't trigger mutation observer.
-        NodeList nodeList;
-
-        // Add event handlers for <a> hyperlinks.
-        nodeList = addedNode.getElementsByTagName("a");
-        for (int i = 0; i < nodeList.getLength(); i++) {
-          EventTarget node = (EventTarget) nodeList.item(i);
-          node.addEventListener("click", HTMLWebViewManager.this::fixHref, true);
-        }
-
-        // Add event handlers for hyperlinks for maps.
-        nodeList = addedNode.getElementsByTagName("area");
-        for (int i = 0; i < nodeList.getLength(); i++) {
-          EventTarget node = (EventTarget) nodeList.item(i);
-          node.addEventListener("click", HTMLWebViewManager.this::fixHref, true);
-        }
-
-        // Set the "submit" handler to get the data on submission not based on buttons
-        nodeList = addedNode.getElementsByTagName("form");
-        for (int i = 0; i < nodeList.getLength(); i++) {
-          EventTarget target = (EventTarget) nodeList.item(i);
-          target.addEventListener("submit", HTMLWebViewManager.this::getDataAndSubmit, true);
-        }
-
-        // Set the "submit" handler to get the data on submission based on input
-        nodeList = addedNode.getElementsByTagName("input");
-        for (int i = 0; i < nodeList.getLength(); i++) {
-          EventTarget target = (EventTarget) nodeList.item(i);
-          target.addEventListener("click", HTMLWebViewManager.this::getDataAndSubmit, true);
-        }
-        // Set the "submit" handler to get the data on submission based on button
-        nodeList = addedNode.getElementsByTagName("button");
-        for (int i = 0; i < nodeList.getLength(); i++) {
-          EventTarget target = (EventTarget) nodeList.item(i);
-          target.addEventListener("click", HTMLWebViewManager.this::getDataAndSubmit, true);
-        }
       }
     }
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves on PR #4259 for bug #4048

### Description of the Change

Our JS `MutationObserver` observes all added nodes, so `HTMLWebViewManager::handleAddedNode()` will be called for every node in the document. Thus we don't need to "discover" child nodes ourselves as they will be directly handled by `handleAddedNode`.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4285)
<!-- Reviewable:end -->
