### PR TITLE
Disable developer options by default

### DIFF
--- a/src/main/java/net/rptools/maptool/client/DeveloperOptions.java
+++ b/src/main/java/net/rptools/maptool/client/DeveloperOptions.java
@@ -18,13 +18,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.prefs.Preferences;
 import net.rptools.maptool.language.I18N;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class DeveloperOptions {
-  private static final Logger log = LogManager.getLogger(DeveloperOptions.class);
   private static final Preferences prefs =
-      Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs");
+      Preferences.userRoot().node(AppConstants.APP_NAME + "/dev");
 
   public enum Toggle {
     /**
@@ -57,7 +54,7 @@ public class DeveloperOptions {
     }
 
     public boolean isEnabled() {
-      return prefs.getBoolean(key, true);
+      return prefs.getBoolean(key, false);
     }
 
     public void setEnabled(boolean enabled) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #4061, fixing an issue with #4063

### Description of the Change

The default value for the preference lookup has been fixed to be `false` so that the devleoper options are by default considered disabled.

The developer options are also in a different node so they stay separate from regular application preferences. This will make it easier to manipulate during testing without messing with all the other preferences.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4329)
<!-- Reviewable:end -->
