### PR TITLE
MetaMacro Functionality for GM & Campaign Panel Buttons

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -1221,32 +1221,131 @@ public class MacroFunctions extends AbstractFunction {
 
   /**
    * I don't know how to actually make tests, but these are the macros I used when developing the
-   * functions for dealing with macros on the campaign panels.
-   * These macros create test macro buttons containing applications of the various functions.
-   * This is mostly so I have them stored somewhere relelvant.
+   * functions for dealing with macros on the campaign panels. These macros create test macro
+   * buttons containing applications of the various functions. This is mostly so I have them stored
+   * somewhere relevant.
    */
-  public void campaignMacroFunctionsTest() throws ParserException {
-    String macroTestCampaign = "[h: props = json.set(\\\"\\\",\n" +
-            "    \\\"autoExecute\\\", true,\n" +
-            "    \\\"label\\\", \\\"CampaignMacro\\\",\n" +
-            "    \\\"playerEditable\\\", false,\n" +
-            "    \\\"command\\\", decode(\\\"%5Bh%3A%20broadcast(%22%3Cb%3EPanel%20%22%20%2B%20panel.campaign%20%2B%20%22%3C%2Fb%3E%22)%5D%0D%0A%5Bh%3A%20broadcast('getMacroName()%20%2B%20%26quot%3B%20%40%20%26quot%3B%20%2B%20getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroName()%20%2B%20'%20%40%20'getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroButtonIndex()%20-%3E%20'%20%2B%20getMacroButtonIndex())%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22json%22%2C%20panel.campaign)%20-%3E%20'%20%2B%20getMacros(%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22%22%2C%20panel.campaign)%20-%3E%20'%20%2B%20getMacros(%22%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation())%20-%3E%20'%20%2B%0D%0A%09getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation()))%5D%0D%0A%5Bh%3A%20mbp%20%3D%20getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%20-%3E%20%3Cpre%3E'%0D%0A%09%2B%20json.indent(mbp%2C3)%20%2B%20'%3C%2Fpre%3E')%5D%0D%0A%5Bh%3A%20mbp%20%3D%20json.remove(mbp%2C%22index%22)%5D%0D%0A%5Bh%3A%20broadcast('createMacro(mbp%2C%20panel.campaign)%20-%3E%20'%20%2B%20createMacro(mbp%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroCommand(getMacroButtonIndex()%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroCommand(getMacroButtonIndex()%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(%22%22%2C%0D%0A%22applyToSelected%22%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22autoExecute%22%20%20%20%20%20%20%20%20%20%20%2C%20true%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22color%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22red%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22command%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22%5Bh%3A%20this%20%3D%20getMacroName()%5D%0D%0A%5Bh%3A%20here%20%3D%20getMacroLocation()%5D%0D%0A%5Bh%3A%20broadcast(strformat('%25%7Bthis%7D%40%25%7Bhere%7D'))%5D%22%2C%0D%0A%22fontColor%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22white%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22fontSize%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%2213pt%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22includeLabel%22%20%20%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22sortBy%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22a1%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22label%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Macro%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22maxWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Sneaky%20hiding%20place%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22minWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%2090%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22playerEditable%22%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22tooltip%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Three%20cheers%20for%20the%20sun%20god.%20Ra!%20Ra!%20Ra!%22%2C%0D%0A%22compare%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20json.append(%22%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22applyToSelected%22%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22autoExecute%22%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22command%22%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22includeLabel%22%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22sortPrefix%22)%0D%0A)%5D%0D%0A%0D%0A%5Bh%3A%20indices%20%3D%20getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.campaign)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.campaign)%20-%3E'%20%2B%0D%0A%09setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(props%2C%20%22fontColor%22%2C%20%22black%22)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.campaign)%20-%3E'%20%2B%0D%0A%09setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('hasMacro(%22New%20Macro%22%2C%20panel.campaign)%20-%3E%20'%20%2B%20hasMacro(%22New%20Macro%22%2C%20panel.campaign))%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40campaign%22)%3A%22%22%5D%0D%0A%5Bh%3A%20setMacroCommand(%0D%0A%09%09json.get(getMacroIndexes(%22New%20Macro%22%2C%20%22json%22%2C%20panel.campaign)%2C0)%2C%09%22%5Bh%3A%20broadcast(strformat('%25s%40%25s%20remastered.'%2C%20getMacroName()%2C%20getMacroLocation()))%5D%5Bh%3A%20removeMacro(listGet(getMacroIndexes('New%20Macro'%2C%20''%2C%20panel.campaign)%2C%200)%2C%20panel.campaign)%5D%22%2C%20panel.campaign)%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40campaign%22)%3A%22%22%5D%0D%0A%5Bh%3A%20broadcast('getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.campaign)%20-%3E'%20%2B%20getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.campaign)%5D\\\"),\n" +
-            "    \\\"applyToSelected\\\", false,\n" +
-            "    \\\"compare\\\", json.append(\\\"\\\", \\\"group\\\", \\\"sortPrefix\\\", \\\"command\\\", \\\"includeLabel\\\", \\\"autoExecute\\\", \\\"applyToSelected\\\")\n" +
-            ")]\n" +
-            "[h: createMacro(props, panel.campaign)]\n" +
-            "[r, macro(\\\"CampaignMacro@campaign\\\"):\\\"\\\"]";
-    String macroTestGM = "[h: props = json.set(\\\"\\\",\n" +
-            "    \\\"autoExecute\\\", true,\n" +
-            "    \\\"label\\\", \\\"GMMacro\\\",\n" +
-            "    \\\"playerEditable\\\", false,\n" +
-            "    \\\"command\\\", decode(\\\"%5Bh%3A%20broadcast(%22%3Cb%3EPanel%20%22%20%2B%20panel.gm%20%2B%20%22%3C%2Fb%3E%22)%5D%0D%0A%5Bh%3A%20broadcast('getMacroName()%20%2B%20%26quot%3B%20%40%20%26quot%3B%20%2B%20getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroName()%20%2B%20'%20%40%20'getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroButtonIndex()%20-%3E%20'%20%2B%20getMacroButtonIndex())%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22json%22%2C%20panel.gm)%20-%3E%20'%20%2B%20getMacros(%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22%22%2C%20panel.gm)%20-%3E%20'%20%2B%20getMacros(%22%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation())%20-%3E%20'%20%2B%0D%0A%09getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation()))%5D%0D%0A%5Bh%3A%20mbp%20%3D%20getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%20-%3E%20%3Cpre%3E'%0D%0A%09%2B%20json.indent(mbp%2C3)%20%2B%20'%3C%2Fpre%3E')%5D%0D%0A%5Bh%3A%20mbp%20%3D%20json.remove(mbp%2C%22index%22)%5D%0D%0A%5Bh%3A%20broadcast('createMacro(mbp%2C%20panel.gm)%20-%3E%20'%20%2B%20createMacro(mbp%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroCommand(getMacroButtonIndex()%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroCommand(getMacroButtonIndex()%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(%22%22%2C%0D%0A%22applyToSelected%22%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22autoExecute%22%20%20%20%20%20%20%20%20%20%20%2C%20true%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22color%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22red%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22command%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22%5Bh%3A%20this%20%3D%20getMacroName()%5D%0D%0A%5Bh%3A%20here%20%3D%20getMacroLocation()%5D%0D%0A%5Bh%3A%20broadcast(strformat('%25%7Bthis%7D%40%25%7Bhere%7D'))%5D%22%2C%0D%0A%22fontColor%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22white%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22fontSize%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%2213pt%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22includeLabel%22%20%20%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22sortBy%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22a1%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22label%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Macro%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22maxWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Sneaky%20hiding%20place%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22minWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%2090%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22playerEditable%22%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22tooltip%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Three%20cheers%20for%20the%20sun%20god.%20Ra!%20Ra!%20Ra!%22%2C%0D%0A%22compare%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20json.append(%22%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22applyToSelected%22%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22autoExecute%22%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22command%22%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22includeLabel%22%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22sortPrefix%22)%0D%0A)%5D%0D%0A%0D%0A%5Bh%3A%20indices%20%3D%20getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.gm)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.gm)%20-%3E'%20%2B%0D%0A%09setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(props%2C%20%22fontColor%22%2C%20%22black%22)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.gm)%20-%3E'%20%2B%0D%0A%09setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('hasMacro(%22New%20Macro%22%2C%20panel.gm)%20-%3E%20'%20%2B%20hasMacro(%22New%20Macro%22%2C%20panel.gm))%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40gm%22)%3A%22%22%5D%0D%0A%5Bh%3A%20setMacroCommand(%0D%0A%09%09json.get(getMacroIndexes(%22New%20Macro%22%2C%20%22json%22%2C%20panel.gm)%2C0)%2C%09%22%5Bh%3A%20broadcast(strformat('%25s%40%25s%20remastered.'%2C%20getMacroName()%2C%20getMacroLocation()))%5D%5Bh%3A%20removeMacro(listGet(getMacroIndexes('New%20Macro'%2C%20''%2C%20panel.gm)%2C%200)%2C%20panel.gm)%5D%22%2C%20panel.gm)%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40gm%22)%3A%22%22%5D%0D%0A%5Bh%3A%20broadcast('getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.gm)%20-%3E'%20%2B%20getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.gm)%5D\\\"),\n" +
-            "    \\\"applyToSelected\\\", false,\n" +
-            "    \\\"compare\\\", json.append(\\\"\\\", \\\"group\\\", \\\"sortPrefix\\\", \\\"command\\\", \\\"includeLabel\\\", \\\"autoExecute\\\", \\\"applyToSelected\\\")\n" +
-            ")]\n" +
-            "[h: createMacro(props, panel.gm)]\n" +
-            "[r, macro(\\\"CampaignMacro@gm\\\"):\\\"\\\"]";
-    MapTool.getParser().parseExpression(macroTestGM,false);
-    MapTool.getParser().parseExpression(macroTestCampaign,false);
-  }
+/*
+[h: broadcast("<b>Panel " + panel.campaign + "</b>")]
+[h: broadcast('getMacroName() + &quot; @ &quot; + getMacroLocation() - > ' + getMacroName() + ' @ 'getMacroLocation())]
+[h: broadcast('getMacroLocation() - > ' + getMacroLocation())]
+[h: broadcast('getMacroButtonIndex() -> ' + getMacroButtonIndex())]
+[h: broadcast('getMacros("json", panel.campaign) -> ' + getMacros("json", panel.campaign))]
+[h: broadcast('getMacros("", panel.campaign) -> ' + getMacros("", panel.campaign))]
+[h: broadcast('getMacroProps(getMacroButtonIndex(),";", getMacroLocation()) -> ' +
+              getMacroProps(getMacroButtonIndex(),";", getMacroLocation()))]
+[h: mbp = getMacroProps(getMacroButtonIndex(),"json", getMacroLocation())]
+[h: broadcast('getMacroProps(getMacroButtonIndex(),"json", getMacroLocation()) -> <pre>'
+                      + json.indent(mbp,3) + '</pre>')]
+[h: mbp = json.remove(mbp,"index")]
+[h: broadcast('createMacro(mbp, panel.campaign) -> ' + createMacro(mbp, panel.campaign))]
+[h: broadcast('getMacroIndices(getMacroName(), "json", panel.campaign) -> ' +
+              getMacroIndices(getMacroName(), "json", panel.campaign))]
+[h: broadcast('getMacroIndices(getMacroName(), "", panel.campaign) -> ' +
+              getMacroIndices(getMacroName(), "", panel.campaign))]
+[h: broadcast('getMacroIndexes(getMacroName(), "json", panel.campaign) -> ' +
+              getMacroIndexes(getMacroName(), "json", panel.campaign))]
+[h: broadcast('getMacroIndexes(getMacroName(), "", panel.campaign) -> ' +
+              getMacroIndexes(getMacroName(), "", panel.campaign))]
+[h: broadcast('getMacroCommand(getMacroButtonIndex(), panel.campaign) -> ' +
+              getMacroCommand(getMacroButtonIndex(), panel.campaign))]
+[h: props = json.set("",
+"applyToSelected"      , false                                     ,
+"autoExecute"          , true                                      ,
+"color"                , "red"                                     ,
+"command"              , "[h: this = getMacroName()]
+[h: here = getMacroLocation()]
+[h: broadcast(strformat('%{this}@%{here}'))]",
+"fontColor"            , "white"                                   ,
+"fontSize"             , "13pt"                                    ,
+"includeLabel"         , false                                     ,
+"group"                , "New Group"                               ,
+"sortBy"               , "a1"                                      ,
+"label"                , "New Macro"                               ,
+"maxWidth"             , "Sneaky hiding place"                     ,
+"minWidth"             , 90                                        ,
+"playerEditable"       , false                                     ,
+"tooltip"              , "Three cheers for the sun god. Ra! Ra! Ra!",
+"compare"              , json.append(""                            ,
+"applyToSelected"  ,
+"autoExecute"      ,
+"command"          ,
+"group"            ,
+"includeLabel"     ,
+"sortPrefix")
+)]
+[h: indices = getMacroIndices(getMacroName(), "json", panel.campaign)]
+[h: broadcast('setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.campaign) ->' +
+              setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.campaign))]
+[h: props = json.set(props, "fontColor", "black")]
+[h: broadcast('setMacroProps("New Macro", props,"json", panel.campaign) ->' +
+              setMacroProps("New Macro", props,"json", panel.campaign))]
+[h: broadcast('hasMacro("New Macro", panel.campaign) -> ' + hasMacro("New Macro", panel.campaign))]
+[h, macro("New Macro@campaign"):""]
+[h: setMacroCommand(
+json.get(getMacroIndexes("New Macro", "json", panel.campaign),0),	"[h: broadcast(strformat('%s@%s remastered... and deleted.', getMacroName(), getMacroLocation()))][r: removeMacro(listGet(getMacroIndexes('New Macro', '', panel.campaign), 0), panel.campaign)]", panel.campaign)]
+[h, macro("New Macro@campaign"):""]
+[h: broadcast('getMacroGroup("New Group","", panel.campaign) ->' + getMacroGroup("New Group","", panel.campaign)]
+
+[h: broadcast("<b>Panel " + panel.gm + "</b>")]
+[h: broadcast('getMacroName() + &quot; @ &quot; + getMacroLocation() - > ' + getMacroName() + ' @ 'getMacroLocation())]
+[h: broadcast('getMacroLocation() - > ' + getMacroLocation())]
+[h: broadcast('getMacroButtonIndex() -> ' + getMacroButtonIndex())]
+[h: broadcast('getMacros("json", panel.gm) -> ' + getMacros("json", panel.gm))]
+[h: broadcast('getMacros("", panel.gm) -> ' + getMacros("", panel.gm))]
+[h: broadcast('getMacroProps(getMacroButtonIndex(),";", getMacroLocation()) -> ' +
+	getMacroProps(getMacroButtonIndex(),";", getMacroLocation()))]
+[h: mbp = getMacroProps(getMacroButtonIndex(),"json", getMacroLocation())]
+[h: broadcast('getMacroProps(getMacroButtonIndex(),"json", getMacroLocation()) -> <pre>'
+	+ json.indent(mbp,3) + '</pre>')]
+[h: mbp = json.remove(mbp,"index")]
+[h: broadcast('createMacro(mbp, panel.gm) -> ' + createMacro(mbp, panel.gm))]
+[h: broadcast('getMacroIndices(getMacroName(), "json", panel.gm) -> ' +
+	getMacroIndices(getMacroName(), "json", panel.gm))]
+[h: broadcast('getMacroIndices(getMacroName(), "", panel.gm) -> ' +
+	getMacroIndices(getMacroName(), "", panel.gm))]
+[h: broadcast('getMacroIndexes(getMacroName(), "json", panel.gm) -> ' +
+	getMacroIndexes(getMacroName(), "json", panel.gm))]
+[h: broadcast('getMacroIndexes(getMacroName(), "", panel.gm) -> ' +
+	getMacroIndexes(getMacroName(), "", panel.gm))]
+[h: broadcast('getMacroCommand(getMacroButtonIndex(), panel.gm) -> ' +
+	getMacroCommand(getMacroButtonIndex(), panel.gm))]
+[h: props = json.set("",
+"applyToSelected"      , false                                     ,
+"autoExecute"          , true                                      ,
+"color"                , "red"                                     ,
+"command"              , "[h: this = getMacroName()]
+[h: here = getMacroLocation()]
+[h: broadcast(strformat('%{this}@%{here}'))]",
+"fontColor"            , "white"                                   ,
+"fontSize"             , "13pt"                                    ,
+"includeLabel"         , false                                     ,
+"group"                , "New Group"                               ,
+"sortBy"               , "a1"                                      ,
+"label"                , "New Macro"                               ,
+"maxWidth"             , "Sneaky hiding place"                     ,
+"minWidth"             , 90                                        ,
+"playerEditable"       , false                                     ,
+"tooltip"              , "Three cheers for the sun god. Ra! Ra! Ra!",
+"compare"              , json.append(""                            ,
+                            "applyToSelected"  ,
+                            "autoExecute"      ,
+                            "command"          ,
+                            "group"            ,
+                            "includeLabel"     ,
+                            "sortPrefix")
+)]
+[h: indices = getMacroIndices(getMacroName(), "json", panel.gm)]
+[h: broadcast('setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.gm) ->' +
+	setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.gm))]
+[h: props = json.set(props, "fontColor", "black")]
+[h: broadcast('setMacroProps("New Macro", props,"json", panel.gm) ->' +
+	setMacroProps("New Macro", props,"json", panel.gm))]
+[h: broadcast('hasMacro("New Macro", panel.gm) -> ' + hasMacro("New Macro", panel.gm))]
+[h, macro("New Macro@gm"):""]
+[h: setMacroCommand(
+		json.get(getMacroIndexes("New Macro", "json", panel.gm),0),	"[h: broadcast(strformat('%s@%s remastered.', getMacroName(), getMacroLocation()))][h: removeMacro(listGet(getMacroIndexes('New Macro', '', panel.gm), 0), panel.gm)]", panel.gm)]
+[h, macro("New Macro@gm"):""]
+[h: broadcast('getMacroGroup("New Group","", panel.gm) ->' + getMacroGroup("New Group","", panel.gm)]
+*/
 }

