### PR TITLE
Removed auto inserting quotes from code editor

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
@@ -471,7 +471,7 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
 
     // Macro Editor setup
     macroEditorRSyntaxTextArea.setSyntaxEditingStyle("text/MapToolScript");
-
+    macroEditorRSyntaxTextArea.setInsertPairedCharacters(false);
     macroEditorRSyntaxTextArea.setEditable(true);
     macroEditorRSyntaxTextArea.setCodeFoldingEnabled(true);
     macroEditorRSyntaxTextArea.setLineWrap(true);


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #4534

### Description of the Change
Auto-insertion of quotes in code editor pane disabled by adding 
macroEditorRSyntaxTextArea.**setInsertPairedCharacters(false);**


### Possible Drawbacks
None. Common-sense returns

### Documentation Notes
Auto-insertion of quotes in code editor pane disabled.

### Release Notes
Auto-insertion of quotes in code editor pane disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4535)
<!-- Reviewable:end -->
