### PR TITLE
Input() to handle `lib://` asset paths

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -1273,7 +1273,9 @@ public class InputFunction extends AbstractFunction {
   /** Gets icon from the asset manager. Code copied and modified from EditTokenDialog.java */
   private ImageIcon getIcon(String id, int size, ImageObserver io) {
     // Extract the MD5Key from the URL
-    if (id == null) return null;
+    if (id == null) {
+      return null;
+    }
     var assetKey = new AssetResolver().getAssetKey(id);
     String assetId = null;
     if (assetKey.isPresent()) {

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -74,9 +74,9 @@ import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.ui.htmlframe.HTMLPane;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.util.AssetResolver;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool.util.StringUtil;
-import net.rptools.maptool.util.AssetResolver;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
@@ -129,7 +129,8 @@ import org.apache.commons.lang.StringUtils;
 // @formatter:on
 
 public class InputFunction extends AbstractFunction {
-  private static final Pattern ASSET_PATTERN = Pattern.compile("^(.*)((?:asset|lib)://[0-9a-z-A-Z ./]+)");
+  private static final Pattern ASSET_PATTERN =
+      Pattern.compile("^(.*)((?:asset|lib)://[0-9a-z-A-Z ./]+)");
 
   /** The singleton instance. */
   private static final InputFunction instance = new InputFunction();
@@ -1281,7 +1282,7 @@ public class InputFunction extends AbstractFunction {
     MD5Key assetMD5 = null;
     if (assetId != null) {
       assetMD5 = new MD5Key(assetId);
-    }else{
+    } else {
       assetMD5 = new MD5Key(id);
     }
 

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -76,6 +76,7 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool.util.StringUtil;
+import net.rptools.maptool.util.AssetResolver;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
@@ -128,7 +129,7 @@ import org.apache.commons.lang.StringUtils;
 // @formatter:on
 
 public class InputFunction extends AbstractFunction {
-  private static final Pattern ASSET_PATTERN = Pattern.compile("^(.*)asset://(\\w+)");
+  private static final Pattern ASSET_PATTERN = Pattern.compile("^(.*)((?:asset|lib)://[0-9a-z-A-Z ./]+)");
 
   /** The singleton instance. */
   private static final InputFunction instance = new InputFunction();
@@ -1272,10 +1273,20 @@ public class InputFunction extends AbstractFunction {
   private ImageIcon getIcon(String id, int size, ImageObserver io) {
     // Extract the MD5Key from the URL
     if (id == null) return null;
-    MD5Key assetID = new MD5Key(id);
+    var assetKey = new AssetResolver().getAssetKey(id);
+    String assetId = null;
+    if (assetKey.isPresent()) {
+      assetId = assetKey.get().toString();
+    }
+    MD5Key assetMD5 = null;
+    if (assetId != null) {
+      assetMD5 = new MD5Key(assetId);
+    }else{
+      assetMD5 = new MD5Key(id);
+    }
 
     // Get the base image && find the new size for the icon
-    BufferedImage assetImage = ImageManager.getImage(assetID, io);
+    BufferedImage assetImage = ImageManager.getImage(assetMD5, io);
 
     // Resize
     if (assetImage.getWidth() > size || assetImage.getHeight() > size) {


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #4620


### Description of the Change
Updates regex to capture asset string and pass through AssetResolver to handle both `asset://` and `lib://` paths

### Possible Drawbacks
None

### Documentation Notes
Regex capture includes the 'asset://' OR 'lib://' portion of the URI
Now depends on Asset Resolver

### Release Notes
Added ability for Input() to handle `lib://` URIs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4621)
<!-- Reviewable:end -->
