### PR TITLE
Allow build to succeed even with stray sentry.properties file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -516,6 +516,7 @@ processResources {
     with copySpec {
         from("build-resources/sentry.properties.template")
         rename("sentry.properties.template", "sentry.properties")
+        duplicatesStrategy = DuplicatesStrategy.WARN
         def tokens = [
                 AppVersion : "${tagVersion}",
                 Environment: "${environment}",


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves PR #4401 for #4399

### Description of the Change

When evaluating older commits, the lingering `sentry.properties` file makes the build fail due to conflicts with the new directly written version. This makes testing and bisecting more tedious than it needs to be. This PR introduces a change to allow the file to exist, but to ultimately have no effect other than this warning being generated:
> Encountered duplicate path "sentry.properties" during copy operation configured with DuplicatesStrategy.WARN

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4423)
<!-- Reviewable:end -->
