### PR TITLE
Fixed missing <br> in light explanations

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -975,12 +975,12 @@ The second creates a round GM-only aura in red with a 15-foot diameter. \
 Lines three and four do the same thing, but with a green aura that is only \
 visible to players who own the token with the aura attached to it. Lines \
 five and six are visible to all players and are in blue.</p>\
-<pre>\
+<br><pre>\
 New Interesting Auras: 5' grid<br>\
 ----<br>\
-Side Fields - 12.5: aura cone arc=90 12.5#6666ff offset=90  12.5#aadd00 offset=-90  12.5#aadd00 offset=180  12.5#bb00aa
+Side Fields - 12.5: aura cone arc=90 12.5#6666ff offset=90  12.5#aadd00 offset=-90  12.5#aadd00 offset=180  12.5#bb00aa<br>\
 Doughnut Hole - 40: aura circle 20 40#ffff00<br>\
-Doughnut Cone - 20: aura cone arc=30 20#ffff00<br>\
+Doughnut Cone - 20: aura cone arc=30 10 20#ffff00<br>\
 Range Circles 30/60/90: aura circle 30.5 30.9#000000 60.5 60.9#000000 90.5 90.9#000000<br>\
 Range Arcs    30/60/90: aura cone arc=135 30.5 30.9#000000 60.5 60.9#000000 90.5 90.9#000000<br>\
 Beam - 50: aura beam arc=4 150#ffff00<br>\

--- a/src/main/resources/net/rptools/maptool/language/i18n_en_au.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en_au.properties
@@ -977,12 +977,12 @@ The second creates a round GM-only aura in red with a 15-foot diameter. \
 Lines three and four do the same thing, but with a green aura that is only \
 visible to players who own the token with the aura attached to it. Lines \
 five and six are visible to all players and are in blue.</p>\
-<pre>\
+<br><pre>\
 New Interesting Auras: 5' grid<br>\
 ----<br>\
-Side Fields - 12.5: aura cone arc=90 12.5#6666ff offset=90  12.5#aadd00 offset=-90  12.5#aadd00 offset=180  12.5#bb00aa
+Side Fields - 12.5: aura cone arc=90 12.5#6666ff offset=90  12.5#aadd00 offset=-90  12.5#aadd00 offset=180  12.5#bb00aa<br>\
 Doughnut Hole - 40: aura circle 20 40#ffff00<br>\
-Doughnut Cone - 20: aura cone arc=30 20#ffff00<br>\
+Doughnut Cone - 20: aura cone arc=30 10 20#ffff00<br>\
 Range Circles 30/60/90: aura circle 30.5 30.9#000000 60.5 60.9#000000 90.5 90.9#000000<br>\
 Range Arcs    30/60/90: aura cone arc=135 30.5 30.9#000000 60.5 60.9#000000 90.5 90.9#000000<br>\
 Beam - 50: aura beam arc=4 150#ffff00<br>\

--- a/src/main/resources/net/rptools/maptool/language/i18n_en_gb.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en_gb.properties
@@ -977,12 +977,12 @@ The second creates a round GM-only aura in red with a 15-foot diameter. \
 Lines three and four do the same thing, but with a green aura that is only \
 visible to players who own the token with the aura attached to it. Lines \
 five and six are visible to all players and are in blue.</p>\
-<pre>\
+<br><pre>\
 New Interesting Auras: 5' grid<br>\
 ----<br>\
-Side Fields - 12.5: aura cone arc=90 12.5#6666ff offset=90  12.5#aadd00 offset=-90  12.5#aadd00 offset=180  12.5#bb00aa
+Side Fields - 12.5: aura cone arc=90 12.5#6666ff offset=90  12.5#aadd00 offset=-90  12.5#aadd00 offset=180  12.5#bb00aa<br>\
 Doughnut Hole - 40: aura circle 20 40#ffff00<br>\
-Doughnut Cone - 20: aura cone arc=30 20#ffff00<br>\
+Doughnut Cone - 20: aura cone arc=30 10 20#ffff00<br>\
 Range Circles 30/60/90: aura circle 30.5 30.9#000000 60.5 60.9#000000 90.5 90.9#000000<br>\
 Range Arcs    30/60/90: aura cone arc=135 30.5 30.9#000000 60.5 60.9#000000 90.5 90.9#000000<br>\
 Beam - 50: aura beam arc=4 150#ffff00<br>\


### PR DESCRIPTION
### Identify the Bug or Feature request
Tweak for #4448
### Description of the Change
Fixed missing <br> in lighting descriptive text for Campaign Properties dialog

### Possible Drawbacks
none

### Documentation Notes
N/A

### Release Notes
N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4499)
<!-- Reviewable:end -->
