### PR TITLE
Fix For Unable to load/save campaign when running from Jar file

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -216,6 +216,11 @@ public class AppUtil {
       path = path.getParent().getParent().getParent();
     } else { // First try to find MapTool* directory in path
       while (path != null) {
+        if (path.getFileName() == null) {
+          // We have gone too far!
+          path = null;
+          break;
+        }
         if (path.getFileName().toString().matches("(?i).*maptool.*")) {
           break;
         }


### PR DESCRIPTION


### Identify the Bug or Feature request
Fixes #4355 


### Description of the Change
Check to see if the filename exists before trying to compare to the word maptool

### Possible Drawbacks

Should be none


### Documentation Notes
Fixes problem with saving/loading campaign files when using jar file and installation dir doesn't contain the word maptool

### Release Notes
- Fixes problem with saving/loading campaign files when using jar file and installation dir doesn't contain the word maptool

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4366)
<!-- Reviewable:end -->
