### PR TITLE
Hide token stack indicator

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2848,30 +2848,27 @@ public class AppActions {
           chooser.setSelectedFile(new File(zr.getZone().getName()));
           boolean tryAgain = true;
           while (tryAgain) {
-            if (chooser.showSaveDialog(MapTool.getFrame()) == JFileChooser.APPROVE_OPTION) {
-              File mapFile = chooser.getSelectedFile();
-              var installDir = AppUtil.getInstallDirectory().toAbsolutePath();
-              var saveDir = chooser.getSelectedFile().toPath().getParent().toAbsolutePath();
-              if (saveDir.startsWith(installDir)) {
-                MapTool.showWarning("msg.warning.saveMapToInstallDir");
-              } else {
-                tryAgain = false;
-                try {
-                  mapFile = getFileWithExtension(mapFile, AppConstants.MAP_FILE_EXTENSION);
-                  if (mapFile.exists()) {
-                    if (!MapTool.confirm("msg.confirm.fileExists")) {
-                      return;
-                    }
-                  }
-                  PersistenceUtil.saveMap(zr.getZone(), mapFile);
-                  AppPreferences.setSaveMapDir(mapFile.getParentFile());
-                  MapTool.showInformation("msg.info.mapSaved");
-                } catch (IOException ioe) {
-                  MapTool.showError("msg.error.failedSaveMap", ioe);
-                }
-              }
+            if (chooser.showSaveDialog(MapTool.getFrame()) != JFileChooser.APPROVE_OPTION) break;
+            File mapFile = chooser.getSelectedFile();
+            var installDir = AppUtil.getInstallDirectory().toAbsolutePath();
+            var saveDir = chooser.getSelectedFile().toPath().getParent().toAbsolutePath();
+            if (saveDir.startsWith(installDir)) {
+              MapTool.showWarning("msg.warning.saveMapToInstallDir");
             } else {
               tryAgain = false;
+              try {
+                mapFile = getFileWithExtension(mapFile, AppConstants.MAP_FILE_EXTENSION);
+                if (mapFile.exists()) {
+                  if (!MapTool.confirm("msg.confirm.fileExists")) {
+                    return;
+                  }
+                }
+                PersistenceUtil.saveMap(zr.getZone(), mapFile);
+                AppPreferences.setSaveMapDir(mapFile.getParentFile());
+                MapTool.showInformation("msg.info.mapSaved");
+              } catch (IOException ioe) {
+                MapTool.showError("msg.error.failedSaveMap", ioe);
+              }
             }
           }
         }

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2870,6 +2870,8 @@ public class AppActions {
                   MapTool.showError("msg.error.failedSaveMap", ioe);
                 }
               }
+            } else {
+                tryAgain = false;
             }
           }
         }

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2848,7 +2848,9 @@ public class AppActions {
           chooser.setSelectedFile(new File(zr.getZone().getName()));
           boolean tryAgain = true;
           while (tryAgain) {
-            if (chooser.showSaveDialog(MapTool.getFrame()) != JFileChooser.APPROVE_OPTION) break;
+            if (chooser.showSaveDialog(MapTool.getFrame()) != JFileChooser.APPROVE_OPTION) {
+              break;
+            }
             File mapFile = chooser.getSelectedFile();
             var installDir = AppUtil.getInstallDirectory().toAbsolutePath();
             var saveDir = chooser.getSelectedFile().toPath().getParent().toAbsolutePath();

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2871,7 +2871,7 @@ public class AppActions {
                 }
               }
             } else {
-                tryAgain = false;
+              tryAgain = false;
             }
           }
         }

