### PR TITLE
fix overeager parser preprocessor

### DIFF
--- a/src/main/java/net/rptools/dicelib/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/dicelib/expression/ExpressionParser.java
@@ -215,8 +215,8 @@ public class ExpressionParser {
 
   private final List<Pair<Pattern, String>> preprocessPatterns =
       List.of(
-          new Pair<>(Pattern.compile("([A-z]+)!\"([^\"]*)\""), "advancedRoll('$1', " + "'$2')"),
-          new Pair<>(Pattern.compile("([A-z]+)!'([^']*)'"), "advancedRoll('$1', " + "'$2')"));
+          new Pair<>(Pattern.compile("^([A-z]+)!\"([^\"]*)\"$"), "advancedRoll('$1', " + "'$2')"),
+          new Pair<>(Pattern.compile("^([A-z]+)!'([^']*)'$"), "advancedRoll('$1', " + "'$2')"));
 
   public ExpressionParser() {
     this(DICE_PATTERNS);
@@ -314,9 +314,10 @@ public class ExpressionParser {
    * @return The pre-processed expression
    */
   private String preProcess(String expression) {
+    var trimmed = expression.trim();
     for (Pair<Pattern, String> p : preprocessPatterns) {
-      if (p.getValue0().matcher(expression).find()) {
-        return p.getValue0().matcher(expression).replaceAll(p.getValue1());
+      if (p.getValue0().matcher(trimmed).find()) {
+        return p.getValue0().matcher(trimmed).replaceAll(p.getValue1());
       }
     }
     return expression;


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #4312


### Description of the Change
The change in PR #4304 was a bit overeager when trying to preprocess advanced rolls. This change ensures that the preprocessing will only occur when there is nothing else in the expression (other than white space).


### Possible Drawbacks

There should be none, as the result can't sensibly be assigned to a variable or take part in arithmetic operations etc.

### Documentation Notes
Fixes problems with if and strings that end with a letter and !

### Release Notes
- Fixes problems with if and strings that end with a letter and !

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4313)
<!-- Reviewable:end -->
