### PR TITLE
Fix handling of assert failures in event handlers

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/exceptions/AssertFunctionException.java
+++ b/src/main/java/net/rptools/maptool/client/functions/exceptions/AssertFunctionException.java
@@ -14,10 +14,10 @@
  */
 package net.rptools.maptool.client.functions.exceptions;
 
-import net.rptools.parser.function.ParameterException;
+import net.rptools.parser.ParserException;
 
 /** Exception type thrown by assert() function, allowing a user-defined error message. */
-public class AssertFunctionException extends ParameterException {
+public class AssertFunctionException extends ParserException {
   public AssertFunctionException(String msg) {
     super(msg);
   }

--- a/src/main/java/net/rptools/maptool/util/EventMacroUtil.java
+++ b/src/main/java/net/rptools/maptool/util/EventMacroUtil.java
@@ -222,6 +222,8 @@ public class EventMacroUtil {
       }
     } catch (AbortFunctionException afe) {
       // Do nothing
+    } catch (AssertFunctionException e) {
+      MapTool.addLocalMessage(e.getMessage());
     } catch (ParserException | ExecutionException | InterruptedException e) {
       MapTool.addLocalMessage(
           I18N.getText(
@@ -289,6 +291,8 @@ public class EventMacroUtil {
       }
     } catch (AbortFunctionException afe) {
       // Do nothing
+    } catch (AssertFunctionException e) {
+      MapTool.addLocalMessage(e.getMessage());
     } catch (ParserException e) {
       MapTool.addLocalMessage(
           "Event continuing after error running " + macroTarget + ": " + e.getMessage());


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4391

### Description of the Change

This adds `catch` blocks for `AssertFunctionException` whereever `AbortFunctionException` is being caught. There were only two remaining places, which were in the event macro code.

Also `AssertFunctionException` no longer extends `ParameterException` as it is not necessarily an indicator of parameter validation. No functional difference as `ParameterExecption` is not caught exlicitly anywhere.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed assertions in event macros so that they function the same as in other contexts when failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4392)
<!-- Reviewable:end -->
