### PR TITLE
Convert MTScript input numbers and output objects

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroJavaScriptBridge.java
@@ -206,6 +206,13 @@ public class MacroJavaScriptBridge extends AbstractFunction implements DefinesSp
           return jPrim.getAsString();
         }
       }
+    } else if (obj instanceof BigDecimal) {
+      BigDecimal bd = (BigDecimal) obj;
+      try {
+        return Long.valueOf(bd.longValueExact());
+      } catch (ArithmeticException e) {
+        return Double.valueOf(bd.doubleValue());
+      }
     }
     return obj;
   }

--- a/src/main/java/net/rptools/maptool/client/script/javascript/JSMacro.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/JSMacro.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.script.javascript;
 
+import com.google.gson.*;
 import java.util.*;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.*;
@@ -25,6 +26,7 @@ import net.rptools.parser.function.AbstractFunction;
 import org.graalvm.polyglot.*;
 
 public class JSMacro extends AbstractFunction {
+  private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
   private static JSMacro instance = new JSMacro();
   private static HashMap<String, JSAPIRegisteredMacro> macros = new HashMap<>();
 
@@ -60,7 +62,11 @@ public class JSMacro extends AbstractFunction {
       if (ret instanceof Value val) {
         return MacroJavaScriptBridge.getInstance().ValueToMTScriptType(val, new ArrayList());
       }
-      return MacroJavaScriptBridge.getInstance().HostObjectToMTScriptType(ret, new ArrayList());
+      Object r = MacroJavaScriptBridge.getInstance().HostObjectToMTScriptType(ret, new ArrayList());
+      if (r instanceof List || r instanceof AbstractMap) {
+        return gson.toJson(r);
+      }
+      return r;
     }
     return "";
   }


### PR DESCRIPTION
MTScript numbers are BigDecimals, so require conversion to a number type that graal Values can contain.

Objects returned from JavaScript functions are PolyglotMaps, which are Host Objects instead of subclasses of Value and get turned into a HashMap,
which needs to be serialized to JSON to be usable from MTScript.

This allows numbers to be passed to JavaScript macros without serializing them to Strings first and allows them to return objects without serializing to JSON first.

### Identify the Bug or Feature request

fixes #4290 

### Description of the Change

This converts the BigDecimal values that are passed to JavaScript into Long or Double so that they become a JavaScript Number instead of an Object, and serializes returned Objects to JSON.

### Possible Drawbacks

I am not sufficiently familiar with the codebase to know whether the changes should be elsewhere.

It may be desirable for returned objects to be left unmodified if they are going to be passed back into other JavaScript functions, but they appear to be translated into HashMaps already, so this would already not work.

### Release Notes

* Fixed numbers being passed to JavaScript macro functions.
* Objects returned from JavaScript macro functions are serialized as JSON.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4291)
<!-- Reviewable:end -->
