### PR TITLE
Apply compat fix for json.path.set and json.path.delete as well

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -872,7 +872,12 @@ public class JSONMacroFunctions extends AbstractFunction {
    * @return The resulting json data.
    */
   private JsonElement jsonPathDelete(JsonElement json, String path) {
-    return JsonPath.using(jaywayConfig).parse(shallowCopy(json)).delete(path).json();
+    try {
+      return JsonPath.using(jaywayConfig).parse(shallowCopy(json)).delete(path).json();
+    } catch (PathNotFoundException ex) {
+      // Return original json, this is to preserve backwards compatability pre library update
+      return json;
+    }
   }
 
   /**
@@ -906,7 +911,12 @@ public class JSONMacroFunctions extends AbstractFunction {
   private JsonElement jsonPathSet(JsonElement json, String path, Object info) {
     Object value = asJsonElement(info);
 
-    return JsonPath.using(jaywayConfig).parse(shallowCopy(json)).set(path, value).json();
+    try {
+      return JsonPath.using(jaywayConfig).parse(shallowCopy(json)).set(path, value).json();
+    } catch (PathNotFoundException ex) {
+      // Return original json, this is to preserve backwards compatability pre library update
+      return json;
+    }
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request
Applies fix for #4123 to set and delete as well


### Description of the Change
Ignore the missing path for json.path.set and json.path.delete to maintain compatibility with previous versions after the changes to the library.


### Possible Drawbacks
Should be none

### Documentation Notes
Ignore the missing path for json.path.set and json.path.delete to maintain compatibility with previous versions after the changes to the library.


### Release Notes
- Ignore the missing path for json.path.set and json.path.delete to maintain compatibility with previous versions after the changes to the library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4317)
<!-- Reviewable:end -->
