### PR TITLE
fix for statsheet error when renaming property type

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -203,7 +203,6 @@ public class CampaignPropertiesDialog extends JDialog {
           .forEach(
               (o, n) -> {
                 campaign.renameTokenTypes(o, n);
-                System.out.println("Renaming " + o + " to " + n);
               });
       MapTool.getFrame().hideGlassPane();
       copyUIToCampaign();

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -182,7 +182,6 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
           var type = (String) getTokenTypeList().getSelectedValue();
           if (type != null) {
             JPanel renameToPanel = new JPanel();
-            // renameToPanel.setLayout(new BoxLayout(renameToPanel, BoxLayout.PAGE_AXIS));
             JComboBox<String> types =
                 new JComboBox<>(
                     tokenTypeMap.keySet().stream()
@@ -332,6 +331,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
             var oldName = (String) ttList.getSelectedValue();
             var newName = field.getText();
             tokenTypeMap.put(newName, tokenTypeMap.remove(oldName));
+            tokenTypeStatSheetMap.put(newName, tokenTypeStatSheetMap.remove(oldName));
             ttList.setSelectedValue(newName, true);
             updateExistingTokenTypes(oldName, newName);
           }

--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -190,7 +190,11 @@ public class CampaignProperties {
    */
   public void setTokenTypeDefaultStatSheet(
       String propertyType, StatSheetProperties statSheetProperties) {
-    tokenTypeStatSheetMap.put(propertyType, statSheetProperties);
+    if (statSheetProperties == null) {
+      tokenTypeStatSheetMap.remove(propertyType);
+    } else {
+      tokenTypeStatSheetMap.put(propertyType, statSheetProperties);
+    }
   }
 
   public Map<String, SightType> getSightTypeMap() {


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #4293


### Description of the Change
Fixes a problem copying statsheets when a property type is renamed.


### Possible Drawbacks
Should be none

### Documentation Notes
Fixes a problem copying statsheets when a property type is renamed.


### Release Notes
- Fixes a problem copying statsheets when a property type is renamed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4309)
<!-- Reviewable:end -->
