### PR TITLE
Avoid failure when touching up asset names during release build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,11 +68,11 @@ jobs:
       #   | |/ |/ // // / / // /_/ // /_/ /| |/ |/ /(__  )
       #   |__/|__//_//_/ /_/ \__,_/ \____/ |__/|__//____/
       #
-    - name: Copy Windows Release Files
+    - name: Rename Windows Release Files
       if: matrix.os == 'windows-latest'
       run: |
-        cp releases/MapTool*.exe releases/MapTool-${{ github.event.release.tag_name }}.exe
-        cp releases/MapTool*.msi releases/MapTool-${{ github.event.release.tag_name }}.msi
+        mv releases/MapTool*.exe releases/MapTool-${{ github.event.release.tag_name }}.exe
+        mv releases/MapTool*.msi releases/MapTool-${{ github.event.release.tag_name }}.msi
       continue-on-error: true
     - name: Upload Windows EXE Release Asset
       id: upload-release-asset-exe
@@ -113,12 +113,12 @@ jobs:
       #    / /___ / // / / // /_/ /_>  <
       #   /_____//_//_/ /_/ \__,_//_/|_|
       #
-    - name: Copy Linux Release Files
+    - name: Rename Linux Release Files
       if: matrix.os == 'ubuntu-latest'
       run: |
-        cp releases/maptool*.x86_64.rpm releases/maptool-${{ github.event.release.tag_name }}.x86_64.rpm
-        cp releases/maptool*_amd64.deb releases/maptool_${{ github.event.release.tag_name }}_amd64.deb
-        cp package/archlinux/maptool/maptool-*-x86_64.pkg.tar.zst releases/maptool-${{ github.event.release.tag_name }}-x86_64.pkg.tar.zst
+        mv -n releases/maptool*.x86_64.rpm releases/maptool-${{ github.event.release.tag_name }}.x86_64.rpm
+        mv -n releases/maptool*_amd64.deb releases/maptool_${{ github.event.release.tag_name }}_amd64.deb
+        mv -n package/archlinux/maptool/maptool-*-x86_64.pkg.tar.zst releases/maptool-${{ github.event.release.tag_name }}-x86_64.pkg.tar.zst
       continue-on-error: true
     - name: Upload Linux RPM Release Asset
       id: upload-release-asset-rpm
@@ -159,11 +159,11 @@ jobs:
       #    / / / / / // /_/ // /__ / /_/ /___/ /
       #   /_/ /_/ /_/ \__,_/ \___/ \____//____/
       #
-    - name: Copy Mac OS Release Files
+    - name: Rename Mac OS Release Files
       if: matrix.os == 'macOS-latest'
       run: |
-        cp releases/MapTool*.dmg releases/MapTool-${{ github.event.release.tag_name }}.dmg
-        cp releases/MapTool*.pkg releases/MapTool-${{ github.event.release.tag_name }}.pkg
+        mv releases/MapTool*.dmg releases/MapTool-${{ github.event.release.tag_name }}.dmg
+        mv releases/MapTool*.pkg releases/MapTool-${{ github.event.release.tag_name }}.pkg
       continue-on-error: true
     - name: Upload Mac DMG Release Asset
       id: upload-release-asset-dmg


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4432

### Description of the Change

`jpackage` now allows the release sufficx on DEB files to be optional. Since we don't use them, our produced `.deb` file does not have a release suffix. This makes the name of the generated file identical to the final name we want it to have. Later in the build, when we attempt to `cp` the file to its final location we get an error since the source and target are the same file. This error prevents subsequent commands from running, in this case, the copying of the `.zst` file from `package/` to `releases/`. Investigation reveals the same happened on Windows and Mac OS, but we get lucky because all of their packages are already named correctly in the expected location, so the problem happens to not have negative effects there.

This PR changes the use of `cp` to `mv` since we don't really need to keep the original name around. All platforms also have decent `mv` behaviour when the source and target files are the same, though Linux does require an extra flag to exit without error.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4433)
<!-- Reviewable:end -->
