### PR TITLE
Add UI for defining unique lights

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -87,6 +87,7 @@ import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
 import net.rptools.maptool.util.ExtractHeroLab;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.ImageManager;
+import net.rptools.maptool.util.LightSyntax;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -173,6 +173,10 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     EnumSet.allOf(TerrainModifierOperation.class).forEach(operationModel::addElement);
   }
 
+  public void initUniqueLightSourcesTextPane() {
+    setUniqueLightSourcesEnabled(MapTool.getPlayer().isGM());
+  }
+
   public void initJtsMethodComboBox() {
     getJtsMethodComboBox().setModel(new DefaultComboBoxModel<>(JTS_SimplifyMethodType.values()));
   }
@@ -201,6 +205,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     getRootPane().setDefaultButton(getOKButton());
     setGmNotesEnabled(MapTool.getPlayer().isGM());
     getComponent("@GMName").setEnabled(MapTool.getPlayer().isGM());
+
+    setUniqueLightSourcesEnabled(MapTool.getPlayer().isGM());
 
     dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
@@ -371,6 +377,9 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                 .stream()
                 .mapToInt(Integer::valueOf)
                 .toArray());
+
+    getUniqueLightSourcesTextPane()
+        .setText(new LightSyntax().stringifyLights(token.getUniqueLightSources()));
 
     // Jamz: Init the Topology tab...
     JTabbedPane tabbedPane = getTabbedPane();
@@ -710,6 +719,15 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     return (JList<TerrainModifierOperation>) getComponent("terrainModifiersIgnored");
   }
 
+  public void setUniqueLightSourcesEnabled(boolean enabled) {
+    getUniqueLightSourcesTextPane().setEnabled(enabled);
+    getLabel("uniqueLightSourcesLabel").setEnabled(enabled);
+  }
+
+  public JTextPane getUniqueLightSourcesTextPane() {
+    return (JTextPane) getComponent("uniqueLightSources");
+  }
+
   public JLabel getLibTokenURIErrorLabel() {
     return (JLabel) getComponent("Label.LibURIError");
   }
@@ -783,6 +801,14 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     token.setTerrainModifiersIgnored(
         new HashSet<>(getTerrainModifiersIgnoredList().getSelectedValuesList()));
+
+    var uniqueLightSources =
+        new LightSyntax()
+            .parseLights(getUniqueLightSourcesTextPane().getText(), token.getUniqueLightSources());
+    token.removeAllUniqueLightsources();
+    for (var lightSource : uniqueLightSources.values()) {
+      token.addUniqueLightSource(lightSource);
+    }
 
     // Get the states
     Component[] stateComponents = getStatesPanel().getComponents();
