### PR TITLE
Alternate Encoding Handling for Addon Content

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -494,7 +494,7 @@ public final class Asset {
             try {
               decoder = StandardCharsets.ISO_8859_1.newDecoder();
               decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
-            } catch (Exception eThree) {
+            } catch (Exception eFour) {
               decodedString = null;
             }
           }

--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -27,6 +27,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Objects;
@@ -471,7 +475,32 @@ public final class Asset {
     }
 
     if (type.isStringType()) {
-      dataAsString = new String(data);
+      CharsetDecoder decoder = StandardCharsets.US_ASCII.newDecoder();
+      decoder
+          .onMalformedInput(CodingErrorAction.REPORT)
+          .onUnmappableCharacter(CodingErrorAction.REPORT);
+      String decodedString;
+      try {
+        decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
+      } catch (Exception eOne) {
+        try {
+          decoder = StandardCharsets.UTF_8.newDecoder();
+          decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
+        } catch (Exception eTwo) {
+          try {
+            decoder = StandardCharsets.UTF_16.newDecoder();
+            decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
+          } catch (Exception eThree) {
+            try {
+              decoder = StandardCharsets.ISO_8859_1.newDecoder();
+              decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
+            } catch (Exception eThree) {
+              decodedString = null;
+            }
+          }
+        }
+      }
+      dataAsString = decodedString;
     } else {
       dataAsString = null;
     }

--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -475,7 +475,7 @@ public final class Asset {
     }
 
     if (type.isStringType()) {
-      CharsetDecoder decoder = StandardCharsets.US_ASCII.newDecoder();
+      CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
       decoder
           .onMalformedInput(CodingErrorAction.REPORT)
           .onUnmappableCharacter(CodingErrorAction.REPORT);
@@ -484,22 +484,13 @@ public final class Asset {
         decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
       } catch (Exception eOne) {
         try {
-          decoder = StandardCharsets.UTF_8.newDecoder();
+          decoder = StandardCharsets.UTF_16.newDecoder();
           decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
         } catch (Exception eTwo) {
-          try {
-            decoder = StandardCharsets.UTF_16.newDecoder();
-            decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
-          } catch (Exception eThree) {
-            try {
-              decoder = StandardCharsets.ISO_8859_1.newDecoder();
-              decodedString = decoder.decode(ByteBuffer.wrap(data)).toString();
-            } catch (Exception eFour) {
-              decodedString = null;
-            }
-          }
+          decodedString = null;
         }
       }
+
       dataAsString = decodedString;
     } else {
       dataAsString = null;


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4594


### Description of the Change
Adds an ugly try/catch chain that attempts to determine the encoding of the byte array instead of assuming UTF8


### Possible Drawbacks
Only handles ASCII, UTF-8, UTF-16, or Latin1 - and doesn't read file if can't determine encoding (null).

### Documentation Notes
Uses Standard Java Charset Decoding, assuming different encodings until it matches or fails entirely.

### Release Notes
Added Encoding Checks for Addon File Import

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4596)
<!-- Reviewable:end -->
