### PR TITLE
Reenforce uniqueness of attached light sources as in ye olden days

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
+++ b/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
@@ -28,6 +28,19 @@ public final class AttachedLightSource {
   }
 
   /**
+   * Get the ID of the attached light source.
+   *
+   * <p>If you're trying to use this to look up a {@link net.rptools.maptool.model.LightSource},
+   * consider using {@link #resolve(Token, Campaign)} instead. If you're trying to compare to
+   * another {@code GUID}, consider using {@link #matches(GUID)}.
+   *
+   * @return The ID of the attached light source.
+   */
+  public GUID getId() {
+    return lightSourceId;
+  }
+
+  /**
    * Obtain the attached {@code LightSource} from the token or campaign.
    *
    * @param token The token in which to look up light source IDs.


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4376

### Description of the Change

A casualty of the protobuf changes in 1.12 was the removal of uniqueness checks in `Token.lightSourceList`. This PR adds back the necessary checks to make sure we don't get duplicate lights and auras on a token.

### Possible Drawbacks

Likely none, unless someone discovered and depended specifically on have multiple auras via `setLight()`.

### Documentation Notes

N/A

### Release Notes

- Fixed lights and auras so more than one of each cannot be added to tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4377)
<!-- Reviewable:end -->
