### PR TITLE
Feature devmode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ sourceSets {
 run {
     args = ['-v=' + appSemVer]
     applicationDefaultJvmArgs = ["-Xss8M", "-Dsun.java2d.d3d=false", "-Dsentry.environment=Development", "-Dfile.encoding=UTF-8",
-                                 "-Dpolyglot.engine.WarnInterpreterOnly=false",
+                                 "-Dpolyglot.engine.WarnInterpreterOnly=false","-DRUN_FROM_IDE=true",
                                  "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
                                  "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
                                  "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
@@ -217,7 +217,8 @@ runtime {
                'jdk.unsupported.desktop',
                'jdk.xml.dom',
                'jdk.crypto.cryptoki',
-               'jdk.crypto.ec'
+               'jdk.crypto.ec',
+               'jdk.zipfs'
     ]
 
 

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -741,10 +741,7 @@ public class MapTool {
   }
 
   public static boolean isDevelopment() {
-    return "DEVELOPMENT".equals(version)
-        || "@buildNumber@".equals(version)
-        || "0.0.1".equals(version)
-        || (version != null && version.startsWith("SNAPSHOT"));
+    return System.getProperty("RUN_FROM_IDE") != null;
   }
 
   public static ServerPolicy getServerPolicy() {


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #4310


### Description of the Change

We now no longer check if the version name contains SNAPSHOT or something but tell MT with a -DRUN_IN_IDE=true switch if it runs in a IDE. This way installed versions never think themselves as "in development."


### Possible Drawbacks
Unless there is a reason for installed snapshots to know that they are "in development": none.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4311)
<!-- Reviewable:end -->
