### PR TITLE
Fix Grid Size labels

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -79,6 +79,7 @@ public class PreferencesDialog extends JDialog {
   private final JCheckBox tokensStartSnapToGridCheckBox;
   private final JCheckBox tokensSnapWhileDraggingCheckBox;
   private final JCheckBox hideMousePointerWhileDraggingCheckBox;
+  private final JCheckBox hideTokenStackIndicatorCheckBox;
   private final JCheckBox newMapsVisibleCheckBox;
   private final JCheckBox newTokensVisibleCheckBox;
   private final JCheckBox tokensStartFreeSizeCheckBox;
@@ -323,6 +324,7 @@ public class PreferencesDialog extends JDialog {
     tokensStartSnapToGridCheckBox = panel.getCheckBox("tokensStartSnapToGridCheckBox");
     tokensSnapWhileDraggingCheckBox = panel.getCheckBox("tokensSnapWhileDragging");
     hideMousePointerWhileDraggingCheckBox = panel.getCheckBox("hideMousePointerWhileDragging");
+    hideTokenStackIndicatorCheckBox = panel.getCheckBox("hideTokenStackIndicator");
     newMapsVisibleCheckBox = panel.getCheckBox("newMapsVisibleCheckBox");
     newTokensVisibleCheckBox = panel.getCheckBox("newTokensVisibleCheckBox");
     stampsStartFreeSizeCheckBox = panel.getCheckBox("stampsStartFreeSize");
@@ -657,6 +659,10 @@ public class PreferencesDialog extends JDialog {
         e ->
             AppPreferences.setHideMousePointerWhileDragging(
                 hideMousePointerWhileDraggingCheckBox.isSelected()));
+    hideTokenStackIndicatorCheckBox.addActionListener(
+        e ->
+            AppPreferences.setHideTokenStackIndicator(
+                hideTokenStackIndicatorCheckBox.isSelected()));
     newMapsVisibleCheckBox.addActionListener(
         e -> AppPreferences.setNewMapsVisible(newMapsVisibleCheckBox.isSelected()));
     newTokensVisibleCheckBox.addActionListener(
@@ -1134,6 +1140,7 @@ public class PreferencesDialog extends JDialog {
     tokensSnapWhileDraggingCheckBox.setSelected(AppPreferences.getTokensSnapWhileDragging());
     hideMousePointerWhileDraggingCheckBox.setSelected(
         AppPreferences.getHideMousePointerWhileDragging());
+    hideTokenStackIndicatorCheckBox.setSelected(AppPreferences.getHideTokenStackIndicator());
     newMapsVisibleCheckBox.setSelected(AppPreferences.getNewMapsVisible());
     newTokensVisibleCheckBox.setSelected(AppPreferences.getNewTokensVisible());
     stampsStartFreeSizeCheckBox.setSelected(AppPreferences.getObjectsStartFreesize());

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -35,7 +35,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="b641a" layout-manager="GridLayoutManager" row-count="16" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="b641a" layout-manager="GridLayoutManager" row-count="17" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -323,14 +323,33 @@
                     </constraints>
                     <properties>
                       <name value="hideMousePointerWhileDragging"/>
+                      <selected value="false"/>
                       <text value="&#9;"/>
                     </properties>
                   </component>
                   <vspacer id="a9eb4">
                     <constraints>
-                      <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                      <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </vspacer>
+                  <component id="60bed" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide.tooltip"/>
+                    </properties>
+                  </component>
+                  <component id="93234" class="javax.swing.JCheckBox">
+                    <constraints>
+                      <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <name value="hideTokenStackIndicator"/>
+                      <text value="&#9;"/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
               <grid id="f38d9" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -966,7 +985,7 @@
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.application"/>
             </constraints>
             <properties>
-              <visible value="true"/>
+              <visible value="false"/>
             </properties>
             <border type="none"/>
             <children>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2821,3 +2821,5 @@ advanced.roll.unknownProperty              = Unknown Property {0}.
 advanced.roll.propertyNotNumber            = Property {0} is not a number.
 advanced.roll.noTokenInContext             = No token in context.
 advanced.roll.inputNotNumber               = Input {0} is not a number.
+Preferences.label.tokens.stack.hide=Hide Token stack indicator
+Preferences.label.tokens.stack.hide.tooltip=Token Layer stack inidicator will be hidden


### PR DESCRIPTION

### Identify the Bug or Feature request
fixes #4292 

### Description of the Change
Preferences, Map, and Grid Adjust dialogues now consistently refer to Grid Size with a tooltip detailing it as cells size in pixels

### Possible Drawbacks
none

### Documentation Notes
Fix inconsistency in UI reference to grid size

### Release Notes
Fix inconsistency in UI reference to grid size

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4349)
<!-- Reviewable:end -->
