### PR TITLE
Fix for cover island edge case

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisionBlockingAccumulator.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisionBlockingAccumulator.java
@@ -250,6 +250,7 @@ public final class VisionBlockingAccumulator {
         addVisionBlockingSegments(childOcean, false);
       }
       addVisionBlockingSegments(parentOcean, false);
+      addVisionBlockingSegments(island, true);
 
     } else if (container instanceof AreaOcean ocean) {
       final var parentIsland = ocean.getParentIsland();


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4437

### Description of the Change
Adds a step to include ones own cover island to the vision blocking

### Possible Drawbacks
None?

### Documentation Notes
The front sides of the containing island of cover now block vision.

### Release Notes
Can no longer see back into your own cover when looking out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4438)
<!-- Reviewable:end -->
