### PR TITLE
Fix MBL in non-noded situations

### DIFF
--- a/src/main/java/net/rptools/lib/GeometryUtil.java
+++ b/src/main/java/net/rptools/lib/GeometryUtil.java
@@ -17,16 +17,23 @@ package net.rptools.lib;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.awt.ShapeReader;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.noding.NodableSegmentString;
+import org.locationtech.jts.noding.NodedSegmentString;
+import org.locationtech.jts.noding.SegmentString;
+import org.locationtech.jts.noding.snapround.SnapRoundingNoder;
 import org.locationtech.jts.operation.polygonize.Polygonizer;
 
 public class GeometryUtil {
+  private static final Logger log = LogManager.getLogger(GeometryUtil.class);
   private static final PrecisionModel precisionModel = new PrecisionModel(1_000_000.0);
   private static final GeometryFactory geometryFactory = new GeometryFactory(precisionModel);
 
@@ -65,15 +72,33 @@ public class GeometryUtil {
     final var pathIterator = area.getPathIterator(null);
     final var polygonizer = new Polygonizer(true);
     final var coords = (List<Coordinate[]>) ShapeReader.toCoordinates(pathIterator);
-    final var geometries = new ArrayList<LineString>();
-    for (final var coordinateArray : coords) {
-      for (final var coord : coordinateArray) {
-        precisionModel.makePrecise(coord);
-      }
-      final var lineString = geometryFactory.createLineString(coordinateArray);
-      geometries.add(lineString);
+
+    // Make sure the geometry is noded and precise before polygonizing.
+    final var strings = new ArrayList<NodableSegmentString>(coords.size());
+    for (var string : coords) {
+      strings.add(new NodedSegmentString(string, null));
     }
-    polygonizer.add(geometries);
+    final var noder = new SnapRoundingNoder(precisionModel);
+    noder.computeNodes(strings);
+    final Collection<? extends SegmentString> nodedStrings = noder.getNodedSubstrings();
+
+    // Now build the polygons from our corrected geometry.
+    for (var string : nodedStrings) {
+      final var lineString = geometryFactory.createLineString(string.getCoordinates());
+      polygonizer.add(lineString);
+    }
+
+    final var danglingEdges = polygonizer.getDangles().size();
+    final var cutEdges = polygonizer.getCutEdges().size();
+    final var invalidRings = polygonizer.getInvalidRingLines().size();
+    if (danglingEdges != 0 || cutEdges != 0 || invalidRings != 0) {
+      log.error(
+          "Found invalid geometry: {} dangling edges; {} cut edges; {} invalid rings",
+          danglingEdges,
+          cutEdges,
+          invalidRings);
+    }
+
     return polygonizer.getGeometry();
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4528

### Description of the Change

In the test case attached in the bug report, AWT returns the left and right triangles as separate paths, but the top and bottom triangles are treated as part of the surrounding rectangle by using a self-intersecting path. JTS' `Polygonizer` expects well-behaved input, which includes not allowing these self-intersection paths.

To solve this, we now make sure to node our geometry prior to polygonizing. This is done using a `SnapRoundingNoder` to make sure it is robust while also freeing us from having to enforce precision ourselves. And to make sure this sort of problem doesn't fly under the radar in the future, we log any errors that the polygonizer reports.

~~I've tested on some complex geometry and have not noticed any significant slowdown related to this change.~~

### Possible Drawbacks

Performance is reduced for expose last path when the paths are long.

### Documentation Notes

N/A

### Release Notes

- Fixed MBL when a corner of one region is on the edge of another.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4529)
<!-- Reviewable:end -->