--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -25,6 +25,7 @@ import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
+import net.rptools.maptool.client.ui.macrobuttons.panels.AbstractMacroPanel;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.MacroButtonProperties;
 import net.rptools.maptool.model.Token;
@@ -33,6 +34,7 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -60,6 +62,7 @@ public class MacroFunctions extends AbstractFunction {
         "getMacros",
         "getMacroProps",
         "getMacroIndexes",
+        "getMacroIndices",
         "getMacroName",
         "getMacroLocation",
         "setMacroCommand",
@@ -77,68 +80,194 @@ public class MacroFunctions extends AbstractFunction {
   public Object childEvaluate(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    if (functionName.equalsIgnoreCase("hasMacro")) {
+
+    if (functionName.equalsIgnoreCase("createMacro")) {
+      if (parameters.size() > 3) {
+        if (parameters.get(4).toString().equalsIgnoreCase("campaign")) {
+          return createMacro(parameters, false);
+        } else if (parameters.get(4).toString().equalsIgnoreCase("gm")) {
+          return createMacro(parameters, true);
+        }
+      } else {
+        if (parameters.get(1).toString().equalsIgnoreCase("campaign")) {
+          return createMacro(parameters, false);
+        } else if (parameters.get(1).toString().equalsIgnoreCase("gm")) {
+          return createMacro(parameters, true);
+        }
+      }
+      return createMacro((MapToolVariableResolver) resolver, parameters);
+
+    } else if (functionName.equalsIgnoreCase("hasMacro")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       String label = parameters.get(0).toString();
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return token.getMacroNames(false).contains(label) ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else if (functionName.equalsIgnoreCase("createMacro")) {
-      return createMacro((MapToolVariableResolver) resolver, parameters);
+      if (parameters.get(1).toString().equalsIgnoreCase("campaign")) {
+        return hasMacro(label, false) ? BigDecimal.ONE : BigDecimal.ZERO;
+      } else if (parameters.get(1).toString().equalsIgnoreCase("gm")) {
+        return hasMacro(label, true) ? BigDecimal.ONE : BigDecimal.ZERO;
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
+        return token.getMacroNames(false).contains(label) ? BigDecimal.ONE : BigDecimal.ZERO;
+      }
+
     } else if (functionName.equalsIgnoreCase("getMacros")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
       String delim = parameters.size() > 0 ? parameters.get(0).toString() : ",";
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return getMacros(delim, token);
+      if (parameters.get(1).toString().equalsIgnoreCase("campaign")) {
+        return getMacros(delim, MapTool.getCampaign().getMacroButtonPropertiesArray());
+      } else if (parameters.get(1).toString().equalsIgnoreCase("gm")) {
+        return getMacros(delim, MapTool.getCampaign().getGmMacroButtonPropertiesArray());
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
+        return getMacros(delim, token);
+      }
+
     } else if (functionName.equalsIgnoreCase("getMacroProps")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 4);
       int index = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ";";
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
-      return getMacroButtonProps(token, index, delim);
+      if (parameters.get(2).toString().equalsIgnoreCase("campaign")) {
+        return getMacroButtonProps(index, delim, false);
+      } else if (parameters.get(2).toString().equalsIgnoreCase("gm")) {
+        return getMacroButtonProps(index, delim, true);
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
+        return getMacroButtonProps(token, index, delim);
+      }
+
     } else if (functionName.equalsIgnoreCase("setMacroProps")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 5);
       Object value = parameters.get(0);
       String props = parameters.get(1).toString();
       String delim = parameters.size() > 2 ? parameters.get(2).toString() : ";";
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 3, 4);
-      return setMacroProps(value, props, delim, token);
-    } else if (functionName.equalsIgnoreCase("getMacroIndexes")) {
+      if (parameters.get(3).toString().equalsIgnoreCase("campaign")) {
+        return setMacroProps(value, props, delim, false);
+      } else if (parameters.get(3).toString().equalsIgnoreCase("gm")) {
+        return setMacroProps(value, props, delim, true);
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 3, 4);
+        return setMacroProps(value, props, delim, token);
+      }
+
+    } else if (functionName.equalsIgnoreCase("getMacroIndexes")
+        || functionName.equalsIgnoreCase("getMacroIndices")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 4);
       String label = parameters.get(0).toString();
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
-      return getMacroIndexes(label, delim, token);
+      if (parameters.get(2).toString().equalsIgnoreCase("campaign")) {
+        return getMacroIndexes(label, delim, MapTool.getCampaign().getMacroButtonPropertiesArray());
+      } else if (parameters.get(2).toString().equalsIgnoreCase("gm")) {
+        return getMacroIndexes(
+            label, delim, MapTool.getCampaign().getGmMacroButtonPropertiesArray());
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
+        return getMacroIndexes(label, delim, token);
+      }
+
     } else if (functionName.equalsIgnoreCase("getMacroName")) {
       return MapTool.getParser().getMacroName();
+
     } else if (functionName.equalsIgnoreCase("getMacroLocation")) {
       return MapTool.getParser().getMacroSource();
+
     } else if (functionName.equalsIgnoreCase("setMacroCommand")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 4);
       FunctionUtil.blockUntrustedMacro(functionName);
       int index = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
       String command = FunctionUtil.paramAsString(functionName, parameters, 1, true);
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
-      return setMacroCommand(index, command, token);
+      if (parameters.get(2).toString().equalsIgnoreCase("gm")) {
+        return setMacroCommand(index, command, true);
+      } else if (parameters.get(2).toString().equalsIgnoreCase("campaign")) {
+        return setMacroCommand(index, command, false);
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
+        return setMacroCommand(index, command, token);
+      }
+
     } else if (functionName.equalsIgnoreCase("getMacroCommand")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
       int index = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return getMacroCommand(index, token);
+      if (parameters.get(1).toString().equalsIgnoreCase("gm")) {
+        return getMacroCommand(index, true);
+      } else if (parameters.get(1).toString().equalsIgnoreCase("campaign")) {
+        return getMacroCommand(index, false);
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
+        return getMacroCommand(index, token);
+      }
+
     } else if (functionName.equalsIgnoreCase("getMacroButtonIndex")) {
       return BigDecimal.valueOf(MapTool.getParser().getMacroButtonIndex());
-    } else if (functionName.equalsIgnoreCase("removeMacro")) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
-      int index = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return removeMacro(index, token);
+
     } else if (functionName.equalsIgnoreCase("getMacroGroup")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 4);
       String group = parameters.get(0).toString();
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
-      return getMacroGroup(group, delim, token);
+      if (parameters.get(2).toString().equalsIgnoreCase("gm")) {
+        return getMacroGroup(group, delim, true);
+      } else if (parameters.get(2).toString().equalsIgnoreCase("campaign")) {
+        return getMacroGroup(group, delim, false);
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
+        return getMacroGroup(group, delim, token);
+      }
+
+    } else if (functionName.equalsIgnoreCase("removeMacro")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
+      int index = FunctionUtil.paramAsInteger(functionName, parameters, 0, false);
+      if (parameters.get(1).toString().equalsIgnoreCase("gm")) {
+        return removeMacro(index, true);
+      } else if (parameters.get(1).toString().equalsIgnoreCase("campaign")) {
+        return removeMacro(index, false);
+      } else {
+        Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
+        return removeMacro(index, token);
+      }
+
     } else { // should never happen, hopefully ;)
       throw new ParserException(I18N.getText(KEY_UNKNOWN_MACRO, functionName));
+    }
+  }
+
+  /**
+   * Campaign version of hasMacro().
+   *
+   * @param label match text
+   * @param gmPanel true for GM panel, false for Campaign panel
+   * @return boolean
+   */
+  private boolean hasMacro(String label, boolean gmPanel) {
+    List<MacroButtonProperties> list = getCampaignMbpList(gmPanel);
+    return getCampaignMbpByIndexOrLabel(list, null, label).right != null;
+  }
+
+  /**
+   * Campaign version of getMacroButtonProps().
+   *
+   * @param index The index of the macro button.
+   * @param delim The delimiter to use.
+   * @return Properties string.
+   * @throws ParserException if an error occurs.
+   */
+  public Object getMacroButtonProps(int index, String delim, boolean gmPanel)
+      throws ParserException {
+    List<MacroButtonProperties> list =
+        gmPanel
+            ? MapTool.getCampaign().getGmMacroButtonPropertiesArray()
+            : MapTool.getCampaign().getMacroButtonPropertiesArray();
+    MacroButtonProperties mbp = null;
+    for (MacroButtonProperties mb : list) {
+      if (mb.getIndex() == index) {
+        mbp = mb;
+        break;
+      }
+    }
+    if (mbp == null) {
+      throw new ParserException(I18N.getText(KEY_OUT_OF_RANGE, "getMacroProps", index, "panel"));
+    }
+    if ("json".equals(delim)) {
+      return macroButtonPropertiesToJSON(mbp);
+    } else {
+      return macroButtonPropertiesToString(mbp, delim.equals("") ? "," : delim);
     }
   }
 
