### PR TITLE
Include FOW exposure in pathfinding bounds

### DIFF
--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -190,7 +190,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
     // Note: zoneRenderer will be null if map is not visible to players.
     Area newVbl = new Area();
     Area newFowExposedArea = new Area();
-    final var zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
+    final var zoneRenderer = MapTool.getFrame().getZoneRenderer(zone);
     if (zoneRenderer != null) {
       final var zoneView = zoneRenderer.getZoneView();
 
@@ -229,10 +229,9 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
         newVbl = mbl;
       }
 
+      var view = zoneRenderer.getPlayerView();
       newFowExposedArea =
-          zoneRenderer.getZone().hasFog()
-              ? zoneView.getExposedArea(zoneRenderer.getPlayerView())
-              : null;
+          zone.hasFog() && !view.isGMView() ? zoneView.getExposedArea(view) : new Area();
     }
 
     if (!newVbl.equals(vbl)) {
@@ -269,7 +268,7 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
 
       fowExposedArea = newFowExposedArea;
       // FoW has changed. Let's update the JTS geometry to match.
-      if (fowExposedArea == null || fowExposedArea.isEmpty()) {
+      if (fowExposedArea.isEmpty()) {
         this.fowExposedAreaGeometry = null;
       } else {
         try {
@@ -656,10 +655,6 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
   }
 
   private boolean fowBlocksMovement(CellPoint start, CellPoint goal) {
-    if (MapTool.getPlayer().isEffectiveGM()) {
-      return false;
-    }
-
     if (fowExposedAreaGeometry == null) {
       return false;
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4406

### Description of the Change

FOW can influence pathfinding, but its bounds were not affecting the pathfinding bounds. This caused the walker to exclude cells that were actually valid. This PR fixes that, and also includes debug logging and minor clean up to improve the maintainability a bit.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where pathfinding around FOW would fail even with available paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4407)
<!-- Reviewable:end -->
