### PR TITLE
JS API setProperty() fix.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -134,7 +134,6 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     String playerId = MapTool.getPlayer().getName();
     if (trusted || token.isOwner(playerId)) {
       this.token.setProperty(name, value.toString());
-      // this.map.putToken(this.token);
       MapTool.serverCommand()
           .updateTokenProperty(token, Token.Update.setProperty, name, value.toString());
     }
@@ -192,7 +191,6 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     return this.token == findToken;
   }
 
-  @HostAccess.Export
   public void setMap(Zone m) {
     this.map = m;
   }

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -21,6 +21,7 @@ import net.rptools.maptool.client.script.javascript.*;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Zone;
 import net.rptools.parser.ParserException;
 import org.graalvm.polyglot.HostAccess;
 
@@ -33,6 +34,7 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   private final Token token;
   private Set<String> names;
   private Iterator<String> names_iter;
+  private Zone map;
 
   public JSAPIToken(Token token) {
     this.token = token;
@@ -130,6 +132,7 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     String playerId = MapTool.getPlayer().getName();
     if (trusted || token.isOwner(playerId)) {
       this.token.setProperty(name, value.toString());
+      this.map.putToken(this.token);
     }
   }
 
@@ -183,5 +186,15 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     Token findToken =
         MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(this.getId()));
     return this.token == findToken;
+  }
+
+  @HostAccess.Export
+  public void setMap(Zone m) {
+    this.map = m;
+  }
+
+  @HostAccess.Export
+  public String getMapName() {
+    return this.map.getDisplayName();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -60,6 +60,7 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     String playerId = MapTool.getPlayer().getName();
     if (trusted || token.isOwner(playerId)) {
       token.setNotes(notes);
+      MapTool.serverCommand().updateTokenProperty(token, Token.Update.setNotes, notes);
     }
   }
 
@@ -79,6 +80,7 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     String playerId = MapTool.getPlayer().getName();
     if (trusted || token.isOwner(playerId)) {
       token.setName(name);
+      MapTool.serverCommand().updateTokenProperty(token, Token.Update.setName, name);
     }
   }
 
@@ -132,7 +134,9 @@ public class JSAPIToken implements MapToolJSAPIInterface {
     String playerId = MapTool.getPlayer().getName();
     if (trusted || token.isOwner(playerId)) {
       this.token.setProperty(name, value.toString());
-      this.map.putToken(this.token);
+      // this.map.putToken(this.token);
+      MapTool.serverCommand()
+          .updateTokenProperty(token, Token.Update.setProperty, name, value.toString());
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPITokens.java
@@ -97,12 +97,14 @@ public class JSAPITokens implements MapToolJSAPIInterface {
         MapTool.getFrame().getCurrentZoneRenderer().getZone().getToken(new GUID(uuid));
     if (findToken != null) {
       token = new JSAPIToken(findToken);
+      token.setMap(MapTool.getFrame().getCurrentZoneRenderer().getZone());
     } else {
       List<ZoneRenderer> zrenderers = MapTool.getFrame().getZoneRenderers();
       for (ZoneRenderer zr : zrenderers) {
         findToken = zr.getZone().resolveToken(uuid);
         if (findToken != null) {
           token = new JSAPIToken(findToken);
+          token.setMap(zr.getZone());
           break;
         }
       }
@@ -122,6 +124,7 @@ public class JSAPITokens implements MapToolJSAPIInterface {
     if (findToken != null
         && (JSScriptEngine.inTrustedContext() || token.isOwner(MapTool.getPlayer().getName()))) {
       token = new JSAPIToken(findToken);
+      token.setMap(MapTool.getFrame().getCurrentZoneRenderer().getZone());
     }
     return token;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #4237


### Description of the Change
Resolves the Server/Client inconsistency when server updates a token via one of the JS API `setName()`, `setNotes()`, or `setProperty()`.

### Possible Drawbacks
Needs some more testing, and commentary by someone who understands the client<->server communication better.

### Documentation Notes
Not much to really document - issue "how to reproduce" shows the problem fairly well - and now it shouldn't exist.

### Release Notes
- Fixed an issue where server token changes via JS `setName()`, `setNotes()`, or `setProperty()` didn't propagate to clients.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4301)
<!-- Reviewable:end -->
