### PR TITLE
Replace home-grown uberJar task with shadowJar plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
         pkgname: 'package/archlinux/maptool'
     - name: Build uberJar on Windows
       if: matrix.os == 'windows-latest'
-      run: ./gradlew uberJar
+      run: ./gradlew shadowJar
       # For debugging purposes...
     - name: List releases
       run: ls releases

--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,10 @@ dependencies {
 
     // parsing of configuration data
     implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.9.0'
-
+    // Specialized collections: ReferenceMap, LinkedMap.
+    implementation 'org.apache.commons:commons-collections4:4.4'
+    // Various file utilities
+    implementation 'commons-io:commons-io:2.15.0'
     // ftp client
     implementation 'commons-net:commons-net:3.9.0'
     // commandline parsing
@@ -459,7 +462,7 @@ dependencies {
     implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
 
     // Apache Tika Parsers for determining file type
-    implementation 'com.github.lafa.tikaNoExternal:tika-parsers:1.0.18'
+    implementation 'org.apache.tika:tika-core:2.9.1'
 
     // Noise Generator
     implementation 'com.github.cwisniew:NoiseLib:1.0.0' // The most recent version, 1.0.0 is build for a later java version: major version 55 is newer than 54, the highest major version supported by this compiler

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
     id 'org.beryx.runtime' version '1.13.0'
     id "com.google.protobuf" version "0.9.3"
     id 'io.github.file5.guidesigner' version '1.0.2'
-
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 // Definitions
@@ -526,14 +526,14 @@ task configSentryRelease(type: Copy) {
     inputs.properties(tokens)
 }
 
-task uberJar(type: Jar) {
-    group = 'distribution'
+shadowJar {
     zip64 = true
-    description = 'Create uber jar for native installers'
+    mergeServiceFiles()
 
     archiveBaseName = project.name + '-' + tagVersion
     destinationDirectory = file("$rootDir/releases")
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    archiveClassifier = null
 
     manifest {
         attributes 'Implementation-Title': project.name + developerRelease,
@@ -550,13 +550,6 @@ task uberJar(type: Jar) {
                 'Multi-Release': true
     }
 
-    from {
-        configurations.runtimeClasspath.collect {
-            it.isDirectory() ? it : zipTree(it)
-        }
-    }
-    with jar
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'	// Jamz: This is needed to prevent org.bouncycastle:bcmail resigning and security errors
     exclude 'module-info.class' //This is to make sure maptool doesn't become a module by including module-info of dependencies. Probably needs to be fixed before we go to jdk 11+
 }
 

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -293,7 +293,7 @@ public class MapTool {
    */
   public static void showError(String msgKey, Throwable t) {
     String msg = generateMessage(msgKey, t);
-    log.error(I18N.getString(msgKey), t);
+    log.error(I18N.getText(msgKey), t);
     showMessage(msg, "msg.title.messageDialogError", JOptionPane.ERROR_MESSAGE);
   }
 

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -47,7 +47,6 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import javax.imageio.ImageIO;
-import javax.imageio.spi.IIORegistry;
 import javax.swing.*;
 import javax.swing.plaf.FontUIResource;
 import net.rptools.lib.BackupManager;
@@ -1770,11 +1769,6 @@ public class MapTool {
     }
 
     URL.setURLStreamHandlerFactory(factory);
-
-    // Register ImageReaderSpi for jpeg2000 from JAI manually (issue due to uberJar packaging)
-    // https://github.com/jai-imageio/jai-imageio-core/issues/29
-    IIORegistry registry = IIORegistry.getDefaultInstance();
-    registry.registerServiceProvider(new com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi());
 
     final Toolkit tk = Toolkit.getDefaultToolkit();
     tk.getSystemEventQueue().push(new MapToolEventQueue());

--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -14,6 +14,8 @@
  */
 package net.rptools.maptool.model;
 
+import static org.apache.tika.metadata.TikaCoreProperties.RESOURCE_NAME_KEY;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.protobuf.ByteString;
@@ -729,7 +731,7 @@ public final class Asset {
 
   private static MediaType getMediaType(String filename, TikaInputStream tis) throws IOException {
     Metadata metadata = new Metadata();
-    metadata.set(Metadata.RESOURCE_NAME_KEY, filename);
+    metadata.set(RESOURCE_NAME_KEY, filename);
     try {
       TikaConfig tika = new TikaConfig();
       MediaType mediaType = tika.getDetector().detect(tis, metadata);

--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -45,7 +45,6 @@ import net.rptools.maptool.server.proto.*;
 import net.rptools.maptool.transfer.AssetProducer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tika.utils.ExceptionUtils;
 
 /**
  * This class is used by the server host to receive client commands sent through {@link
@@ -262,8 +261,7 @@ public class ServerMessageHandler implements MessageHandler {
       }
       log.debug("from " + id + " handled: " + msgType);
     } catch (Exception e) {
-      log.error(ExceptionUtils.getStackTrace(e));
-      MapTool.showError(ExceptionUtils.getStackTrace(e));
+      MapTool.showError("Unexpected error during message handling", e);
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #4354

### Description of the Change

This isn't a huge change, but is still kind of involved in its details.

The main change is switching away from `uberJar` in favour of `shadowJar` in order to gain support for service file merging. This fixes SPI registration for our dependencies, including Graal languages (JS, regex), and `jai-imageio-jpeg2000` (which we had a workaround for that is now removed). There was also a bunch of other stuff that was missing but is now present in the service files. Here's a complete diff of the service files for those interested:
```diff
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/com.oracle.truffle.api.TruffleLanguage$Provider MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/com.oracle.truffle.api.TruffleLanguage$Provider
0a1
> com.oracle.truffle.js.lang.JavaScriptLanguageProvider
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/javax.imageio.spi.ImageInputStreamSpi MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/javax.imageio.spi.ImageInputStreamSpi
0a1,5
> com.twelvemonkeys.imageio.stream.BufferedFileImageInputStreamSpi
> com.twelvemonkeys.imageio.stream.BufferedRAFImageInputStreamSpi
> com.twelvemonkeys.imageio.stream.BufferedInputStreamImageInputStreamSpi
> # Use SPI loading as a hook for early profile activation
> com.twelvemonkeys.imageio.color.ProfileDeferralActivator$Spi
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/javax.imageio.spi.ImageReaderSpi MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/javax.imageio.spi.ImageReaderSpi
0a1,141
> com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderSpi
> com.twelvemonkeys.imageio.plugins.psd.PSDImageReaderSpi
> com.twelvemonkeys.imageio.plugins.tiff.TIFFImageReaderSpi
> com.twelvemonkeys.imageio.plugins.tiff.BigTIFFImageReaderSpi
> com.twelvemonkeys.imageio.plugins.svg.SVGImageReaderSpi
> com.twelvemonkeys.imageio.plugins.wmf.WMFImageReaderSpi
> com.twelvemonkeys.imageio.plugins.tga.TGAImageReaderSpi
> #
> # Copyright (c) 2017, Harald Kuhr
> # All rights reserved.
> #
> # Redistribution and use in source and binary forms, with or without
> # modification, are permitted provided that the following conditions are met:
> #
> # * Redistributions of source code must retain the above copyright notice, this
> #   list of conditions and the following disclaimer.
> #
> # * Redistributions in binary form must reproduce the above copyright notice,
> #   this list of conditions and the following disclaimer in the documentation
> #   and/or other materials provided with the distribution.
> #
> # * Neither the name of the copyright holder nor the names of its
> #   contributors may be used to endorse or promote products derived from
> #   this software without specific prior written permission.
> #
> # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
> # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
> # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
> # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
> # FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
> # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
> # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
> # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
> # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
> # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
> com.twelvemonkeys.imageio.plugins.bmp.BMPImageReaderSpi
> com.twelvemonkeys.imageio.plugins.bmp.CURImageReaderSpi
> com.twelvemonkeys.imageio.plugins.bmp.ICOImageReaderSpi
> #
> # $RCSfile: javax.imageio.spi.ImageReaderSpi,v $
> #
> # 
> # Copyright (c) 2005 Sun Microsystems, Inc. All  Rights Reserved.
> # 
> # Redistribution and use in source and binary forms, with or without
> # modification, are permitted provided that the following conditions
> # are met: 
> # 
> # - Redistribution of source code must retain the above copyright 
> #   notice, this  list of conditions and the following disclaimer.
> # 
> # - Redistribution in binary form must reproduce the above copyright
> #   notice, this list of conditions and the following disclaimer in 
> #   the documentation and/or other materials provided with the
> #   distribution.
> # 
> # Neither the name of Sun Microsystems, Inc. or the names of 
> # contributors may be used to endorse or promote products derived 
> # from this software without specific prior written permission.
> # 
> # This software is provided "AS IS," without a warranty of any 
> # kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND 
> # WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, 
> # FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
> # EXCLUDED. SUN MIDROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL 
> # NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF 
> # USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
> # DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR 
> # ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
> # CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
> # REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
> # INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS BEEN ADVISED OF THE
> # POSSIBILITY OF SUCH DAMAGES. 
> # 
> # You acknowledge that this software is not designed or intended for 
> # use in the design, construction, operation or maintenance of any 
> # nuclear facility. 
> #
> # $Revision: 1.2 $
> # $Date: 2007/09/05 00:21:08 $
> # $State: Exp $
> #
> # --- JAI-Image I/O ImageReader plug-ins ---
> #
> com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi
> #
> # $RCSfile: javax.imageio.spi.ImageReaderSpi,v $
> #
> # 
> # Copyright (c) 2005 Sun Microsystems, Inc. All  Rights Reserved.
> # 
> # Redistribution and use in source and binary forms, with or without
> # modification, are permitted provided that the following conditions
> # are met: 
> # 
> # - Redistribution of source code must retain the above copyright 
> #   notice, this  list of conditions and the following disclaimer.
> # 
> # - Redistribution in binary form must reproduce the above copyright
> #   notice, this list of conditions and the following disclaimer in 
> #   the documentation and/or other materials provided with the
> #   distribution.
> # 
> # Neither the name of Sun Microsystems, Inc. or the names of 
> # contributors may be used to endorse or promote products derived 
> # from this software without specific prior written permission.
> # 
> # This software is provided "AS IS," without a warranty of any 
> # kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND 
> # WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, 
> # FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
> # EXCLUDED. SUN MIDROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL 
> # NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF 
> # USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
> # DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR 
> # ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
> # CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
> # REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
> # INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS BEEN ADVISED OF THE
> # POSSIBILITY OF SUCH DAMAGES. 
> # 
> # You acknowledge that this software is not designed or intended for 
> # use in the design, construction, operation or maintenance of any 
> # nuclear facility. 
> #
> # $Revision: 1.2 $
> # $Date: 2007/09/05 00:21:08 $
> # $State: Exp $
> #
> # --- JAI-Image I/O ImageReader plug-ins ---
> #
> #com.github.jaiimageio.impl.plugins.jpeg.CLibJPEGImageReaderSpi
> #com.github.jaiimageio.impl.plugins.png.CLibPNGImageReaderSpi
> #com.github.jaiimageio.impl.plugins.jpeg2000.J2KImageReaderSpi
> #com.github.jaiimageio.impl.plugins.jpeg2000.J2KImageReaderCodecLibSpi
> com.github.jaiimageio.impl.plugins.wbmp.WBMPImageReaderSpi
> com.github.jaiimageio.impl.plugins.bmp.BMPImageReaderSpi
> com.github.jaiimageio.impl.plugins.pcx.PCXImageReaderSpi
> com.github.jaiimageio.impl.plugins.pnm.PNMImageReaderSpi
> com.github.jaiimageio.impl.plugins.raw.RawImageReaderSpi
> com.github.jaiimageio.impl.plugins.tiff.TIFFImageReaderSpi
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/javax.imageio.spi.ImageWriterSpi MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/javax.imageio.spi.ImageWriterSpi
0a1,139
> com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageWriterSpi
> com.twelvemonkeys.imageio.plugins.psd.PSDImageWriterSpi
> com.twelvemonkeys.imageio.plugins.tiff.TIFFImageWriterSpi
> com.twelvemonkeys.imageio.plugins.tiff.BigTIFFImageWriterSpi
> com.twelvemonkeys.imageio.plugins.tga.TGAImageWriterSpi
> #
> # Copyright (c) 2017, Harald Kuhr
> # All rights reserved.
> #
> # Redistribution and use in source and binary forms, with or without
> # modification, are permitted provided that the following conditions are met:
> #
> # * Redistributions of source code must retain the above copyright notice, this
> #   list of conditions and the following disclaimer.
> #
> # * Redistributions in binary form must reproduce the above copyright notice,
> #   this list of conditions and the following disclaimer in the documentation
> #   and/or other materials provided with the distribution.
> #
> # * Neither the name of the copyright holder nor the names of its
> #   contributors may be used to endorse or promote products derived from
> #   this software without specific prior written permission.
> #
> # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
> # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
> # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
> # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
> # FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
> # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
> # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
> # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
> # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
> # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
> com.twelvemonkeys.imageio.plugins.bmp.BMPImageWriterSpi
> com.twelvemonkeys.imageio.plugins.bmp.ICOImageWriterSpi
> #
> # $RCSfile: javax.imageio.spi.ImageWriterSpi,v $
> #
> # 
> # Copyright (c) 2005 Sun Microsystems, Inc. All  Rights Reserved.
> # 
> # Redistribution and use in source and binary forms, with or without
> # modification, are permitted provided that the following conditions
> # are met: 
> # 
> # - Redistribution of source code must retain the above copyright 
> #   notice, this  list of conditions and the following disclaimer.
> # 
> # - Redistribution in binary form must reproduce the above copyright
> #   notice, this list of conditions and the following disclaimer in 
> #   the documentation and/or other materials provided with the
> #   distribution.
> # 
> # Neither the name of Sun Microsystems, Inc. or the names of 
> # contributors may be used to endorse or promote products derived 
> # from this software without specific prior written permission.
> # 
> # This software is provided "AS IS," without a warranty of any 
> # kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND 
> # WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, 
> # FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
> # EXCLUDED. SUN MIDROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL 
> # NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF 
> # USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
> # DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR 
> # ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
> # CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
> # REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
> # INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS BEEN ADVISED OF THE
> # POSSIBILITY OF SUCH DAMAGES. 
> # 
> # You acknowledge that this software is not designed or intended for 
> # use in the design, construction, operation or maintenance of any 
> # nuclear facility. 
> #
> # $Revision: 1.2 $
> # $Date: 2007/09/05 00:21:08 $
> # $State: Exp $
> #
> # --- JAI-Image I/O ImageWriter plug-ins ---
> #
> com.github.jaiimageio.jpeg2000.impl.J2KImageWriterSpi
> #
> # $RCSfile: javax.imageio.spi.ImageWriterSpi,v $
> #
> # 
> # Copyright (c) 2005 Sun Microsystems, Inc. All  Rights Reserved.
> # 
> # Redistribution and use in source and binary forms, with or without
> # modification, are permitted provided that the following conditions
> # are met: 
> # 
> # - Redistribution of source code must retain the above copyright 
> #   notice, this  list of conditions and the following disclaimer.
> # 
> # - Redistribution in binary form must reproduce the above copyright
> #   notice, this list of conditions and the following disclaimer in 
> #   the documentation and/or other materials provided with the
> #   distribution.
> # 
> # Neither the name of Sun Microsystems, Inc. or the names of 
> # contributors may be used to endorse or promote products derived 
> # from this software without specific prior written permission.
> # 
> # This software is provided "AS IS," without a warranty of any 
> # kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND 
> # WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, 
> # FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
> # EXCLUDED. SUN MIDROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL 
> # NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF 
> # USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
> # DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR 
> # ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
> # CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
> # REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
> # INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS BEEN ADVISED OF THE
> # POSSIBILITY OF SUCH DAMAGES. 
> # 
> # You acknowledge that this software is not designed or intended for 
> # use in the design, construction, operation or maintenance of any 
> # nuclear facility. 
> #
> # $Revision: 1.2 $
> # $Date: 2007/09/05 00:21:08 $
> # $State: Exp $
> #
> # --- JAI-Image I/O ImageWriter plug-ins ---
> #
> #com.github.jaiimageio.impl.plugins.jpeg.CLibJPEGImageWriterSpi
> #com.github.jaiimageio.impl.plugins.png.CLibPNGImageWriterSpi
> #com.github.jaiimageio.impl.plugins.jpeg2000.J2KImageWriterSpi
> #com.github.jaiimageio.impl.plugins.jpeg2000.J2KImageWriterCodecLibSpi
> com.github.jaiimageio.impl.plugins.wbmp.WBMPImageWriterSpi
> com.github.jaiimageio.impl.plugins.bmp.BMPImageWriterSpi
> com.github.jaiimageio.impl.plugins.gif.GIFImageWriterSpi
> com.github.jaiimageio.impl.plugins.pcx.PCXImageWriterSpi
> com.github.jaiimageio.impl.plugins.pnm.PNMImageWriterSpi
> com.github.jaiimageio.impl.plugins.raw.RawImageWriterSpi
> com.github.jaiimageio.impl.plugins.tiff.TIFFImageWriterSpi
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/javax.servlet.ServletContainerInitializer MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/javax.servlet.ServletContainerInitializer
0a1
> io.sentry.servlet.SentryServletContainerInitializer
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/org.apache.sis.internal.jaxb.TypeRegistration MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/org.apache.sis.internal.jaxb.TypeRegistration
0a1,2
> # Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
> org.apache.sis.internal.referencing.ReferencingTypes
diff '--color=auto' -rbBw MapTool-SNAPSHOT-7d89f48-uberJar/META-INF/services/org.apache.sis.storage.DataStoreProvider MapTool-SNAPSHOT-e421d6e-shadowJar/META-INF/services/org.apache.sis.storage.DataStoreProvider
0a1
> org.apache.sis.storage.netcdf.NetcdfStoreProvider
```

Outside of `META-INF/services/`, the `shadowJar` task only keeps one copy of any duplicated file. This is the same as `uberJar`, but the two don't necessarily pick the same copy. Mainly this happens with many unimportant text files, but I also noticed that there were differences in class files as well. Looking into this, I found that there was a conflict between our dependencies `com.github.jai-imageio:jai-imageio-jpeg2000` and `edu.ucar:jj2000`. The latter comes from from `tika-parser`, a redistribution of a very old version of a library which we don't actually need (we only use stuff from `tika-core`). So I switched to using an updated `tika-core` from `org.apache.tika` instead, which avoids the conflicts while also reducing our dependency graph by a fair amount (315 -> 242).

### Possible Drawbacks

As mentioned, a different set of files are produce by `shadowJar` vs `uberJar`. The differences should now be benign, but it is possible I overlooked something important. This can only impact the JAR release, not the other packaged releases.

As far as I can tell, `tika-parsers` does not accomplish anything for us beyond what `tika-core` provides. But if I'm wrong, this could negatively impact media type detection, and would affect the JAR release as well as the package releases.

### Documentation Notes

JS UDFs can now be used with the standalone JAR.

### Release Notes

- Fixed JS UDFs so they are able to be created when running on the standalone JAR release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4385)
<!-- Reviewable:end -->
