### PR TITLE
Fix note rendering when labels are present.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -819,9 +819,12 @@ public class ZoneRenderer extends JComponent
             timer.stop("paintComponent:createView");
 
             renderZone(bufferG2d, pl);
-            int noteVPos = 20;
-            if (MapTool.getFrame().areFullScreenToolsShown()) noteVPos += 40;
 
+            int noteVPos = 20;
+            bufferG2d.setFont(AppStyle.labelFont);
+            if (MapTool.getFrame().areFullScreenToolsShown()) {
+              noteVPos += 40;
+            }
             if (!AppPreferences.getMapVisibilityWarning() && (!zone.isVisible() && pl.isGMView())) {
               GraphicsUtil.drawBoxedString(
                   bufferG2d, I18N.getText("zone.map_not_visible"), getSize().width / 2, noteVPos);
@@ -921,8 +924,7 @@ public class ZoneRenderer extends JComponent
     final var timer = CodeTimer.get();
 
     timer.start("setup");
-    // store previous rendering settings
-    RenderingHints oldRenderingHints = g2d.getRenderingHints();
+    g2d = (Graphics2D) g2d.create();
 
     // Clear internal state
     tokenLocationMap.clear();
@@ -936,14 +938,12 @@ public class ZoneRenderer extends JComponent
     Rectangle viewRect = new Rectangle(getSize().width, getSize().height);
 
     g2d.setFont(AppStyle.labelFont);
-    Object oldAA = SwingUtil.useAntiAliasing(g2d);
+    SwingUtil.useAntiAliasing(g2d);
 
     Area viewArea = new Area(viewRect);
     // much of the raster code assumes the user clip is set
-    boolean resetClip = false;
     if (g2d.getClipBounds() == null) {
       g2d.setClip(0, 0, viewRect.width, viewRect.height);
-      resetClip = true;
     }
     // Are we still waiting to show the zone ?
     if (isLoading()) {
@@ -1223,22 +1223,6 @@ public class ZoneRenderer extends JComponent
     timer.stop("lightSourceIconOverlay.paintOverlay");
 
     debugRenderer.renderShapes(g2d, Arrays.asList(shape, shape2));
-
-    // g2d.setColor(Color.red);
-    // for (AreaMeta meta : getTopologyAreaData().getAreaList()) {
-    // Area area = new
-    // Area(meta.getArea().getBounds()).createTransformedArea(AffineTransform.getScaleInstance(getScale(),
-    // getScale()));
-    // area =
-    // area.createTransformedArea(AffineTransform.getTranslateInstance(zoneScale.getOffsetX(),
-    // zoneScale.getOffsetY()));
-    // g2d.draw(area);
-    // }
-    g2d.setRenderingHints(oldRenderingHints);
-
-    if (resetClip) {
-      g2d.setClip(null);
-    }
   }
 
   private void delayRendering(ItemRenderer renderer) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #3691

### Description of the Change

With the switch to `setRenderingHints()` for restoring graphics state, we ran into a bug in `Graphics2D` where its cached font state is not invalidated since it doesn't detect that a change has occurred. This causes the wrong state to be used back in `paintComponent()`, but only if the problematic state is in play (e.g., if a label has been rendered).

The new approach has `renderZone()`  work on a copy of the `Graphics2D` object, so that `paintComponent()` isn't affected by any changes to its state. This also removes the need for `renderZone()` to reset any state, including rendering hints and clips. To be sure it works properly, `paintComponent()` has to set its font prior to rendering the notes now.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4557)
<!-- Reviewable:end -->
