### PR TITLE
Propagate frame rate cap changes  to each ZoneRenderer

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -602,6 +602,10 @@ public class PreferencesDialog extends JDialog {
               @Override
               protected void storeNumericValue(Integer value) {
                 AppPreferences.setFrameRateCap(value);
+
+                for (final var renderer : MapTool.getFrame().getZoneRenderers()) {
+                  renderer.setFrameRateCap(value);
+                }
               }
 
               @Override

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -176,9 +176,7 @@ public class ZoneRenderer extends JComponent
     }
     this.zone = zone;
 
-    // The interval, in milliseconds, during which calls to repaint() will be debounced.
-    int repaintDebounceInterval = 1000 / AppPreferences.getFrameRateCap();
-    repaintDebouncer = new DebounceExecutor(repaintDebounceInterval, this::repaint);
+    repaintDebouncer = new DebounceExecutor(1000 / AppPreferences.getFrameRateCap(), this::repaint);
 
     setFocusable(true);
     setZoneScale(new Scale());
@@ -221,6 +219,10 @@ public class ZoneRenderer extends JComponent
     // fps.start();
 
     new MapToolEventBus().getMainEventBus().register(this);
+  }
+
+  public void setFrameRateCap(int cap) {
+    this.repaintDebouncer.setDelay(1000 / cap);
   }
 
   public void setAutoResizeStamp(boolean value) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4335

### Description of the Change

The `DebounceExecutor` is now allows its delay to be modified so that existing maps can receive updates to the frame rate cap. Now that the delay can change, it has been made an `AtomicLong` instead of a plain `long`.

### Possible Drawbacks

An extra frame can be rendered around the time that the cap is modified.

### Documentation Notes

N/A

### Release Notes

- The frame rate cap is now consistently applied to existing maps after being changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4361)
<!-- Reviewable:end -->
