### PR TITLE
Replace configSentryRelease task with processResources configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ out/
 # Automatically Generated
 ################################################################################
 package/windows/MapTool.iss
-src/main/resources/sentry.properties
 
 
 # IDEs

--- a/build.gradle
+++ b/build.gradle
@@ -514,18 +514,18 @@ dependencies {
     implementation 'com.github.RPTools:advanced-dice-roller:1.0.3'
 }
 
-
-task configSentryRelease(type: Copy) {
-    from("build-resources/sentry.properties.template")
-    into("src/main/resources/")
-    rename("sentry.properties.template", "sentry.properties")
-    def tokens = [
-            AppVersion : "${tagVersion}",
-            Environment: "${environment}",
-            SentryDSN  : "${sentryDSN}"
-    ]
-    expand(tokens)
-    inputs.properties(tokens)
+processResources {
+    with copySpec {
+        from("build-resources/sentry.properties.template")
+        rename("sentry.properties.template", "sentry.properties")
+        def tokens = [
+                AppVersion : "${tagVersion}",
+                Environment: "${environment}",
+                SentryDSN  : "${sentryDSN}"
+        ]
+        expand(tokens)
+        inputs.properties(tokens)
+    }
 }
 
 shadowJar {
@@ -599,7 +599,3 @@ test {
 task createWrapper(type: Wrapper) {
     gradleVersion = '8.2.1'
 }
-
-// Configure current release tag in Sentry.io properties
-processResources.dependsOn configSentryRelease
-configSentryRelease.dependsOn 'spotlessCheck'


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #4399

### Description of the Change

This avoids dirtying the `src/` directory with build artifacts, thus introducing unexpected dependencies between tasks. The `:run` task naturally no longer depends on `:spotlessCheck` in any way.

### Possible Drawbacks

Devs will need to do a one-time deletion of the `src/main/resources/sentry.properties` build artifact as it is not being tracked by git.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4401)
<!-- Reviewable:end -->
