### PR TITLE
Factor out more rendering logic into separate renderers

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -610,12 +610,7 @@ public class ZoneView {
    * @param token the token to get the visible area of.
    * @return the visible area of a token, including the effect of other lights.
    */
-  public Area getVisibleArea(Token token, PlayerView view) {
-    // Sanity
-    if (token == null) {
-      return null;
-    }
-
+  public Area getVisibleArea(@Nonnull Token token, PlayerView view) {
     // Cache ?
     Map<GUID, Area> tokenVisionCache =
         tokenVisionCachePerView.computeIfAbsent(view, v -> new HashMap<>());

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/DarknessRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/DarknessRenderer.java
@@ -1,0 +1,57 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import net.rptools.maptool.client.ui.zone.PlayerView;
+import net.rptools.maptool.client.ui.zone.ZoneView;
+
+/**
+ * Draws a solid black overlay wherever a non-GM player should see darkness.
+ *
+ * <p>If the current view is a GM view, this renders nothing since darkness is rendered as a light
+ * source for GMs.
+ */
+public class DarknessRenderer {
+  private final RenderHelper renderHelper;
+  private final ZoneView zoneView;
+
+  public DarknessRenderer(RenderHelper renderHelper, ZoneView zoneView) {
+    this.renderHelper = renderHelper;
+    this.zoneView = zoneView;
+  }
+
+  public void render(Graphics2D g2d, PlayerView view) {
+    if (!view.isGMView()) {
+      return;
+    }
+    final Area darkness = zoneView.getIllumination(view).getDarkenedArea();
+    if (darkness.isEmpty()) {
+      // Skip the rendering work if it isn't necessary.
+      return;
+    }
+
+    renderHelper.render(g2d, worldG -> renderWorld(worldG, darkness));
+  }
+
+  private void renderWorld(Graphics2D worldG, Area darkness) {
+    worldG.setComposite(AlphaComposite.Src);
+    worldG.setPaint(Color.black);
+    worldG.fill(darkness);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/DebugRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/DebugRenderer.java
@@ -1,0 +1,64 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import com.google.common.collect.Iterators;
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+
+public class DebugRenderer {
+  private final RenderHelper renderHelper;
+  private final Color[] palette;
+
+  public DebugRenderer(RenderHelper renderHelper) {
+    this.renderHelper = renderHelper;
+    palette = new Color[] {Color.red, Color.green, Color.blue};
+  }
+
+  public void renderShapes(Graphics2D g2d, Iterable<Shape> shapes) {
+    renderHelper.render(g2d, worldG -> renderWorld(worldG, shapes));
+  }
+
+  private void renderWorld(Graphics2D worldG, Iterable<Shape> shapes) {
+    worldG.setComposite(AlphaComposite.SrcOver);
+    // Keep the line a consistent thickness
+    worldG.setStroke(new BasicStroke(1 / (float) worldG.getTransform().getScaleX()));
+
+    var paletteIterator = Iterators.cycle(palette);
+    for (final var shape : shapes) {
+      final var color = paletteIterator.next();
+
+      if (shape == null) {
+        continue;
+      }
+
+      var fillColor = color.darker();
+      fillColor =
+          new Color(
+              fillColor.getRed(),
+              fillColor.getGreen(),
+              fillColor.getBlue(),
+              fillColor.getAlpha() / 3);
+      worldG.setColor(fillColor);
+      worldG.fill(shape);
+
+      worldG.setColor(color);
+      worldG.draw(shape);
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
@@ -1,0 +1,127 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import net.rptools.lib.CodeTimer;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.ui.zone.PlayerView;
+import net.rptools.maptool.client.ui.zone.ZoneView;
+import net.rptools.maptool.model.Zone;
+
+public class FogRenderer {
+  private final RenderHelper renderHelper;
+  private final Zone zone;
+  private final ZoneView zoneView;
+
+  public FogRenderer(RenderHelper renderHelper, Zone zone, ZoneView zoneView) {
+    this.renderHelper = renderHelper;
+    this.zone = zone;
+    this.zoneView = zoneView;
+  }
+
+  public void render(Graphics2D g, PlayerView view) {
+    var timer = CodeTimer.get();
+    timer.start("renderFog");
+    try {
+      if (!zone.hasFog()) {
+        return;
+      }
+
+      this.renderHelper.bufferedRender(
+          g, AlphaComposite.SrcOver, worldG -> renderWorld(worldG, view));
+    } finally {
+      timer.stop("renderFog");
+    }
+  }
+
+  private void renderWorld(Graphics2D worldG, PlayerView view) {
+    var timer = CodeTimer.get();
+
+    /* The tricky thing in this method is that the areas we have (exposed, visible) are the areas
+     * where we should _not_ render. So we have to do clipped fills and clears instead of directly
+     * rendering the areas. */
+    timer.start("renderFog-getVisibleArea");
+    Area visibleArea = zoneView.getVisibleArea(view);
+    timer.stop("renderFog-getVisibleArea");
+
+    String msg = null;
+    if (timer.isEnabled()) {
+      msg =
+          "renderFog-getExposedArea("
+              + (view.isUsingTokenView() ? view.getTokens().size() : 0)
+              + ")";
+    }
+    timer.start(msg);
+    Area exposedArea = zoneView.getExposedArea(view);
+    timer.stop(msg);
+
+    // Hard FOW is cleared by exposed areas. The exposed area itself has two regions: the visible
+    // area (rendered clear) and the soft FOW area (rendered translucent). But if vision is off,
+    // treat the entire exposed area as visible.
+    Area softFogArea;
+    Area clearArea;
+    if (zoneView.isUsingVision()) {
+      softFogArea = exposedArea;
+      clearArea = new Area(visibleArea);
+      clearArea.intersect(softFogArea);
+    } else {
+      softFogArea = new Area();
+      clearArea = exposedArea;
+    }
+
+    var originalClip = worldG.getClip();
+
+    timer.start("renderFog-hardFow");
+    // Fill. This will be cleared out later to produce soft fog and clear visible area.
+    worldG.setPaint(zone.getFogPaint().getPaint());
+    // JFJ this fixes the GM exposed area view.
+    worldG.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC, view.isGMView() ? .6f : 1f));
+    var bounds = originalClip.getBounds();
+    worldG.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+    timer.start("renderFog-hardFow");
+
+    timer.start("renderFog-softFow");
+    if (!softFogArea.isEmpty()) {
+      worldG.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC));
+      worldG.setColor(new Color(0, 0, 0, AppPreferences.getFogOverlayOpacity()));
+      worldG.fill(softFogArea);
+    }
+    timer.stop("renderFog-softFow");
+
+    timer.start("renderFog-exposedArea");
+    if (!clearArea.isEmpty()) {
+      // Now fill in the visible area.
+      worldG.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR));
+      worldG.fill(clearArea);
+    }
+    timer.stop("renderFog-exposedArea");
+
+    timer.start("renderFog-outline");
+    // If there is no boundary between soft fog and visible area, there is no need for an outline.
+    if (!softFogArea.isEmpty() && !clearArea.isEmpty()) {
+      worldG.setComposite(AlphaComposite.Src);
+      // Keep the line a consistent thickness
+      worldG.setStroke(new BasicStroke(1 / (float) worldG.getTransform().getScaleX()));
+      worldG.setColor(Color.BLACK);
+      worldG.draw(clearArea);
+    }
+    timer.stop("renderFog-outline");
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LightsRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LightsRenderer.java
@@ -1,0 +1,142 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Composite;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import net.rptools.lib.CodeTimer;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppState;
+import net.rptools.maptool.client.ui.zone.DrawableLight;
+import net.rptools.maptool.client.ui.zone.LightingComposite;
+import net.rptools.maptool.client.ui.zone.PlayerView;
+import net.rptools.maptool.client.ui.zone.ZoneView;
+import net.rptools.maptool.model.Zone;
+
+/**
+ * Draws a solid black overlay wherever a non-GM player should see darkness.
+ *
+ * <p>If the current view is a GM view, this renders nothing since darkness is rendered as a light
+ * source for GMs.
+ */
+public class LightsRenderer {
+  private final RenderHelper renderHelper;
+  private final Zone zone;
+  private final ZoneView zoneView;
+
+  public LightsRenderer(RenderHelper renderHelper, Zone zone, ZoneView zoneView) {
+    this.renderHelper = renderHelper;
+    this.zone = zone;
+    this.zoneView = zoneView;
+  }
+
+  public void renderAuras(Graphics2D g2d, PlayerView view) {
+    var timer = CodeTimer.get();
+    timer.start("renderAuras");
+    try {
+      final var drawableAuras = zoneView.getDrawableAuras();
+      if (drawableAuras.isEmpty()) {
+        return;
+      }
+
+      final var lightBlending =
+          AlphaComposite.SrcOver.derive(AppPreferences.getAuraOverlayOpacity() / 255.0f);
+      final var overlayFillColor = new Color(0, 0, 0, 0);
+
+      renderHelper.bufferedRender(
+          g2d,
+          AlphaComposite.SrcOver,
+          worldG -> renderWorld(worldG, view, drawableAuras, lightBlending, overlayFillColor));
+    } finally {
+      timer.stop("renderAuras");
+    }
+  }
+
+  public void renderLights(Graphics2D g2d, PlayerView view) {
+    var timer = CodeTimer.get();
+    timer.start("renderLights");
+    try {
+      if (!AppState.isShowLights()) {
+        return;
+      }
+
+      final var drawableLights = zoneView.getDrawableLights(view);
+      if (drawableLights.isEmpty()) {
+        return;
+      }
+
+      final var overlayBlending =
+          switch (zone.getLightingStyle()) {
+            case OVERTOP -> AlphaComposite.SrcOver.derive(
+                AppPreferences.getLightOverlayOpacity() / 255.f);
+            case ENVIRONMENTAL -> LightingComposite.OverlaidLights;
+          };
+      final var overlayFillColor =
+          switch (zone.getLightingStyle()) {
+            case OVERTOP -> new Color(0, 0, 0, 0);
+            case ENVIRONMENTAL -> Color.black;
+          };
+
+      renderHelper.bufferedRender(
+          g2d,
+          overlayBlending,
+          worldG ->
+              renderWorld(
+                  worldG, view, drawableLights, LightingComposite.BlendedLights, overlayFillColor));
+    } finally {
+      timer.stop("renderLights");
+    }
+  }
+
+  private void renderWorld(
+      Graphics2D worldG,
+      PlayerView view,
+      Iterable<DrawableLight> lights,
+      Composite lightBlending,
+      Color backgroundFill) {
+    var timer = CodeTimer.get();
+
+    var visibleArea = zoneView.getVisibleArea(view);
+
+    var originalClip = worldG.getClip();
+    var bounds = originalClip.getBounds();
+    worldG.setComposite(AlphaComposite.Src);
+    worldG.setPaint(backgroundFill);
+    worldG.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+    if (!view.isGMView()) {
+      timer.start("renderLightOverlay:setClip");
+      var clip = new Area(originalClip);
+      clip.intersect(visibleArea);
+      worldG.setClip(clip);
+      timer.stop("renderLightOverlay:setClip");
+    }
+
+    worldG.setComposite(lightBlending);
+
+    // Draw lights onto the buffer image so the map doesn't affect how they blend
+    timer.start("renderLightOverlay:drawLights");
+    for (var light : lights) {
+      worldG.setPaint(light.getPaint().getPaint());
+      timer.start("renderLightOverlay:fillLight");
+      worldG.fill(light.getArea());
+      timer.stop("renderLightOverlay:fillLight");
+    }
+    timer.stop("renderLightOverlay:drawLights");
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LumensRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LumensRenderer.java
@@ -1,0 +1,135 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import net.rptools.lib.CodeTimer;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppState;
+import net.rptools.maptool.client.ui.zone.PlayerView;
+import net.rptools.maptool.client.ui.zone.ZoneView;
+import net.rptools.maptool.model.Zone;
+
+/**
+ * Draws a solid black overlay wherever a non-GM player should see darkness.
+ *
+ * <p>If the current view is a GM view, this renders nothing since darkness is rendered as a light
+ * source for GMs.
+ */
+public class LumensRenderer {
+  private final RenderHelper renderHelper;
+  private final Zone zone;
+  private final ZoneView zoneView;
+
+  public LumensRenderer(RenderHelper renderHelper, Zone zone, ZoneView zoneView) {
+    this.renderHelper = renderHelper;
+    this.zone = zone;
+    this.zoneView = zoneView;
+  }
+
+  public void render(Graphics2D g2d, PlayerView view) {
+    var timer = CodeTimer.get();
+    timer.start("renderLumensOverlay");
+    try {
+      if (!AppState.isShowLumensOverlay()) {
+        return;
+      }
+
+      renderHelper.bufferedRender(g2d, AlphaComposite.SrcOver, worldG -> renderWorld(worldG, view));
+    } finally {
+      timer.stop("renderLumensOverlay");
+    }
+  }
+
+  private void renderWorld(Graphics2D worldG, PlayerView view) {
+    var timer = CodeTimer.get();
+    var overlayOpacity = AppPreferences.getLumensOverlayOpacity() / 255.0f;
+
+    var visibleArea = zoneView.getVisibleArea(view);
+    final var disjointLumensLevels = zoneView.getDisjointObscuredLumensLevels(view);
+
+    var originalClip = worldG.getClip();
+    var bounds = originalClip.getBounds();
+    worldG.setComposite(AlphaComposite.Src.derive(overlayOpacity));
+    // At night, show any uncovered areas as dark. In daylight, show them as light (clear).
+    var backgroundFill =
+        zone.getVisionType() == Zone.VisionType.NIGHT
+            ? new Color(0.f, 0.f, 0.f, 1.f)
+            : new Color(0.f, 0.f, 0.f, 0.f);
+    worldG.setPaint(backgroundFill);
+    worldG.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+    if (!view.isGMView()) {
+      timer.start("renderLumensOverlay:setClip");
+      Area clip = new Area(originalClip);
+      clip.intersect(visibleArea);
+      worldG.setClip(clip);
+      timer.stop("renderLumensOverlay:setClip");
+    }
+
+    worldG.setComposite(AlphaComposite.SrcOver.derive(overlayOpacity));
+
+    timer.start("renderLumensOverlay:drawLumens");
+    for (final var lumensLevel : disjointLumensLevels) {
+      final var lumensStrength = lumensLevel.lumensStrength();
+
+      // Light is weaker than darkness, so do it first.
+      float lightOpacity;
+      float lightShade;
+      if (lumensStrength == 0) {
+        // This area represents daylight, so draw it as clear despite the low value.
+        lightShade = 1.f;
+        lightOpacity = 0;
+      } else if (lumensStrength >= 100) {
+        // Bright light, render mostly clear.
+        lightShade = 1.f;
+        lightOpacity = 1.f / 10.f;
+      } else {
+        lightShade = Math.max(0.f, Math.min(lumensStrength / 100.f, 1.f));
+        lightShade *= lightShade;
+        lightOpacity = 1.f;
+      }
+
+      timer.start("renderLumensOverlay:drawLights:fillArea");
+      worldG.setPaint(new Color(lightShade, lightShade, lightShade, lightOpacity));
+      worldG.fill(lumensLevel.lightArea());
+
+      worldG.setPaint(new Color(0.f, 0.f, 0.f, 1.f));
+      worldG.fill(lumensLevel.darknessArea());
+      timer.stop("renderLumensOverlay:drawLights:fillArea");
+    }
+
+    // Now draw borders around each region if configured.
+    final var borderThickness = AppPreferences.getLumensOverlayBorderThickness();
+    if (borderThickness > 0) {
+      worldG.setStroke(
+          new BasicStroke((float) borderThickness, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+      worldG.setComposite(AlphaComposite.SrcOver);
+      worldG.setPaint(new Color(0.f, 0.f, 0.f, 1.f));
+      for (final var lumensLevel : disjointLumensLevels) {
+        timer.start("renderLumensOverlay:drawLights:drawArea");
+        worldG.draw(lumensLevel.lightArea());
+        worldG.draw(lumensLevel.darknessArea());
+        timer.stop("renderLumensOverlay:drawLights:drawArea");
+      }
+    }
+
+    timer.stop("renderLumensOverlay:drawLumens");
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/RenderHelper.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/RenderHelper.java
@@ -1,0 +1,93 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import java.awt.Composite;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
+import java.util.function.Consumer;
+import net.rptools.lib.CodeTimer;
+import net.rptools.maptool.client.swing.SwingUtil;
+import net.rptools.maptool.client.ui.Scale;
+import net.rptools.maptool.client.ui.zone.BufferedImagePool;
+
+/**
+ * Transform graphics objects into world space to enable more convenient rendering for some layers.
+ *
+ * <p>Also optionally renders onto an intermediate buffer.
+ */
+public class RenderHelper {
+  private final ZoneRenderer renderer;
+  private final BufferedImagePool tempBufferPool;
+
+  public RenderHelper(ZoneRenderer renderer, BufferedImagePool tempBufferPool) {
+    this.renderer = renderer;
+    this.tempBufferPool = tempBufferPool;
+  }
+
+  private void doRender(Graphics2D g, Consumer<Graphics2D> render) {
+    var timer = CodeTimer.get();
+
+    Dimension size = renderer.getSize();
+    Scale scale = renderer.getZoneScale();
+    g.setClip(new Area(new Rectangle(0, 0, size.width, size.height)));
+    SwingUtil.useAntiAliasing(g);
+
+    AffineTransform af = new AffineTransform();
+    af.translate(scale.getOffsetX(), scale.getOffsetY());
+    af.scale(scale.getScale(), scale.getScale());
+    g.setTransform(af);
+
+    timer.start("bufferRender-render");
+    render.accept(g);
+    timer.stop("bufferRender-render");
+  }
+
+  public void render(Graphics2D g, Consumer<Graphics2D> render) {
+    g = (Graphics2D) g.create();
+    try {
+      doRender(g, render);
+    } finally {
+      g.dispose();
+    }
+  }
+
+  public void bufferedRender(Graphics2D g, Composite blitComposite, Consumer<Graphics2D> render) {
+    var timer = CodeTimer.get();
+    g = (Graphics2D) g.create();
+    timer.start("bufferRender-acquireBuffer");
+    try (final var entry = tempBufferPool.acquire()) {
+      final var buffer = entry.get();
+      timer.stop("bufferRender-acquireBuffer");
+
+      Graphics2D buffG = buffer.createGraphics();
+      try {
+        doRender(buffG, render);
+      } finally {
+        buffG.dispose();
+      }
+
+      timer.start("bufferRender-blit");
+      g.setComposite(blitComposite);
+      g.drawImage(buffer, 0, 0, renderer);
+      timer.stop("bufferRender-blit");
+    } finally {
+      g.dispose();
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
@@ -1,0 +1,103 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.renderer;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import java.util.List;
+import net.rptools.lib.CodeTimer;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppUtil;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.ui.zone.PlayerView;
+import net.rptools.maptool.client.ui.zone.ZoneView;
+import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Zone;
+
+/**
+ * This outlines the area visible to the token under the cursor. For player views, this is clipped
+ * to the current fog-of-war, while for GMs they see everything.
+ */
+public class VisionOverlayRenderer {
+  private final RenderHelper renderHelper;
+  private final Zone zone;
+  private final ZoneView zoneView;
+
+  public VisionOverlayRenderer(RenderHelper renderHelper, Zone zone, ZoneView zoneView) {
+    this.renderHelper = renderHelper;
+    this.zone = zone;
+    this.zoneView = zoneView;
+  }
+
+  public void render(Graphics2D g, PlayerView view, Token tokenUnderMouse) {
+    var timer = CodeTimer.get();
+    timer.start("renderVisionOverlay");
+    try {
+      if (tokenUnderMouse == null) {
+        return;
+      }
+
+      boolean isOwner = AppUtil.playerOwns(tokenUnderMouse);
+      boolean tokenIsPC = tokenUnderMouse.getType() == Token.Type.PC;
+      boolean strictOwnership =
+          MapTool.getServerPolicy() != null && MapTool.getServerPolicy().useStrictTokenManagement();
+      boolean showVisionAndHalo = isOwner || view.isGMView() || (tokenIsPC && !strictOwnership);
+      if (!showVisionAndHalo) {
+        return;
+      }
+
+      this.renderHelper.render(g, worldG -> renderWorld(worldG, view, tokenUnderMouse));
+    } finally {
+      timer.stop("renderVisionOverlay");
+    }
+  }
+
+  private void renderWorld(Graphics2D worldG, PlayerView view, Token token) {
+    // The vision of the token is not necessarily related to the current view.
+    // final var tokenView = view.derive(Collections.singleton(token));
+    final var tokenView = new PlayerView(view.getRole(), List.of(token));
+
+    Area currentTokenVisionArea = zoneView.getVisibleArea(token, tokenView);
+    // Nothing to show.
+    if (currentTokenVisionArea.isEmpty()) {
+      return;
+    }
+    if (zone.hasFog()) {
+      currentTokenVisionArea = new Area(currentTokenVisionArea);
+      currentTokenVisionArea.intersect(zoneView.getExposedArea(tokenView));
+    }
+
+    // Keep the line a consistent thickness
+    worldG.setStroke(new BasicStroke(1 / (float) worldG.getTransform().getScaleX()));
+    worldG.setColor(new Color(255, 255, 255)); // outline around visible area
+    worldG.draw(currentTokenVisionArea);
+
+    Color visionColor = token.getVisionOverlayColor();
+    if (visionColor == null && AppPreferences.getUseHaloColorOnVisionOverlay()) {
+      visionColor = token.getHaloColor();
+    }
+    if (visionColor != null) {
+      worldG.setColor(
+          new Color(
+              visionColor.getRed(),
+              visionColor.getGreen(),
+              visionColor.getBlue(),
+              AppPreferences.getHaloOverlayOpacity()));
+      worldG.fill(currentTokenVisionArea);
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -156,6 +156,7 @@ public class ZoneRenderer extends JComponent
   private final ZoneCompositor compositor;
   private final GridRenderer gridRenderer;
   private final HaloRenderer haloRenderer;
+  private final DarknessRenderer darknessRenderer;
 
   /**
    * Constructor for the ZoneRenderer from a zone.
@@ -174,6 +175,7 @@ public class ZoneRenderer extends JComponent
     this.compositor = new ZoneCompositor();
     this.gridRenderer = new GridRenderer();
     this.haloRenderer = new HaloRenderer();
+    this.darknessRenderer = new DarknessRenderer(renderHelper, zoneView);
     repaintDebouncer = new DebounceExecutor(1000 / AppPreferences.getFrameRateCap(), this::repaint);
 
     setFocusable(true);
@@ -1069,7 +1071,7 @@ public class ZoneRenderer extends JComponent
       timer.stop("auras");
     }
 
-    renderPlayerDarkness(g2d, view);
+    darknessRenderer.render(g2d, view);
 
     /**
      * The following sections used to handle rendering of the Hidden (i.e. "GM") layer followed by
@@ -1511,45 +1513,6 @@ public class ZoneRenderer extends JComponent
       g.setComposite(overlayBlending);
       g.drawImage(lightOverlay, null, 0, 0);
       timer.stop("renderLightOverlay:drawBuffer");
-    }
-  }
-
-  /**
-   * Draws a solid black overlay wherever a non-GM player should see darkness.
-   *
-   * <p>If {@code view} is a GM view, this renders nothing.
-   *
-   * @param g The graphics object used to render the zone.
-   * @param view The player view.
-   */
-  private void renderPlayerDarkness(Graphics2D g, PlayerView view) {
-    final var timer = CodeTimer.get();
-
-    if (view.isGMView()) {
-      // GMs see the darkness rendered as lights, not as blackness.
-      return;
-    }
-
-    final var darkness = zoneView.getIllumination(view).getDarkenedArea();
-    if (darkness.isEmpty()) {
-      // Skip the rendering work if it isn't necessary.
-      return;
-    }
-
-    g = (Graphics2D) g.create();
-    try {
-      timer.start("renderPlayerDarkness:setTransform");
-      AffineTransform af = new AffineTransform();
-      af.translate(getViewOffsetX(), getViewOffsetY());
-      af.scale(getScale(), getScale());
-      g.setTransform(af);
-      timer.stop("renderPlayerDarkness:setTransform");
-
-      g.setComposite(AlphaComposite.Src);
-      g.setPaint(Color.black);
-      g.fill(darkness);
-    } finally {
-      g.dispose();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -160,6 +160,7 @@ public class ZoneRenderer extends JComponent
   private final LumensRenderer lumensRenderer;
   private final FogRenderer fogRenderer;
   private final VisionOverlayRenderer visionOverlayRenderer;
+  private final DebugRenderer debugRenderer;
 
   /**
    * Constructor for the ZoneRenderer from a zone.
@@ -183,6 +184,7 @@ public class ZoneRenderer extends JComponent
     this.lumensRenderer = new LumensRenderer(renderHelper, zone, zoneView);
     this.fogRenderer = new FogRenderer(renderHelper, zone, zoneView);
     this.visionOverlayRenderer = new VisionOverlayRenderer(renderHelper, zone, zoneView);
+    this.debugRenderer = new DebugRenderer(renderHelper);
     repaintDebouncer = new DebounceExecutor(1000 / AppPreferences.getFrameRateCap(), this::repaint);
 
     setFocusable(true);
@@ -1219,6 +1221,9 @@ public class ZoneRenderer extends JComponent
       lightSourceIconOverlay.paintOverlay(this, g2d);
     }
     timer.stop("lightSourceIconOverlay.paintOverlay");
+
+    debugRenderer.renderShapes(g2d, Arrays.asList(shape, shape2));
+
     // g2d.setColor(Color.red);
     // for (AreaMeta meta : getTopologyAreaData().getAreaList()) {
     // Area area = new
@@ -1920,20 +1925,6 @@ public class ZoneRenderer extends JComponent
       timer.stop("renderPath-3");
     }
 
-    // g.translate(getViewOffsetX(), getViewOffsetY());
-    // g.scale(getScale(), getScale());
-    // for debugging purposes...
-    if (shape != null) {
-      g.setColor(Color.red);
-      g.fill(shape);
-      g.draw(shape);
-    }
-    if (shape2 != null) {
-      g.setColor(Color.blue);
-      g.fill(shape2);
-      g.draw(shape2);
-    }
-
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldRendering);
   }
 
@@ -1983,11 +1974,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
 
-    AffineTransform at = new AffineTransform();
-    at.translate(getViewOffsetX(), getViewOffsetY());
-    at.scale(getScale(), getScale());
-
-    this.shape = at.createTransformedShape(shape);
+    this.shape = shape;
   }
 
   public void setShape2(Shape shape) {
@@ -1995,36 +1982,7 @@ public class ZoneRenderer extends JComponent
       return;
     }
 
-    AffineTransform at = new AffineTransform();
-    at.translate(getViewOffsetX(), getViewOffsetY());
-    at.scale(getScale(), getScale());
-
-    this.shape2 = at.createTransformedShape(shape);
-  }
-
-  public Shape getShape() {
-    return shape;
-  }
-
-  public Shape getShape2() {
-    return shape2;
-  }
-
-  public void drawShape(Shape shape, int x, int y) {
-    Graphics2D g = (Graphics2D) this.getGraphics();
-
-    Grid grid = zone.getGrid();
-    double cwidth = grid.getCellWidth() * getScale();
-    double cheight = grid.getCellHeight() * getScale();
-
-    double iwidth = cwidth;
-    double iheight = cheight;
-
-    ScreenPoint sp = ScreenPoint.fromZonePoint(this, x, y);
-
-    AffineTransform at = new AffineTransform();
-    at.translate(sp.x, sp.y);
-    g.draw(at.createTransformedShape(shape));
+    this.shape2 = shape;
   }
 
   public void showBlockedMoves(

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -154,8 +154,8 @@ public class ZoneRenderer extends JComponent
 
   private final EnumSet<Layer> disabledLayers = EnumSet.noneOf(Layer.class);
   private final ZoneCompositor compositor;
-  public GridRenderer gridRenderer;
-  private HaloRenderer haloRenderer;
+  private final GridRenderer gridRenderer;
+  private final HaloRenderer haloRenderer;
 
   /**
    * Constructor for the ZoneRenderer from a zone.

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -167,14 +167,16 @@ public class ZoneRenderer extends JComponent
       throw new IllegalArgumentException("Zone cannot be null");
     }
     this.zone = zone;
+    zoneView = new ZoneView(zone);
+    setZoneScale(new Scale());
+
+    var renderHelper = new RenderHelper(this, tempBufferPool);
     this.compositor = new ZoneCompositor();
     this.gridRenderer = new GridRenderer();
     this.haloRenderer = new HaloRenderer();
     repaintDebouncer = new DebounceExecutor(1000 / AppPreferences.getFrameRateCap(), this::repaint);
 
     setFocusable(true);
-    setZoneScale(new Scale());
-    zoneView = new ZoneView(zone);
     selectionModel = new SelectionModel(zone);
 
     // add(MapTool.getFrame().getFxPanel(), PositionalLayout.Position.NW);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRendererConstants.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRendererConstants.java
@@ -29,9 +29,4 @@ public class ZoneRendererConstants {
     FALSE,
     OTHER
   }
-
-  enum LightOverlayClipStyle {
-    CLIP_TO_VISIBLE_AREA,
-    CLIP_TO_NOT_VISIBLE_AREA,
-  }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Progresses #3691
Fixes #4429

### Description of the Change

Rendering of lights, auras, player darkness, fog of war, vision, and debug shapes are now handled by separate renderer classes. For the most part, logic was simply copied over, but some simplifications and alterations were made.

Points of interest:
- The new `RenderHelper` takes care of setting up `Graphics2D` with initial clips and transforms. It can optionally use a temporary buffer as a render target. Each of the new renderers uses the `RenderHelper`.
- Fog rendering case work has been consolidated and simplified to make it a bit more direct in terms of what is happening.
- The player-specific logic for vision overlays has been eliminated. The clip set there was not used (it was always overwritten prior to use), and the logic was broken anyways due to mixing screen space and world space areas.
- The debug shape renderer shows that shapes are translucent so they don't completely occlude what is rendered behind it.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- More modularization of the zone renderer for fog, lights, and vision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4538)
<!-- Reviewable:end -->
