### PR TITLE
Add missing tooltip for cover VBL

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2804,6 +2804,7 @@ EditTokenDialog.button.movevbltoggle.tooltip=Include Wall Vision Blocking Layer 
 EditTokenDialog.button.movembltoggle.tooltip=Include Movement Blocking Layer (MBL) during move or copy
 EditTokenDialog.button.movehbltoggle.tooltip=Include Hill Vision Blocking Layer (Hill VBL) during move or copy
 EditTokenDialog.button.movepbltoggle.tooltip=Include Pit Vision Blocking Layer (Pit VBL) during move or copy
+EditTokenDialog.button.movecbltoggle.tooltip=Include Cover Vision Blocking Layer (Cover VBL) during move or copy
 EditTokenDialog.button.movefrommap.tooltip=Move or Copy selected blocking layer from Map
 EditTokenDialog.button.movetomap.tooltip=Move or Copy selected blocking layer to Map
 Label.label=Label:


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves PR #4299 for #3732

### Description of the Change

Add the missing cover VBL tooltip for the Edit Token dialog. Without this the dialog does not open.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4375)
<!-- Reviewable:end -->
