### PR TITLE
Implement a CodeTimer stack

### DIFF
--- a/src/main/java/net/rptools/lib/CodeTimer.java
+++ b/src/main/java/net/rptools/lib/CodeTimer.java
@@ -14,30 +14,21 @@
  */
 package net.rptools.lib;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class CodeTimer {
-  private final Map<String, Timer> timeMap = new HashMap<String, Timer>();
-  private final Map<String, Integer> orderMap = new HashMap<String, Integer>();
+  private final Map<String, Timer> timeMap = new HashMap<>();
+  private final Map<String, Integer> orderMap = new HashMap<>();
   private final String name;
-  private final long created = System.currentTimeMillis();
   private boolean enabled;
   private int threshold = 1;
-
-  private final DecimalFormat df = new DecimalFormat();
-
-  public CodeTimer() {
-    this("");
-  }
 
   public CodeTimer(String n) {
     name = n;
     enabled = true;
-    df.setMinimumIntegerDigits(5);
   }
 
   public boolean isEnabled() {
@@ -79,26 +70,6 @@ public class CodeTimer {
     timeMap.get(id).stop();
   }
 
-  public long getElapsed(String id) {
-    if (!enabled) {
-      return 0;
-    }
-    if (!orderMap.containsKey(id)) {
-      throw new IllegalArgumentException("Could not find orderMap id: " + id);
-    }
-    if (!timeMap.containsKey(id)) {
-      throw new IllegalArgumentException("Could not find timer id: " + id);
-    }
-    return timeMap.get(id).getElapsed();
-  }
-
-  public void reset(String id) {
-    if (!orderMap.containsKey(id)) {
-      throw new IllegalArgumentException("Could not find orderMap id: " + id);
-    }
-    timeMap.remove(id);
-  }
-
   public void clear() {
     orderMap.clear();
     timeMap.clear();
@@ -123,8 +94,6 @@ public class CodeTimer {
         continue;
       }
       builder.append(String.format("  %3d.  %6d ms  %s\n", orderMap.get(id), elapsed, id));
-      // builder.append("\t").append(orderMap.get(id)).append(". ").append(id).append(":
-      // ").append(timer.getElapsed()).append(" ms\n");
     }
     return builder.toString();
   }

--- a/src/main/java/net/rptools/lib/CodeTimer.java
+++ b/src/main/java/net/rptools/lib/CodeTimer.java
@@ -14,9 +14,7 @@
  */
 package net.rptools.lib;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 public class CodeTimer {
@@ -42,17 +40,24 @@ public class CodeTimer {
     this.enabled = enabled;
   }
 
-  public void start(String id) {
+  public void start(String id, Object... parameters) {
     if (!enabled) {
       return;
     }
+    if (parameters.length > 0) {
+      id = String.format(id, parameters);
+    }
+
     Timer timer = timeMap.computeIfAbsent(id, key -> new Timer());
     timer.start();
   }
 
-  public void stop(String id) {
+  public void stop(String id, Object... parameters) {
     if (!enabled) {
       return;
+    }
+    if (parameters.length > 0) {
+      id = String.format(id, parameters);
     }
 
     Timer timer = timeMap.get(id);

--- a/src/main/java/net/rptools/maptool/client/swing/ImagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/ImagePanel.java
@@ -229,11 +229,7 @@ public class ImagePanel extends JComponent
     int itemHeight = getItemHeight();
 
     int numToProcess = model.getImageCount();
-    String timerField = null;
-    if (timer.isEnabled()) {
-      timerField = "time to process " + numToProcess + " images";
-      timer.start(timerField);
-    }
+    timer.start("time to process %d images", numToProcess);
     for (int i = 0; i < numToProcess; i++) {
       int row = i / itemsPerRow;
       int column = i % itemsPerRow;
@@ -328,8 +324,8 @@ public class ImagePanel extends JComponent
       }
     }
     g.setFont(savedFont);
+    timer.stop("time to process %d images", numToProcess);
     if (timer.isEnabled()) {
-      timer.stop(timerField);
       System.out.println(timer);
     }
   }

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1756,39 +1756,38 @@ public class PointerTool extends DefaultTool {
         LinkedList<TextLayout> lineLayouts = new LinkedList<TextLayout>();
         if (AppPreferences.getShowStatSheet()
             && new StatSheetManager().isLegacyStatSheet(tokenUnderMouse.getStatSheet())) {
-          CodeTimer timer = new CodeTimer("statSheet");
-          timer.setEnabled(AppState.isCollectProfilingData());
-          timer.setThreshold(5);
-          timer.start("allProps");
-          for (TokenProperty property :
-              MapTool.getCampaign().getTokenPropertyList(tokenUnderMouse.getPropertyType())) {
-            if (property.isShowOnStatSheet()) {
-              if (property.isGMOnly() && !MapTool.getPlayer().isGM()) {
-                continue;
-              }
-              if (property.isOwnerOnly() && !AppUtil.playerOwns(tokenUnderMouse)) {
-                continue;
-              }
-              timer.start(property.getName());
-              MapToolVariableResolver resolver = new MapToolVariableResolver(tokenUnderMouse);
-              resolver.initialize();
-              resolver.setAutoPrompt(false);
-              Object propertyValue =
-                  tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
-              resolver.flush();
-              if (propertyValue != null && propertyValue.toString().length() > 0) {
-                String propName = property.getShortName();
-                if (StringUtils.isEmpty(propName)) propName = property.getName();
-                propertyMap.put(propName, propertyValue.toString());
-              }
-              timer.stop(property.getName());
-            }
-          }
-          timer.stop("allProps");
-          if (timer.isEnabled()) {
-            String results = timer.toString();
-            MapTool.getProfilingNoteFrame().addText(results);
-          }
+          CodeTimer.using(
+              "statSheet",
+              timer -> {
+                timer.setThreshold(5);
+
+                timer.start("allProps");
+                for (TokenProperty property :
+                    MapTool.getCampaign().getTokenPropertyList(tokenUnderMouse.getPropertyType())) {
+                  if (property.isShowOnStatSheet()) {
+                    if (property.isGMOnly() && !MapTool.getPlayer().isGM()) {
+                      continue;
+                    }
+                    if (property.isOwnerOnly() && !AppUtil.playerOwns(tokenUnderMouse)) {
+                      continue;
+                    }
+                    timer.start(property.getName());
+                    MapToolVariableResolver resolver = new MapToolVariableResolver(tokenUnderMouse);
+                    resolver.initialize();
+                    resolver.setAutoPrompt(false);
+                    Object propertyValue =
+                        tokenUnderMouse.getEvaluatedProperty(resolver, property.getName());
+                    resolver.flush();
+                    if (propertyValue != null && propertyValue.toString().length() > 0) {
+                      String propName = property.getShortName();
+                      if (StringUtils.isEmpty(propName)) propName = property.getName();
+                      propertyMap.put(propName, propertyValue.toString());
+                    }
+                    timer.stop(property.getName());
+                  }
+                }
+                timer.stop("allProps");
+              });
         }
         if (tokenUnderMouse.getPortraitImage() != null || !propertyMap.isEmpty()) {
           Font font = AppStyle.labelFont;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/TokenLocation.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/TokenLocation.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui.zone.renderer;
 import java.awt.*;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
+import net.rptools.lib.CodeTimer;
 import net.rptools.maptool.model.Token;
 
 class TokenLocation {
@@ -81,12 +82,12 @@ class TokenLocation {
     offsetX = renderer.getViewOffsetX();
     offsetY = renderer.getViewOffsetY();
 
-    renderer.timer.start("maybeOnsceen");
-    if (!boundsCache.intersects(viewport)) {
-      renderer.timer.stop("maybeOnsceen");
-      return false;
+    final var timer = CodeTimer.get();
+    timer.start("maybeOnsceen");
+    try {
+      return boundsCache.intersects(viewport);
+    } finally {
+      timer.stop("maybeOnsceen");
     }
-    renderer.timer.stop("maybeOnsceen");
-    return true;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1211,15 +1211,9 @@ public class ZoneRenderer extends JComponent
     }
     timer.start("overlays");
     for (ZoneOverlay overlay : overlayList) {
-      String msg = null;
-      if (timer.isEnabled()) {
-        msg = "overlays:" + overlay.getClass().getSimpleName();
-        timer.start(msg);
-      }
+      timer.start("overlays: %s", overlay.getClass().getSimpleName());
       overlay.paintOverlay(this, g2d);
-      if (timer.isEnabled()) {
-        timer.stop(msg);
-      }
+      timer.stop("overlays: %s", overlay.getClass().getSimpleName());
     }
     timer.stop("overlays");
 
@@ -1736,13 +1730,9 @@ public class ZoneRenderer extends JComponent
       Area visibleArea = zoneView.getVisibleArea(view);
       timer.stop("renderFog-visibleArea");
 
-      String msg = null;
-      if (timer.isEnabled()) {
-        msg = "renderFog-combined(" + (view.isUsingTokenView() ? view.getTokens().size() : 0) + ")";
-      }
-      timer.start(msg);
+      timer.start("renderFog-combined(%d)", view.isUsingTokenView() ? view.getTokens().size() : 0);
       Area combined = zoneView.getExposedArea(view);
-      timer.stop(msg);
+      timer.stop("renderFog-combined(%d)", view.isUsingTokenView() ? view.getTokens().size() : 0);
 
       timer.start("renderFogArea");
       buffG.fill(combined);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -144,7 +144,6 @@ public class ZoneRenderer extends JComponent
   private final List<ItemRenderer> itemRenderList = new LinkedList<ItemRenderer>();
   private PlayerView lastView;
   private Set<GUID> visibleTokenSet = new HashSet<>();
-  CodeTimer timer;
 
   private boolean autoResizeStamp = false;
 
@@ -385,7 +384,6 @@ public class ZoneRenderer extends JComponent
     removeMoveSelectionSet(keyTokenId);
     MapTool.serverCommand().stopTokenMove(getZone().getId(), keyTokenId);
     Token keyToken = zone.getToken(keyTokenId);
-    boolean topologyTokenMoved = false; // If any token has topology we need to reset FoW
 
     /*
      * Lee: if the lead token is snapped-to-grid and has not moved, every follower should return to where they were. Flag set at PointerTool and StampTool's stopTokenDrag() Handling the rest here.
@@ -403,147 +401,145 @@ public class ZoneRenderer extends JComponent
 
     // Lee: check only matters for snap-to-grid
     if (stg) {
-      CodeTimer moveTimer = new CodeTimer("ZoneRenderer.commitMoveSelectionSet");
-      moveTimer.setEnabled(AppState.isCollectProfilingData());
-      moveTimer.setThreshold(1);
+      CodeTimer.using(
+          "ZoneRenderer.commitMoveSelectionSet",
+          moveTimer -> {
+            moveTimer.setThreshold(1);
 
-      moveTimer.start("setup");
+            moveTimer.start("setup");
 
-      // Lee: the 1st of evils. changing it to handle proper computation
-      // for a key token's snapped state
-      AbstractPoint originPoint, tokenCell;
-      if (keyToken.isSnapToGrid()) {
-        originPoint = zone.getGrid().convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
-      } else {
-        originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
-      }
+            boolean topologyTokenMoved = false; // If any token has topology we need to reset FoW
 
-      Path<? extends AbstractPoint> path =
-          set.getWalker() != null ? set.getWalker().getPath() : set.gridlessPath;
-      // Jamz: add final path render here?
+            // Lee: the 1st of evils. changing it to handle proper computation
+            // for a key token's snapped state
+            AbstractPoint originPoint, tokenCell;
+            if (keyToken.isSnapToGrid()) {
+              originPoint = zone.getGrid().convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
+            } else {
+              originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
+            }
 
-      List<GUID> filteredTokens = new ArrayList<GUID>();
-      moveTimer.stop("setup");
+            Path<? extends AbstractPoint> path =
+                set.getWalker() != null ? set.getWalker().getPath() : set.gridlessPath;
+            // Jamz: add final path render here?
 
-      int offsetX, offsetY;
+            List<GUID> filteredTokens = new ArrayList<GUID>();
+            moveTimer.stop("setup");
 
-      moveTimer.start("eachtoken");
-      for (GUID tokenGUID : selectionSet) {
-        Token token = zone.getToken(tokenGUID);
-        // If the token has been deleted, the GUID will still be in the
-        // set but getToken() will return null.
-        if (token == null) {
-          continue;
-        }
+            int offsetX, offsetY;
 
-        // Lee: get offsets based on key token's snapped state
-        if (token.isSnapToGrid()) {
-          tokenCell = zone.getGrid().convert(new ZonePoint(token.getX(), token.getY()));
-        } else {
-          tokenCell = new ZonePoint(token.getX(), token.getY());
-        }
+            moveTimer.start("eachtoken");
+            for (GUID tokenGUID : selectionSet) {
+              Token token = zone.getToken(tokenGUID);
+              // If the token has been deleted, the GUID will still be in the
+              // set but getToken() will return null.
+              if (token == null) {
+                continue;
+              }
 
-        int cellOffX, cellOffY;
-        if (token.isSnapToGrid() == keyToken.isSnapToGrid()) {
-          cellOffX = originPoint.x - tokenCell.x;
-          cellOffY = originPoint.y - tokenCell.y;
-        } else {
-          cellOffX = cellOffY = 0; // not used unless both are of same SnapToGrid
-        }
+              // Lee: get offsets based on key token's snapped state
+              if (token.isSnapToGrid()) {
+                tokenCell = zone.getGrid().convert(new ZonePoint(token.getX(), token.getY()));
+              } else {
+                tokenCell = new ZonePoint(token.getX(), token.getY());
+              }
 
-        if (token.isSnapToGrid()
-            && (!AppPreferences.getTokensSnapWhileDragging() || !keyToken.isSnapToGrid())) {
-          // convert to Cellpoint and back to ensure token ends up at correct X and Y
-          CellPoint cellEnd =
-              zone.getGrid()
-                  .convert(
-                      new ZonePoint(
-                          token.getX() + set.getOffsetX(), token.getY() + set.getOffsetY()));
-          ZonePoint pointEnd = cellEnd.convertToZonePoint(zone.getGrid());
-          offsetX = pointEnd.x - token.getX();
-          offsetY = pointEnd.y - token.getY();
-        } else {
-          offsetX = set.getOffsetX();
-          offsetY = set.getOffsetY();
-        }
+              int cellOffX, cellOffY;
+              if (token.isSnapToGrid() == keyToken.isSnapToGrid()) {
+                cellOffX = originPoint.x - tokenCell.x;
+                cellOffY = originPoint.y - tokenCell.y;
+              } else {
+                cellOffX = cellOffY = 0; // not used unless both are of same SnapToGrid
+              }
 
-        /*
-         * Lee: the problem now is to keep the precise coordinate computations for unsnapped tokens following a snapped key token. The derived path in the following section contains rounded
-         * down values because the integer cell values were passed. If these were double in nature, the precision would be kept, but that would be too difficult to change at this stage...
-         */
+              if (token.isSnapToGrid()
+                  && (!AppPreferences.getTokensSnapWhileDragging() || !keyToken.isSnapToGrid())) {
+                // convert to Cellpoint and back to ensure token ends up at correct X and Y
+                CellPoint cellEnd =
+                    zone.getGrid()
+                        .convert(
+                            new ZonePoint(
+                                token.getX() + set.getOffsetX(), token.getY() + set.getOffsetY()));
+                ZonePoint pointEnd = cellEnd.convertToZonePoint(zone.getGrid());
+                offsetX = pointEnd.x - token.getX();
+                offsetY = pointEnd.y - token.getY();
+              } else {
+                offsetX = set.getOffsetX();
+                offsetY = set.getOffsetY();
+              }
 
-        token.applyMove(set, path, offsetX, offsetY, keyToken, cellOffX, cellOffY);
+              /*
+               * Lee: the problem now is to keep the precise coordinate computations for unsnapped tokens following a snapped key token. The derived path in the following section contains rounded
+               * down values because the integer cell values were passed. If these were double in nature, the precision would be kept, but that would be too difficult to change at this stage...
+               */
 
-        // Lee: setting originPoint to landing point
-        token.setOriginPoint(new ZonePoint(token.getX(), token.getY()));
+              token.applyMove(set, path, offsetX, offsetY, keyToken, cellOffX, cellOffY);
 
-        flush(token);
-        MapTool.serverCommand().putToken(zone.getId(), token);
+              // Lee: setting originPoint to landing point
+              token.setOriginPoint(new ZonePoint(token.getX(), token.getY()));
 
-        // No longer need this version
-        // Lee: redundant flush() already did this above
-        // replacementImageMap.remove(token);
+              flush(token);
+              MapTool.serverCommand().putToken(zone.getId(), token);
 
-        // Only add certain tokens to the list to process in the move
-        // Macro function(s).
-        if (token.getLayer().supportsWalker() && token.isVisible()) {
-          filteredTokens.add(tokenGUID);
-        }
+              // No longer need this version
+              // Lee: redundant flush() already did this above
+              // replacementImageMap.remove(token);
 
-        if (token.hasAnyTopology()) {
-          topologyTokenMoved = true;
-        }
+              // Only add certain tokens to the list to process in the move
+              // Macro function(s).
+              if (token.getLayer().supportsWalker() && token.isVisible()) {
+                filteredTokens.add(tokenGUID);
+              }
 
-        // renderPath((Graphics2D) this.getGraphics(), path, token.getFootprint(zone.getGrid()));
-      }
-      moveTimer.stop("eachtoken");
+              if (token.hasAnyTopology()) {
+                topologyTokenMoved = true;
+              }
+            }
+            moveTimer.stop("eachtoken");
 
-      moveTimer.start("onTokenMove");
-      if (!filteredTokens.isEmpty()) {
-        // give onTokenMove a chance to reject each token's movement.
-        // pass in all the tokens at once so it doesn't have to re-scan for handlers for each token
-        List<Token> tokensToCheck =
-            filteredTokens.stream().map(zone::getToken).collect(Collectors.toList());
-        List<Token> tokensDenied =
-            TokenMoveFunctions.callForIndividualTokenMoveVetoes(path, tokensToCheck);
-        for (Token token : tokensDenied) {
-          denyMovement(token);
-        }
-      }
-      moveTimer.stop("onTokenMove");
+            moveTimer.start("onTokenMove");
+            if (!filteredTokens.isEmpty()) {
+              // give onTokenMove a chance to reject each token's movement.
+              // pass in all the tokens at once so it doesn't have to re-scan for handlers for each
+              // token
+              List<Token> tokensToCheck =
+                  filteredTokens.stream().map(zone::getToken).collect(Collectors.toList());
+              List<Token> tokensDenied =
+                  TokenMoveFunctions.callForIndividualTokenMoveVetoes(path, tokensToCheck);
+              for (Token token : tokensDenied) {
+                denyMovement(token);
+              }
+            }
+            moveTimer.stop("onTokenMove");
 
-      moveTimer.start("onMultipleTokensMove");
-      // Multiple tokens, the list of tokens and call
-      // onMultipleTokensMove() macro function.
-      if (filteredTokens.size() > 1) {
-        // now determine if the macro returned false and if so
-        // revert each token's move to the last path.
-        boolean moveDenied = TokenMoveFunctions.callForMultiTokenMoveVeto(filteredTokens);
-        if (moveDenied) {
-          for (GUID tokenGUID : filteredTokens) {
-            Token token = zone.getToken(tokenGUID);
-            denyMovement(token);
-          }
-        }
-      }
-      moveTimer.stop("onMultipleTokensMove");
+            moveTimer.start("onMultipleTokensMove");
+            // Multiple tokens, the list of tokens and call
+            // onMultipleTokensMove() macro function.
+            if (filteredTokens.size() > 1) {
+              // now determine if the macro returned false and if so
+              // revert each token's move to the last path.
+              boolean moveDenied = TokenMoveFunctions.callForMultiTokenMoveVeto(filteredTokens);
+              if (moveDenied) {
+                for (GUID tokenGUID : filteredTokens) {
+                  Token token = zone.getToken(tokenGUID);
+                  denyMovement(token);
+                }
+              }
+            }
+            moveTimer.stop("onMultipleTokensMove");
 
-      moveTimer.start("updateTokenTree");
-      MapTool.getFrame().updateTokenTree();
-      moveTimer.stop("updateTokenTree");
+            moveTimer.start("updateTokenTree");
+            MapTool.getFrame().updateTokenTree();
+            moveTimer.stop("updateTokenTree");
 
-      if (moveTimer.isEnabled()) {
-        MapTool.getProfilingNoteFrame().addText(moveTimer.toString());
-        moveTimer.clear();
-      }
+            if (topologyTokenMoved) {
+              zone.tokenTopologyChanged();
+            }
+          });
     } else {
       for (GUID tokenGUID : selectionSet) {
         denyMovement(zone.getToken(tokenGUID));
       }
-    }
-
-    if (topologyTokenMoved) {
-      zone.tokenTopologyChanged();
     }
   }
 
@@ -784,57 +780,53 @@ public class ZoneRenderer extends JComponent
 
   @Override
   public void paintComponent(Graphics g) {
-    if (timer == null) {
-      timer = new CodeTimer("ZoneRenderer.renderZone");
-    }
-    timer.setEnabled(AppState.isCollectProfilingData());
-    timer.clear();
-    timer.setThreshold(10);
-    timer.start("paintComponent");
+    CodeTimer.using(
+        "ZoneRenderer.renderZone",
+        timer -> {
+          timer.setThreshold(10);
 
-    Graphics2D g2d = (Graphics2D) g;
+          timer.start("paintComponent");
 
-    timer.start("paintComponent:allocateBuffer");
-    tempBufferPool.setWidth(getSize().width);
-    tempBufferPool.setHeight(getSize().height);
-    tempBufferPool.setConfiguration(g2d.getDeviceConfiguration());
-    timer.stop("paintComponent:allocateBuffer");
+          Graphics2D g2d = (Graphics2D) g;
 
-    try (final var bufferHandle = tempBufferPool.acquire()) {
-      final var buffer = bufferHandle.get();
-      final var bufferG2d = buffer.createGraphics();
-      // Keep the clip so we don't render more than we have to.
-      bufferG2d.setClip(g2d.getClip());
+          timer.start("paintComponent:allocateBuffer");
+          tempBufferPool.setWidth(getSize().width);
+          tempBufferPool.setHeight(getSize().height);
+          tempBufferPool.setConfiguration(g2d.getDeviceConfiguration());
+          timer.stop("paintComponent:allocateBuffer");
 
-      timer.start("paintComponent:createView");
-      PlayerView pl = getPlayerView();
-      timer.stop("paintComponent:createView");
+          try (final var bufferHandle = tempBufferPool.acquire()) {
+            final var buffer = bufferHandle.get();
+            final var bufferG2d = buffer.createGraphics();
+            // Keep the clip so we don't render more than we have to.
+            bufferG2d.setClip(g2d.getClip());
 
-      renderZone(bufferG2d, pl);
-      int noteVPos = 20;
-      if (MapTool.getFrame().areFullScreenToolsShown()) noteVPos += 40;
+            timer.start("paintComponent:createView");
+            PlayerView pl = getPlayerView();
+            timer.stop("paintComponent:createView");
 
-      if (!AppPreferences.getMapVisibilityWarning() && (!zone.isVisible() && pl.isGMView())) {
-        GraphicsUtil.drawBoxedString(
-            bufferG2d, I18N.getText("zone.map_not_visible"), getSize().width / 2, noteVPos);
-        noteVPos += 20;
-      }
-      if (AppState.isShowAsPlayer()) {
-        GraphicsUtil.drawBoxedString(
-            bufferG2d, I18N.getText("zone.player_view"), getSize().width / 2, noteVPos);
-      }
+            renderZone(bufferG2d, pl);
+            int noteVPos = 20;
+            if (MapTool.getFrame().areFullScreenToolsShown()) noteVPos += 40;
 
-      timer.start("paintComponent:renderBuffer");
-      bufferG2d.dispose();
-      g2d.drawImage(buffer, null, 0, 0);
-      timer.stop("paintComponent:renderBuffer");
-    }
+            if (!AppPreferences.getMapVisibilityWarning() && (!zone.isVisible() && pl.isGMView())) {
+              GraphicsUtil.drawBoxedString(
+                  bufferG2d, I18N.getText("zone.map_not_visible"), getSize().width / 2, noteVPos);
+              noteVPos += 20;
+            }
+            if (AppState.isShowAsPlayer()) {
+              GraphicsUtil.drawBoxedString(
+                  bufferG2d, I18N.getText("zone.player_view"), getSize().width / 2, noteVPos);
+            }
 
-    timer.stop("paintComponent");
-    if (timer.isEnabled()) {
-      MapTool.getProfilingNoteFrame().addText(timer.toString());
-      timer.clear();
-    }
+            timer.start("paintComponent:renderBuffer");
+            bufferG2d.dispose();
+            g2d.drawImage(buffer, null, 0, 0);
+            timer.stop("paintComponent:renderBuffer");
+          }
+
+          timer.stop("paintComponent");
+        });
   }
 
   public PlayerView getPlayerView() {
@@ -913,6 +905,8 @@ public class ZoneRenderer extends JComponent
    * @param view PlayerView object that describes whether the view is a Player or GM view
    */
   public void renderZone(Graphics2D g2d, PlayerView view) {
+    final var timer = CodeTimer.get();
+
     timer.start("setup");
     // store previous rendering settings
     RenderingHints oldRenderingHints = g2d.getRenderingHints();
@@ -1271,6 +1265,8 @@ public class ZoneRenderer extends JComponent
    * @param view the player view
    */
   private void renderLights(Graphics2D g, PlayerView view) {
+    final var timer = CodeTimer.get();
+
     // Collect and organize lights
     timer.start("renderLights:getLights");
     final var drawableLights = zoneView.getDrawableLights(view);
@@ -1320,6 +1316,8 @@ public class ZoneRenderer extends JComponent
    * @param view the player view.
    */
   private void renderAuras(Graphics2D g, PlayerView view) {
+    final var timer = CodeTimer.get();
+
     // Setup
     timer.start("renderAuras:getAuras");
     final var drawableAuras = zoneView.getDrawableAuras();
@@ -1341,6 +1339,8 @@ public class ZoneRenderer extends JComponent
       PlayerView view,
       @Nullable ZoneRendererConstants.LightOverlayClipStyle clipStyle,
       float overlayOpacity) {
+    final var timer = CodeTimer.get();
+
     g = (Graphics2D) g.create();
 
     final var disjointLumensLevels = zoneView.getDisjointObscuredLumensLevels(view);
@@ -1453,6 +1453,8 @@ public class ZoneRenderer extends JComponent
       @Nullable ZoneRendererConstants.LightOverlayClipStyle clipStyle,
       Collection<DrawableLight> lights,
       Paint backgroundFill) {
+    final var timer = CodeTimer.get();
+
     if (lights.isEmpty()) {
       // No point spending resources accomplishing nothing.
       return;
@@ -1519,6 +1521,8 @@ public class ZoneRenderer extends JComponent
    * @param view The player view.
    */
   private void renderPlayerDarkness(Graphics2D g, PlayerView view) {
+    final var timer = CodeTimer.get();
+
     if (view.isGMView()) {
       // GMs see the darkness rendered as lights, not as blackness.
       return;
@@ -1647,6 +1651,8 @@ public class ZoneRenderer extends JComponent
   }
 
   private void renderLabels(Graphics2D g, PlayerView view) {
+    final var timer = CodeTimer.get();
+
     timer.start("labels-1");
     labelLocationList.clear();
     for (Label label : zone.getLabels()) {
@@ -1686,6 +1692,8 @@ public class ZoneRenderer extends JComponent
   }
 
   private void renderFog(Graphics2D g, PlayerView view) {
+    final var timer = CodeTimer.get();
+
     Dimension size = getSize();
     Area fogClip = new Area(new Rectangle(0, 0, size.width, size.height));
 
@@ -2231,6 +2239,8 @@ public class ZoneRenderer extends JComponent
   @SuppressWarnings("unchecked")
   public void renderPath(
       Graphics2D g, Path<? extends AbstractPoint> path, TokenFootprint footprint) {
+    final var timer = CodeTimer.get();
+
     if (path == null) {
       return;
     }
@@ -2728,6 +2738,8 @@ public class ZoneRenderer extends JComponent
 
   protected void renderTokens(
       Graphics2D g, List<Token> tokenList, PlayerView view, boolean figuresOnly) {
+    final var timer = CodeTimer.get();
+
     Graphics2D clippedG = g;
 
     boolean isGMView = view.isGMView(); // speed things up


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #4514 

### Description of the Change

A new per-thread stack of `CodeTimer` is available to allow getting a `CodeTimer` from anywhere. The top of the stack is always available by calling the `CodeTimer.get()` static method. When a section of code needs to be timed with a report, `CodeTimer.using(name, callback)` is used. This method creates a new timer, enables it if necessary, pushes it onto the stack, runs the callback, pops the timer back off the stack, and generates a report. In other words, it runs the callback during which a new timer is available via `CodeTimer.get()`, then reports the results.

Additional changes include cleaning up `CodeTimer` by removing unused bits, making the `start()`/`stop()` methods leaner in terms of its `HashMap<>` usage, and allowing dynamic IDs to clean up some calling code.

I would advise ignoring whitespace in the diff, as the use of `CodeTimer.using()` has modified the indentation of the code.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Added a stack of CodeTimer to make timing of code easier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4518)
<!-- Reviewable:end -->
