### PR TITLE
Workaround for windows duplicate file issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,8 @@ sourceSets {
 run {
     args = ['-v=' + appSemVer]
     applicationDefaultJvmArgs = ["-Xss8M", "-Dsun.java2d.d3d=false", "-Dsentry.environment=Development", "-Dfile.encoding=UTF-8",
-                                 "-Dpolyglot.engine.WarnInterpreterOnly=false","-DRUN_FROM_IDE=true",
+                                 "-Dpolyglot.engine.WarnInterpreterOnly=false", "-DRUN_FROM_IDE=true",
+                                 "-Djava.util.Arrays.useLegacyMergeSort=true",
                                  "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
                                  "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
                                  "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
@@ -227,6 +228,7 @@ runtime {
         installerOutputDir = file("releases")
         jvmArgs = ["-Xss8M", "-Dsun.java2d.d3d=false", "-Dsentry.environment=Production", "-Dfile.encoding=UTF-8",
                    "-Dpolyglot.engine.WarnInterpreterOnly=false",
+                   "-Djava.util.Arrays.useLegacyMergeSort=true",
                    "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
                    "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
                    "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #4336
Fixes #4320


### Description of the Change
Set the java.util.Arrays.useLegacyMergeSort property to true so that the legacy merge sort (which does not require a stable sort) instead of timsort is used in the swing dialog (well everywhere really).


### Possible Drawbacks
Smaller arrays will be less efficient to sort, but on the plus side people experiencing this issue will be able to save and load. When its fixed in the JDK we can easily revert this change.

### Documentation Notes
Work around for error encountered when you have two files with same name in windows (happens with dropbox, google drive, mega drive etc...)

### Release Notes
- Work around for error encountered when you have two files with same name in windows (happens with dropbox, google drive, mega drive etc...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4337)
<!-- Reviewable:end -->
