### PR TITLE
onChangeMap add-on compliance, output added

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -39,7 +39,6 @@ import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 
 public class MapFunctions extends AbstractFunction {
-  public static final String ON_CHANGE_MAP_CALLBACK = "onChangeMap";
   private static final MapFunctions instance = new MapFunctions();
 
   private MapFunctions() {

--- a/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
+++ b/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptSyntax.java
@@ -22,6 +22,7 @@ import net.rptools.maptool.client.MapToolExpressionParser;
 import net.rptools.maptool.client.functions.DefinesSpecialVariables;
 import net.rptools.maptool.client.functions.TokenMoveFunctions;
 import net.rptools.maptool.client.functions.UserDefinedMacroFunctions;
+import net.rptools.maptool.events.ZoneLoadedListener;
 import net.rptools.maptool.model.InitiativeList;
 import net.rptools.maptool.model.TokenProperty;
 import net.rptools.parser.function.Function;
@@ -97,9 +98,9 @@ public class MapToolScriptSyntax extends MapToolScriptTokenMaker {
 
   static String[] RESERVED_WORDS_2 = {
     "onCampaignLoad",
-    "onChangeMap",
     "onChangeSelection",
     "onMouseOverEvent",
+    ZoneLoadedListener.ON_CHANGE_MAP_CALLBACK,
     TokenMoveFunctions.ON_MULTIPLE_TOKENS_MOVED_COMPLETE_CALLBACK,
     TokenMoveFunctions.ON_TOKEN_MOVE_COMPLETE_CALLBACK,
     InitiativeList.ON_INITIATIVE_CHANGE_VETOABLE_MACRO_CALLBACK,

--- a/src/main/java/net/rptools/maptool/events/ZoneLoadedListener.java
+++ b/src/main/java/net/rptools/maptool/events/ZoneLoadedListener.java
@@ -40,19 +40,19 @@ public class ZoneLoadedListener {
     ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
     try {
       var libs = new LibraryManager().getLegacyEventTargets(ON_CHANGE_MAP_CALLBACK).get();
-      if (!libs.isEmpty()) {
-        for (Library handler : libs) {
-          try {
-            String libraryNamespace = handler.getNamespace().get();
-            EventMacroUtil.callEventHandler(
-                ON_CHANGE_MAP_CALLBACK,
-                libraryNamespace,
-                currentZR.getZone().getId().toString() + "," + currentZR.getZone().toString(),
-                null,
-                Collections.emptyMap());
-          } catch (InterruptedException | ExecutionException e) {
-            throw new AssertionError("Error retrieving library namespace");
-          }
+      if (libs.isEmpty()) return;
+      for (Library handler : libs) {
+        try {
+          String libraryNamespace = handler.getNamespace().get();
+          EventMacroUtil.callEventHandler(
+              ON_CHANGE_MAP_CALLBACK,
+              libraryNamespace,
+              currentZR.getZone().getId().toString() + "," + currentZR.getZone().toString(),
+              null,
+              Collections.emptyMap());
+        } catch (InterruptedException | ExecutionException e) {
+          LOGGER.error(I18N.getText("library.error.notFound"), e);
+          throw new AssertionError("Error retrieving library namespace");
         }
       }
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/net/rptools/maptool/events/ZoneLoadedListener.java
+++ b/src/main/java/net/rptools/maptool/events/ZoneLoadedListener.java
@@ -40,14 +40,16 @@ public class ZoneLoadedListener {
     ZoneRenderer currentZR = MapTool.getFrame().getCurrentZoneRenderer();
     try {
       var libs = new LibraryManager().getLegacyEventTargets(ON_CHANGE_MAP_CALLBACK).get();
-      if (libs.isEmpty()) return;
+      if (libs.isEmpty()) {
+        return;
+      }
       for (Library handler : libs) {
         try {
           String libraryNamespace = handler.getNamespace().get();
           EventMacroUtil.callEventHandler(
               ON_CHANGE_MAP_CALLBACK,
               libraryNamespace,
-              currentZR.getZone().getId().toString() + "," + currentZR.getZone().toString(),
+              currentZR.getZone().getId().toString(),
               null,
               Collections.emptyMap());
         } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/net/rptools/maptool/events/ZoneLoadedListener.java
+++ b/src/main/java/net/rptools/maptool/events/ZoneLoadedListener.java
@@ -14,8 +14,6 @@
  */
 package net.rptools.maptool.events;
 
-import static net.rptools.maptool.client.functions.MapFunctions.ON_CHANGE_MAP_CALLBACK;
-
 import com.google.common.eventbus.Subscribe;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
@@ -31,6 +29,7 @@ import org.apache.log4j.Logger;
 
 public class ZoneLoadedListener {
   private static final Logger LOGGER = LogManager.getLogger(EventMacroUtil.class);
+  public static final String ON_CHANGE_MAP_CALLBACK = "onChangeMap";
 
   public ZoneLoadedListener() {
     new MapToolEventBus().getMainEventBus().register(this);


### PR DESCRIPTION
### Identify the Bug or Feature request
Feature #1574 

Initial creation of `onChangeMap` was not add-on compliant.
This also resolves a false/positive event trigger when entering the menu Map - Edit Map dialog - Cancel (the event will still trigger if variables are changed and selecting OK).
### Description of the Change
Compliance, tested with add-ons
Added output `mapID`,`mapName`
### Possible Drawbacks
No additional drawbacks from prior PR

### Release Notes

Any macro named `onChangeMap` located on a library token will execute when the map is changed.
The macro will also receive the `mapID` and `mapName` through `macro.args`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4318)
<!-- Reviewable:end -->