@@ -1211,6 +1237,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
   public void initTokenLayoutPanel() {
     TokenLayoutPanel layoutPanel = new TokenLayoutPanel();
+    layoutPanel.setMinimumSize(new Dimension(150, 125));
     layoutPanel.setPreferredSize(new Dimension(150, 125));
     layoutPanel.setName("tokenLayout");
 
@@ -1219,6 +1246,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
   public void initCharsheetPanel() {
     ImageAssetPanel panel = new ImageAssetPanel();
+    panel.setMinimumSize(new Dimension(150, 125));
     panel.setPreferredSize(new Dimension(150, 125));
     panel.setName("charsheet");
     panel.setLayout(new GridLayout());
@@ -1228,6 +1256,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
   public void initPortraitPanel() {
     ImageAssetPanel panel = new ImageAssetPanel();
+    panel.setMinimumSize(new Dimension(150, 125));
     panel.setPreferredSize(new Dimension(150, 125));
     panel.setName("portrait");
     panel.setLayout(new GridLayout());

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -550,7 +550,7 @@
               </vspacer>
             </children>
           </grid>
-          <grid id="3a658" layout-manager="GridLayoutManager" row-count="8" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="3a658" layout-manager="GridLayoutManager" row-count="10" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="4" left="4" bottom="4" right="4"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="EditTokenDialog.tab.config"/>
@@ -562,7 +562,7 @@
             <children>
               <component id="13844" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.shape"/>
@@ -570,7 +570,7 @@
               </component>
               <component id="eff39" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="3" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="3" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.snaptogrid"/>
@@ -578,7 +578,7 @@
               </component>
               <component id="1b31d" class="javax.swing.JCheckBox">
                 <constraints>
-                  <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="@visible"/>
@@ -587,7 +587,7 @@
               </component>
               <component id="3a215" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.size"/>
@@ -595,7 +595,7 @@
               </component>
               <component id="40754" class="javax.swing.JComboBox">
                 <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <actionCommand value="comboBoxChanged"/>
@@ -604,7 +604,7 @@
               </component>
               <component id="fd1d2" class="javax.swing.JComboBox">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <actionCommand value="comboBoxChanged"/>
@@ -613,7 +613,7 @@
               </component>
               <component id="50e1d" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="3" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="3" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="visibleOnlyToOwnerLabel"/>
@@ -622,7 +622,7 @@
               </component>
               <component id="bc69d" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="6" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="6" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="visibleLabel"/>
@@ -631,7 +631,7 @@
               </component>
               <component id="c605" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="6" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="6" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="terrainModifierLabel"/>
@@ -641,7 +641,7 @@
               </component>
               <component id="6612" class="javax.swing.JComboBox">
                 <constraints>
-                  <grid row="2" column="7" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="7" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <actionCommand value="comboBoxChanged"/>
@@ -654,7 +654,7 @@
               </component>
               <component id="5d599" class="javax.swing.JTextField">
                 <constraints>
-                  <grid row="2" column="8" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="8" row-span="1" col-span="1" vsize-policy="1" hsize-policy="2" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <columns value="4"/>
@@ -665,7 +665,7 @@
               </component>
               <component id="38e08" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.properties"/>
@@ -673,7 +673,7 @@
               </component>
               <component id="ecad1" class="javax.swing.JComboBox">
                 <constraints>
-                  <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <actionCommand value="comboBoxChanged"/>
@@ -682,7 +682,7 @@
               </component>
               <component id="e431c" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="tokenOpacityLabel"/>
@@ -692,7 +692,7 @@
               </component>
               <component id="4f77a" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.sight.has"/>
@@ -700,7 +700,7 @@
               </component>
               <component id="b9654" class="javax.swing.JCheckBox">
                 <constraints>
-                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="@hasSight"/>
@@ -710,7 +710,7 @@
               <grid id="d2ea5" layout-manager="GridLayoutManager" row-count="2" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="7" column="0" row-span="1" col-span="9" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="9" column="0" row-span="1" col-span="9" vsize-policy="2" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -809,7 +809,7 @@
               </grid>
               <component id="bdded" class="javax.swing.JComboBox">
                 <constraints>
-                  <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <actionCommand value="comboBoxChanged"/>
@@ -818,7 +818,7 @@
               </component>
               <component id="2300a" class="javax.swing.JComboBox">
                 <constraints>
-                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <actionCommand value="comboBoxChanged"/>
@@ -827,7 +827,7 @@
               </component>
               <component id="752e0" class="javax.swing.JCheckBox">
                 <constraints>
-                  <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="@hasImageTable"/>
@@ -836,7 +836,7 @@
               </component>
               <component id="44ef" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.image"/>
@@ -844,7 +844,7 @@
               </component>
               <component id="38159" class="javax.swing.JCheckBox">
                 <constraints>
-                  <grid row="2" column="5" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="@visibleOnlyToOwner"/>
@@ -853,7 +853,7 @@
               </component>
               <component id="7d548" class="javax.swing.JCheckBox">
                 <constraints>
-                  <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="@snapToGrid"/>
@@ -862,7 +862,7 @@
               </component>
               <component id="70e96" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="5" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="tokenOpacityValueLabel"/>
@@ -871,7 +871,7 @@
               </component>
               <component id="5971d" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="3" column="6" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="6" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="ignoreTerrainModifierLabel"/>
@@ -881,7 +881,7 @@
               </component>
               <component id="c1350" class="javax.swing.JList">
                 <constraints>
-                  <grid row="3" column="7" row-span="3" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="7" row-span="4" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <name value="terrainModifiersIgnored"/>
@@ -896,7 +896,8 @@
               </hspacer>
               <component id="3401a" class="javax.swing.JSlider">
                 <constraints>
-                  <grid row="3" column="4" row-span="4" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="3" column="4" row-span="4" col-span="1" vsize-policy="1" hsize-policy="3" anchor="1" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="-1" height="100"/>
                     <maximum-size width="-1" height="100"/>
                   </grid>
                 </constraints>
@@ -912,11 +913,6 @@
                   <valueIsAdjusting value="true"/>
                 </properties>
               </component>
-              <vspacer id="57cb0">
-                <constraints>
-                  <grid row="6" column="6" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </vspacer>
               <component id="62fd4" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -941,6 +937,42 @@
                   <name value="statSheetLocationComboBox"/>
                 </properties>
               </component>
+              <component id="86a4f" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="7" column="0" row-span="1" col-span="6" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <labelFor value="c3057"/>
+                  <name value="uniqueLightSourcesLabel"/>
+                  <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.uniqueLightSources"/>
+                </properties>
+              </component>
+              <scrollpane id="45ccf">
+                <constraints>
+                  <grid row="8" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                    <preferred-size width="-1" height="100"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <background color="-1"/>
+                  <name value="uniqueLights"/>
+                </properties>
+                <border type="none"/>
+                <children>
+                  <component id="c3057" class="javax.swing.JTextPane">
+                    <constraints/>
+                    <properties>
+                      <background color="-1"/>
+                      <name value="uniqueLightSources"/>
+                    </properties>
+                  </component>
+                </children>
+              </scrollpane>
+              <vspacer id="57cb0">
+                <constraints>
+                  <grid row="6" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </vspacer>
             </children>
           </grid>
           <grid id="81e06" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.client.ui.token.dialog.edit;
 
-import java.awt.*;
 import javax.swing.*;
 import net.rptools.maptool.client.swing.htmleditorsplit.HtmlEditorSplit;
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -933,6 +933,10 @@ public class Token implements Cloneable {
     uniqueLightSources.remove(lightSourceId);
   }
 
+  public void removeAllUniqueLightsources() {
+    uniqueLightSources.clear();
+  }
+
   public void addLightSource(GUID lightSourceId) {
     if (lightSourceList.stream().anyMatch(source -> source.matches(lightSourceId))) {
       // Avoid duplicates.

--- a/src/main/java/net/rptools/maptool/util/LightSyntax.java
+++ b/src/main/java/net/rptools/maptool/util/LightSyntax.java
@@ -39,6 +39,8 @@ import net.rptools.maptool.model.ShapeType;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 
 public class LightSyntax {
+  private static final int DEFAULT_LUMENS = 100;
+
   public Map<GUID, LightSource> parseLights(String text, Iterable<LightSource> original) {
     final var lightSourceMap = new HashMap<GUID, LightSource>();
     final var reader = new LineNumberReader(new BufferedReader(new StringReader(text)));
@@ -217,10 +219,12 @@ public class LightSyntax {
         }
         if (lightSource.getType() == LightSource.Type.NORMAL) {
           final var lumens = light.getLumens();
-          if (lumens >= 0) {
-            builder.append('+');
+          if (lumens != DEFAULT_LUMENS) {
+            if (lumens >= 0) {
+              builder.append('+');
+            }
+            builder.append(Integer.toString(lumens, 10));
           }
-          builder.append(Integer.toString(lumens, 10));
         }
       }
       builder.append('\n');
@@ -325,7 +329,7 @@ public class LightSyntax {
       }
 
       Color color = null;
-      int perRangeLumens = 100;
+      int perRangeLumens = DEFAULT_LUMENS;
       distance = arg;
 
       final var rangeRegex = Pattern.compile("([^#+-]*)(#[0-9a-fA-F]+)?([+-]\\d*)?");
@@ -343,7 +347,7 @@ public class LightSyntax {
           perRangeLumens = Integer.parseInt(lumensString, 10);
           if (perRangeLumens == 0) {
             errlog.add(I18N.getText("msg.error.mtprops.light.zerolumens", lineNumber));
-            perRangeLumens = 100;
+            perRangeLumens = DEFAULT_LUMENS;
           }
         }
       }

--- a/src/main/java/net/rptools/maptool/util/LightSyntax.java
+++ b/src/main/java/net/rptools/maptool/util/LightSyntax.java
@@ -1,0 +1,391 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.util;
+
+import java.awt.Color;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.StringReader;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Light;
+import net.rptools.maptool.model.LightSource;
+import net.rptools.maptool.model.ShapeType;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
+
+public class LightSyntax {
+  public Map<GUID, LightSource> parseLights(String text, Iterable<LightSource> original) {
+    final var lightSourceMap = new HashMap<GUID, LightSource>();
+    final var reader = new LineNumberReader(new BufferedReader(new StringReader(text)));
+    List<String> errlog = new LinkedList<>();
+
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+
+        var source = parseLightLine(line, reader.getLineNumber(), original, errlog);
+        if (source != null) {
+          lightSourceMap.put(source.getId(), source);
+        }
+      }
+    } catch (IOException ioe) {
+      MapTool.showError("msg.error.mtprops.light.ioexception", ioe);
+    }
+
+    if (!errlog.isEmpty()) {
+      MapTool.showFeedback(errlog.toArray());
+      errlog.clear();
+      throw new IllegalArgumentException(
+          "msg.error.mtprops.light.definition"); // Don't save lights...
+    }
+
+    return lightSourceMap;
+  }
+
+  public Map<String, Map<GUID, LightSource>> parseCategorizedLights(
+      String text, final Map<String, Map<GUID, LightSource>> originalLightSourcesMap) {
+    final var lightMap = new TreeMap<String, Map<GUID, LightSource>>();
+    final var reader = new LineNumberReader(new BufferedReader(new StringReader(text)));
+    List<String> errlog = new LinkedList<>();
+
+    try {
+      Collection<LightSource> currentGroupOriginalLightSources = Collections.emptyList();
+      Map<GUID, LightSource> lightSourceMap = null;
+
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+
+        // Blank lines
+        if (line.isEmpty()) {
+          lightSourceMap = null;
+          continue;
+        }
+        // New group
+        if (lightSourceMap == null) {
+          final var currentGroupName = line;
+          currentGroupOriginalLightSources =
+              originalLightSourcesMap
+                  .getOrDefault(currentGroupName, Collections.emptyMap())
+                  .values();
+          lightSourceMap = new HashMap<>();
+          lightMap.put(currentGroupName, lightSourceMap);
+          continue;
+        }
+
+        var source =
+            parseLightLine(line, reader.getLineNumber(), currentGroupOriginalLightSources, errlog);
+        if (source != null) {
+          lightSourceMap.put(source.getId(), source);
+        }
+      }
+      lightMap.values().removeIf(Map::isEmpty);
+    } catch (IOException ioe) {
+      MapTool.showError("msg.error.mtprops.light.ioexception", ioe);
+    }
+
+    if (!errlog.isEmpty()) {
+      MapTool.showFeedback(errlog.toArray());
+      errlog.clear();
+      throw new IllegalArgumentException(
+          "msg.error.mtprops.light.definition"); // Don't save lights...
+    }
+
+    return lightMap;
+  }
+
+  public String stringifyLights(Iterable<LightSource> lights) {
+    StringBuilder builder = new StringBuilder();
+    writeLightLines(builder, lights);
+    return builder.toString();
+  }
+
+  public String stringifyCategorizedLights(Map<String, Map<GUID, LightSource>> lightSources) {
+    StringBuilder builder = new StringBuilder();
+    for (Map.Entry<String, Map<GUID, LightSource>> entry : lightSources.entrySet()) {
+      builder.append(entry.getKey());
+      builder.append("\n----\n");
+
+      writeLightLines(builder, entry.getValue().values());
+      builder.append('\n');
+    }
+    return builder.toString();
+  }
+
+  private void writeLightLines(StringBuilder builder, Iterable<LightSource> lights) {
+    for (LightSource lightSource : lights) {
+      builder.append(lightSource.getName()).append(":");
+
+      if (lightSource.getType() != LightSource.Type.NORMAL) {
+        builder.append(' ').append(lightSource.getType().name().toLowerCase());
+      }
+      if (lightSource.isScaleWithToken()) {
+        builder.append(" scale");
+      }
+
+      final var lastParameters = new LinkedHashMap<String, Object>();
+      lastParameters.put("", null);
+      lastParameters.put("arc", 0.);
+      lastParameters.put("offset", 0.);
+      lastParameters.put("GM", false);
+      lastParameters.put("OWNER", false);
+
+      for (Light light : lightSource.getLightList()) {
+        final var parameters = new HashMap<>();
+
+        // TODO: This HAS to change, the lights need to be auto describing, this hard wiring sucks
+        if (lightSource.getType() == LightSource.Type.AURA) {
+          parameters.put("GM", light.isGM());
+          parameters.put("OWNER", light.isOwnerOnly());
+        }
+
+        parameters.put("", light.getShape().name().toLowerCase());
+        switch (light.getShape()) {
+          default:
+            throw new RuntimeException(
+                "Unrecognized shape: " + light.getShape().toString().toLowerCase());
+          case SQUARE, GRID, CIRCLE, HEX:
+            break;
+          case BEAM:
+            parameters.put("arc", light.getArcAngle());
+            parameters.put("offset", light.getFacingOffset());
+            break;
+          case CONE:
+            parameters.put("arc", light.getArcAngle());
+            parameters.put("offset", light.getFacingOffset());
+            break;
+        }
+
+        for (final var parameterEntry : lastParameters.entrySet()) {
+          final var key = parameterEntry.getKey();
+          final var oldValue = parameterEntry.getValue();
+          final var newValue = parameters.get(key);
+
+          if (newValue != null && !newValue.equals(oldValue)) {
+            lastParameters.put(key, newValue);
+
+            // Special case: booleans are flags that are either present or not.
+            if (newValue instanceof Boolean b) {
+              if (b) {
+                builder.append(" ").append(key);
+              }
+            } else {
+              builder.append(" ");
+              if (!"".equals(key)) {
+                // Special case: don't include a key= for shapes.
+                builder.append(key).append("=");
+              }
+              builder.append(
+                  switch (newValue) {
+                    case Double d -> StringUtil.formatDecimal(d);
+                    default -> newValue.toString();
+                  });
+            }
+          }
+        }
+
+        builder.append(' ').append(StringUtil.formatDecimal(light.getRadius()));
+        if (light.getPaint() instanceof DrawableColorPaint) {
+          Color color = (Color) light.getPaint().getPaint();
+          builder.append(toHex(color));
+        }
+        if (lightSource.getType() == LightSource.Type.NORMAL) {
+          final var lumens = light.getLumens();
+          if (lumens >= 0) {
+            builder.append('+');
+          }
+          builder.append(Integer.toString(lumens, 10));
+        }
+      }
+      builder.append('\n');
+    }
+  }
+
+  private LightSource parseLightLine(
+      String line, int lineNumber, Iterable<LightSource> originalInCategory, List<String> errlog) {
+    // Blank lines, comments
+    if (line.isEmpty() || line.charAt(0) == '-') {
+      return null;
+    }
+
+    // Item
+    int split = line.indexOf(':');
+    if (split < 1) {
+      return null;
+    }
+
+    // region Light source properties.
+    String name = line.substring(0, split).trim();
+    GUID id = new GUID();
+    LightSource.Type type = LightSource.Type.NORMAL;
+    boolean scaleWithToken = false;
+    List<Light> lights = new ArrayList<>();
+    // endregion
+    // region Individual light properties
+    ShapeType shape = ShapeType.CIRCLE; // TODO: Make a preference for default shape
+    double arc = 0;
+    double offset = 0;
+    boolean gmOnly = false;
+    boolean ownerOnly = false;
+    String distance;
+    // endregion
+
+    for (String arg : line.substring(split + 1).split("\\s+")) {
+      arg = arg.trim();
+      if (arg.isEmpty()) {
+        continue;
+      }
+      if (arg.equalsIgnoreCase("GM")) {
+        gmOnly = true;
+        ownerOnly = false;
+        continue;
+      }
+      if (arg.equalsIgnoreCase("OWNER")) {
+        gmOnly = false;
+        ownerOnly = true;
+        continue;
+      }
+      // Scale with token designation
+      if (arg.equalsIgnoreCase("SCALE")) {
+        scaleWithToken = true;
+        continue;
+      }
+      // Shape designation ?
+      try {
+        shape = ShapeType.valueOf(arg.toUpperCase());
+        arc = shape == ShapeType.BEAM ? 4 : arc;
+        continue;
+      } catch (IllegalArgumentException iae) {
+        // Expected when not defining a shape
+      }
+
+      // Type designation ?
+      try {
+        type = LightSource.Type.valueOf(arg.toUpperCase());
+        continue;
+      } catch (IllegalArgumentException iae) {
+        // Expected when not defining a shape
+      }
+
+      // Facing offset designation
+      if (arg.toUpperCase().startsWith("OFFSET=")) {
+        try {
+          offset = Integer.parseInt(arg.substring(7));
+          continue;
+        } catch (NullPointerException noe) {
+          errlog.add(I18N.getText("msg.error.mtprops.light.offset", lineNumber, arg));
+        }
+      }
+
+      // Parameters
+      split = arg.indexOf('=');
+      if (split > 0) {
+        String key = arg.substring(0, split);
+        String value = arg.substring(split + 1);
+
+        // TODO: Make this a generic map to pass instead of 'arc'
+        if ("arc".equalsIgnoreCase(key)) {
+          try {
+            arc = StringUtil.parseDecimal(value);
+            shape =
+                (shape != ShapeType.CONE && shape != ShapeType.BEAM)
+                    ? ShapeType.CONE
+                    : shape; // If the user specifies an arc, force the shape to CONE
+          } catch (ParseException pe) {
+            errlog.add(I18N.getText("msg.error.mtprops.light.arc", lineNumber, value));
+          }
+        }
+        continue;
+      }
+
+      Color color = null;
+      int perRangeLumens = 100;
+      distance = arg;
+
+      final var rangeRegex = Pattern.compile("([^#+-]*)(#[0-9a-fA-F]+)?([+-]\\d*)?");
+      final var matcher = rangeRegex.matcher(arg);
+      if (matcher.find()) {
+        distance = matcher.group(1);
+        final var colorString = matcher.group(2);
+        final var lumensString = matcher.group(3);
+        // Note that Color.decode() _wants_ the leading "#", otherwise it might not treat the
+        // value as a hex code.
+        if (colorString != null) {
+          color = Color.decode(colorString);
+        }
+        if (lumensString != null) {
+          perRangeLumens = Integer.parseInt(lumensString, 10);
+          if (perRangeLumens == 0) {
+            errlog.add(I18N.getText("msg.error.mtprops.light.zerolumens", lineNumber));
+            perRangeLumens = 100;
+          }
+        }
+      }
+
+      boolean isAura = type == LightSource.Type.AURA;
+      if (!isAura && (gmOnly || ownerOnly)) {
+        errlog.add(I18N.getText("msg.error.mtprops.light.gmOrOwner", lineNumber));
+        gmOnly = false;
+        ownerOnly = false;
+      }
+      ownerOnly = !gmOnly && ownerOnly;
+      try {
+        Light t =
+            new Light(
+                shape,
+                offset,
+                StringUtil.parseDecimal(distance),
+                arc,
+                color == null ? null : new DrawableColorPaint(color),
+                perRangeLumens,
+                gmOnly,
+                ownerOnly);
+        lights.add(t);
+      } catch (ParseException pe) {
+        errlog.add(I18N.getText("msg.error.mtprops.light.distance", lineNumber, distance));
+      }
+    }
+
+    // Keep ID the same if modifying existing light. This avoids tokens losing their lights when
+    // the light definition is modified.
+    for (LightSource ls : originalInCategory) {
+      if (name.equalsIgnoreCase(ls.getName())) {
+        assert ls.getId() != null;
+        id = ls.getId();
+        break;
+      }
+    }
+
+    return LightSource.createRegular(name, id, type, scaleWithToken, lights);
+  }
+
+  private String toHex(Color color) {
+    return String.format("#%06x", color.getRGB() & 0x00FFFFFF);
+  }
+}

--- a/src/main/java/net/rptools/maptool/util/SightSyntax.java
+++ b/src/main/java/net/rptools/maptool/util/SightSyntax.java
@@ -34,6 +34,8 @@ import net.rptools.maptool.model.SightType;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 
 public class SightSyntax {
+  private static final int DEFAULT_LUMENS = 100;
+
   public List<SightType> parse(String text) {
     final var sightList = new LinkedList<SightType>();
     final var reader = new LineNumberReader(new BufferedReader(new StringReader(text)));
@@ -105,13 +107,13 @@ public class SightSyntax {
                 if (colorString != null) {
                   personalLightColor = Color.decode(colorString);
                 }
-                int perRangeLumens = 100;
+                int perRangeLumens = DEFAULT_LUMENS;
                 if (lumensString != null) {
                   perRangeLumens = Integer.parseInt(lumensString, 10);
                   if (perRangeLumens == 0) {
                     errlog.add(
                         I18N.getText("msg.error.mtprops.sight.zerolumens", reader.getLineNumber()));
-                    perRangeLumens = 100;
+                    perRangeLumens = DEFAULT_LUMENS;
                   }
                 }
 
@@ -249,10 +251,12 @@ public class SightSyntax {
             builder.append(toHex(color));
           }
           final var lumens = light.getLumens();
-          if (lumens >= 0) {
-            builder.append('+');
+          if (lumens != DEFAULT_LUMENS) {
+            if (lumens >= 0) {
+              builder.append('+');
+            }
+            builder.append(Integer.toString(lumens, 10));
           }
-          builder.append(Integer.toString(lumens, 10));
           builder.append(' ');
         }
       }

--- a/src/main/java/net/rptools/maptool/util/SightSyntax.java
+++ b/src/main/java/net/rptools/maptool/util/SightSyntax.java
@@ -1,0 +1,267 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.util;
+
+import java.awt.Color;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.StringReader;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.Light;
+import net.rptools.maptool.model.LightSource;
+import net.rptools.maptool.model.ShapeType;
+import net.rptools.maptool.model.SightType;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
+
+public class SightSyntax {
+  public List<SightType> parse(String text) {
+    final var sightList = new LinkedList<SightType>();
+    final var reader = new LineNumberReader(new BufferedReader(new StringReader(text)));
+    String line;
+    String toBeParsed = null, errmsg = null;
+    List<String> errlog = new LinkedList<>();
+    try {
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+
+        // Blanks
+        if (line.isEmpty() || line.indexOf(':') < 1) {
+          continue;
+        }
+        // Parse line
+        int split = line.indexOf(':');
+        String label = line.substring(0, split).trim();
+        String value = line.substring(split + 1).trim();
+
+        if (label.isEmpty()) {
+          continue;
+        }
+        // Parse Details
+        double magnifier = 1;
+        // If null, no personal light has been defined.
+        List<Light> personalLightLights = null;
+
+        String[] args = value.split("\\s+");
+        ShapeType shape = ShapeType.CIRCLE;
+        boolean scaleWithToken = false;
+        int arc = 90;
+        float range = 0;
+        int offset = 0;
+
+        for (String arg : args) {
+          assert !arg.isEmpty(); // The split() uses "one or more spaces", removing empty strings
+          try {
+            shape = ShapeType.valueOf(arg.toUpperCase());
+            arc = shape == ShapeType.BEAM ? 4 : arc;
+            continue;
+          } catch (IllegalArgumentException iae) {
+            // Expected when not defining a shape
+          }
+          // Scale with Token
+          if (arg.equalsIgnoreCase("SCALE")) {
+            scaleWithToken = true;
+            continue;
+          }
+          try {
+
+            if (arg.startsWith("x")) {
+              toBeParsed = arg.substring(1); // Used in the catch block, below
+              errmsg = "msg.error.mtprops.sight.multiplier"; // (ditto)
+              magnifier = StringUtil.parseDecimal(toBeParsed);
+            } else if (arg.startsWith("r")) { // XXX Why not "r=#" instead of "r#"??
+              toBeParsed = arg.substring(1);
+              errmsg = "msg.error.mtprops.sight.range";
+
+              final var rangeRegex = Pattern.compile("([^#+-]*)(#[0-9a-fA-F]+)?([+-]\\d*)?");
+              final var matcher = rangeRegex.matcher(toBeParsed);
+              if (matcher.find()) {
+                var pLightRange = 0.;
+                pLightRange = StringUtil.parseDecimal(matcher.group(1));
+                final var colorString = matcher.group(2);
+                final var lumensString = matcher.group(3);
+                // Note that Color.decode() _wants_ the leading "#", otherwise it might not treat
+                // the value as a hex code.
+                Color personalLightColor = null;
+                if (colorString != null) {
+                  personalLightColor = Color.decode(colorString);
+                }
+                int perRangeLumens = 100;
+                if (lumensString != null) {
+                  perRangeLumens = Integer.parseInt(lumensString, 10);
+                  if (perRangeLumens == 0) {
+                    errlog.add(
+                        I18N.getText("msg.error.mtprops.sight.zerolumens", reader.getLineNumber()));
+                    perRangeLumens = 100;
+                  }
+                }
+
+                if (personalLightLights == null) {
+                  personalLightLights = new ArrayList<>();
+                }
+                personalLightLights.add(
+                    new Light(
+                        shape,
+                        0,
+                        pLightRange,
+                        arc,
+                        personalLightColor == null
+                            ? null
+                            : new DrawableColorPaint(personalLightColor),
+                        perRangeLumens,
+                        false,
+                        false));
+              } else {
+                throw new ParseException(
+                    String.format("Unrecognized personal light syntax: %s", arg), 0);
+              }
+            } else if (arg.startsWith("arc=") && arg.length() > 4) {
+              toBeParsed = arg.substring(4);
+              errmsg = "msg.error.mtprops.sight.arc";
+              arc = StringUtil.parseInteger(toBeParsed);
+            } else if (arg.startsWith("distance=") && arg.length() > 9) {
+              toBeParsed = arg.substring(9);
+              errmsg = "msg.error.mtprops.sight.distance";
+              range = StringUtil.parseDecimal(toBeParsed).floatValue();
+            } else if (arg.startsWith("offset=") && arg.length() > 7) {
+              toBeParsed = arg.substring(7);
+              errmsg = "msg.error.mtprops.sight.offset";
+              offset = StringUtil.parseInteger(toBeParsed);
+            } else {
+              toBeParsed = arg;
+              errmsg =
+                  I18N.getText(
+                      "msg.error.mtprops.sight.unknownField", reader.getLineNumber(), toBeParsed);
+              errlog.add(errmsg);
+            }
+          } catch (ParseException e) {
+            assert errmsg != null;
+            errlog.add(I18N.getText(errmsg, reader.getLineNumber(), toBeParsed));
+          }
+        }
+
+        LightSource personalLight =
+            personalLightLights == null
+                ? null
+                : LightSource.createPersonal(scaleWithToken, personalLightLights);
+        SightType sight =
+            new SightType(label, magnifier, personalLight, shape, arc, scaleWithToken);
+        sight.setDistance(range);
+        sight.setOffset(offset);
+
+        // Store
+        sightList.add(sight);
+      }
+    } catch (IOException ioe) {
+      MapTool.showError("msg.error.mtprops.sight.ioexception", ioe);
+    }
+    if (!errlog.isEmpty()) {
+      // Show the user a list of errors so they can (attempt to) correct all of them at once
+      MapTool.showFeedback(errlog.toArray());
+      errlog.clear();
+      throw new IllegalArgumentException(
+          "msg.error.mtprops.sight.definition"); // Don't save sights...
+    }
+
+    return sightList;
+  }
+
+  public String stringify(Map<String, SightType> sightTypeMap) {
+    StringBuilder builder = new StringBuilder();
+    for (SightType sight : sightTypeMap.values()) {
+      builder.append(sight.getName()).append(": ");
+
+      builder.append(sight.getShape().name().toLowerCase()).append(" ");
+
+      switch (sight.getShape()) {
+        case SQUARE, CIRCLE, GRID, HEX:
+          break;
+        case BEAM:
+          if (sight.getArc() != 0) {
+            builder.append("arc=").append(StringUtil.formatDecimal(sight.getArc())).append(' ');
+          } else {
+            builder.append("arc=4").append(StringUtil.formatDecimal(sight.getArc())).append(' ');
+          }
+          if (sight.getOffset() != 0) {
+            builder
+                .append("offset=")
+                .append(StringUtil.formatDecimal(sight.getOffset()))
+                .append(' ');
+          }
+          break;
+        case CONE:
+          if (sight.getArc() != 0) {
+            builder.append("arc=").append(StringUtil.formatDecimal(sight.getArc())).append(' ');
+          }
+          if (sight.getOffset() != 0) {
+            builder
+                .append("offset=")
+                .append(StringUtil.formatDecimal(sight.getOffset()))
+                .append(' ');
+          }
+          break;
+      }
+      if (sight.getDistance() != 0) {
+        builder
+            .append("distance=")
+            .append(StringUtil.formatDecimal(sight.getDistance()))
+            .append(' ');
+      }
+
+      // Scale with Token
+      if (sight.isScaleWithToken()) {
+        builder.append("scale ");
+      }
+      // Multiplier
+      if (sight.getMultiplier() != 1 && sight.getMultiplier() != 0) {
+        builder.append("x").append(StringUtil.formatDecimal(sight.getMultiplier())).append(' ');
+      }
+      // Personal light
+      if (sight.getPersonalLightSource() != null) {
+        LightSource source = sight.getPersonalLightSource();
+
+        for (Light light : source.getLightList()) {
+          double range = light.getRadius();
+
+          builder.append("r").append(StringUtil.formatDecimal(range));
+
+          if (light.getPaint() != null && light.getPaint() instanceof DrawableColorPaint) {
+            Color color = (Color) light.getPaint().getPaint();
+            builder.append(toHex(color));
+          }
+          final var lumens = light.getLumens();
+          if (lumens >= 0) {
+            builder.append('+');
+          }
+          builder.append(Integer.toString(lumens, 10));
+          builder.append(' ');
+        }
+      }
+      builder.append('\n');
+    }
+    return builder.toString();
+  }
+
+  private static String toHex(Color color) {
+    return String.format("#%06x", color.getRGB() & 0x00FFFFFF);
+  }
+}

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -276,6 +276,7 @@ EditTokenDialog.label.sight.has          = Has Sight:
 EditTokenDialog.label.terrain.mod        = Terrain Modifier:
 EditTokenDialog.label.terrain.mod.tooltip= Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 = 1).
 EditTokenDialog.label.image              = Image Table:
+EditTokenDialog.label.uniqueLightSources = Unique Light Sources:
 EditTokenDialog.label.opacity            = Token Opacity:
 EditTokenDialog.label.opacity.tooltip    = Change the opacity of the token.
 EditTokenDialog.label.opacity.100 = 100%


### PR DESCRIPTION
### Identify the Bug or Feature request

Addresses #3087
Improves #331 / #4356

### Description of the Change

Adds a new text box to the **Edit Token** dialog where light sources can be added. The syntax is the same as in the **Campaign Properties** dialog, except that no categories are supported. The text box is only enabled when a GM is editing the token, in keeping with the trusted requirements of the macro functions.

Some minor attached changes:
1. Fix the width of the terrain modifer so it can actually show its valuie.
2. To save some horizontal space, and to just be less noisy in general, we only include lumens values if they are not the default of +100.

Before (1.14):
![image](https://github.com/RPTools/maptool/assets/7492219/56dcc10f-188c-4a3a-a996-82c205718e0c)

After:
![image](https://github.com/RPTools/maptool/assets/7492219/f4e96040-a1d3-45cb-9361-59c9aa9868d2)

### Possible Drawbacks

_Config_ tabs is getting more crowded. No good place to put help text as in **Campaign Properties**

### Documentation Notes

It is possible to add unique lights to a token using the **Edit Token** dialog, _Config_ tab. The syntax is the same as for campaign properties, except that categories cannot be used.
![unique-light-sources](https://github.com/RPTools/maptool/assets/7492219/2744d64d-ae92-4339-b71a-2ec8a3e3228d)


### Release Notes

- Added a text box to the Edit Token dialog for defining unique lights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4553)
<!-- Reviewable:end -->