@@ -157,75 +286,10 @@ public class MacroFunctions extends AbstractFunction {
       throw new ParserException(
           I18N.getText(KEY_OUT_OF_RANGE, "getMacroProps", index, token.getName()));
     }
-
     if ("json".equals(delim)) {
-      JsonObject props = new JsonObject();
-      props.addProperty("autoExecute", mbp.getAutoExecute());
-      props.addProperty("color", mbp.getColorKey());
-      props.addProperty("fontColor", mbp.getFontColorKey());
-      props.addProperty("group", mbp.getGroup());
-      props.addProperty("includeLabel", mbp.getIncludeLabel());
-      props.addProperty("sortBy", mbp.getSortby());
-      props.addProperty("index", mbp.getIndex());
-      props.addProperty("label", mbp.getLabel());
-      props.addProperty("fontSize", mbp.getFontSize());
-      props.addProperty("minWidth", mbp.getMinWidth());
-      props.addProperty("playerEditable", mbp.getAllowPlayerEdits());
-      props.addProperty("command", mbp.getCommand());
-      props.addProperty("maxWidth", mbp.getMaxWidth());
-      props.addProperty("tooltip", mbp.getToolTip());
-      props.addProperty("applyToSelected", mbp.getApplyToTokens());
-
-      JsonArray compare = new JsonArray();
-
-      if (mbp.getCompareGroup()) {
-        compare.add("group");
-      }
-      if (mbp.getCompareSortPrefix()) {
-        compare.add("sortPrefix");
-      }
-      if (mbp.getCompareCommand()) {
-        compare.add("command");
-      }
-      if (mbp.getCompareIncludeLabel()) {
-        compare.add("includeLabel");
-      }
-      if (mbp.getCompareAutoExecute()) {
-        compare.add("autoExecute");
-      }
-      if (mbp.getCompareApplyToSelectedTokens()) {
-        compare.add("applyToSelected");
-      }
-
-      props.add("compare", compare);
-
-      JsonObject propsMetadata = new JsonObject();
-      propsMetadata.addProperty("uuid", mbp.getMacroUUID());
-      propsMetadata.addProperty(
-          "commandChecksum", new MD5Key(mbp.getCommand().getBytes()).toString());
-      propsMetadata.addProperty(
-          "propsChecksum", new MD5Key(props.toString().getBytes()).toString());
-
-      props.add("metadata", propsMetadata);
-
-      return props;
+      return macroButtonPropertiesToJSON(mbp);
     } else {
-      StringBuilder sb = new StringBuilder();
-      sb.append("autoExecute=").append(mbp.getAutoExecute()).append(delim);
-      sb.append("color=").append(mbp.getColorKey()).append(delim);
-      sb.append("fontColor=").append(mbp.getFontColorKey()).append(delim);
-      sb.append("group=").append(mbp.getGroup()).append(delim);
-      sb.append("includeLabel=").append(mbp.getIncludeLabel()).append(delim);
-      sb.append("sortBy=").append(mbp.getSortby()).append(delim);
-      sb.append("index=").append(mbp.getIndex()).append(delim);
-      sb.append("label=").append(mbp.getLabel()).append(delim);
-      sb.append("fontSize=").append(mbp.getFontSize()).append(delim);
-      sb.append("minWidth=").append(mbp.getMinWidth()).append(delim);
-      sb.append("playerEditable=").append(mbp.getAllowPlayerEdits()).append(delim);
-      sb.append("maxWidth=").append(mbp.getMaxWidth()).append(delim);
-      sb.append("tooltip=").append(mbp.getToolTip()).append(delim);
-      sb.append("applyToSelected=").append(mbp.getApplyToTokens()).append(delim);
-      return sb.toString();
+      return macroButtonPropertiesToString(mbp, delim.equals("") ? "," : delim);
     }
   }
 
@@ -251,7 +315,7 @@ public class MacroFunctions extends AbstractFunction {
       json =
           JSONMacroFunctions.getInstance().getJsonObjectFunctions().fromStrProp(propString, delim);
     }
