### PR TITLE
Upgrade PDF libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -433,8 +433,8 @@ dependencies {
     implementation 'com.jayway.jsonpath:json-path:2.8.0'
 
     // For PDF image extraction
-    implementation 'org.apache.pdfbox:pdfbox:2.0.28'
-    implementation 'org.apache.pdfbox:pdfbox-tools:2.0.28'
+    implementation 'org.apache.pdfbox:pdfbox:3.0.0'
+    implementation 'org.apache.pdfbox:pdfbox-tools:3.0.0'
     implementation 'org.bouncycastle:bcmail-jdk15on:1.70'								// To decrypt passworded/secured pdf's
     implementation 'com.github.jai-imageio:jai-imageio-core:1.4.0'						// For pdf image extraction, specifically for jpeg2000 (jpx) support.
     implementation 'com.github.jai-imageio:jai-imageio-jpeg2000:1.4.0'					// For pdf image extraction, specifically for jpeg2000 (jpx) support.

--- a/src/main/java/net/rptools/maptool/util/ExtractImagesFromPDF.java
+++ b/src/main/java/net/rptools/maptool/util/ExtractImagesFromPDF.java
@@ -34,6 +34,7 @@ import net.rptools.maptool.client.AppUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -105,7 +106,7 @@ public final class ExtractImagesFromPDF {
       return;
     }
 
-    document = PDDocument.load(pdfFile);
+    document = Loader.loadPDF(pdfFile);
 
     if (extractRenderedPages) {
       renderer = new PDFRenderer(document);


### PR DESCRIPTION
### Identify the Bug or Feature request
Resolves #4470


### Description of the Change
Updates the pdfbox libraries to 3.0, including change to using the version 3 method of loading PDFs


### Possible Drawbacks
Hopefully none

### Documentation Notes
Update PDF libraries.

### Release Notes
- Update to pdfbox 3.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4471)
<!-- Reviewable:end -->
