### PR TITLE
Add unique light sources on tokens, and macros for manipulating them.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -674,10 +674,16 @@ public class ServerCommandClientImpl implements ServerCommand {
 
   @Override
   public void updateTokenProperty(Token token, Token.Update update, LightSource value) {
-    updateTokenProperty(
-        token,
-        update,
-        TokenPropertyValueDto.newBuilder().setLightSourceId(value.getId().toString()).build());
+    if (update == Token.Update.createUniqueLightSource) {
+      // This case requires sending the full light source definition.
+      updateTokenProperty(
+          token, update, TokenPropertyValueDto.newBuilder().setLightSource(value.toDto()).build());
+    } else {
+      updateTokenProperty(
+          token,
+          update,
+          TokenPropertyValueDto.newBuilder().setLightSourceId(value.getId().toString()).build());
+    }
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -675,17 +675,9 @@ public class ServerCommandClientImpl implements ServerCommand {
   @Override
   public void updateTokenProperty(Token token, Token.Update update, LightSource value) {
     updateTokenProperty(
-        token, update, TokenPropertyValueDto.newBuilder().setLightSource(value.toDto()).build());
-  }
-
-  @Override
-  public void updateTokenProperty(
-      Token token, Token.Update update, LightSource value1, String value2) {
-    updateTokenProperty(
         token,
         update,
-        TokenPropertyValueDto.newBuilder().setLightSource(value1.toDto()).build(),
-        TokenPropertyValueDto.newBuilder().setStringValue(value2).build());
+        TokenPropertyValueDto.newBuilder().setLightSourceId(value.getId().toString()).build());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
@@ -32,6 +32,8 @@ import net.rptools.parser.function.AbstractFunction;
 public class TokenLightFunctions extends AbstractFunction {
   private static final TokenLightFunctions instance = new TokenLightFunctions();
 
+  private static final String TOKEN_CATEGORY = "$unique";
+
   private TokenLightFunctions() {
     super(0, 5, "hasLightSource", "clearLights", "setLight", "getLights");
   }
@@ -83,8 +85,9 @@ public class TokenLightFunctions extends AbstractFunction {
    * Gets the names of the light sources that are on.
    *
    * @param token The token to get the light sources for.
-   * @param category The category to get the light sources for, if null then the light sources for
-   *     all categories will be returned.
+   * @param category The category to get the light sources for. If "*" then the light sources for
+   *     all categories will be returned. If "$unique" then the light sources defined on the token
+   *     will be returned.
    * @param delim the delimiter for the list.
    * @return a string list containing the lights that are on.
    * @throws ParserException if the light type can't be found.
@@ -95,7 +98,13 @@ public class TokenLightFunctions extends AbstractFunction {
     Map<String, Map<GUID, LightSource>> lightSourcesMap =
         MapTool.getCampaign().getLightSourcesMap();
 
-    if (category == null || category.equals("*")) {
+    if (category.equals("*")) {
+      // Look up on both token and campaign.
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if (token.hasLightSource(ls)) {
+          lightList.add(ls.getName());
+        }
+      }
       for (Map<GUID, LightSource> lsMap : lightSourcesMap.values()) {
         for (LightSource ls : lsMap.values()) {
           if (token.hasLightSource(ls)) {
@@ -103,18 +112,23 @@ public class TokenLightFunctions extends AbstractFunction {
           }
         }
       }
-    } else {
-      if (lightSourcesMap.containsKey(category)) {
-        for (LightSource ls : lightSourcesMap.get(category).values()) {
-          if (token.hasLightSource(ls)) {
-            lightList.add(ls.getName());
-          }
+    } else if (TOKEN_CATEGORY.equals(category)) {
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if (token.hasLightSource(ls)) {
+          lightList.add(ls.getName());
         }
-      } else {
-        throw new ParserException(
-            I18N.getText("macro.function.tokenLight.unknownLightType", "getLights", category));
       }
+    } else if (lightSourcesMap.containsKey(category)) {
+      for (LightSource ls : lightSourcesMap.get(category).values()) {
+        if (token.hasLightSource(ls)) {
+          lightList.add(ls.getName());
+        }
+      }
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.tokenLight.unknownLightType", "getLights", category));
     }
+
     if ("json".equals(delim)) {
       JsonArray jarr = new JsonArray();
       lightList.forEach(l -> jarr.add(new JsonPrimitive(l)));
@@ -128,7 +142,8 @@ public class TokenLightFunctions extends AbstractFunction {
    * Sets the light value for a token.
    *
    * @param token the token to set the light for.
-   * @param category the category of the light source.
+   * @param category the category of the light source. Use "$unique" for light sources defined on
+   *     the token.
    * @param name the name of the light source.
    * @param val the value to set for the light source, 0 for off non 0 for on.
    * @return 0 if the light was not found, otherwise 1;
@@ -140,21 +155,25 @@ public class TokenLightFunctions extends AbstractFunction {
     Map<String, Map<GUID, LightSource>> lightSourcesMap =
         MapTool.getCampaign().getLightSourcesMap();
 
-    if (lightSourcesMap.containsKey(category)) {
-      for (LightSource ls : lightSourcesMap.get(category).values()) {
-        if (ls.getName().equals(name)) {
-          found = true;
-          if (val.equals(BigDecimal.ZERO)) {
-            MapTool.serverCommand().updateTokenProperty(token, Token.Update.removeLightSource, ls);
-          } else {
-            MapTool.serverCommand().updateTokenProperty(token, Token.Update.addLightSource, ls);
-          }
-        }
-      }
+    Iterable<LightSource> sources;
+    if (TOKEN_CATEGORY.equals(category)) {
+      sources = token.getUniqueLightSources();
+    } else if (lightSourcesMap.containsKey(category)) {
+      sources = lightSourcesMap.get(category).values();
     } else {
       throw new ParserException(
           I18N.getText("macro.function.tokenLight.unknownLightType", "setLights", category));
     }
+
+    final var updateAction =
+        BigDecimal.ZERO.equals(val) ? Token.Update.removeLightSource : Token.Update.addLightSource;
+    for (LightSource ls : sources) {
+      if (name.equals(ls.getName())) {
+        found = true;
+        MapTool.serverCommand().updateTokenProperty(token, updateAction, ls);
+      }
+    }
+
     return found ? BigDecimal.ONE : BigDecimal.ZERO;
   }
 
@@ -162,6 +181,7 @@ public class TokenLightFunctions extends AbstractFunction {
    * Checks to see if the token has a light source. The token is checked to see if it has a light
    * source with the name in the second parameter from the category in the first parameter. A "*"
    * for category indicates all categories are checked; a "*" for name indicates all names are
+   * checked. The "$unique" category indicates that only light sources defined on the token are
    * checked.
    *
    * @param token the token to check.
@@ -180,6 +200,12 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     if ("*".equals(category)) {
+      // Look up on both token and campaign.
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if (ls.getName().equals(name) && token.hasLightSource(ls)) {
+          return true;
+        }
+      }
       for (Map<GUID, LightSource> lsMap : lightSourcesMap.values()) {
         for (LightSource ls : lsMap.values()) {
           if (ls.getName().equals(name) && token.hasLightSource(ls)) {
@@ -187,19 +213,21 @@ public class TokenLightFunctions extends AbstractFunction {
           }
         }
       }
-    } else {
-      if (lightSourcesMap.containsKey(category)) {
-        for (LightSource ls : lightSourcesMap.get(category).values()) {
-          if (ls.getName().equals(name) || "*".equals(name)) {
-            if (token.hasLightSource(ls)) {
-              return true;
-            }
-          }
+    } else if (TOKEN_CATEGORY.equals(category)) {
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if ((ls.getName().equals(name) || "*".equals(name)) && token.hasLightSource(ls)) {
+          return true;
         }
-      } else {
-        throw new ParserException(
-            I18N.getText("macro.function.tokenLight.unknownLightType", "hasLightSource", category));
       }
+    } else if (lightSourcesMap.containsKey(category)) {
+      for (LightSource ls : lightSourcesMap.get(category).values()) {
+        if ((ls.getName().equals(name) || "*".equals(name)) && token.hasLightSource(ls)) {
+          return true;
+        }
+      }
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.tokenLight.unknownLightType", "hasLightSource", category));
     }
 
     return false;

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -22,7 +22,7 @@ import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -143,17 +143,46 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       }
       menu.addSeparator();
     }
+
+    // Add unique light sources for the token.
+    {
+      JMenu subMenu = new JMenu("Unique");
+
+      List<LightSource> lightSources = new ArrayList<>(tokenUnderMouse.getUniqueLightSources());
+      Collections.sort(lightSources);
+
+      LIGHTSOURCES:
+      for (LightSource lightSource : lightSources) {
+        for (Light light : lightSource.getLightList()) {
+          // TODO Shouldn't we only skip if *all* child lights are GM only. And what about owner
+          //  only?
+          if (light.isGM() && !MapTool.getPlayer().isGM()) {
+            continue LIGHTSOURCES;
+          }
+        }
+        JCheckBoxMenuItem menuItem =
+            new JCheckBoxMenuItem(new ToggleLightSourceAction(lightSource));
+        menuItem.setSelected(tokenUnderMouse.hasLightSource(lightSource));
+        subMenu.add(menuItem);
+      }
+      if (subMenu.getItemCount() != 0) {
+        menu.add(subMenu);
+        menu.addSeparator();
+      }
+    }
+
     for (Entry<String, Map<GUID, LightSource>> entry :
         MapTool.getCampaign().getLightSourcesMap().entrySet()) {
       JMenu subMenu = new JMenu(entry.getKey());
 
-      List<LightSource> lightSources = new ArrayList<LightSource>(entry.getValue().values());
-      LightSource[] lightSourceList = new LightSource[entry.getValue().size()];
-      lightSources.toArray(lightSourceList);
-      Arrays.sort(lightSourceList);
+      List<LightSource> lightSources = new ArrayList<>(entry.getValue().values());
+      Collections.sort(lightSources);
+
       LIGHTSOURCES:
-      for (LightSource lightSource : lightSourceList) {
+      for (LightSource lightSource : lightSources) {
         for (Light light : lightSource.getLightList()) {
+          // TODO Shouldn't we only skip if *all* child lights are GM only. And what about owner
+          //  only?
           if (light.isGM() && !MapTool.getPlayer().isGM()) {
             continue LIGHTSOURCES;
           }

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -466,9 +466,9 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
           continue;
         }
         if (token.hasLightSource(lightSource)) {
-          token.removeLightSource(lightSource);
+          token.removeLightSource(lightSource.getId());
         } else {
-          token.addLightSource(lightSource);
+          token.addLightSource(lightSource.getId());
         }
         MapTool.serverCommand().putToken(renderer.getZone().getId(), token);
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
@@ -34,7 +34,7 @@ public class LightSourceIconOverlay implements ZoneOverlay {
       if (token.hasLightSources()) {
         boolean foundNormalLight = false;
         for (AttachedLightSource attachedLightSource : token.getLightSources()) {
-          LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
+          LightSource lightSource = attachedLightSource.resolve(token, MapTool.getCampaign());
           if (lightSource != null && lightSource.getType() == LightSource.Type.NORMAL) {
             foundNormalLight = true;
             break;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
@@ -34,8 +34,7 @@ public class LightSourceIconOverlay implements ZoneOverlay {
       if (token.hasLightSources()) {
         boolean foundNormalLight = false;
         for (AttachedLightSource attachedLightSource : token.getLightSources()) {
-          LightSource lightSource =
-              MapTool.getCampaign().getLightSource(attachedLightSource.getLightSourceId());
+          LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
           if (lightSource != null && lightSource.getType() == LightSource.Type.NORMAL) {
             foundNormalLight = true;
             break;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -294,8 +294,7 @@ public class ZoneView {
     final var result = new ArrayList<ContributedLight>();
 
     for (final var attachedLightSource : lightSourceToken.getLightSources()) {
-      LightSource lightSource =
-          MapTool.getCampaign().getLightSource(attachedLightSource.getLightSourceId());
+      LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
       if (lightSource == null) {
         continue;
       }
@@ -653,7 +652,7 @@ public class ZoneView {
         Point p = FogUtil.calculateVisionCenter(token, zone);
 
         for (AttachedLightSource als : token.getLightSources()) {
-          LightSource lightSource = MapTool.getCampaign().getLightSource(als.getLightSourceId());
+          LightSource lightSource = als.resolve(MapTool.getCampaign());
           if (lightSource == null) {
             continue;
           }
@@ -721,7 +720,7 @@ public class ZoneView {
       if (token.hasLightSources() && token.isVisible()) {
         if (!token.isVisibleOnlyToOwner() || AppUtil.playerOwns(token)) {
           for (AttachedLightSource als : token.getLightSources()) {
-            LightSource lightSource = MapTool.getCampaign().getLightSource(als.getLightSourceId());
+            LightSource lightSource = als.resolve(MapTool.getCampaign());
             if (lightSource == null) {
               continue;
             }
@@ -911,7 +910,7 @@ public class ZoneView {
     for (Token token : event.tokens()) {
       if (token.hasAnyTopology()) tokenChangedTopology = true;
       for (AttachedLightSource als : token.getLightSources()) {
-        LightSource lightSource = MapTool.getCampaign().getLightSource(als.getLightSourceId());
+        LightSource lightSource = als.resolve(MapTool.getCampaign());
         if (lightSource == null) {
           continue;
         }
@@ -966,7 +965,7 @@ public class ZoneView {
           token.hasLightSources() && (token.isVisible() || MapTool.getPlayer().isEffectiveGM());
       if (token.hasAnyTopology()) hasTopology = true;
       for (AttachedLightSource als : token.getLightSources()) {
-        LightSource lightSource = c.getLightSource(als.getLightSourceId());
+        LightSource lightSource = als.resolve(c);
         if (lightSource != null) {
           Set<GUID> lightSet = lightSourceMap.get(lightSource.getType());
           if (hasLightSource) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -294,7 +294,8 @@ public class ZoneView {
     final var result = new ArrayList<ContributedLight>();
 
     for (final var attachedLightSource : lightSourceToken.getLightSources()) {
-      LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
+      LightSource lightSource =
+          attachedLightSource.resolve(lightSourceToken, MapTool.getCampaign());
       if (lightSource == null) {
         continue;
       }
@@ -652,7 +653,7 @@ public class ZoneView {
         Point p = FogUtil.calculateVisionCenter(token, zone);
 
         for (AttachedLightSource als : token.getLightSources()) {
-          LightSource lightSource = als.resolve(MapTool.getCampaign());
+          LightSource lightSource = als.resolve(token, MapTool.getCampaign());
           if (lightSource == null) {
             continue;
           }
@@ -720,7 +721,7 @@ public class ZoneView {
       if (token.hasLightSources() && token.isVisible()) {
         if (!token.isVisibleOnlyToOwner() || AppUtil.playerOwns(token)) {
           for (AttachedLightSource als : token.getLightSources()) {
-            LightSource lightSource = als.resolve(MapTool.getCampaign());
+            LightSource lightSource = als.resolve(token, MapTool.getCampaign());
             if (lightSource == null) {
               continue;
             }
@@ -910,7 +911,7 @@ public class ZoneView {
     for (Token token : event.tokens()) {
       if (token.hasAnyTopology()) tokenChangedTopology = true;
       for (AttachedLightSource als : token.getLightSources()) {
-        LightSource lightSource = als.resolve(MapTool.getCampaign());
+        LightSource lightSource = als.resolve(token, MapTool.getCampaign());
         if (lightSource == null) {
           continue;
         }
@@ -965,7 +966,7 @@ public class ZoneView {
           token.hasLightSources() && (token.isVisible() || MapTool.getPlayer().isEffectiveGM());
       if (token.hasAnyTopology()) hasTopology = true;
       for (AttachedLightSource als : token.getLightSources()) {
-        LightSource lightSource = als.resolve(c);
+        LightSource lightSource = als.resolve(token, c);
         if (lightSource != null) {
           Set<GUID> lightSet = lightSourceMap.get(lightSource.getType());
           if (hasLightSource) {

--- a/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
+++ b/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
@@ -28,13 +28,19 @@ public final class AttachedLightSource {
   }
 
   /**
-   * Obtain the attached {@code LightSource} from the campaign.
+   * Obtain the attached {@code LightSource} from the token or campaign.
    *
+   * @param token The token in which to look up light source IDs.
    * @param campaign The campaign in which to look up light source IDs.
    * @return The {@code LightSource} referenced by this {@code AttachedLightSource}, or {@code null}
    *     if no such light source exists.
    */
-  public @Nullable LightSource resolve(Campaign campaign) {
+  public @Nullable LightSource resolve(Token token, Campaign campaign) {
+    final var uniqueLightSource = token.getUniqueLightSource(lightSourceId);
+    if (uniqueLightSource != null) {
+      return uniqueLightSource;
+    }
+
     for (Map<GUID, LightSource> map : campaign.getLightSourcesMap().values()) {
       if (map.containsKey(lightSourceId)) {
         return map.get(lightSourceId);

--- a/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
+++ b/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
@@ -14,26 +14,45 @@
  */
 package net.rptools.maptool.model;
 
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.rptools.maptool.server.proto.AttachedLightSourceDto;
 
-public class AttachedLightSource {
+public final class AttachedLightSource {
 
-  private GUID lightSourceId;
+  private final @Nonnull GUID lightSourceId;
 
-  public AttachedLightSource() {
-    // for serialization
-  }
-
-  private AttachedLightSource(GUID lightSourceId) {
+  public AttachedLightSource(@Nonnull GUID lightSourceId) {
     this.lightSourceId = lightSourceId;
   }
 
-  public AttachedLightSource(LightSource source) {
-    lightSourceId = source.getId();
+  /**
+   * Obtain the attached {@code LightSource} from the campaign.
+   *
+   * @param campaign The campaign in which to look up light source IDs.
+   * @return The {@code LightSource} referenced by this {@code AttachedLightSource}, or {@code null}
+   *     if no such light source exists.
+   */
+  public @Nullable LightSource resolve(Campaign campaign) {
+    for (Map<GUID, LightSource> map : campaign.getLightSourcesMap().values()) {
+      if (map.containsKey(lightSourceId)) {
+        return map.get(lightSourceId);
+      }
+    }
+
+    return null;
   }
 
-  public GUID getLightSourceId() {
-    return lightSourceId;
+  /**
+   * Check if this {@code AttachedLightSource} references a {@code LightSource} with a matching ID.
+   *
+   * @param lightSourceId The ID of the light source to match against.
+   * @return {@code true} If {@code lightSourceId} is the same as the ID of the attached light
+   *     source.
+   */
+  public boolean matches(@Nonnull GUID lightSourceId) {
+    return lightSourceId.equals(this.lightSourceId);
   }
 
   public static AttachedLightSource fromDto(AttachedLightSourceDto dto) {
@@ -42,7 +61,7 @@ public class AttachedLightSource {
 
   public AttachedLightSourceDto toDto() {
     var dto = AttachedLightSourceDto.newBuilder();
-    dto.setLightSourceId(getLightSourceId().toString());
+    dto.setLightSourceId(lightSourceId.toString());
     return dto.build();
   }
 }

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -329,23 +329,6 @@ public class Campaign {
   }
 
   /**
-   * Convenience method that iterates through {@link #getLightSourcesMap()} and returns the value
-   * for the key <code>lightSourceId</code>.
-   *
-   * @param lightSourceId the id to look for
-   * @return the {@link LightSource} or null if not found
-   */
-  public LightSource getLightSource(GUID lightSourceId) {
-
-    for (Map<GUID, LightSource> map : getLightSourcesMap().values()) {
-      if (map.containsKey(lightSourceId)) {
-        return map.get(lightSourceId);
-      }
-    }
-    return null;
-  }
-
-  /**
    * Stub that calls <code>campaignProperties.getLightSourcesMap()</code>.
    *
    * @return the {@link Map} of between lightSourceIds and {@link LightSource}s

--- a/src/main/java/net/rptools/maptool/model/Light.java
+++ b/src/main/java/net/rptools/maptool/model/Light.java
@@ -23,7 +23,7 @@ import net.rptools.maptool.model.drawing.DrawablePaint;
 import net.rptools.maptool.server.proto.LightDto;
 import net.rptools.maptool.server.proto.ShapeTypeDto;
 
-public class Light implements Serializable {
+public final class Light implements Serializable {
   private final @Nonnull ShapeType shape;
   private final double facingOffset;
   private final double radius;

--- a/src/main/java/net/rptools/maptool/model/LightSource.java
+++ b/src/main/java/net/rptools/maptool/model/LightSource.java
@@ -48,6 +48,20 @@ public final class LightSource implements Comparable<LightSource>, Serializable 
   private final @Nullable GUID id;
   private final @Nonnull Type type;
   private final boolean scaleWithToken;
+
+  /**
+   * This light segments that make up the light source.
+   *
+   * <p>In practice this will be an {@code ImmutableList} during runtime. However, previously
+   * serialized {@code LightSource} instances may have specified that it must be a {@code
+   * LinkedList} or other specific {@code List} implementation. So we need to keep this as a {@code
+   * List} in order to deserialize those.
+   *
+   * <p>There is also one case where it won't be an {@code ImmutableList}, and that is during
+   * serialization. At such a time, a temporary {@code LightSource} is created with an {@code
+   * ArrayList} instead. (see {@link #writeReplace()}) so that the XML does not depend on the use of
+   * {@code ImmutableList} or any other particular {@code List} implementation.
+   */
   private final @Nonnull List<Light> lightList;
 
   // Lumens are now in the individual Lights. This field is only here for backwards compatibility

--- a/src/main/java/net/rptools/maptool/model/SightType.java
+++ b/src/main/java/net/rptools/maptool/model/SightType.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.model;
 
 import java.awt.geom.Area;
+import javax.annotation.Nullable;
 import net.rptools.maptool.server.proto.ShapeTypeDto;
 import net.rptools.maptool.server.proto.SightTypeDto;
 
@@ -64,12 +65,12 @@ public class SightType {
     // For serialization
   }
 
-  public SightType(String name, double multiplier, LightSource personalLightSource) {
+  public SightType(String name, double multiplier, @Nullable LightSource personalLightSource) {
     this(name, multiplier, personalLightSource, ShapeType.CIRCLE);
   }
 
   public SightType(
-      String name, double multiplier, LightSource personalLightSource, ShapeType shape) {
+      String name, double multiplier, @Nullable LightSource personalLightSource, ShapeType shape) {
     this.name = name;
     this.multiplier = multiplier;
     this.personalLightSource = personalLightSource;

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -211,6 +211,8 @@ public class Token implements Cloneable {
     setPortraitImage,
     setCharsheetImage,
     setLayout,
+    createUniqueLightSource,
+    deleteUniqueLightSource,
     clearLightSources,
     removeLightSource,
     addLightSource,
@@ -335,6 +337,7 @@ public class Token implements Cloneable {
   private MD5Key charsheetImage;
   private MD5Key portraitImage;
 
+  private Map<GUID, LightSource> uniqueLightSources = new LinkedHashMap<>();
   private List<AttachedLightSource> lightSourceList = new ArrayList<>();
   private String sightType;
   private boolean hasSight;
@@ -473,7 +476,10 @@ public class Token implements Cloneable {
 
     ownerType = token.ownerType;
     ownerList.addAll(token.ownerList);
+
+    uniqueLightSources.putAll(token.uniqueLightSources);
     lightSourceList.addAll(token.lightSourceList);
+
     state.putAll(token.state);
     getPropertyMap().clear();
     getPropertyMap().putAll(token.propertyMapCI);
@@ -918,6 +924,22 @@ public class Token implements Cloneable {
     return imageTableName;
   }
 
+  public @Nonnull Collection<LightSource> getUniqueLightSources() {
+    return uniqueLightSources.values();
+  }
+
+  public @Nullable LightSource getUniqueLightSource(GUID lightSourceId) {
+    return uniqueLightSources.getOrDefault(lightSourceId, null);
+  }
+
+  public void addUniqueLightSource(LightSource source) {
+    uniqueLightSources.put(source.getId(), source);
+  }
+
+  public void removeUniqueLightSource(GUID lightSourceId) {
+    uniqueLightSources.remove(lightSourceId);
+  }
+
   public void addLightSource(GUID lightSourceId) {
     lightSourceList.add(new AttachedLightSource(lightSourceId));
   }
@@ -925,7 +947,7 @@ public class Token implements Cloneable {
   public void removeLightSourceType(LightSource.Type lightType) {
     for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
       AttachedLightSource als = i.next();
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
       if (lightSource != null && lightSource.getType() == lightType) {
         i.remove();
       }
@@ -935,7 +957,7 @@ public class Token implements Cloneable {
   public void removeGMAuras() {
     for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
       AttachedLightSource als = i.next();
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -950,7 +972,7 @@ public class Token implements Cloneable {
   public void removeOwnerOnlyAuras() {
     for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
       AttachedLightSource als = i.next();
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -964,7 +986,7 @@ public class Token implements Cloneable {
 
   public boolean hasOwnerOnlyAuras() {
     for (AttachedLightSource als : lightSourceList) {
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -979,7 +1001,7 @@ public class Token implements Cloneable {
 
   public boolean hasGMAuras() {
     for (AttachedLightSource als : lightSourceList) {
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -994,7 +1016,7 @@ public class Token implements Cloneable {
 
   public boolean hasLightSourceType(LightSource.Type lightType) {
     for (AttachedLightSource als : lightSourceList) {
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
       if (lightSource != null && lightSource.getType() == lightType) {
         return true;
       }
@@ -2500,6 +2522,9 @@ public class Token implements Cloneable {
     if (ownerList == null) {
       ownerList = new HashSet<>();
     }
+    if (uniqueLightSources == null) {
+      uniqueLightSources = new LinkedHashMap<>();
+    }
     if (lightSourceList == null) {
       lightSourceList = new ArrayList<>();
     }
@@ -2813,6 +2838,14 @@ public class Token implements Cloneable {
         setSizeScale(parameters.get(0).getDoubleValue());
         setAnchor(parameters.get(1).getIntValue(), parameters.get(2).getIntValue());
         break;
+      case createUniqueLightSource:
+        lightChanged = true;
+        addUniqueLightSource(LightSource.fromDto(parameters.get(0).getLightSource()));
+        break;
+      case deleteUniqueLightSource:
+        lightChanged = true;
+        removeUniqueLightSource(GUID.valueOf(parameters.get(0).getLightSourceId()));
+        break;
       case clearLightSources:
         if (hasLightSources()) {
           lightChanged = true;
@@ -2946,6 +2979,10 @@ public class Token implements Cloneable {
         dto.hasCharsheetImage() ? new MD5Key(dto.getCharsheetImage().getValue()) : null;
     token.portraitImage =
         dto.hasPortraitImage() ? new MD5Key(dto.getPortraitImage().getValue()) : null;
+
+    dto.getUniqueLightSourcesList().stream()
+        .map(LightSource::fromDto)
+        .forEach(source -> token.uniqueLightSources.put(source.getId(), source));
     token.lightSourceList.addAll(
         dto.getLightSourcesList().stream()
             .map(AttachedLightSource::fromDto)
@@ -3073,6 +3110,8 @@ public class Token implements Cloneable {
     if (portraitImage != null) {
       dto.setPortraitImage(StringValue.of(portraitImage.toString()));
     }
+    dto.addAllUniqueLightSources(
+        uniqueLightSources.values().stream().map(LightSource::toDto).collect(Collectors.toList()));
     dto.addAllLightSources(
         lightSourceList.stream().map(AttachedLightSource::toDto).collect(Collectors.toList()));
     if (sightType != null) {

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -204,8 +204,6 @@ public interface ServerCommand {
 
   void updateTokenProperty(Token token, Token.Update update, LightSource value);
 
-  void updateTokenProperty(Token token, Token.Update update, LightSource value1, String value2);
-
   void updateTokenProperty(Token token, Token.Update update, int value1, int value2);
 
   void updateTokenProperty(Token token, Token.Update update, boolean value);

--- a/src/main/java/net/rptools/maptool/tool/LightSourceCreator.java
+++ b/src/main/java/net/rptools/maptool/tool/LightSourceCreator.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.rptools.lib.FileUtil;
+import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Light;
 import net.rptools.maptool.model.LightSource;
 import net.rptools.maptool.model.ShapeType;
@@ -57,28 +58,33 @@ public class LightSourceCreator {
   }
 
   private static LightSource createLightSource(String name, double radius, double arcAngle) {
-    LightSource source = new LightSource(name);
-    // source.add(new Light(0, 5, arcAngle, new DrawableColorPaint(new Color(255, 255, 0, 50))));
-    source.add(new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false));
-    return source;
+    return LightSource.createRegular(
+        name,
+        new GUID(),
+        LightSource.Type.NORMAL,
+        false,
+        List.of(
+            // new Light(0, 5, arcAngle, new DrawableColorPaint(new Color(255, 255, 0, 50)))
+            new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false)));
   }
 
   private static LightSource createD20LightSource(String name, double radius, double arcAngle) {
-    LightSource source = new LightSource(name);
-
-    // source.add(new Light(0, 5, arcAngle, new DrawableColorPaint(new Color(255, 255, 0, 50))));
-    source.add(new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false));
-    source.add(
-        new Light(
-            ShapeType.CIRCLE,
-            0,
-            radius * 2,
-            arcAngle,
-            new DrawableColorPaint(new Color(0, 0, 0, 100)),
-            100,
-            false,
-            false));
-
-    return source;
+    return LightSource.createRegular(
+        name,
+        new GUID(),
+        LightSource.Type.NORMAL,
+        false,
+        List.of(
+            // new Light(0, 5, arcAngle, new DrawableColorPaint(new Color(255, 255, 0, 50)))
+            new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false),
+            new Light(
+                ShapeType.CIRCLE,
+                0,
+                radius * 2,
+                arcAngle,
+                new DrawableColorPaint(new Color(0, 0, 0, 100)),
+                100,
+                false,
+                false)));
   }
 }

--- a/src/main/java/net/rptools/maptool/tool/LightSourceCreator.java
+++ b/src/main/java/net/rptools/maptool/tool/LightSourceCreator.java
@@ -63,9 +63,7 @@ public class LightSourceCreator {
         new GUID(),
         LightSource.Type.NORMAL,
         false,
-        List.of(
-            // new Light(0, 5, arcAngle, new DrawableColorPaint(new Color(255, 255, 0, 50)))
-            new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false)));
+        List.of(new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false)));
   }
 
   private static LightSource createD20LightSource(String name, double radius, double arcAngle) {
@@ -75,7 +73,6 @@ public class LightSourceCreator {
         LightSource.Type.NORMAL,
         false,
         List.of(
-            // new Light(0, 5, arcAngle, new DrawableColorPaint(new Color(255, 255, 0, 50)))
             new Light(ShapeType.CIRCLE, 0, radius, arcAngle, null, 100, false, false),
             new Light(
                 ShapeType.CIRCLE,

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -674,7 +674,7 @@ message TokenPropertyValueDto {
     string string_value = 3;
     double double_value = 4;
     MacroButtonPropertiesListDto macros = 5;
-    LightSourceDto light_source = 6;
+    string light_source_id = 6;
     AreaDto area = 7;
     StringListDto string_values = 8;
     GridDto grid = 9;

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -342,6 +342,7 @@ message TokenDto {
   bool is_flipped_iso = 47;
   google.protobuf.StringValue charsheet_image = 48;
   google.protobuf.StringValue portrait_image = 49;
+  repeated LightSourceDto unique_light_sources = 72;
   repeated AttachedLightSourceDto light_sources = 50;
   google.protobuf.StringValue sight_type = 51;
   bool has_sight = 52;
@@ -644,16 +645,18 @@ enum TokenUpdateDto {
     setPortraitImage = 43;
     setCharsheetImage = 44;
     setLayout = 45;
-    clearLightSources = 46;
-    removeLightSource = 47;
-    addLightSource = 48;
-    setHasSight = 49;
-    setSightType = 50;
-    flipX = 51;
-    flipY = 52;
-    flipIso = 53;
-    setSpeechName = 54;
-    removeFacing = 55;
+    createUniqueLightSource = 46;
+    deleteUniqueLightSource = 47;
+    clearLightSources = 48;
+    removeLightSource = 49;
+    addLightSource = 50;
+    setHasSight = 51;
+    setSightType = 52;
+    flipX = 53;
+    flipY = 54;
+    flipIso = 55;
+    setSpeechName = 56;
+    removeFacing = 57;
 }
 
 message AssetTransferHeaderDto {
@@ -675,11 +678,12 @@ message TokenPropertyValueDto {
     double double_value = 4;
     MacroButtonPropertiesListDto macros = 5;
     string light_source_id = 6;
-    AreaDto area = 7;
-    StringListDto string_values = 8;
-    GridDto grid = 9;
-    TokenFootPrintDto token_foot_print = 10;
-    string topology_type = 11;
+    LightSourceDto light_source = 7;
+    AreaDto area = 8;
+    StringListDto string_values = 9;
+    GridDto grid = 10;
+    TokenFootPrintDto token_foot_print = 11;
+    string topology_type = 12;
   }
 }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Implements #331 and so also relates to #3087.

### Description of the Change

This changes adds the concept of "unique light sources", which are lights sources defined on tokens rather than in the campaign as a whole. A token with such a unique light source can equipped or unequip it just like any other light sources in its right-click menu.

Macro functions are provided for defining and manipulating unique light sources. No UI is provided at this time for defining the lights (doing so would round out #3087).

#### Existing macro function changes

The following existing macro functions have been updated:
- `getLights([category, [delim, [token, [map]]]])`
- `setLight(category, name, state, [token, [map]])`
- `hasLightSource(category, name, [token, [map]])`

The `category` parameter of each can now be set to the special `"$unique"` category to identify unique light sources. The wildcard `"*"` will likewise now include the token's unique light sources. I.e., these function treat the token's unique light sources as though they just belong to a specially named category.

#### New macro functions

The following new macro functions have been added:
- `createUniqueLightSource(lightSourceJson, [token, [map]])` to create a new unique light source.
- `updateUniqueLightSource(lightSourceJson, [token, [map]])` to modify a unique light source with the matching name.
- `deleteUniqueLightSource(name, [token, [map]])` to delete a unique light source by name.
- `getUniqueLightSource(name, [token, [map]])` to get a unique light source by name, as a JSON object.
- `getUniqueLightSources([token, [map]])` to get all of a token's unique light sources as a JSON array of JSON objects.
- `getUniqueLightSourceNames([token, [map]])` to get the names of all of a token's light sources, as a JSON array.

A consistent JSON format is used for light sources in the parameters and return values of these functions, and uses terminology from the **Campaign Properties** dialog. It looks like this:
```json
{
	"name": "Torch - 20",
	"type": "NORMAL",
	"scale": false,
	"lights": [
		{"shape": "CIRCLE", "range": 20, "lumens": 100},
		{"shape": "CIRCLE", "range": 40, "color": "#000000", "lumens": 50}
	]
}
```

The exact fields are:
- `"name"`: `string`; required.
- `"type"`: (`"NORMAL"`|`"AURA"`); defaults to `"NORMAL"`.
- `"scale"`: `boolean`; defaults to `false`.
- `"lights"` `array`; defauls to `[]`.

And for each light:
- `"range"`: `number`, required.
- `"shape"`: (`"SQUARE"`|`"CIRCLE"`|`"CONE"`|`"HEX"`|`"GRID"`), defaults to `"CIRCLE"`.
- `"offset"`: `number`, defaults to `0`. Only permitted if the shape is `"CONE"`.
- `"arc"`: `number`, defaults to `0`. Only permitted if the shape is `"CONE"`.
- `"gmOnly"`: `boolean`, defaults to `false`. Only permitted if the light source type is `"AURA"`.
- `"ownerOnly"`: `boolean`, defaults to `false`. Only permitted if the light source type is `"AURA"`.
- `"color"`: `string` of the form `"#rrggbb`, defaults to `null`.
- `"lumens"`: `number` (integer), defaults to 100.

#### Refactoring

There was some refactoring done as groundwork.

`LightSource` is now immutable to avoid worries about cloning them along with tokens. In practice lights weren't been modified anyways - only `CampaignPropertiesDialog` and `LightSourceCreator` used the mutators, and that was only to build the light. Once built, the `LightSource` instances were never being modifed.

The existing token update messages for light sources (e.g., for attaching to a token) were reduced to passing around the light source ID instead of the entire light source definition. The ID was the only thing ever used, so there was no point serializing everything for one GUID. Now the only time a complete light source is sent in a token update is the new case of creating a unique light source.

`AttachedLightSource` has been encapsulated more and made responsible for the common case of looking up light sources by ID. Callers just need to provide the current campaign (and now also the associated token) and the `AttachedLightSource` will look itself up and return a `LightSource`.

### Possible Drawbacks

There were some changes to the model. Should be benign, but need to watch for deserialization failures on existing campaigns.

If someone is already using `$unique` as a light source category, it won't be possible to find them with the macro functions  now.

### Documentation Notes

For the existing functions `getLights()`, `setLight()`, and `hasLightSource()`, the type parameter (which should be called "category") can now be set to `"$unique"` to access unique light sources on the token.

#### createUniqueLightSource() function

_Trusted function_

Creates a new unique light source on a token.

**Usage**
```
createUniqueLightSource(lightSourceJson)
createUniqueLightSource(lightSourceJson, token)
createUniqueLightSource(lightSourceJson, token, map)
```

**Parameters**
- `lightSourceJson` - a JSON object defining the new unique light source. See below for details.
- `token` - the name or ID of the token to add the unique light source to. Defaults to the current token.
- `map` - the name or ID of the map on which to find `token`. Defaults to the current map.

The `lightSourceJson` is a JSON object with these fields:
- `"name"`: The user-visible name of the unique light source. A unique light source with the same name must not already exist on the token. Required field.
- `"type"`: The type of the unique light source. Either `"NORMAL"` or `"AURA"`; defaults to `"NORMAL"`.
- `"scale"`: Whether to add the token footprint (size) to the range, so that the light starts at the token's edge vs the token's center. Either `json.true` or `json.false`; defaults to `json.false`.
- `"lights"`: A JSON array of lights; defauls to `[]`.

Each light has this JSON format:
- `"range"`: The distance that the light extends, in map units. Required field.
- `"shape"`: The shape of the boundary of the light. Must be one of `"SQUARE"`, `"CIRCLE"`, `"CONE"`, `"HEX"`, or `"GRID"`; defaults to `"CIRCLE"`.
- `"offset"`: (_for cones only_) The counterclockwise angle (in degrees) to shift the cone relative to the token's facing. Defaults to `0`.
- `"arc"`: (_for cones only_) The angle of the cone in degrees. Defaults to `0`.
- `"gmOnly"`: (_for auras only_) Whether the aura should only be shown to GMs. Either `json.true` or `json.false`; defaults to `json.false`.
- `"ownerOnly"`: (_for auras only_) Whether the aura should only be shown to the tokens owners. Either `json.true` or `json.false`; defaults to `json.false`.
- `"color"`: The color of the light, in the form `"#rrggbb"`; defaults to no color (transparent).
- `"lumens"`: How bright the light should be treated, with negative values indicating darkness. Defaults to 100.

**Return value**

The name of the new unique light source.

**Examples**

To create a standard D&D torch, but with a blue flame:
```
createUniqueLightSource(json.set("{}",
	"name", "Blue Flame Torch",
	"type", "NORMAL",
	"scale", false,
	"lights", json.append("[]",
		json.set("{}", "shape", "CIRCLE", "range", 20, "color", "#0000ff", "lumens", 100),
		json.set("{}", "shape", "CIRCLE", "range", 40, "color", "#000077", "lumens", 50)
	)
))
```

And the same example, but using defaults where possible:
```
createUniqueLightSource(json.set("{}",
	"name", "Blue Flame Torch",
	"lights", json.append("[]",
		json.set("{}", "range", 20, "color", "#0000ff"),
		json.set("{}", "range", 40, "color", "#000077", "lumens", 50)
	)
))
```

#### updateUniqueLightSource() function

_Trusted function_

Modifies a unique light source on a token.

**Usage**
```
updateUniqueLightSource(lightSourceJson)
updateUniqueLightSource(lightSourceJson, token)
updateUniqueLightSource(lightSourceJson, token, map)
```

**Parameters**

- `lightSourceJson` - a JSON object defining the new unique light source. The format is the same as for `createUniqueLightSource()`.
- `token` - the name or ID of the token to to find the unique light source on. Defaults to the current token.
- `map` - the name or ID of the map on which to find `token`. Defaults to the current map.

**Return value**

The name of the modified unique light source.

#### deleteUniqueLightSource() function

Removes a unique light source from a token.

Note: if you merely want to unequip or turn off the unique light source, but keep it around for later, use `setLight()` instead.

**Usage**
```
deleteUniqueLightSource(name)
deleteUniqueLightSource(name, token)
deleteUniqueLightSource(name, token, map)
```

**Parameters**
- `name` - the name of the unique light source to delete.
- `token` - the name or ID of the token to delete the unique light source from. Defaults to the current token. _This parameter can only be used in a trusted macro._
- `map` - the name or ID of the map on which to find `token`. Defaults to the current map.

#### getUniqueLightSource() function

Looks up a unique light source by name on a token, returning the 

**Usage**
```
getUniqueLightSource(name)
getUniqueLightSource(name, token)
getUniqueLightSource(name, token, map)
```

**Parameters**
- `name` - the name of the unique light source to delete.
- `token` - the name or ID of the token to find the unique light source on. Defaults to the current token. _This parameter can only be used in a trusted macro._
- `map` - the name or ID of the map on which to find `token`. Defaults to the current map.

**Return value**

The matching unique light source, as a JSON object. See `createUniqueLightSource()` for the JSON format of a light source.

If there is no match unique light source, an empty string is returned.

**Examples**

```
[h: createUniqueLightSource(json.set("{}",
	"name", "Simple Torch",
	"lights", json.append("[]", json.set("{}", "range", 40))
))]

[r: getUniqueLightSource("Simple Torch")]
```
This will print `{"name":"Simple Torch","type":"NORMAL","scale":false,"lights":[{"shape":"CIRCLE","range":40.0,"lumens":100}]}`

#### getUniqueLightSources() function

Gets all the unique light sources defined on a token.

**Usage**
```
getUniqueLightSources()
getUniqueLightSources(token)
getUniqueLightSources(token, map)
```

**Parameters**
- `token` - the name or ID of the token to get the unique light sources from. Defaults to the current token.  _This parameter can only be used in a trusted macro._
- `map` - the name or ID of the map on which to find `token`. Defaults to the current map.

** Return value**

A JSON array of all the token's unique light sources. As if `getUniqueLightSource()` was call for each unique light source on the token and the results put in an array.

#### getUniqueLightSourceNames() function

Get the names of all the unique light sources defined on a token.

**Usage**
```
getUniqueLightSourceNames()
getUniqueLightSourceNames(token)
getUniqueLightSourceNames(token, map)
```

**Parameters**
- `token` - the name or ID of the token to get the unique light source from. Defaults to the current token.  _This parameter can only be used in a trusted macro._
- `map` - the name or ID of the map on which to find `token`. Defaults to the current map.

** Return value**

A JSON array of all the names of the token's unique light sources.

### Release Notes

- Added macro functions for creating and manipulating unique light sources on tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4356)
<!-- Reviewable:end -->