-
+    mbp = macroButtonPropertiesFromJSON(mbp, null, json);
     JsonObject jobj = json.getAsJsonObject();
 
     if (jobj.has("command") && !MapTool.getParser().isMacroTrusted()) {
@@ -333,24 +397,26 @@ public class MacroFunctions extends AbstractFunction {
   }
 
   /**
-   * Calculates the boolean value based in an input string.
+   * Campaign version of getMacros().
    *
-   * @param val The input string.
-   * @return the boolean value of the input string.
+   * @param delim delimiter used to separate the values in the returned String List
+   * @param list MacroButtonProperties list
+   * @return The string containing the macro names.
    */
-  private boolean boolVal(String val) {
-    if ("true".equalsIgnoreCase(val)) {
-      return true;
+  private Object getMacros(String delim, List<MacroButtonProperties> list) {
+    String[] names = new String[list.size()];
+    JsonArray jsonArray = new JsonArray();
+
+    for (int i = 0; i < list.size(); i++) {
+      String label = list.get(i).getLabel();
+      jsonArray.add(label);
+      names[i] = label;
     }
 
-    if ("false".equalsIgnoreCase(val)) {
-      return false;
-    }
-
-    try {
-      return Integer.parseInt(val) != 0;
-    } catch (NumberFormatException e) {
-      return true;
+    if ("json".equals(delim)) {
+      return jsonArray;
+    } else {
+      return StringFunctions.getInstance().join(names, delim);
     }
   }
 
@@ -373,6 +439,35 @@ public class MacroFunctions extends AbstractFunction {
       return jsonArray;
     } else {
       return StringFunctions.getInstance().join(token.getMacroNames(false).toArray(names), delim);
+    }
+  }
+
+  /**
+   * Campaign version of getMacroIndexes().
+   *
+   * @param label the label for the macro buttons to return
+   * @param delim the delimiter separating the indexes. If "json", returns a JSON Array.
+   * @param list the panel macro list
+   * @return the indexes for the macro buttons.
+   */
+  private Object getMacroIndexes(String label, String delim, List<MacroButtonProperties> list) {
+    List<String> strIndexes = new ArrayList<>();
+    List<Integer> indexes = new ArrayList<>();
+    for (MacroButtonProperties mbp : list) {
+      if (mbp.getLabel().equals(label)) {
+        strIndexes.add(Integer.toString(mbp.getIndex()));
+        indexes.add(mbp.getIndex());
+      }
+    }
+    if ("json".equals(delim)) {
+      JsonArray indArray = new JsonArray();
+      for (int ind : indexes) {
+        indArray.add(ind);
+      }
+      return indArray;
+    } else {
+      if (delim.equals("")) delim = ",";
+      return StringFunctions.getInstance().join(strIndexes, delim);
     }
   }
 
@@ -405,6 +500,25 @@ public class MacroFunctions extends AbstractFunction {
   }
 
   /**
+   * Campaign version of getMacroCommand.
+   *
+   * @param index the index of the macro.
+   * @param gmPanel True for GM Panel, false for Campaign panel.
+   * @return the macro command or "" if it has no command.
+   * @throws ParserException if there is no macro at the index.
+   */
+  private String getMacroCommand(int index, boolean gmPanel) throws ParserException {
+    List<MacroButtonProperties> list = getCampaignMbpList(gmPanel);
+    MacroButtonProperties mbp = getCampaignMbpByIndexOrLabel(list, index, null).getRight();
+    if (mbp == null) {
+      throw new ParserException(
+          I18N.getText(
+              KEY_OUT_OF_RANGE, "getMacroCommand", index, gmPanel ? "gm panel" : "campaign panel"));
+    }
+    return mbp.getCommand();
+  }
+
+  /**
    * Gets the command for a macro button on a token.
    *
    * @param index the index of the macro.
@@ -413,13 +527,65 @@ public class MacroFunctions extends AbstractFunction {
    * @throws ParserException if there is no macro at the index.
    */
   private String getMacroCommand(int index, Token token) throws ParserException {
-
     MacroButtonProperties mbp = token.getMacro(index, false);
     if (mbp == null) {
       throw new ParserException(
           I18N.getText(KEY_OUT_OF_RANGE, "getMacroCommand", index, token.getName()));
     }
     return mbp.getCommand();
+  }
+
+  /**
+   * Campaign version of createMacro.
+   *
+   * @param param The arguments passed to the function.
+   * @param gmPanel True to create on GM panel, flase to create on Campaign panel
+   * @return the index of the newly created button.
+   * @throws ParserException if an error occurs.
+   */
+  private BigDecimal createMacro(List<Object> param, boolean gmPanel) throws ParserException {
+    if (!MapTool.getParser().isMacroTrusted()) {
+      throw new ParserException(
+          I18N.getText(KEY_NO_PERM, "createMacro", gmPanel ? "gm panel" : "campaign panel"));
+    }
+    String label;
+    String command;
+    String prop;
+    String delim;
+
+    JsonObject jobj;
+    MacroButtonProperties mbp =
+        new MacroButtonProperties(
+            gmPanel
+                ? MapTool.getCampaign().getGmMacroButtonNextIndex()
+                : MapTool.getCampaign().getMacroButtonNextIndex());
+    try {
+      jobj =
+          JSONMacroFunctions.getInstance().asJsonElement(param.get(0).toString()).getAsJsonObject();
+    } catch (IllegalStateException e) {
+      jobj = null;
+    }
+    if (jobj == null) {
+      FunctionUtil.checkNumberParam("createMacro", param, 2, 6);
+      label = param.get(0).toString();
+      command = param.get(1).toString();
+      prop = param.size() > 2 ? param.get(2).toString() : null;
+      delim = param.size() > 3 ? param.get(3).toString() : ";";
+      mbp = macroButtonPropertiesFromStringProp(mbp, prop, delim);
+      mbp.setLabel(label);
+      mbp.setCommand(command);
+    } else {
+      FunctionUtil.checkNumberParam("createMacro", param, 1, 3);
+      prop = param.get(0).toString();
+      mbp = macroButtonPropertiesFromJSON(mbp, prop, null);
+      mbp.setCommand(JSONMacroFunctions.getInstance().jsonToScriptString(jobj.get("command")));
+    }
+    mbp.setSaveLocation(gmPanel ? "GmPanel" : "CampaignPanel");
+    List<MacroButtonProperties> list = new ArrayList<>(1);
+    list.add(0, mbp);
+    MapTool.getCampaign().addMacroButtonPropertiesAtNextIndex(list, gmPanel);
+
+    return BigDecimal.valueOf(mbp.getIndex());
   }
 
   /**
@@ -439,7 +605,6 @@ public class MacroFunctions extends AbstractFunction {
   private BigDecimal createMacro(MapToolVariableResolver resolver, List<Object> param)
       throws ParserException {
     FunctionUtil.checkNumberParam("createMacro", param, 1, 6);
-
     String label;
     String command;
     Token token;
@@ -447,6 +612,7 @@ public class MacroFunctions extends AbstractFunction {
     String delim;
 
     JsonObject jobj;
+    MacroButtonProperties mbp;
 
     try {
       jobj =
@@ -455,49 +621,125 @@ public class MacroFunctions extends AbstractFunction {
       jobj = null;
     }
 
-    if (jobj != null) {
-      FunctionUtil.checkNumberParam("createMacro", param, 1, 3);
-      if (!jobj.has("label")) {
-        throw new ParserException(I18N.getText(KEY_MISSING_LABEL, "createMacro"));
-      }
-      label = JSONMacroFunctions.getInstance().jsonToScriptString(jobj.get("label"));
-      if (!jobj.has("command")) {
-        throw new ParserException(I18N.getText(KEY_MISSING_COMMAND, "createMacro"));
-      }
-      command = JSONMacroFunctions.getInstance().jsonToScriptString(jobj.get("command"));
-      prop = param.get(0).toString();
-      delim = "json";
-      token = FunctionUtil.getTokenFromParam(resolver, "createMacro", param, 1, 2);
-    } else {
+    if (jobj == null) {
       FunctionUtil.checkNumberParam("createMacro", param, 2, 6);
       label = param.get(0).toString();
       command = param.get(1).toString();
       prop = param.size() > 2 ? param.get(2).toString() : null;
       delim = param.size() > 3 ? param.get(3).toString() : ";";
       token = FunctionUtil.getTokenFromParam(resolver, "createMacro", param, 4, 5);
+      mbp =
+          macroButtonPropertiesFromStringProp(
+              new MacroButtonProperties(token.getMacroNextIndex()), param.get(0).toString(), delim);
+      mbp.setLabel(label);
+      mbp.setCommand(command);
+    } else {
+      FunctionUtil.checkNumberParam("createMacro", param, 1, 3);
+      prop = param.get(0).toString();
+      delim = "json";
+      token = FunctionUtil.getTokenFromParam(resolver, "createMacro", param, 1, 2);
+      mbp =
+          macroButtonPropertiesFromJSON(
+              new MacroButtonProperties(token.getMacroNextIndex()), prop, null);
     }
-
-    MacroButtonProperties mbp = new MacroButtonProperties(token.getMacroNextIndex());
-
-    mbp.setLabel(label);
+    mbp.setTokenId(token); // Token Id is used in the exception messages of setMacroProps
     mbp.setSaveLocation("Token");
-    mbp.setCommand(command);
-
-    // Token Id is used in the exception messages of setMacroProps
-    mbp.setTokenId(token);
 
     // Sets the props, if any
-    if (prop != null) {
-      setMacroProps(mbp, prop, delim);
-    }
+    if (prop != null) setMacroProps(mbp, prop, delim);
 
     // Untrusted macros are set to be editable by players
-    if (!MapTool.getParser().isMacroTrusted()) {
-      mbp.setAllowPlayerEdits(true);
-    }
+    if (!MapTool.getParser().isMacroTrusted()) mbp.setAllowPlayerEdits(true);
 
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.saveMacro, mbp);
     return BigDecimal.valueOf(mbp.getIndex());
+  }
+
+  /**
+   * Campaign version of setMacroProps
+   *
+   * @param value Index or Label
+   * @param props Props to set
+   * @param delim Delimiter
+   * @param gmPanel True for GM panel, false for Campaign panel
+   * @return An empty string.
+   * @throws ParserException on error
+   */
+  private String setMacroProps(Object value, String props, String delim, boolean gmPanel)
+      throws ParserException {
+    if (!MapTool.getParser().isMacroTrusted()) {
+      throw new ParserException(
+          I18N.getText(
+              KEY_NO_PERM_COMMAND,
+              "setMacroProps",
+              value.toString(),
+              gmPanel ? "gm panel" : "campaign panel"));
+    }
+    MacroButtonProperties mbp = null;
+    List<MacroButtonProperties> list = getCampaignMbpList(gmPanel);
+    ImmutablePair<Integer, MacroButtonProperties> pair;
+    if ((value instanceof BigDecimal)) {
+      int index = ((BigDecimal) value).intValue();
+      pair = getCampaignMbpByIndexOrLabel(list, index, null);
+      mbp = pair.getRight();
+      if (mbp == null) {
+        throw new ParserException(
+            I18N.getText(
+                KEY_OUT_OF_RANGE, "setMacroProps", index, gmPanel ? "gm panel" : "campaign panel"));
+      }
+      if (!mbp.getAllowPlayerEdits() && !MapTool.getParser().isMacroTrusted()) {
+        throw new ParserException(
+            I18N.getText(
+                KEY_NO_PERM, "setMacroProps", index, gmPanel ? "gm panel" : "campaign panel"));
+      }
+      if (delim.equals("json")) {
+        try {
+          mbp =
+              macroButtonPropertiesFromJSON(
+                  mbp, null, JSONMacroFunctions.getInstance().asJsonElement(props));
+        } catch (IllegalStateException e) {
+          throw new ParserException(
+              I18N.getText(
+                  "macro.function.json.unknownType",
+                  "setMacroProps",
+                  index,
+                  gmPanel ? "gm panel" : "campaign panel"));
+        }
+      } else {
+        mbp = macroButtonPropertiesFromStringProp(mbp, props, delim);
+      }
+    } else {
+      pair = getCampaignMbpByIndexOrLabel(list, null, value.toString());
+      mbp = pair.getRight();
+      if (mbp == null) {
+        throw new ParserException(
+            I18N.getText(
+                KEY_OUT_OF_RANGE, "setMacroProps", value, gmPanel ? "gm panel" : "campaign panel"));
+      }
+      if (!mbp.getAllowPlayerEdits() && !MapTool.getParser().isMacroTrusted()) {
+        throw new ParserException(
+            I18N.getText(
+                KEY_NO_PERM, "setMacroProps", value, gmPanel ? "gm panel" : "campaign panel"));
+      }
+      if (delim.equals("json")) {
+        try {
+          mbp =
+              macroButtonPropertiesFromJSON(
+                  mbp, null, JSONMacroFunctions.getInstance().asJsonElement(props));
+        } catch (IllegalStateException e) {
+          throw new ParserException(
+              I18N.getText(
+                  "macro.function.json.unknownType",
+                  "setMacroProps",
+                  value,
+                  gmPanel ? "gm panel" : "campaign panel"));
+        }
+      } else {
+        mbp = macroButtonPropertiesFromStringProp(mbp, props, delim);
+      }
+    }
+    MapTool.getCampaign().saveMacroButtonProperty(mbp, gmPanel);
+    return "";
   }
 
   /**
@@ -550,6 +792,44 @@ public class MacroFunctions extends AbstractFunction {
   }
 
   /**
+   * Campaign version of setMacroCommand().
+   *
+   * @param index the index of the macro button
+   * @param command a string containing the command to set on the macro button
+   * @param gmPanel True for GM panel, false for Campaign panel.
+   * @return An empty string.
+   * @throws ParserException If an error occurs.
+   */
+  private String setMacroCommand(int index, String command, boolean gmPanel)
+      throws ParserException {
+    if (!MapTool.getParser().isMacroTrusted()) {
+      throw new ParserException(
+          I18N.getText(
+              KEY_NO_PERM_COMMAND,
+              "setMacroCommand",
+              index,
+              gmPanel ? "gm panel" : "campaign panel"));
+    }
+    List<MacroButtonProperties> list = getCampaignMbpList(gmPanel);
+    ImmutablePair<Integer, MacroButtonProperties> pair =
+        getCampaignMbpByIndexOrLabel(list, index, null);
+    MacroButtonProperties mbp = pair.right;
+    if (mbp == null) {
+      throw new ParserException(
+          I18N.getText(
+              KEY_OUT_OF_RANGE, "setMacroCommand", index, gmPanel ? "gm panel" : "campaign panel"));
+    }
+    mbp.setCommand(command);
+    list.set(pair.left, mbp);
+    if (gmPanel) {
+      MapTool.getCampaign().setGmMacroButtonPropertiesArray(list);
+    } else {
+      MapTool.getCampaign().setMacroButtonPropertiesArray(list);
+    }
+    return "";
+  }
+
+  /**
    * Sets the command for a macro button on a token.
    *
    * @param index the index of the macro button
@@ -559,7 +839,6 @@ public class MacroFunctions extends AbstractFunction {
    * @throws ParserException If an error occurs.
    */
   private String setMacroCommand(int index, String command, Token token) throws ParserException {
-
     MacroButtonProperties mbp = token.getMacro(index, false);
     if (mbp == null) {
       throw new ParserException(
@@ -571,6 +850,48 @@ public class MacroFunctions extends AbstractFunction {
   }
 
   /**
+   * Campaign version of removeMacro().
+   *
+   * @param index the index of the macro button.
+   * @param gmPanel True for GM panel, false for Campaign panel.
+   * @return the details of the button that was removed.
+   * @throws ParserException if the index is invalid.
+   */
+  private String removeMacro(int index, boolean gmPanel) throws ParserException {
+    if (!MapTool.getParser().isMacroTrusted()) {
+      throw new ParserException(
+          I18N.getText(
+              KEY_NO_PERM_COMMAND, "removeMacro", index, gmPanel ? "gm panel" : "campaign panel"));
+    }
+    List<MacroButtonProperties> list = getCampaignMbpList(gmPanel);
+    ImmutablePair<Integer, MacroButtonProperties> pair =
+        getCampaignMbpByIndexOrLabel(list, index, null);
+    if (pair.left == null) {
+      throw new ParserException(
+          I18N.getText(
+              KEY_OUT_OF_RANGE, "removeMacro", index, gmPanel ? "gm panel" : "campaign panel"));
+    } else {
+      String label = pair.right.getLabel();
+      int listIndex = pair.left;
+      list.remove(listIndex);
+      if (gmPanel) {
+        MapTool.getCampaign().setGmMacroButtonPropertiesArray(list);
+      } else {
+        MapTool.getCampaign().setMacroButtonPropertiesArray(list);
+      }
+      AbstractMacroPanel macroPanel =
+          gmPanel ? MapTool.getFrame().getGmPanel() : MapTool.getFrame().getCampaignPanel();
+      macroPanel.reset();
+      return "Removed macro button "
+          + label
+          + "(index = "
+          + index
+          + ") from "
+          + (gmPanel ? "gm panel" : "campaign panel");
+    }
+  }
+
+  /**
    * Removes a macro button from a token.
    *
    * @param index the index of the macro button.
@@ -579,7 +900,6 @@ public class MacroFunctions extends AbstractFunction {
    * @throws ParserException if the index is invalid.
    */
   private String removeMacro(int index, Token token) throws ParserException {
-
     MacroButtonProperties mbp = token.getMacro(index, false);
     if (mbp == null) {
       throw new ParserException(
@@ -592,7 +912,41 @@ public class MacroFunctions extends AbstractFunction {
   }
 
   /**
-   * Gets the index of the macros for a token in the specified group.
+   * Campaign version of getMacroGroup
+   *
+   * @param group the name of the macro group to get the macro button indexes from.
+   * @param delim the delimiter used in the string list returned, defaults to ",".
+   * @param gmPanel True for GM panel, false for Campaign panel.
+   * @return The string containing the macro names.
+   */
+  private Object getMacroGroup(String group, String delim, boolean gmPanel) {
+    // Has to be a string or the list functions won't like it :\
+    List<String> strIndexes = new LinkedList<>();
+    List<Integer> indexes = new LinkedList<>();
+    List<MacroButtonProperties> mbpList = getCampaignMbpList(gmPanel);
+    delim = delim == "" ? "," : delim;
+    for (MacroButtonProperties props : mbpList) {
+      if (props.getGroup().equals(group)) {
+        strIndexes.add(String.valueOf(props.getIndex()));
+        indexes.add(props.getIndex());
+      }
+    }
+
+    String[] vals = new String[strIndexes.size()];
+
+    if ("json".equals(delim)) {
+      JsonArray jarray = new JsonArray();
+      for (Integer i : indexes) {
+        jarray.add(i);
+      }
+      return jarray;
+    } else {
+      return StringFunctions.getInstance().join(strIndexes.toArray(vals), delim);
+    }
+  }
+
+  /**
+   * Gets the index of the macros for a token in the specified group. *
    *
    * @param group the name of the macro group to get the macro button indexes from.
    * @param delim the delimiter used in the string list returned, defaults to ",".
@@ -600,7 +954,7 @@ public class MacroFunctions extends AbstractFunction {
    * @return The string containing the macro names.
    */
   private Object getMacroGroup(String group, String delim, Token token) {
-    // Has to be a string or the list functions wont like it :\
+    // Has to be a string or the list functions won't like it :\
     List<String> strIndexes = new LinkedList<>();
     List<Integer> indexes = new LinkedList<>();
     for (MacroButtonProperties props : token.getMacroList(false)) {
@@ -621,5 +975,278 @@ public class MacroFunctions extends AbstractFunction {
     } else {
       return StringFunctions.getInstance().join(strIndexes.toArray(vals), delim);
     }
+  }
+
+  /**
+   * Getter for lists of macros in campaign panels.
+   *
+   * @param gmPanel True for GM panel, False for Campaign panel.
+   * @return MacroButtonProperties list
+   */
+  private List<MacroButtonProperties> getCampaignMbpList(boolean gmPanel) {
+    return gmPanel
+        ? MapTool.getCampaign().getGmMacroButtonPropertiesArray()
+        : MapTool.getCampaign().getMacroButtonPropertiesArray();
+  }
+
+  /**
+   * Get the MacroButtonProperties from MacroButtonProperties lists.
+   *
+   * @param list The list to search
+   * @param index Macro index to find. NULL to search by label
+   * @param label Macro label to find. NULL when searching by index.
+   * @return an Immutable pair of list index and the MacroButtonProperties
+   */
+  private ImmutablePair<Integer, MacroButtonProperties> getCampaignMbpByIndexOrLabel(
+      List<MacroButtonProperties> list, Integer index, String label) {
+    for (int i = 0; i < list.size(); i++) {
+      MacroButtonProperties mbp = list.get(i);
+      if (index == null) {
+        if (mbp.getLabel().equals(label)) {
+          return new ImmutablePair<>(i, mbp);
+        }
+      } else {
+        if (mbp.getIndex() == index) {
+          return new ImmutablePair<>(i, mbp);
+        }
+      }
+    }
+    return new ImmutablePair<>(null, null);
+  }
+
+  /**
+   * Returns string constructed from Macro Button Properties
+   *
+   * @param mbp Button props
+   * @param delim Delimiter to use
+   * @return String
+   */
+  private String macroButtonPropertiesToString(MacroButtonProperties mbp, String delim) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("autoExecute=").append(mbp.getAutoExecute()).append(delim);
+    sb.append("color=").append(mbp.getColorKey()).append(delim);
+    sb.append("fontColor=").append(mbp.getFontColorKey()).append(delim);
+    sb.append("group=").append(mbp.getGroup()).append(delim);
+    sb.append("includeLabel=").append(mbp.getIncludeLabel()).append(delim);
+    sb.append("sortBy=").append(mbp.getSortby()).append(delim);
+    sb.append("index=").append(mbp.getIndex()).append(delim);
+    sb.append("label=").append(mbp.getLabel()).append(delim);
+    sb.append("fontSize=").append(mbp.getFontSize()).append(delim);
+    sb.append("minWidth=").append(mbp.getMinWidth()).append(delim);
+    sb.append("playerEditable=").append(mbp.getAllowPlayerEdits()).append(delim);
+    sb.append("maxWidth=").append(mbp.getMaxWidth()).append(delim);
+    sb.append("tooltip=").append(mbp.getToolTip()).append(delim);
+    sb.append("applyToSelected=").append(mbp.getApplyToTokens()).append(delim);
+    return sb.toString();
+  }
+
+  /**
+   * Builds MacroButtonProperties from JSON, either as String or JsonElement.
+   *
+   * @param mbp MacroButtonProperties to add properties to
+   * @param propString Set to null to build from json
+   * @param json Set to null to build from propString
+   * @return MacroButtonProperties
+   * @throws ParserException If missing label or permission failure;
+   */
+  private MacroButtonProperties macroButtonPropertiesFromJSON(
+      MacroButtonProperties mbp, String propString, JsonElement json) throws ParserException {
+    if (json == null) json = JSONMacroFunctions.getInstance().asJsonElement(propString);
+    JsonObject jobj = json.getAsJsonObject();
+    if (jobj != null) {
+      if (!jobj.has("label"))
+        throw new ParserException(I18N.getText(KEY_MISSING_LABEL, "createMacro"));
+      if (jobj.has("command") && !MapTool.getParser().isMacroTrusted()) {
+        int index = mbp.getIndex();
+        throw new ParserException(
+            I18N.getText(KEY_NO_PERM_COMMAND, "setMacroProps", index, mbp.getToken().getName()));
+      }
+      for (Object o : jobj.keySet()) {
+        String key = o.toString();
+        String value = JSONMacroFunctions.getInstance().jsonToScriptString(jobj.get(key));
+        if ("autoexecute".equalsIgnoreCase(key)) {
+          mbp.setAutoExecute(boolVal(value));
+        } else if ("color".equalsIgnoreCase(key)) {
+          mbp.setColorKey(value);
+        } else if ("fontColor".equalsIgnoreCase(key)) {
+          mbp.setFontColorKey(value);
+        } else if ("fontSize".equalsIgnoreCase(key)) {
+          mbp.setFontSize(value);
+        } else if ("group".equalsIgnoreCase(key)) {
+          mbp.setGroup(value);
+        } else if ("includeLabel".equalsIgnoreCase(key)) {
+          mbp.setIncludeLabel(boolVal(value));
+        } else if ("sortBy".equalsIgnoreCase(key)) {
+          mbp.setSortby(value);
+        } else if ("index".equalsIgnoreCase(key)) {
+          mbp.setIndex(Integer.parseInt(value));
+        } else if ("label".equalsIgnoreCase(key)) {
+          mbp.setLabel(value);
+        } else if ("minWidth".equalsIgnoreCase(key)) {
+          mbp.setMinWidth(value);
+        } else if ("maxWidth".equalsIgnoreCase(key)) {
+          mbp.setMaxWidth(value);
+        } else if ("playerEditable".equalsIgnoreCase(key)) {
+          if (!MapTool.getParser().isMacroTrusted()) {
+            int index = mbp.getIndex();
+            throw new ParserException(
+                I18N.getText(
+                    KEY_NO_PERM_EDITABLE, "setMacroProps", index, mbp.getToken().getName()));
+          }
+          mbp.setAllowPlayerEdits(boolVal(value));
+        } else if ("command".equals(key)) {
+          mbp.setCommand(value);
+        } else if ("tooltip".equalsIgnoreCase(key)) {
+          if (value.trim().length() == 0) {
+            mbp.setToolTip(null);
+          } else {
+            mbp.setToolTip(value);
+          }
+        } else if ("applyToSelected".equalsIgnoreCase(key)) {
+          mbp.setApplyToTokens(boolVal(value));
+        } else if ("compare".equalsIgnoreCase(key)) {
+          JsonArray compareArray = jobj.get("compare").getAsJsonArray();
+          // First set everything to false as script will specify what is compared
+          mbp.setCompareGroup(false);
+          mbp.setCompareSortPrefix(false);
+          mbp.setCompareCommand(false);
+          mbp.setCompareIncludeLabel(false);
+          mbp.setCompareAutoExecute(false);
+          mbp.setCompareApplyToSelectedTokens(false);
+
+          for (Object co : compareArray) {
+            String comp = co.toString();
+            if (comp.equalsIgnoreCase("group")) {
+              mbp.setCompareGroup(true);
+            } else if (comp.equalsIgnoreCase("sortPrefix")) {
+              mbp.setCompareSortPrefix(true);
+            } else if (comp.equalsIgnoreCase("command")) {
+              mbp.setCompareCommand(true);
+            } else if (comp.equalsIgnoreCase("includeLabel")) {
+              mbp.setCompareIncludeLabel(true);
+            } else if (comp.equalsIgnoreCase("autoExecute")) {
+              mbp.setCompareAutoExecute(true);
+            } else if (comp.equalsIgnoreCase("applyToSelected")) {
+              mbp.setCompareApplyToSelectedTokens(true);
+            }
+          }
+        }
+      }
+    }
+
+    return mbp;
+  }
+
+  /**
+   * Builds MacroButtonProperties from StringProp.
+   *
+   * @param mbp MacroButtonProperties to add properties to
+   * @param propString Set to null to build from json
+   * @param delim Delimiter used in propString (NOT "json")
+   * @return MacroButtonProperties
+   * @throws ParserException If missing label or permission failure
+   */
+  private MacroButtonProperties macroButtonPropertiesFromStringProp(
+      MacroButtonProperties mbp, String propString, String delim) throws ParserException {
+    JsonElement json =
+        JSONMacroFunctions.getInstance().getJsonObjectFunctions().fromStrProp(propString, delim);
+    return macroButtonPropertiesFromJSON(mbp, null, json);
+  }
+
+  /**
+   * Builds JSON from Macro Button Props
+   *
+   * @param mbp Button props
+   * @return JSON Object
+   */
+  private JsonObject macroButtonPropertiesToJSON(MacroButtonProperties mbp) {
+    JsonObject props = new JsonObject();
+    props.addProperty("autoExecute", mbp.getAutoExecute());
+    props.addProperty("color", mbp.getColorKey());
+    props.addProperty("fontColor", mbp.getFontColorKey());
+    props.addProperty("group", mbp.getGroup());
+    props.addProperty("includeLabel", mbp.getIncludeLabel());
+    props.addProperty("sortBy", mbp.getSortby());
+    props.addProperty("index", mbp.getIndex());
+    props.addProperty("label", mbp.getLabel());
+    props.addProperty("fontSize", mbp.getFontSize());
+    props.addProperty("minWidth", mbp.getMinWidth());
+    props.addProperty("playerEditable", mbp.getAllowPlayerEdits());
+    props.addProperty("command", mbp.getCommand());
+    props.addProperty("maxWidth", mbp.getMaxWidth());
+    props.addProperty("tooltip", mbp.getToolTip());
+    props.addProperty("applyToSelected", mbp.getApplyToTokens());
+
+    JsonArray compare = new JsonArray();
+    if (mbp.getCompareGroup()) compare.add("group");
+    if (mbp.getCompareSortPrefix()) compare.add("sortPrefix");
+    if (mbp.getCompareCommand()) compare.add("command");
+    if (mbp.getCompareIncludeLabel()) compare.add("includeLabel");
+    if (mbp.getCompareAutoExecute()) compare.add("autoExecute");
+    if (mbp.getCompareApplyToSelectedTokens()) compare.add("applyToSelected");
+
+    props.add("compare", compare);
+
+    JsonObject propsMetadata = new JsonObject();
+    propsMetadata.addProperty("uuid", mbp.getMacroUUID());
+    propsMetadata.addProperty(
+        "commandChecksum", new MD5Key(mbp.getCommand().getBytes()).toString());
+    propsMetadata.addProperty("propsChecksum", new MD5Key(props.toString().getBytes()).toString());
+    props.add("metadata", propsMetadata);
+
+    return props;
+  }
+
+  /**
+   * Calculates the boolean value based in an input string.
+   *
+   * @param val The input string.
+   * @return the boolean value of the input string.
+   */
+  private boolean boolVal(String val) {
+    if ("true".equalsIgnoreCase(val)) {
+      return true;
+    }
+
+    if ("false".equalsIgnoreCase(val)) {
+      return false;
+    }
+
+    try {
+      return Integer.parseInt(val) != 0;
+    } catch (NumberFormatException e) {
+      return true;
+    }
+  }
+
+  /**
+   * I don't know how to actually make tests, but these are the macros I used when developing the
+   * functions for dealing with macros on the campaign panels.
+   * These macros create test macro buttons containing applications of the various functions.
+   * This is mostly so I have them stored somewhere relelvant.
+   */
+  public void campaignMacroFunctionsTest() throws ParserException {
+    String macroTestCampaign = "[h: props = json.set(\\\"\\\",\n" +
+            "    \\\"autoExecute\\\", true,\n" +
+            "    \\\"label\\\", \\\"CampaignMacro\\\",\n" +
+            "    \\\"playerEditable\\\", false,\n" +
+            "    \\\"command\\\", decode(\\\"%5Bh%3A%20broadcast(%22%3Cb%3EPanel%20%22%20%2B%20panel.campaign%20%2B%20%22%3C%2Fb%3E%22)%5D%0D%0A%5Bh%3A%20broadcast('getMacroName()%20%2B%20%26quot%3B%20%40%20%26quot%3B%20%2B%20getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroName()%20%2B%20'%20%40%20'getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroButtonIndex()%20-%3E%20'%20%2B%20getMacroButtonIndex())%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22json%22%2C%20panel.campaign)%20-%3E%20'%20%2B%20getMacros(%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22%22%2C%20panel.campaign)%20-%3E%20'%20%2B%20getMacros(%22%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation())%20-%3E%20'%20%2B%0D%0A%09getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation()))%5D%0D%0A%5Bh%3A%20mbp%20%3D%20getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%20-%3E%20%3Cpre%3E'%0D%0A%09%2B%20json.indent(mbp%2C3)%20%2B%20'%3C%2Fpre%3E')%5D%0D%0A%5Bh%3A%20mbp%20%3D%20json.remove(mbp%2C%22index%22)%5D%0D%0A%5Bh%3A%20broadcast('createMacro(mbp%2C%20panel.campaign)%20-%3E%20'%20%2B%20createMacro(mbp%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('getMacroCommand(getMacroButtonIndex()%2C%20panel.campaign)%20-%3E%20'%20%2B%0D%0A%09getMacroCommand(getMacroButtonIndex()%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(%22%22%2C%0D%0A%22applyToSelected%22%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22autoExecute%22%20%20%20%20%20%20%20%20%20%20%2C%20true%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22color%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22red%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22command%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22%5Bh%3A%20this%20%3D%20getMacroName()%5D%0D%0A%5Bh%3A%20here%20%3D%20getMacroLocation()%5D%0D%0A%5Bh%3A%20broadcast(strformat('%25%7Bthis%7D%40%25%7Bhere%7D'))%5D%22%2C%0D%0A%22fontColor%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22white%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22fontSize%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%2213pt%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22includeLabel%22%20%20%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22sortBy%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22a1%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22label%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Macro%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22maxWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Sneaky%20hiding%20place%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22minWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%2090%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22playerEditable%22%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22tooltip%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Three%20cheers%20for%20the%20sun%20god.%20Ra!%20Ra!%20Ra!%22%2C%0D%0A%22compare%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20json.append(%22%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22applyToSelected%22%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22autoExecute%22%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22command%22%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22includeLabel%22%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22sortPrefix%22)%0D%0A)%5D%0D%0A%0D%0A%5Bh%3A%20indices%20%3D%20getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.campaign)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.campaign)%20-%3E'%20%2B%0D%0A%09setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(props%2C%20%22fontColor%22%2C%20%22black%22)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.campaign)%20-%3E'%20%2B%0D%0A%09setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.campaign))%5D%0D%0A%5Bh%3A%20broadcast('hasMacro(%22New%20Macro%22%2C%20panel.campaign)%20-%3E%20'%20%2B%20hasMacro(%22New%20Macro%22%2C%20panel.campaign))%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40campaign%22)%3A%22%22%5D%0D%0A%5Bh%3A%20setMacroCommand(%0D%0A%09%09json.get(getMacroIndexes(%22New%20Macro%22%2C%20%22json%22%2C%20panel.campaign)%2C0)%2C%09%22%5Bh%3A%20broadcast(strformat('%25s%40%25s%20remastered.'%2C%20getMacroName()%2C%20getMacroLocation()))%5D%5Bh%3A%20removeMacro(listGet(getMacroIndexes('New%20Macro'%2C%20''%2C%20panel.campaign)%2C%200)%2C%20panel.campaign)%5D%22%2C%20panel.campaign)%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40campaign%22)%3A%22%22%5D%0D%0A%5Bh%3A%20broadcast('getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.campaign)%20-%3E'%20%2B%20getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.campaign)%5D\\\"),\n" +
+            "    \\\"applyToSelected\\\", false,\n" +
+            "    \\\"compare\\\", json.append(\\\"\\\", \\\"group\\\", \\\"sortPrefix\\\", \\\"command\\\", \\\"includeLabel\\\", \\\"autoExecute\\\", \\\"applyToSelected\\\")\n" +
+            ")]\n" +
+            "[h: createMacro(props, panel.campaign)]\n" +
+            "[r, macro(\\\"CampaignMacro@campaign\\\"):\\\"\\\"]";
+    String macroTestGM = "[h: props = json.set(\\\"\\\",\n" +
+            "    \\\"autoExecute\\\", true,\n" +
+            "    \\\"label\\\", \\\"GMMacro\\\",\n" +
+            "    \\\"playerEditable\\\", false,\n" +
+            "    \\\"command\\\", decode(\\\"%5Bh%3A%20broadcast(%22%3Cb%3EPanel%20%22%20%2B%20panel.gm%20%2B%20%22%3C%2Fb%3E%22)%5D%0D%0A%5Bh%3A%20broadcast('getMacroName()%20%2B%20%26quot%3B%20%40%20%26quot%3B%20%2B%20getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroName()%20%2B%20'%20%40%20'getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroLocation()%20-%20%3E%20'%20%2B%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroButtonIndex()%20-%3E%20'%20%2B%20getMacroButtonIndex())%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22json%22%2C%20panel.gm)%20-%3E%20'%20%2B%20getMacros(%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacros(%22%22%2C%20panel.gm)%20-%3E%20'%20%2B%20getMacros(%22%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation())%20-%3E%20'%20%2B%0D%0A%09getMacroProps(getMacroButtonIndex()%2C%22%3B%22%2C%20getMacroLocation()))%5D%0D%0A%5Bh%3A%20mbp%20%3D%20getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%5D%0D%0A%5Bh%3A%20broadcast('getMacroProps(getMacroButtonIndex()%2C%22json%22%2C%20getMacroLocation())%20-%3E%20%3Cpre%3E'%0D%0A%09%2B%20json.indent(mbp%2C3)%20%2B%20'%3C%2Fpre%3E')%5D%0D%0A%5Bh%3A%20mbp%20%3D%20json.remove(mbp%2C%22index%22)%5D%0D%0A%5Bh%3A%20broadcast('createMacro(mbp%2C%20panel.gm)%20-%3E%20'%20%2B%20createMacro(mbp%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndices(getMacroName()%2C%20%22%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroIndexes(getMacroName()%2C%20%22%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('getMacroCommand(getMacroButtonIndex()%2C%20panel.gm)%20-%3E%20'%20%2B%0D%0A%09getMacroCommand(getMacroButtonIndex()%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(%22%22%2C%0D%0A%22applyToSelected%22%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22autoExecute%22%20%20%20%20%20%20%20%20%20%20%2C%20true%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22color%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22red%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22command%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22%5Bh%3A%20this%20%3D%20getMacroName()%5D%0D%0A%5Bh%3A%20here%20%3D%20getMacroLocation()%5D%0D%0A%5Bh%3A%20broadcast(strformat('%25%7Bthis%7D%40%25%7Bhere%7D'))%5D%22%2C%0D%0A%22fontColor%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22white%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22fontSize%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%2213pt%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22includeLabel%22%20%20%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Group%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22sortBy%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22a1%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22label%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22New%20Macro%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22maxWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Sneaky%20hiding%20place%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22minWidth%22%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%2090%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22playerEditable%22%20%20%20%20%20%20%20%2C%20false%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%22tooltip%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20%22Three%20cheers%20for%20the%20sun%20god.%20Ra!%20Ra!%20Ra!%22%2C%0D%0A%22compare%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%20json.append(%22%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22applyToSelected%22%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22autoExecute%22%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22command%22%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22group%22%20%20%20%20%20%20%20%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22includeLabel%22%20%20%20%20%20%2C%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22sortPrefix%22)%0D%0A)%5D%0D%0A%0D%0A%5Bh%3A%20indices%20%3D%20getMacroIndices(getMacroName()%2C%20%22json%22%2C%20panel.gm)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.gm)%20-%3E'%20%2B%0D%0A%09setMacroProps(json.get(indices%2C%20json.length(indices)%20-%201)%2C%20props%2C%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20props%20%3D%20json.set(props%2C%20%22fontColor%22%2C%20%22black%22)%5D%0D%0A%5Bh%3A%20broadcast('setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.gm)%20-%3E'%20%2B%0D%0A%09setMacroProps(%22New%20Macro%22%2C%20props%2C%22json%22%2C%20panel.gm))%5D%0D%0A%5Bh%3A%20broadcast('hasMacro(%22New%20Macro%22%2C%20panel.gm)%20-%3E%20'%20%2B%20hasMacro(%22New%20Macro%22%2C%20panel.gm))%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40gm%22)%3A%22%22%5D%0D%0A%5Bh%3A%20setMacroCommand(%0D%0A%09%09json.get(getMacroIndexes(%22New%20Macro%22%2C%20%22json%22%2C%20panel.gm)%2C0)%2C%09%22%5Bh%3A%20broadcast(strformat('%25s%40%25s%20remastered.'%2C%20getMacroName()%2C%20getMacroLocation()))%5D%5Bh%3A%20removeMacro(listGet(getMacroIndexes('New%20Macro'%2C%20''%2C%20panel.gm)%2C%200)%2C%20panel.gm)%5D%22%2C%20panel.gm)%5D%0D%0A%5Bh%2C%20macro(%22New%20Macro%40gm%22)%3A%22%22%5D%0D%0A%5Bh%3A%20broadcast('getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.gm)%20-%3E'%20%2B%20getMacroGroup(%22New%20Group%22%2C%22%22%2C%20panel.gm)%5D\\\"),\n" +
+            "    \\\"applyToSelected\\\", false,\n" +
+            "    \\\"compare\\\", json.append(\\\"\\\", \\\"group\\\", \\\"sortPrefix\\\", \\\"command\\\", \\\"includeLabel\\\", \\\"autoExecute\\\", \\\"applyToSelected\\\")\n" +
+            ")]\n" +
+            "[h: createMacro(props, panel.gm)]\n" +
+            "[r, macro(\\\"CampaignMacro@gm\\\"):\\\"\\\"]";
+    MapTool.getParser().parseExpression(macroTestGM,false);
+    MapTool.getParser().parseExpression(macroTestCampaign,false);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -315,7 +315,7 @@ public class MacroFunctions extends AbstractFunction {
       json =
           JSONMacroFunctions.getInstance().getJsonObjectFunctions().fromStrProp(propString, delim);
     }
-    mbp = macroButtonPropertiesFromJSON(mbp, null, json);
+    macroButtonPropertiesFromJSON(mbp, null, json);
     JsonObject jobj = json.getAsJsonObject();
 
     if (jobj.has("command") && !MapTool.getParser().isMacroTrusted()) {
@@ -577,7 +577,7 @@ public class MacroFunctions extends AbstractFunction {
     } else {
       FunctionUtil.checkNumberParam("createMacro", param, 1, 3);
       prop = param.get(0).toString();
-      mbp = macroButtonPropertiesFromJSON(mbp, prop, null);
+      macroButtonPropertiesFromJSON(mbp, prop, null);
       mbp.setCommand(JSONMacroFunctions.getInstance().jsonToScriptString(jobj.get("command")));
     }
     mbp.setSaveLocation(gmPanel ? "GmPanel" : "CampaignPanel");
@@ -589,8 +589,8 @@ public class MacroFunctions extends AbstractFunction {
   }
 
   /**
-   * Creates a macro button on a token. If There is only one argument in param and it is a json
-   * string then the values in this are used to create the button on the token in context. If there
+   * Creates a macro button on a token. If There is only one argument in param, and it is a json
+   * string, then the values in this are used to create the button on the token in context. If there
    * are two arguments and the first is a json string the second argument is the token to create the
    * button on. If the first argument is not a json string then it is the label for the new button.
    * The second argument is the command, if the third argument is specified then it is the
@@ -675,7 +675,7 @@ public class MacroFunctions extends AbstractFunction {
               value.toString(),
               gmPanel ? "gm panel" : "campaign panel"));
     }
-    MacroButtonProperties mbp = null;
+    MacroButtonProperties mbp;
     List<MacroButtonProperties> list = getCampaignMbpList(gmPanel);
     ImmutablePair<Integer, MacroButtonProperties> pair;
     if ((value instanceof BigDecimal)) {
@@ -694,9 +694,8 @@ public class MacroFunctions extends AbstractFunction {
       }
       if (delim.equals("json")) {
         try {
-          mbp =
-              macroButtonPropertiesFromJSON(
-                  mbp, null, JSONMacroFunctions.getInstance().asJsonElement(props));
+          macroButtonPropertiesFromJSON(
+              mbp, null, JSONMacroFunctions.getInstance().asJsonElement(props));
         } catch (IllegalStateException e) {
           throw new ParserException(
               I18N.getText(
@@ -924,7 +923,7 @@ public class MacroFunctions extends AbstractFunction {
     List<String> strIndexes = new LinkedList<>();
     List<Integer> indexes = new LinkedList<>();
     List<MacroButtonProperties> mbpList = getCampaignMbpList(gmPanel);
-    delim = delim == "" ? "," : delim;
+    delim = delim.isEmpty() ? "," : delim;
     for (MacroButtonProperties props : mbpList) {
       if (props.getGroup().equals(group)) {
         strIndexes.add(String.valueOf(props.getIndex()));
@@ -1218,134 +1217,4 @@ public class MacroFunctions extends AbstractFunction {
       return true;
     }
   }
-
-  /**
-   * I don't know how to actually make tests, but these are the macros I used when developing the
-   * functions for dealing with macros on the campaign panels. These macros create test macro
-   * buttons containing applications of the various functions. This is mostly so I have them stored
-   * somewhere relevant.
-   */
-/*
-[h: broadcast("<b>Panel " + panel.campaign + "</b>")]
-[h: broadcast('getMacroName() + &quot; @ &quot; + getMacroLocation() - > ' + getMacroName() + ' @ 'getMacroLocation())]
-[h: broadcast('getMacroLocation() - > ' + getMacroLocation())]
-[h: broadcast('getMacroButtonIndex() -> ' + getMacroButtonIndex())]
-[h: broadcast('getMacros("json", panel.campaign) -> ' + getMacros("json", panel.campaign))]
-[h: broadcast('getMacros("", panel.campaign) -> ' + getMacros("", panel.campaign))]
-[h: broadcast('getMacroProps(getMacroButtonIndex(),";", getMacroLocation()) -> ' +
-              getMacroProps(getMacroButtonIndex(),";", getMacroLocation()))]
-[h: mbp = getMacroProps(getMacroButtonIndex(),"json", getMacroLocation())]
-[h: broadcast('getMacroProps(getMacroButtonIndex(),"json", getMacroLocation()) -> <pre>'
-                      + json.indent(mbp,3) + '</pre>')]
-[h: mbp = json.remove(mbp,"index")]
-[h: broadcast('createMacro(mbp, panel.campaign) -> ' + createMacro(mbp, panel.campaign))]
-[h: broadcast('getMacroIndices(getMacroName(), "json", panel.campaign) -> ' +
-              getMacroIndices(getMacroName(), "json", panel.campaign))]
-[h: broadcast('getMacroIndices(getMacroName(), "", panel.campaign) -> ' +
-              getMacroIndices(getMacroName(), "", panel.campaign))]
-[h: broadcast('getMacroIndexes(getMacroName(), "json", panel.campaign) -> ' +
-              getMacroIndexes(getMacroName(), "json", panel.campaign))]
-[h: broadcast('getMacroIndexes(getMacroName(), "", panel.campaign) -> ' +
-              getMacroIndexes(getMacroName(), "", panel.campaign))]
-[h: broadcast('getMacroCommand(getMacroButtonIndex(), panel.campaign) -> ' +
-              getMacroCommand(getMacroButtonIndex(), panel.campaign))]
-[h: props = json.set("",
-"applyToSelected"      , false                                     ,
-"autoExecute"          , true                                      ,
-"color"                , "red"                                     ,
-"command"              , "[h: this = getMacroName()]
-[h: here = getMacroLocation()]
-[h: broadcast(strformat('%{this}@%{here}'))]",
-"fontColor"            , "white"                                   ,
-"fontSize"             , "13pt"                                    ,
-"includeLabel"         , false                                     ,
-"group"                , "New Group"                               ,
-"sortBy"               , "a1"                                      ,
-"label"                , "New Macro"                               ,
-"maxWidth"             , "Sneaky hiding place"                     ,
-"minWidth"             , 90                                        ,
-"playerEditable"       , false                                     ,
-"tooltip"              , "Three cheers for the sun god. Ra! Ra! Ra!",
-"compare"              , json.append(""                            ,
-"applyToSelected"  ,
-"autoExecute"      ,
-"command"          ,
-"group"            ,
-"includeLabel"     ,
-"sortPrefix")
-)]
-[h: indices = getMacroIndices(getMacroName(), "json", panel.campaign)]
-[h: broadcast('setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.campaign) ->' +
-              setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.campaign))]
-[h: props = json.set(props, "fontColor", "black")]
-[h: broadcast('setMacroProps("New Macro", props,"json", panel.campaign) ->' +
-              setMacroProps("New Macro", props,"json", panel.campaign))]
-[h: broadcast('hasMacro("New Macro", panel.campaign) -> ' + hasMacro("New Macro", panel.campaign))]
-[h, macro("New Macro@campaign"):""]
-[h: setMacroCommand(
-json.get(getMacroIndexes("New Macro", "json", panel.campaign),0),	"[h: broadcast(strformat('%s@%s remastered... and deleted.', getMacroName(), getMacroLocation()))][r: removeMacro(listGet(getMacroIndexes('New Macro', '', panel.campaign), 0), panel.campaign)]", panel.campaign)]
-[h, macro("New Macro@campaign"):""]
-[h: broadcast('getMacroGroup("New Group","", panel.campaign) ->' + getMacroGroup("New Group","", panel.campaign)]
-
-[h: broadcast("<b>Panel " + panel.gm + "</b>")]
-[h: broadcast('getMacroName() + &quot; @ &quot; + getMacroLocation() - > ' + getMacroName() + ' @ 'getMacroLocation())]
-[h: broadcast('getMacroLocation() - > ' + getMacroLocation())]
-[h: broadcast('getMacroButtonIndex() -> ' + getMacroButtonIndex())]
-[h: broadcast('getMacros("json", panel.gm) -> ' + getMacros("json", panel.gm))]
-[h: broadcast('getMacros("", panel.gm) -> ' + getMacros("", panel.gm))]
-[h: broadcast('getMacroProps(getMacroButtonIndex(),";", getMacroLocation()) -> ' +
-	getMacroProps(getMacroButtonIndex(),";", getMacroLocation()))]
-[h: mbp = getMacroProps(getMacroButtonIndex(),"json", getMacroLocation())]
-[h: broadcast('getMacroProps(getMacroButtonIndex(),"json", getMacroLocation()) -> <pre>'
-	+ json.indent(mbp,3) + '</pre>')]
-[h: mbp = json.remove(mbp,"index")]
-[h: broadcast('createMacro(mbp, panel.gm) -> ' + createMacro(mbp, panel.gm))]
-[h: broadcast('getMacroIndices(getMacroName(), "json", panel.gm) -> ' +
-	getMacroIndices(getMacroName(), "json", panel.gm))]
-[h: broadcast('getMacroIndices(getMacroName(), "", panel.gm) -> ' +
-	getMacroIndices(getMacroName(), "", panel.gm))]
-[h: broadcast('getMacroIndexes(getMacroName(), "json", panel.gm) -> ' +
-	getMacroIndexes(getMacroName(), "json", panel.gm))]
-[h: broadcast('getMacroIndexes(getMacroName(), "", panel.gm) -> ' +
-	getMacroIndexes(getMacroName(), "", panel.gm))]
-[h: broadcast('getMacroCommand(getMacroButtonIndex(), panel.gm) -> ' +
-	getMacroCommand(getMacroButtonIndex(), panel.gm))]
-[h: props = json.set("",
-"applyToSelected"      , false                                     ,
-"autoExecute"          , true                                      ,
-"color"                , "red"                                     ,
-"command"              , "[h: this = getMacroName()]
-[h: here = getMacroLocation()]
-[h: broadcast(strformat('%{this}@%{here}'))]",
-"fontColor"            , "white"                                   ,
-"fontSize"             , "13pt"                                    ,
-"includeLabel"         , false                                     ,
-"group"                , "New Group"                               ,
-"sortBy"               , "a1"                                      ,
-"label"                , "New Macro"                               ,
-"maxWidth"             , "Sneaky hiding place"                     ,
-"minWidth"             , 90                                        ,
-"playerEditable"       , false                                     ,
-"tooltip"              , "Three cheers for the sun god. Ra! Ra! Ra!",
-"compare"              , json.append(""                            ,
-                            "applyToSelected"  ,
-                            "autoExecute"      ,
-                            "command"          ,
-                            "group"            ,
-                            "includeLabel"     ,
-                            "sortPrefix")
-)]
-[h: indices = getMacroIndices(getMacroName(), "json", panel.gm)]
-[h: broadcast('setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.gm) ->' +
-	setMacroProps(json.get(indices, json.length(indices) - 1), props,"json", panel.gm))]
-[h: props = json.set(props, "fontColor", "black")]
-[h: broadcast('setMacroProps("New Macro", props,"json", panel.gm) ->' +
-	setMacroProps("New Macro", props,"json", panel.gm))]
-[h: broadcast('hasMacro("New Macro", panel.gm) -> ' + hasMacro("New Macro", panel.gm))]
-[h, macro("New Macro@gm"):""]
-[h: setMacroCommand(
-		json.get(getMacroIndexes("New Macro", "json", panel.gm),0),	"[h: broadcast(strformat('%s@%s remastered.', getMacroName(), getMacroLocation()))][h: removeMacro(listGet(getMacroIndexes('New Macro', '', panel.gm), 0), panel.gm)]", panel.gm)]
-[h, macro("New Macro@gm"):""]
-[h: broadcast('getMacroGroup("New Group","", panel.gm) ->' + getMacroGroup("New Group","", panel.gm)]
-*/
 }


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #2926

### Description of the Change
Added **CAMPAIGN_PANEL** & **GM_PANEL** to variable resolver for new constants **panel.campaign** & **panel.gm**.
Did a little code refactoring consolidation to make life easier.
Created versions of macro functions that accept above constants in place of Token Id  allowing macro control over campaign and gm panel macro buttons;
- createMacro
- getMacroCommand
- getMacroGroup
- getMacroIndexes
- getMacroProps
- getMacros
- hasMacro
- removeMacro
- setMacroCommand
- setMacroProps

Also added alias for _getMacroIndexes_ -> **getMacroIndices** because I'm a little language OCD

### Possible Drawbacks
Too much power placed in the hands of fools.
That and I may have done things incorrectly, even though it works.

### Documentation Notes
Added constants panel.campaign & panel.gm for use in macros.
The following functions now accept panel.campaign and panel.gm in place of the Token Id as a source or destination;
- createMacro
- getMacroCommand
- getMacroGroup
- getMacroIndexes
- getMacroIndices
- getMacroProps
- getMacros
- hasMacro
- removeMacro
- setMacroCommand
- setMacroProps

### Release Notes
These macro functions now accept "panel.campaign" and "panel.gm" in place of the Token Id allowing macro control over the Campaign and GM panel macro buttons;
- createMacro
- getMacroCommand
- getMacroGroup
- getMacroIndexes
- getMacroProps
- getMacros
- hasMacro
- removeMacro
- setMacroCommand
- setMacroProps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4531)
<!-- Reviewable:end -->
