### PR TITLE
Add zipfs to the jlink package.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,8 @@ runtime {
                'jdk.unsupported.desktop',
                'jdk.xml.dom',
                'jdk.crypto.cryptoki',
-               'jdk.crypto.ec'
+               'jdk.crypto.ec',
+               'jdk.zipfs'
     ]
 
 
@@ -231,7 +232,9 @@ runtime {
                    "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
                    "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED",
                    "--add-opens=java.desktop/javax.swing=ALL-UNNAMED","--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED",
-                   "--add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED"]
+                   "--add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED",
+                   "--add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"
+          ]
 
         imageOptions = []
         imageName = project.name + developerRelease

--- a/build.gradle
+++ b/build.gradle
@@ -232,8 +232,7 @@ runtime {
                    "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
                    "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED",
                    "--add-opens=java.desktop/javax.swing=ALL-UNNAMED","--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED",
-                   "--add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED",
-                   "--add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED"
+                   "--add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED"
           ]
 
         imageOptions = []

--- a/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import net.rptools.maptool.client.AppActions;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.events.MapToolEventBus;

--- a/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 public class LibraryManager {
 
   /** Class for logging messages. */
-  private static final Logger log = LogManager.getLogger(AppActions.class);
+  private static final Logger log = LogManager.getLogger(LibraryManager.class);
 
   /** The reserved library name prefixes. */
   private static final Set<String> RESERVED_PREFIXES =

--- a/src/main/java/net/rptools/maptool/model/library/builtin/BuiltInLibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/BuiltInLibraryManager.java
@@ -138,7 +138,6 @@ public class BuiltInLibraryManager {
       return;
     }
 
-    MapTool.showInformation(uri.toString());
     try (var fs = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
       var resourcePath = fs.getPath(ClassPathAddOnLibrary.BUILTIN_LIB_CLASSPATH_DIR);
       var libs =

--- a/src/main/java/net/rptools/maptool/model/library/builtin/BuiltInLibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/BuiltInLibraryManager.java
@@ -138,6 +138,7 @@ public class BuiltInLibraryManager {
       return;
     }
 
+    MapTool.showInformation(uri.toString());
     try (var fs = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
       var resourcePath = fs.getPath(ClassPathAddOnLibrary.BUILTIN_LIB_CLASSPATH_DIR);
       var libs =


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #4307
There is also a small fix to LibraryManager to use the correct class in the logger, this was not causing the error but was the first fix I tried before stumbling on the real issue, its small enough fix that I left it in this

### Description of the Change
Add js.zipfs to the included modules for jlink 

### Possible Drawbacks
Shoudld be none

### Documentation Notes
Added js.zipfs to the included modules for jlink 


### Release Notes
- Added js.zipfs to the included modules for jlink

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4308)
<!-- Reviewable:end -->
