### PR TITLE
Extended getTokenByID to search other Maps

### DIFF
--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -177,4 +177,11 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   public boolean isOwner(String playerID) {
     return this.token.isOwner(playerID);
   }
+
+  @HostAccess.Export
+  public boolean isOnCurrentMap() {
+    Token findToken =
+        MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(this.getId()));
+    return this.token == findToken;
+  }
 }

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
@@ -101,7 +101,7 @@ public class JSAPITokens implements MapToolJSAPIInterface {
       List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
       for (ZoneRenderer zr : zrenderers) {
         findToken = zr.getZone().resolveToken(uuid);
-        if(findToken!=null){
+        if (findToken != null) {
           token = new JSAPIToken(findToken);
           break;
         }
@@ -118,12 +118,11 @@ public class JSAPITokens implements MapToolJSAPIInterface {
   public JSAPIToken getMapTokenByID(String uuid) {
     JSAPIToken token = null;
     Token findToken =
-            MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(uuid));
+        MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(uuid));
     if (findToken != null
-            && (JSScriptEngine.inTrustedContext() || token.isOwner(MapTool.getPlayer().getName()))) {
+        && (JSScriptEngine.inTrustedContext() || token.isOwner(MapTool.getPlayer().getName()))) {
       token = new JSAPIToken(findToken);
     }
     return token;
   }
 }
-

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
@@ -19,6 +19,7 @@ import java.util.List;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.script.javascript.*;
 import net.rptools.maptool.client.ui.zone.ZoneRenderer;
+import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Token;
 import org.graalvm.polyglot.HostAccess;
 
@@ -91,8 +92,23 @@ public class JSAPITokens implements MapToolJSAPIInterface {
 
   @HostAccess.Export
   public JSAPIToken getTokenByID(String uuid) {
-    JSAPIToken token = new JSAPIToken(uuid);
-    if (JSScriptEngine.inTrustedContext() || token.isOwner(MapTool.getPlayer().getName())) {
+    JSAPIToken token = null;
+    Token findToken =
+        MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(uuid));
+    if (findToken != null) {
+      token = new JSAPIToken(findToken);
+    } else {
+      List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
+      for (ZoneRenderer zr : zrenderers) {
+        findToken = zr.getZone().resolveToken(uuid);
+        if(findToken!=null){
+          token = new JSAPIToken(findToken);
+          break;
+        }
+      }
+    }
+    if (token != null
+        && (JSScriptEngine.inTrustedContext() || token.isOwner(MapTool.getPlayer().getName()))) {
       return token;
     }
     return null;

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
@@ -113,4 +113,17 @@ public class JSAPITokens implements MapToolJSAPIInterface {
     }
     return null;
   }
+
+  @HostAccess.Export
+  public JSAPIToken getMapTokenByID(String uuid) {
+    JSAPIToken token = null;
+    Token findToken =
+            MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(uuid));
+    if (findToken != null
+            && (JSScriptEngine.inTrustedContext() || token.isOwner(MapTool.getPlayer().getName()))) {
+      token = new JSAPIToken(findToken);
+    }
+    return token;
+  }
 }
+


### PR DESCRIPTION
… for tokenID if not found on current Map.

### Identify the Bug or Feature request
Closes #3069

### Description of the Change
Extends the functionality of the JS MapTool.Tokens.getTokenByID(id) function to attempt a search of other maps if token with id not found on the current map.

### Possible Drawbacks
Not great if token on the last map and there's a large quantity of maps.

### Documentation Notes
Attempts to get token from current map, if not found, searches all maps for token, returning null if not found at all.

### Release Notes
 - Fixed an issue where MapTool.Tokens.getTokenByID(id) did not return token with id.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4296)
<!-- Reviewable:end -->
