### PR TITLE
Better encapsulated version of Zone.clearDrawables()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -966,9 +966,8 @@ public class ClientMessageHandler implements MessageHandler {
         () -> {
           var zoneGUID = GUID.valueOf(clearAllDrawingsMsg.getZoneGuid());
           var layer = Zone.Layer.valueOf(clearAllDrawingsMsg.getLayer());
-
           var zone = MapTool.getCampaign().getZone(zoneGUID);
-          zone.clearDrawables(zone.getDrawnElements(layer));
+          zone.clearDrawables(layer);
           MapTool.getFrame().refresh();
         });
   }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1492,12 +1492,15 @@ public class Zone {
     }
   }
 
-  public void clearDrawables(List<DrawnElement> drawableList) {
-    for (DrawnElement drawable : drawableList) {
+  public void clearDrawables(Layer layer) {
+    final var original = drawablesByLayer.get(layer);
+    final var copy = new ArrayList<>(original);
+    original.clear();
+    undo.clear(); // clears the *entire* undo queue, but finer grained control isn't available
+
+    for (final var drawable : copy) {
       new MapToolEventBus().getMainEventBus().post(new DrawableRemoved(this, drawable));
     }
-    drawableList.clear();
-    undo.clear(); // clears the *entire* undo queue, but finer grained control isn't available
   }
 
   public void addDrawable(Pen pen, Drawable drawable) {

--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -650,8 +650,7 @@ public class ServerMessageHandler implements MessageHandler {
           var zoneGUID = GUID.valueOf(clearAllDrawingsMsg.getZoneGuid());
           var layer = Zone.Layer.valueOf(clearAllDrawingsMsg.getLayer());
           Zone zone = server.getCampaign().getZone(zoneGUID);
-          List<DrawnElement> list = zone.getDrawnElements(layer);
-          zone.clearDrawables(list); // FJE Empties the DrawableUndoManager and empties the list
+          zone.clearDrawables(layer);
         });
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4585

### Description of the Change

Only a `Layer` parameter is supported now instead of a `List<>`. The previous approach relied on `.clear()`ing the parameter list - previously returned by `getDrawnElements()` - to effect a change on the `Zone`, which is bad news and not supported by a prior change to returning unmodifiable lists.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes
 
N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4589)
<!-- Reviewable:end -->
