### PR TITLE
Revert inclusion of shadowJar plugin "Replace home-grown uberJar with shadowJar plugin"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
         pkgname: 'package/archlinux/maptool'
     - name: Build uberJar on Windows
       if: matrix.os == 'windows-latest'
-      run: ./gradlew shadowJar
+      run: ./gradlew uberJar
       # For debugging purposes...
     - name: List releases
       run: ls releases

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ plugins {
     id 'org.openjfx.javafxplugin' version '0.0.13'
     id 'org.beryx.runtime' version '1.13.0'
     id "com.google.protobuf" version "0.9.3"
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 // Definitions
@@ -526,14 +525,14 @@ processResources {
     }
 }
 
-shadowJar {
+task uberJar(type: Jar) {
+    group = 'distribution'
     zip64 = true
-    mergeServiceFiles()
+    description = 'Create uber jar for native installers'
 
     archiveBaseName = project.name + '-' + tagVersion
     destinationDirectory = file("$rootDir/releases")
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    archiveClassifier = null
 
     manifest {
         attributes 'Implementation-Title': project.name + developerRelease,
@@ -550,6 +549,13 @@ shadowJar {
                 'Multi-Release': true
     }
 
+    from {
+        configurations.runtimeClasspath.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+    with jar
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'	// Jamz: This is needed to prevent org.bouncycastle:bcmail resigning and security errors
     exclude 'module-info.class' //This is to make sure maptool doesn't become a module by including module-info of dependencies. Probably needs to be fixed before we go to jdk 11+
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -515,6 +515,7 @@ processResources {
     with copySpec {
         from("build-resources/sentry.properties.template")
         rename("sentry.properties.template", "sentry.properties")
+        duplicatesStrategy = DuplicatesStrategy.WARN
         def tokens = [
                 AppVersion : "${tagVersion}",
                 Environment: "${environment}",

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -47,6 +47,7 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import javax.imageio.ImageIO;
+import javax.imageio.spi.IIORegistry;
 import javax.swing.*;
 import javax.swing.plaf.FontUIResource;
 import net.rptools.lib.BackupManager;
@@ -1752,6 +1753,11 @@ public class MapTool {
     }
 
     URL.setURLStreamHandlerFactory(factory);
+
+    // Register ImageReaderSpi for jpeg2000 from JAI manually (issue due to uberJar packaging)
+    // https://github.com/jai-imageio/jai-imageio-core/issues/29
+    IIORegistry registry = IIORegistry.getDefaultInstance();
+    registry.registerServiceProvider(new com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi());
 
     final Toolkit tk = Toolkit.getDefaultToolkit();
     tk.getSystemEventQueue().push(new MapToolEventQueue());


### PR DESCRIPTION
### Identify the Bug or Feature request

Undoes work for #4354

### Description of the Change

Reverts #4385

Also includes a tweak to #4401 so that duplicate sentry.properties files can be coped with (to reduce annoyance with checking out different commits).

### Possible Drawbacks

Still won't be able to use Graal for now.

### Documentation Notes

N/A

### Release Notes

- Reverted fix for JS UDFs running on the standalone JAR release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4421)
<!-- Reviewable:end -->
