### PR TITLE
Make badass runtime plugin ignore the shadow plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,8 +197,23 @@ classes.configure {
     dependsOn instrumentForms
 }
 
-// Badass Runtime Plugin Options
+// Workaround the runtime plugin's hardcoded dependencies on the shadow plugin. It sneakily
+// (dynamically) adds dependencies when shadow is detected, but we don't want it to do that since we
+// only use shadow for a completely separate build artifact.
+tasks.runtime.configure {
+    dependsOn installDist
+    afterEvaluate {
+        dependsOn -= installShadowDist
+    }
+}
+tasks.jpackageImage.configure {
+    dependsOn installDist
+    afterEvaluate {
+        dependsOn -= installShadowDist
+    }
+}
 runtime {
+    distDir.set(installDist.destinationDir)
     options = ['--strip-debug', '--strip-native-commands', '--compress', '2', '--no-header-files', '--no-man-pages']
     modules = ['java.base',
                'java.compiler',
@@ -227,9 +242,9 @@ runtime {
                'jdk.zipfs'
     ]
 
-
-
     jpackage {
+        mainJar = jar.archiveFile.get().asFile.name
+
         installerOutputDir = file("releases")
         jvmArgs = javaArgs
 


### PR DESCRIPTION
### Identify the Bug or Feature request

improves on PR #4385 for #4354

### Description of the Change

`runtime` has logic to prefer `installShadowDist` over `installDist` when available, with no means of disabling it. We don't want that as our shadow JAR is a completely separate build, so we have to be rather forceful with `runtime` to get it to cooperate.

### Possible Drawbacks

Should not be any. But I could only test the Linux produced packages at the moment.

### Documentation Notes

N/A

### Release Notes

- Force runtime gradle plugin to peacefully coexist with the shadow plugin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4422)
<!-- Reviewable:end -->
