### PR TITLE
Add a Facing enum to make facing of topology blocking segments easier to reason about

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaContainer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaContainer.java
@@ -24,6 +24,7 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 
 public interface AreaContainer {
+
   public Area getBounds();
 
   /**
@@ -38,24 +39,20 @@ public interface AreaContainer {
   /**
    * Find sections of the container's boundary that block vision.
    *
-   * <p>Each returned segment is a sequence of connected faces which constitute an unbroken section
-   * of the container's boundary that would block vision. Each segment is aware of `origin` so that
-   * it can construct areas that cannot be seen from `origin`.
+   * <p>Each returned segment is a sequence of connected line segments which constitute an unbroken
+   * section of the container's boundary, where each segment faces the direction chosen by {@code
+   * facing}.
    *
    * <p>The segments that are returned depend on `origin`, and `frontSegments`.
    *
    * @param geometryFactory The strategy for creating geometries, which is used by the
    *     `VisibleAreaSegment` in creating areas of blocked vision.
    * @param origin The point from which visibility is calculated.
-   * @param frontSegments If `true`, only front-facing boundary segments are returned. Otherwise,
-   *     only back-facing boundary segments are returned. Due to winding order, back-facing and
-   *     front-facing are interpreted differently for oceans and islands.
+   * @param facing Whether the returned segments must have their island side or their ocean side
+   *     facing the origin.
    * @return A list of segments, which together represent the complete set of boundary faces that
    *     block vision.
    */
   public List<LineString> getVisionBlockingBoundarySegments(
-      GeometryFactory geometryFactory,
-      Coordinate origin,
-      boolean frontSegments,
-      PreparedGeometry vision);
+      GeometryFactory geometryFactory, Coordinate origin, Facing facing, PreparedGeometry vision);
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaIsland.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaIsland.java
@@ -88,10 +88,7 @@ public class AreaIsland implements AreaContainer {
 
   @Override
   public List<LineString> getVisionBlockingBoundarySegments(
-      GeometryFactory geometryFactory,
-      Coordinate origin,
-      boolean frontSegments,
-      PreparedGeometry vision) {
-    return meta.getFacingSegments(geometryFactory, origin, !frontSegments, vision);
+      GeometryFactory geometryFactory, Coordinate origin, Facing facing, PreparedGeometry vision) {
+    return meta.getFacingSegments(geometryFactory, origin, facing, vision);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaMeta.java
@@ -56,16 +56,29 @@ public class AreaMeta {
   }
 
   /**
-   * @param origin
-   * @param faceAway If `true`, only return segments facing away from origin.
-   * @return
+   * Returns all line segments in the boundary that face the requested direction.
+   *
+   * <p>For each line segment, the exterior region will be on one side of the segment while the
+   * interior region will be on the other side. One of these regions will be an island and one will
+   * be an ocean depending on {@link #isHole()}. The {@code facing} parameter uses this fact to
+   * control whether a segment should be included in the result, based on whether the origin is on
+   * the island-side of the line segment or on its ocean-side.
+   *
+   * <p>If {@code origin} is colinear with a line segment, that segment will never be returned.
+   *
+   * @param origin The vision origin, which is the point by which line segment orientation is
+   *     measured.
+   * @param facing Whether the island-side or the ocean-side of the returned segments must face
+   *     {@code origin}.
+   * @return All line segments with a facing that matches {@code facing} based on the position of
+   *     {@code origin}. The line segments are joined into continguous line strings where possible.
    */
   public List<LineString> getFacingSegments(
-      GeometryFactory geometryFactory,
-      Coordinate origin,
-      boolean faceAway,
-      PreparedGeometry vision) {
-    final var requiredOrientation = faceAway ? Orientation.CLOCKWISE : Orientation.COUNTERCLOCKWISE;
+      GeometryFactory geometryFactory, Coordinate origin, Facing facing, PreparedGeometry vision) {
+    final var requiredOrientation =
+        facing == Facing.ISLAND_SIDE_FACES_ORIGIN
+            ? Orientation.CLOCKWISE
+            : Orientation.COUNTERCLOCKWISE;
     List<LineString> segments = new ArrayList<>();
     List<Coordinate> currentSegmentPoints = new ArrayList<>();
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaOcean.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/AreaOcean.java
@@ -58,15 +58,12 @@ public class AreaOcean implements AreaContainer {
 
   @Override
   public List<LineString> getVisionBlockingBoundarySegments(
-      GeometryFactory geometryFactory,
-      Coordinate origin,
-      boolean frontSegments,
-      PreparedGeometry vision) {
+      GeometryFactory geometryFactory, Coordinate origin, Facing facing, PreparedGeometry vision) {
     if (meta == null) {
       return Collections.emptyList();
     }
 
-    return meta.getFacingSegments(geometryFactory, origin, frontSegments, vision);
+    return meta.getFacingSegments(geometryFactory, origin, facing, vision);
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/Facing.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/Facing.java
@@ -1,0 +1,20 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.vbl;
+
+public enum Facing {
+  OCEAN_SIDE_FACES_ORIGIN,
+  ISLAND_SIDE_FACES_ORIGIN
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisionBlockingAccumulator.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisionBlockingAccumulator.java
@@ -234,9 +234,6 @@ public final class VisionBlockingAccumulator {
       final var parentOcean = island.getParentOcean();
 
       for (final var siblingIsland : parentOcean.getIslands()) {
-        if (siblingIsland == island) {
-          continue;
-        }
         addVisionBlockingSegments(siblingIsland, Facing.OCEAN_SIDE_FACES_ORIGIN);
       }
       for (final var childOcean : island.getOceans()) {
@@ -248,10 +245,7 @@ public final class VisionBlockingAccumulator {
       addVisionBlockingSegments(parentOcean, Facing.OCEAN_SIDE_FACES_ORIGIN);
       addVisionBlockingSegments(island, Facing.OCEAN_SIDE_FACES_ORIGIN);
     } else if (container instanceof AreaOcean ocean) {
-      final var parentIsland = ocean.getParentIsland();
-      if (parentIsland != null) {
-        addVisionBlockingSegments(ocean, Facing.ISLAND_SIDE_FACES_ORIGIN);
-      }
+      addVisionBlockingSegments(ocean, Facing.OCEAN_SIDE_FACES_ORIGIN);
 
       for (var containedIsland : ocean.getIslands()) {
         addVisionBlockingSegments(containedIsland, Facing.OCEAN_SIDE_FACES_ORIGIN);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4469

Also catches a backwards case in Cover VBL, which resulted in surrounding Cover VBL to have no effect.

### Description of the Change

We used to use a boolean to indicate whether segments on the front side of a container should be returned. This was
ambiguous for several reasons:
1. "front side" actually means more than the nearest side.
2. The interpretation of "front side" inverts when the origin is inside the container. In that case it actually means "back side", it just happens to work out that it's the correct thing in all our cases.
3. It was based on a boolean `faceAway` in `AreaMeta` which was unclear for other reasons. For one, we aren't talking about whether the line segment itself points toward or away from the origin, but rather whether an imaginary orientation normal vector would point toward or away from the origin. And more importantly, the programmer had to remember the arbitrary choice of which direction (clockwise, counterclockwise) would give the expected orientation.

Now we have a `Facing` enum that can be used by all components involved, and which has decsriptive names. Since each line segment will have an island on one side and an ocean on the other, the names reflect that the origin might be on the island side of the line, or the ocean side of the line, without any need to remember orientation conventions.

It's a lot easier now to see how each type of VBL works:
- Wall VBL and Cover VBL consistently want the origin on the ocean side of the segment.
- Hill VBL and Pit VBL consistently want the origin on the island side of the segment.

As for the Hill VBL bug fix, the new phrasing made it clear that that we should not be skipping the parent ocean when finding blocking segments for the grandparent island. As this was the only case where we did that, the logic for skipping oceans like that has been removed.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where Hill VBL peninsulas would not block vision.
- Fixed a bug where surrounding Cover VBL would not block vision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4484)
<!-- Reviewable:end -->
