### PR TITLE
Updated FunctionUtil to handle `lib://` assets via AssetResolver

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -66,7 +66,6 @@ import javax.swing.Scrollable;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
-import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.InputFunction.InputType.OptionException;
@@ -74,7 +73,7 @@ import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.ui.htmlframe.HTMLPane;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.util.AssetResolver;
+import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool.util.StringUtil;
 import net.rptools.parser.Parser;
@@ -1276,17 +1275,7 @@ public class InputFunction extends AbstractFunction {
     if (id == null) {
       return null;
     }
-    var assetKey = new AssetResolver().getAssetKey(id);
-    String assetId = null;
-    if (assetKey.isPresent()) {
-      assetId = assetKey.get().toString();
-    }
-    MD5Key assetMD5 = null;
-    if (assetId != null) {
-      assetMD5 = new MD5Key(assetId);
-    } else {
-      assetMD5 = new MD5Key(id);
-    }
+    var assetMD5 = FunctionUtil.getAssetKeyFromString(id);
 
     // Get the base image && find the new size for the icon
     BufferedImage assetImage = ImageManager.getImage(assetMD5, io);

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -129,7 +129,7 @@ import org.apache.commons.lang.StringUtils;
 
 public class InputFunction extends AbstractFunction {
   private static final Pattern ASSET_PATTERN =
-      Pattern.compile("^(.*)((?:asset|lib)://[0-9a-z-A-Z ./]+)");
+      Pattern.compile("^(.*)((?:asset|lib|Image):(//)?[0-9a-z-A-Z ./]+)");
 
   /** The singleton instance. */
   private static final InputFunction instance = new InputFunction();

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
@@ -32,6 +33,7 @@ import net.rptools.maptool.model.InvalidGUIDException;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZoneFactory;
 import net.rptools.maptool.model.drawing.DrawablePaint;
+import net.rptools.maptool.util.AssetResolver;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -280,13 +282,14 @@ public class MapFunctions extends AbstractFunction {
 
       if (config.has("map asset")) {
         final var mapAssetId = config.getAsJsonPrimitive("map asset").getAsString();
-        final var mapAssetKey = FunctionUtil.getAssetKeyFromString(mapAssetId);
-        if (mapAssetKey == null) {
-          throw new ParserException(
-              I18N.getText("macro.function.map.invalidAsset", functionName, mapAssetId));
+        final var mapAssetKey = new AssetResolver().getAssetKey(mapAssetId);
+        MD5Key assetMD5 = null;
+        if (mapAssetKey.isPresent()) {
+          assetMD5 = new MD5Key(mapAssetKey.get().toString());
+        } else {
+          assetMD5 = new MD5Key(mapAssetId);
         }
-
-        final var mapAsset = AssetManager.getAsset(mapAssetKey);
+        final var mapAsset = AssetManager.getAsset(assetMD5);
         if (mapAsset != null) {
           AssetManager.putAsset(mapAsset);
           if (!MapTool.isHostingServer()) {
@@ -294,7 +297,7 @@ public class MapFunctions extends AbstractFunction {
           }
         }
 
-        newMap.setMapAsset(mapAssetKey);
+        newMap.setMapAsset(assetMD5);
       }
 
       MapTool.addZone(newMap, false);

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -20,7 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
@@ -33,7 +32,6 @@ import net.rptools.maptool.model.InvalidGUIDException;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZoneFactory;
 import net.rptools.maptool.model.drawing.DrawablePaint;
-import net.rptools.maptool.util.AssetResolver;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -282,14 +280,12 @@ public class MapFunctions extends AbstractFunction {
 
       if (config.has("map asset")) {
         final var mapAssetId = config.getAsJsonPrimitive("map asset").getAsString();
-        final var mapAssetKey = new AssetResolver().getAssetKey(mapAssetId);
-        MD5Key assetMD5 = null;
-        if (mapAssetKey.isPresent()) {
-          assetMD5 = new MD5Key(mapAssetKey.get().toString());
-        } else {
-          assetMD5 = new MD5Key(mapAssetId);
+        final var mapAssetKey = FunctionUtil.getAssetKeyFromString(mapAssetId);
+        if (mapAssetKey == null) {
+          throw new ParserException(
+              I18N.getText("macro.function.map.invalidAsset", functionName, mapAssetId));
         }
-        final var mapAsset = AssetManager.getAsset(assetMD5);
+        final var mapAsset = AssetManager.getAsset(mapAssetKey);
         if (mapAsset != null) {
           AssetManager.putAsset(mapAsset);
           if (!MapTool.isHostingServer()) {
@@ -297,7 +293,7 @@ public class MapFunctions extends AbstractFunction {
           }
         }
 
-        newMap.setMapAsset(assetMD5);
+        newMap.setMapAsset(mapAssetKey);
       }
 
       MapTool.addZone(newMap, false);

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -524,19 +524,26 @@ public class FunctionUtil {
    * @return The MD5 key present in {@code assetUrlOrId}, or null.
    */
   public static @Nullable MD5Key getAssetKeyFromString(String assetUrlOrId) {
-    final String id;
+    String id = null;
     if (assetUrlOrId.toLowerCase().startsWith("asset://")) {
       id = assetUrlOrId.substring("asset://".length());
     } else if (assetUrlOrId.toLowerCase().startsWith("lib://")) {
       var assetKey = new AssetResolver().getAssetKey(assetUrlOrId);
       if (assetKey.isPresent()) {
         id = assetKey.get().toString();
-      } else {
-        return null;
+      }
+    } else if (assetUrlOrId.toLowerCase().startsWith("image:")) {
+      for (ZoneRenderer z : MapTool.getFrame().getZoneRenderers()) {
+        Token t = z.getZone().getTokenByName(assetUrlOrId);
+        if (t != null) {
+          id = t.getImageAssetId().toString();
+        }
       }
     } else if (assetUrlOrId.length() == 32) {
       id = assetUrlOrId;
-    } else {
+    }
+
+    if (id == null) {
       return null;
     }
 

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -519,13 +519,21 @@ public class FunctionUtil {
   /**
    * Parses a string as an asset URL.
    *
-   * @param assetUrlOrId String containing the asset ID or asset URL.
+   * @param assetUrlOrId String containing the asset ID (ID), asset URL (asset://ID), or addon
+   *     URL(lib://PATH).
    * @return The MD5 key present in {@code assetUrlOrId}, or null.
    */
   public static @Nullable MD5Key getAssetKeyFromString(String assetUrlOrId) {
     final String id;
     if (assetUrlOrId.toLowerCase().startsWith("asset://")) {
       id = assetUrlOrId.substring("asset://".length());
+    } else if (assetUrlOrId.toLowerCase().startsWith("lib://")) {
+      var assetKey = new AssetResolver().getAssetKey(assetUrlOrId);
+      if (assetKey.isPresent()) {
+        id = assetKey.get().toString();
+      } else {
+        return null;
+      }
     } else if (assetUrlOrId.length() == 32) {
       id = assetUrlOrId;
     } else {


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4626
resolves #4620 in a smarter fashion

### Description of the Change
Updates FunctionUtil.getAssetKeyFromString()  to handle both `asset://` and `lib://` asset URLs
Propagates that usage to both createMap, and input functions.

### Possible Drawbacks
None

### Documentation Notes
FunctionUtil now depends on AssetResolver imports
InputFunction now depends on FunctionUtil

### Release Notes
Fixed several inconsistent inabilities to use `lib://` assets

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4629)
<!-- Reviewable:end -->