--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -147,6 +147,9 @@ public class AppPreferences {
       "hideMousePointerWhileDragging";
   private static final boolean DEFAULT_KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING = true;
 
+  private static final String KEY_HIDE_TOKEN_STACK_INDICATOR = "hideTokenStackIndicator";
+  private static final boolean DEFAULT_KEY_HIDE_TOKEN_STACK_INDICATOR = false;
+
   private static final String KEY_OBJECTS_START_SNAP_TO_GRID = "newStampsStartSnapToGrid";
   private static final boolean DEFAULT_OBJECTS_START_SNAP_TO_GRID = false;
 
@@ -958,6 +961,14 @@ public class AppPreferences {
   public static boolean getHideMousePointerWhileDragging() {
     return prefs.getBoolean(
         KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING, DEFAULT_KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING);
+  }
+
+  public static void setHideTokenStackIndicator(boolean flag) {
+    prefs.putBoolean(KEY_HIDE_TOKEN_STACK_INDICATOR, flag);
+  }
+
+  public static boolean getHideTokenStackIndicator() {
+    return prefs.getBoolean(KEY_HIDE_TOKEN_STACK_INDICATOR, DEFAULT_KEY_HIDE_TOKEN_STACK_INDICATOR);
   }
 
   public static void setObjectsStartSnapToGrid(boolean flag) {

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -79,6 +79,7 @@ public class PreferencesDialog extends JDialog {
   private final JCheckBox tokensStartSnapToGridCheckBox;
   private final JCheckBox tokensSnapWhileDraggingCheckBox;
   private final JCheckBox hideMousePointerWhileDraggingCheckBox;
+  private final JCheckBox hideTokenStackIndicatorCheckBox;
   private final JCheckBox newMapsVisibleCheckBox;
   private final JCheckBox newTokensVisibleCheckBox;
   private final JCheckBox tokensStartFreeSizeCheckBox;
@@ -323,6 +324,7 @@ public class PreferencesDialog extends JDialog {
     tokensStartSnapToGridCheckBox = panel.getCheckBox("tokensStartSnapToGridCheckBox");
     tokensSnapWhileDraggingCheckBox = panel.getCheckBox("tokensSnapWhileDragging");
     hideMousePointerWhileDraggingCheckBox = panel.getCheckBox("hideMousePointerWhileDragging");
+    hideTokenStackIndicatorCheckBox = panel.getCheckBox("hideTokenStackIndicator");
     newMapsVisibleCheckBox = panel.getCheckBox("newMapsVisibleCheckBox");
     newTokensVisibleCheckBox = panel.getCheckBox("newTokensVisibleCheckBox");
     stampsStartFreeSizeCheckBox = panel.getCheckBox("stampsStartFreeSize");
@@ -654,6 +656,10 @@ public class PreferencesDialog extends JDialog {
         e ->
             AppPreferences.setHideMousePointerWhileDragging(
                 hideMousePointerWhileDraggingCheckBox.isSelected()));
+    hideTokenStackIndicatorCheckBox.addActionListener(
+        e ->
+            AppPreferences.setHideTokenStackIndicator(
+                hideTokenStackIndicatorCheckBox.isSelected()));
     newMapsVisibleCheckBox.addActionListener(
         e -> AppPreferences.setNewMapsVisible(newMapsVisibleCheckBox.isSelected()));
     newTokensVisibleCheckBox.addActionListener(
@@ -1131,6 +1137,7 @@ public class PreferencesDialog extends JDialog {
     tokensSnapWhileDraggingCheckBox.setSelected(AppPreferences.getTokensSnapWhileDragging());
     hideMousePointerWhileDraggingCheckBox.setSelected(
         AppPreferences.getHideMousePointerWhileDragging());
+    hideTokenStackIndicatorCheckBox.setSelected(AppPreferences.getHideTokenStackIndicator());
     newMapsVisibleCheckBox.setSelected(AppPreferences.getNewMapsVisible());
     newTokensVisibleCheckBox.setSelected(AppPreferences.getNewTokensVisible());
     stampsStartFreeSizeCheckBox.setSelected(AppPreferences.getObjectsStartFreesize());

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -35,7 +35,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="b641a" layout-manager="GridLayoutManager" row-count="16" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="b641a" layout-manager="GridLayoutManager" row-count="17" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -323,14 +323,33 @@
                     </constraints>
                     <properties>
                       <name value="hideMousePointerWhileDragging"/>
+                      <selected value="false"/>
                       <text value="&#9;"/>
                     </properties>
                   </component>
                   <vspacer id="a9eb4">
                     <constraints>
-                      <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                      <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </vspacer>
+                  <component id="60bed" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide.tooltip"/>
+                    </properties>
+                  </component>
+                  <component id="93234" class="javax.swing.JCheckBox">
+                    <constraints>
+                      <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <name value="hideTokenStackIndicator"/>
+                      <text value="&#9;"/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
               <grid id="f38d9" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -966,7 +985,7 @@
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.application"/>
             </constraints>
             <properties>
-              <visible value="true"/>
+              <visible value="false"/>
             </properties>
             <border type="none"/>
             <children>

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -3636,7 +3636,9 @@ public class ZoneRenderer extends JComponent
     // Stacks
     if (!tokenList.isEmpty()
         && !tokenList.get(0).isStamp()) { // TODO: find a cleaner way to indicate token layer
-      if (tokenStackMap != null) { // FIXME Needed to prevent NPE but how can it be null?
+      boolean hideTSI = AppPreferences.getHideTokenStackIndicator();
+      if (tokenStackMap != null
+          && !hideTSI) { // FIXME Needed to prevent NPE but how can it be null?
         for (Token token : tokenStackMap.keySet()) {
           Area bounds = getTokenBounds(token);
           if (bounds == null) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2820,3 +2820,5 @@ advanced.roll.unknownProperty              = Unknown Property {0}.
 advanced.roll.propertyNotNumber            = Property {0} is not a number.
 advanced.roll.noTokenInContext             = No token in context.
 advanced.roll.inputNotNumber               = Input {0} is not a number.
+Preferences.label.tokens.stack.hide=Hide Token stack indicator
+Preferences.label.tokens.stack.hide.tooltip=Token Layer stack inidicator will be hidden


### PR DESCRIPTION
### Identify the Bug or Feature request
Closes #4326 Feature Request to hide the token stack indicator 
### Description of the Change
A new check box was added in "Preferences" - "Interactions" tab "Tokens" section.
When checked it will hide the token stack icon.
Double-click and right-click behavior remains unchanged.
### Possible Drawbacks
None (that I'm aware of)
### Documentation Notes
When checkbox is cleared (default, pre-this change):
![image](https://github.com/RPTools/maptool/assets/100969108/bbcbd235-6b5a-4f5b-9ca8-eda5a60ad985)
Same setup when checkbox is checked (post-this change):
![image](https://github.com/RPTools/maptool/assets/100969108/608ec41d-f094-4e05-920b-96f41a93b039)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4343)
<!-- Reviewable:end -->
