### PR TITLE
Make ownership checks consistent between All Players and explicit assignment

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.CodeSource;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -322,16 +321,7 @@ public class AppUtil {
    * @return true if owned by all, or one of the owners is online and not a gm.
    */
   public static boolean ownedByOnePlayer(Token token) {
-    if (token.isOwnedByAll()) {
-      return true;
-    }
-    List<String> players = MapTool.getNonGMs();
-    for (String owner : token.getOwners()) {
-      if (players.contains(owner)) {
-        return true;
-      }
-    }
-    return false;
+    return token.isOwnedByAny(MapTool.getNonGMs());
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
@@ -225,7 +225,7 @@ public class FindTokenFunctions extends AbstractFunction {
       if (ownership == Ownership.NONE) return (!t.hasOwners());
       if (ownership == Ownership.MULTIPLE) return (t.isOwnedByAll() || t.getOwners().size() > 1);
       if (ownership == Ownership.SINGLE) return (!t.isOwnedByAll() && t.getOwners().size() == 1);
-      if (ownership == Ownership.ARRAY) return (!Collections.disjoint(t.getOwners(), ownerList));
+      if (ownership == Ownership.ARRAY) return (t.isOwnedByAny(ownerList));
 
       boolean isOwner = t.isOwner(playerName);
       if (ownership == Ownership.SELF) return (isOwner);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -1337,11 +1337,10 @@ public class TokenPropertyFunctions extends AbstractFunction {
    * @return a string list of the token owners.
    */
   public String getOwners(Token token, String delim) {
-    String[] owners = new String[token.getOwners().size()];
-    token.getOwners().toArray(owners);
+    var owners = new ArrayList<>(token.getOwners());
     if ("json".endsWith(delim)) {
       JsonArray jarr = new JsonArray();
-      Arrays.stream(owners).forEach(o -> jarr.add(new JsonPrimitive(o)));
+      owners.forEach(o -> jarr.add(new JsonPrimitive(o)));
       return jarr.toString();
     } else {
       return StringFunctions.getInstance().join(owners, delim);

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -833,15 +833,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       // If we are not a GM and the only non GM owner make sure we can't
       // take our selves off of the owners list
       if (!MapTool.getPlayer().isGM()) {
-        boolean hasPlayer = false;
-        Set<String> owners = token.getOwners();
-        if (owners != null) {
-          for (Player pl : MapTool.getPlayerList()) {
-            if (!pl.isGM() && owners.contains(pl.getName())) {
-              hasPlayer = true;
-            }
-          }
-        }
+        boolean hasPlayer = token.isOwnedByAny(MapTool.getNonGMs());
         if (!hasPlayer) {
           token.addOwner(MapTool.getPlayer().getName());
         }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -650,6 +650,14 @@ public class ZoneView {
         if (token == null) {
           continue;
         }
+        if (!token.isVisible() && !MapTool.getPlayer().isEffectiveGM()) {
+          continue;
+        }
+        if (token.isVisibleOnlyToOwner() && !AppUtil.playerOwns(token)) {
+          continue;
+        }
+        boolean isOwner = token.isOwner(MapTool.getPlayer().getName());
+
         Point p = FogUtil.calculateVisionCenter(token, zone);
 
         for (AttachedLightSource als : token.getLightSources()) {
@@ -680,14 +688,7 @@ public class ZoneView {
             if (light.getPaint() == null) {
               continue;
             }
-            boolean isOwner = token.getOwners().contains(MapTool.getPlayer().getName());
             if ((light.isGM() && !MapTool.getPlayer().isEffectiveGM())) {
-              continue;
-            }
-            if ((!token.isVisible()) && !MapTool.getPlayer().isEffectiveGM()) {
-              continue;
-            }
-            if (token.isVisibleOnlyToOwner() && !AppUtil.playerOwns(token)) {
               continue;
             }
             if (light.isOwnerOnly() && !isOwner && !MapTool.getPlayer().isEffectiveGM()) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1109,8 +1109,45 @@ public class Token implements Cloneable {
     ownerList.clear();
   }
 
+  /**
+   * Check if the token is owned by the provided player.
+   *
+   * <p>This method allows implicit ownership when the token is owned by all players.
+   *
+   * @param playerId The player name to check ownership against.
+   * @return {@code true} if {@code playerId} identifies an owner of the token.
+   */
   public synchronized boolean isOwner(String playerId) {
-    return (ownerType == OWNER_TYPE_ALL || ownerList.contains(playerId));
+    return ownerType == OWNER_TYPE_ALL || ownerList.contains(playerId);
+  }
+
+  /**
+   * Checks if the token is owned by any of the provided players.
+   *
+   * <p>This method allows implicit ownership when the token is owned by all players. It is as if
+   * each player was checked individually via {@link #isOwner(String)}, but more convenient and
+   * efficient.
+   *
+   * @param playerIds The player names to check ownership against.
+   * @return {@code true} if there is a player in {@code playerIds} that is an owner of this token.
+   */
+  public synchronized boolean isOwnedByAny(Collection<String> playerIds) {
+    if (playerIds.isEmpty()) {
+      return false;
+    }
+
+    return ownerType == OWNER_TYPE_ALL || !Collections.disjoint(ownerList, playerIds);
+  }
+
+  /**
+   * Checks if the token is not owned by anyone.
+   *
+   * <p>If the token is owned by all players, this will return {@code false}
+   *
+   * @return {@code true} if the token has any owners.
+   */
+  public synchronized boolean isOwnedByNone() {
+    return ownerType != OWNER_TYPE_ALL && ownerList.isEmpty();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
@@ -319,7 +319,7 @@ class LibraryToken implements Library {
                   new MTScriptMacroInfo(
                       macroName,
                       buttonProps.getCommand(),
-                      library.getOwners().size() == 0 || !buttonProps.getAllowPlayerEdits(),
+                      library.isOwnedByNone() || !buttonProps.getAllowPlayerEdits(),
                       !buttonProps.getAllowPlayerEdits() && buttonProps.getAutoExecute(),
                       buttonProps.getEvaluatedToolTip()));
             });


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4403
Fixes #4362

### Description of the Change

These new methods are added to `Token` for easier ownership checks:
- `isOwnedByAny(Collection<String>) playerIds)` to check if a token has any owners out of a set of possible owners.
- `isOwnedByNone()` to check if a token has not owners.

These allow replacing existing and inconsistent uses of `Token.getOwners()`, ensuring that the _All Players_ setting is respected across the board. The remaining uses of `Token.getOwners()` are needed to display and manipulate the owner list, or - in the case of the `getTokens()` macro function - to check very specific conditions.

These bug fixes were done using the new methods:
- `getTokens()` with an owner list will now return tokens owned by all players.
- Owner-only auras are rendered when the token is owned by all players (#4362).
- Player-editable lib:token macros are no longer trusted if the token is owned by all players (#4403).
- `onCampaignLoad` is no longer run on lib:tokens owned by all players (#4403).

### Possible Drawbacks

For `getTokens()`, if any framework code is relying on excluding _All Players_ ownership, it will need updating.

### Documentation Notes

N/A

### Release Notes

- Fixed token ownership so that being owned by all players is more consistent with giving explicit ownership.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4404)
<!-- Reviewable:end -->
