### PR TITLE
Improve performance of the visibility sweep

### DIFF
--- a/src/main/java/net/rptools/lib/CodeTimer.java
+++ b/src/main/java/net/rptools/lib/CodeTimer.java
@@ -61,8 +61,8 @@ public class CodeTimer {
 
   private final Map<String, Timer> timeMap = new LinkedHashMap<>();
   private final String name;
+  private long threshold = 1;
   private boolean enabled;
-  private int threshold = 1;
 
   public CodeTimer(String n) {
     name = n;
@@ -73,7 +73,7 @@ public class CodeTimer {
     return enabled;
   }
 
-  public void setThreshold(int threshold) {
+  public void setThreshold(long threshold) {
     this.threshold = threshold;
   }
 
@@ -128,7 +128,7 @@ public class CodeTimer {
       ++i;
 
       var id = entry.getKey();
-      long elapsed = entry.getValue().getElapsed();
+      long elapsed = entry.getValue().getElapsed() / 1_000_000;
       if (elapsed < threshold) {
         continue;
       }
@@ -141,19 +141,23 @@ public class CodeTimer {
     long elapsed;
     long start = -1;
 
+    private long getTime() {
+      return System.nanoTime();
+    }
+
     public void start() {
-      start = System.currentTimeMillis();
+      start = getTime();
     }
 
     public void stop() {
-      elapsed += (System.currentTimeMillis() - start);
+      elapsed += (getTime() - start);
       start = -1;
     }
 
     public long getElapsed() {
       long time = elapsed;
       if (start > 0) {
-        time += (System.currentTimeMillis() - start);
+        time += (getTime() - start);
       }
       return time;
     }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
@@ -120,7 +120,14 @@ public class FogUtil {
         }
 
         timer.start("calculate visible area");
-        final var visibleArea = solver.solve();
+        final Coordinate[] visibleArea;
+        try {
+          visibleArea = solver.solve();
+        } catch (Exception e) {
+          log.error("Unexpected error while calculating visible area.", e);
+          // Play it safe and dont consider anything to be visible.
+          return new Area();
+        }
         timer.stop("calculate visible area");
 
         timer.start("add visibility polygon");

--- a/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
@@ -48,9 +48,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.awt.ShapeWriter;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 
 public class FogUtil {
   private static final Logger log = LogManager.getLogger(FogUtil.class);
@@ -71,61 +70,85 @@ public class FogUtil {
       AreaTree hillVbl,
       AreaTree pitVbl,
       AreaTree coverVbl) {
-    // We could use the vision envelope instead, but vision geometry tends to be pretty simple.
-    final var visionGeometry = PreparedGeometryFactory.prepare(GeometryUtil.toJts(vision));
+    var timer = CodeTimer.get();
+    timer.start("FogUtil::calculateVisibility");
+    try {
+      timer.start("get vision bounds");
+      Envelope visionBounds;
+      {
+        var awtBounds = vision.getBounds2D();
+        visionBounds =
+            new Envelope(
+                new Coordinate(awtBounds.getMinX(), awtBounds.getMinY()),
+                new Coordinate(awtBounds.getMaxX(), awtBounds.getMaxY()));
+      }
+      timer.stop("get vision bounds");
 
-    /*
-     * Find the visible area for each topology type independently.
-     *
-     * In principle, we could also combine all the vision blocking segments for all topology types
-     * and run the sweep algorithm once. But this is subject to some pathological cases that JTS
-     * cannot handle. These cases do not exist within a single type of topology, but can arise when
-     * we combine them.
-     */
+      /*
+       * Find the visible area for each topology type independently.
+       *
+       * In principle, we could also combine all the vision blocking segments for all topology types
+       * and run the sweep algorithm once. But this is subject to some pathological cases that JTS
+       * cannot handle. These cases do not exist within a single type of topology, but can arise when
+       * we combine them.
+       */
 
-    var topologies = new EnumMap<Zone.TopologyType, AreaTree>(Zone.TopologyType.class);
-    topologies.put(Zone.TopologyType.WALL_VBL, wallVbl);
-    topologies.put(Zone.TopologyType.HILL_VBL, hillVbl);
-    topologies.put(Zone.TopologyType.PIT_VBL, pitVbl);
-    topologies.put(Zone.TopologyType.COVER_VBL, coverVbl);
+      List<Coordinate[]> visibilityPolygons = new ArrayList<>();
+      var topologies = new EnumMap<Zone.TopologyType, AreaTree>(Zone.TopologyType.class);
+      topologies.put(Zone.TopologyType.WALL_VBL, wallVbl);
+      topologies.put(Zone.TopologyType.HILL_VBL, hillVbl);
+      topologies.put(Zone.TopologyType.PIT_VBL, pitVbl);
+      topologies.put(Zone.TopologyType.COVER_VBL, coverVbl);
+      for (final var topology : topologies.entrySet()) {
+        final var solver =
+            new VisibilityProblem(new Coordinate(origin.getX(), origin.getY()), visionBounds);
 
-    List<Geometry> visibleAreas = new ArrayList<>();
+        timer.start("accumulate blocking walls");
+        final var accumulator = new VisionBlockingAccumulator(origin, visionBounds, solver);
+        final var isVisionCompletelyBlocked =
+            accumulator.add(topology.getKey(), topology.getValue());
+        timer.stop("accumulate blocking walls");
+        if (!isVisionCompletelyBlocked) {
+          // Vision has been completely blocked by this topology. Short circuit.
+          return new Area();
+        }
 
-    for (final var topology : topologies.entrySet()) {
-      final var solver =
-          new VisibilityProblem(
-              geometryFactory, new Coordinate(origin.getX(), origin.getY()), visionGeometry);
-      final var accumulator =
-          new VisionBlockingAccumulator(geometryFactory, origin, visionGeometry);
-      final var isVisionCompletelyBlocked = accumulator.add(topology.getKey(), topology.getValue());
-      if (!isVisionCompletelyBlocked) {
-        // Vision has been completely blocked by this topology. Short circuit.
-        return new Area();
+        timer.start("calculate visible area");
+        final var visibleArea = solver.solve();
+        timer.stop("calculate visible area");
+
+        timer.start("add visibility polygon");
+        if (visibleArea != null) {
+          visibilityPolygons.add(visibleArea);
+        }
+        timer.stop("add visibility polygon");
       }
 
-      for (var string : accumulator.getVisionBlockingSegments()) {
-        solver.add(string);
+      if (visibilityPolygons.isEmpty()) {
+        return vision;
       }
 
-      final var visibleArea = solver.solve();
-      if (visibleArea != null) {
-        visibleAreas.add(visibleArea);
-      }
-    }
-
-    // We have to intersect all the results in order to find the true remaining visible area.
-    vision = new Area(vision);
-    if (!visibleAreas.isEmpty()) {
+      // We have to intersect all the results in order to find the true remaining visible area.
+      timer.start("clone existing vision");
+      vision = new Area(vision);
+      timer.stop("clone existing vision");
+      timer.start("combine visibility polygons with vision");
       // We intersect in AWT space because JTS can be really finicky about intersection precision.
       var shapeWriter = new ShapeWriter();
-      for (final var visibleArea : visibleAreas) {
-        var area = new Area(shapeWriter.toShape(visibleArea));
+      for (var visibilityPolygon : visibilityPolygons) {
+        // Even though linear ring is just the boundary, the Area constructor uses the entire
+        // enclosed region.
+        var area =
+            new Area(shapeWriter.toShape(geometryFactory.createLinearRing(visibilityPolygon)));
         vision.intersect(area);
       }
-    }
+      timer.stop("combine visibility polygons with vision");
 
-    // For simplicity, this catches some of the edge cases
-    return vision;
+      // For simplicity, this catches some of the edge cases
+      return vision;
+    } finally {
+      timer.stop("FogUtil::calculateVisibility");
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
@@ -72,6 +72,8 @@ public class FogUtil {
       AreaTree coverVbl) {
     var timer = CodeTimer.get();
     timer.start("FogUtil::calculateVisibility");
+    var originCoordinate = new Coordinate(origin.x, origin.y);
+
     try {
       timer.start("get vision bounds");
       Envelope visionBounds;
@@ -100,11 +102,15 @@ public class FogUtil {
       topologies.put(Zone.TopologyType.PIT_VBL, pitVbl);
       topologies.put(Zone.TopologyType.COVER_VBL, coverVbl);
       for (final var topology : topologies.entrySet()) {
-        final var solver =
-            new VisibilityProblem(new Coordinate(origin.getX(), origin.getY()), visionBounds);
+
+        timer.start("get pooled vision blocking set");
+        final var solver = new VisibilityProblem(originCoordinate, visionBounds);
+        timer.stop("get pooled vision blocking set");
 
         timer.start("accumulate blocking walls");
-        final var accumulator = new VisionBlockingAccumulator(origin, visionBounds, solver);
+        final var accumulator =
+            new VisionBlockingAccumulator(originCoordinate, visionBounds, solver);
+
         final var isVisionCompletelyBlocked =
             accumulator.add(topology.getKey(), topology.getValue());
         timer.stop("accumulate blocking walls");

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
@@ -15,7 +15,6 @@
 package net.rptools.maptool.client.ui.zone.vbl;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -73,7 +72,7 @@ public class EndpointSet {
     timer.stop("deduplicate");
   }
 
-  public @Nonnull Collection<VisibilitySweepEndpoint> getEndpoints() {
+  public @Nonnull Iterable<VisibilitySweepEndpoint> getEndpoints() {
     return endpoints;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
@@ -1,0 +1,117 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.vbl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Nonnull;
+import net.rptools.lib.CodeTimer;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+
+public class EndpointSet {
+  private final Coordinate origin;
+
+  /**
+   * A bounding box on all endpoints in {@link #endpoints}.
+   *
+   * <p>Used to safely add a ring around the problem set and vision, avoiding any possibility of
+   * infinite results when no walls are present in a given direction. It also simplifies the
+   * algorithm as we can always count open walls being available.
+   */
+  private final Envelope envelope;
+
+  private final List<VisibilitySweepEndpoint> endpoints;
+
+  public EndpointSet(Coordinate origin, Envelope bounds) {
+    this.origin = origin;
+    this.envelope = new Envelope(bounds);
+    this.endpoints = new ArrayList<>();
+  }
+
+  public int size() {
+    return endpoints.size();
+  }
+
+  public VisibilitySweepEndpoint add(Coordinate point) {
+    final var endpoint = new VisibilitySweepEndpoint(point, origin);
+    this.endpoints.add(endpoint);
+    this.envelope.expandToInclude(point);
+    return endpoint;
+  }
+
+  public Envelope getBounds() {
+    return new Envelope(envelope);
+  }
+
+  public void simplify() {
+    final var timer = CodeTimer.get();
+
+    timer.start("sort");
+    // We're unlikely to hit the parallelized case, but the use of Timsort is an advantage to us.
+    endpoints.sort(
+        Comparator.comparingDouble(VisibilitySweepEndpoint::getPseudoangle)
+            .thenComparing(VisibilitySweepEndpoint::getDistance));
+    timer.stop("sort");
+
+    timer.start("deduplicate");
+    deduplicateEndpoints(endpoints);
+    timer.stop("deduplicate");
+  }
+
+  public @Nonnull Collection<VisibilitySweepEndpoint> getEndpoints() {
+    return endpoints;
+  }
+
+  /**
+   * Check the sorted endpoint list for duplicates and remove them.
+   *
+   * <p>This check relies on {@code #endpoints} being sorted, otherwise it becomes too expensive.
+   */
+  private void deduplicateEndpoints(List<VisibilitySweepEndpoint> endpoints) {
+    // We might have duplicates we we don't want.
+    VisibilitySweepEndpoint previous = null;
+    for (var i = 0; i < endpoints.size(); ++i) {
+      final var endpoint = endpoints.get(i);
+      if (previous == null) {
+        previous = endpoint;
+        continue;
+      }
+
+      if (previous.getPoint().equals(endpoint.getPoint())) {
+        // TODO Somehow update the counter.
+        // duplicateEndpointCount += 1;
+
+        // endpoint is a duplicate of previous, so merge into previous. Don't keep the duplicate.
+        previous.mergeDuplicate(endpoint);
+
+        // I could also .remove(), but that's expensive for long lists. We're just as well to skip
+        // this while iterating later.
+        endpoints.set(i, null);
+        continue;
+      }
+
+      // Haven't seen this endpoint yet. Add it to the map.
+      previous = endpoint;
+    }
+
+    // Don't keep trailing nulls, those will mess things up.
+    while (endpoints.getLast() == null) {
+      endpoints.removeLast();
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
@@ -14,19 +14,24 @@
  */
 package net.rptools.maptool.client.ui.zone.vbl;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import javax.annotation.Nonnull;
 import net.rptools.lib.CodeTimer;
+import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 
+/** Collects, sorts and deduplicates endpoints of vision blocking segments. */
 public class EndpointSet {
+  // The buckets are eighths of the plane.
+  private static final int BUCKET_COUNT = 8;
+
   private final Coordinate origin;
 
   /**
-   * A bounding box on all endpoints in {@link #endpoints}.
+   * A bounding box on all endpoints in {@link #buckets}.
    *
    * <p>Used to safely add a ring around the problem set and vision, avoiding any possibility of
    * infinite results when no walls are present in a given direction. It also simplifies the
@@ -34,22 +39,57 @@ public class EndpointSet {
    */
   private final Envelope envelope;
 
-  private final List<VisibilitySweepEndpoint> endpoints;
+  /**
+   * All endpoints to check during the sweep.
+   *
+   * <p>Endpoints reference other endpoints, forming a graph where each edge is a vision blocking
+   * line segment connecting two endpoints.
+   *
+   * <p>The endpoints are bucketed in order to improve sorting efficiency, both in terms of buckets
+   * being already sorted relative to one another and in terms of avoiding special cases in {@link
+   * #comparePolar(org.locationtech.jts.geom.Coordinate, org.locationtech.jts.geom.Coordinate)}.
+   */
+  private final VisibilitySweepEndpoint[][] buckets;
+
+  private final int[] bucketSizes;
 
   public EndpointSet(Coordinate origin, Envelope bounds) {
     this.origin = origin;
     this.envelope = new Envelope(bounds);
-    this.endpoints = new ArrayList<>();
+
+    this.buckets = new VisibilitySweepEndpoint[BUCKET_COUNT][];
+    Arrays.setAll(this.buckets, i -> new VisibilitySweepEndpoint[32]);
+
+    this.bucketSizes = new int[BUCKET_COUNT];
+    Arrays.fill(this.bucketSizes, 0);
   }
 
   public int size() {
-    return endpoints.size();
+    return Arrays.stream(this.bucketSizes).sum();
   }
 
   public VisibilitySweepEndpoint add(Coordinate point) {
-    final var endpoint = new VisibilitySweepEndpoint(point, origin);
-    this.endpoints.add(endpoint);
+    final var endpoint = new VisibilitySweepEndpoint(point);
+
+    // 0 .. 3
+    int quadrantIndex = (point.x >= origin.x ? 0b01 : 0b00) ^ (point.y > origin.y ? 0b11 : 0b00);
+    // 0 .. 1
+    int quadrantHalfIndex =
+        (quadrantIndex & 0b01)
+            ^ ((Math.abs(point.x - origin.x) < Math.abs(point.y - origin.y)) ? 0b1 : 0b0);
+    // 0 .. 7
+    int index = (quadrantIndex << 1) | quadrantHalfIndex;
+
+    assert this.bucketSizes[index] <= this.buckets[index].length;
+
+    final var size = this.bucketSizes[index]++;
+    if (size == this.buckets[index].length) {
+      this.buckets[index] = Arrays.copyOf(this.buckets[index], 2 * size);
+    }
+    this.buckets[index][size] = endpoint;
+
     this.envelope.expandToInclude(point);
+
     return endpoint;
   }
 
@@ -61,19 +101,27 @@ public class EndpointSet {
     final var timer = CodeTimer.get();
 
     timer.start("sort");
-    // We're unlikely to hit the parallelized case, but the use of Timsort is an advantage to us.
-    endpoints.sort(
-        Comparator.comparingDouble(VisibilitySweepEndpoint::getPseudoangle)
-            .thenComparing(VisibilitySweepEndpoint::getDistance));
+    for (int i = 0; i < buckets.length; ++i) {
+      final var bucket = buckets[i];
+      final var size = bucketSizes[i];
+
+      // We're unlikely to hit the parallelized case, but the use of Timsort is an advantage to us.
+      Arrays.parallelSort(bucket, 0, size, (l, r) -> comparePolar(l.getPoint(), r.getPoint()));
+    }
     timer.stop("sort");
 
     timer.start("deduplicate");
-    deduplicateEndpoints(endpoints);
+    for (int i = 0; i < buckets.length; ++i) {
+      final var bucket = buckets[i];
+      final var size = bucketSizes[i];
+
+      deduplicateEndpoints(bucket, size);
+    }
     timer.stop("deduplicate");
   }
 
   public @Nonnull Iterable<VisibilitySweepEndpoint> getEndpoints() {
-    return endpoints;
+    return () -> new BucketIterator(buckets, bucketSizes);
   }
 
   /**
@@ -81,36 +129,119 @@ public class EndpointSet {
    *
    * <p>This check relies on {@code #endpoints} being sorted, otherwise it becomes too expensive.
    */
-  private void deduplicateEndpoints(List<VisibilitySweepEndpoint> endpoints) {
-    // We might have duplicates we we don't want.
-    VisibilitySweepEndpoint previous = null;
-    for (var i = 0; i < endpoints.size(); ++i) {
-      final var endpoint = endpoints.get(i);
-      if (previous == null) {
+  private void deduplicateEndpoints(VisibilitySweepEndpoint[] endpoints, int size) {
+    assert size < endpoints.length;
+
+    if (size == 0) {
+      return;
+    }
+
+    // We might have duplicates we don't want.
+    @Nonnull VisibilitySweepEndpoint previous = endpoints[0];
+    for (var i = 1; i < size; ++i) {
+      final var endpoint = endpoints[i];
+      if (!previous.getPoint().equals(endpoint.getPoint())) {
+        // Haven't seen this endpoint yet. Keep it around.
         previous = endpoint;
         continue;
       }
 
-      if (previous.getPoint().equals(endpoint.getPoint())) {
-        // TODO Somehow update the counter.
-        // duplicateEndpointCount += 1;
+      // TODO Somehow increment the main counter.
+      //  duplicateEndpointCount += 1;
 
-        // endpoint is a duplicate of previous, so merge into previous. Don't keep the duplicate.
-        previous.mergeDuplicate(endpoint);
+      // endpoint is a duplicate of previous, so merge into previous. Don't keep the duplicate.
+      previous.mergeDuplicate(endpoint);
 
-        // I could also .remove(), but that's expensive for long lists. We're just as well to skip
-        // this while iterating later.
-        endpoints.set(i, null);
-        continue;
-      }
+      // I could also .remove(), but that's expensive for long lists. We're just as well to skip
+      // this while iterating later.
+      endpoints[i] = null;
+    }
+  }
 
-      // Haven't seen this endpoint yet. Add it to the map.
-      previous = endpoint;
+  /**
+   * Compares two points for their polar ordering around an origin.
+   *
+   * <p>The coordinates are ordered by polar angle ranging in the interval {@code [-π, π)}. If the
+   * angle is equal, they will be ordered so that the point closer to the origin comes first.
+   *
+   * <p>The implementation does not actually compute angles, but is instead based on the clockwise /
+   * counterclockwise orientation of the points around the origin.
+   *
+   * @param a The first coordinate to compare.
+   * @param b The second coordinate to compare.
+   * @return The comparison result of {@code a} and {@code b}.
+   */
+  private int comparePolar(Coordinate a, Coordinate b) {
+    // a and b are in the same half-plane, i.e., they definitely don't straddle the x-axis, nor do
+    // they straddle origin on the x-axis. Now orientation is sufficient to compare, i.e.,
+    // "increase" means move counterclockwise.
+    final var orientation = Orientation.index(origin, a, b);
+    if (orientation == Orientation.COUNTERCLOCKWISE) {
+      return -1;
+    }
+    if (orientation == Orientation.CLOCKWISE) {
+      return 1;
     }
 
-    // Don't keep trailing nulls, those will mess things up.
-    while (endpoints.getLast() == null) {
-      endpoints.removeLast();
+    // Points are collinear with the origin. As a fallback, sort by distance. It's not important
+    // which way, we just need to be consistent.
+    // Since points are in the same quadrant, comparing y-values is almost sufficient for distance.
+    // Points on the x-axis are the only ones not captured.
+
+    final var absAY = Math.abs(a.y);
+    final var absBY = Math.abs(b.y);
+    final var result = Double.compare(absAY, absBY);
+    if (result != 0) {
+      return result;
+    }
+
+    final var absAX = Math.abs(a.x);
+    final var absBX = Math.abs(b.x);
+    return Double.compare(absAX, absBX);
+  }
+
+  private static final class BucketIterator implements Iterator<VisibilitySweepEndpoint> {
+    private final VisibilitySweepEndpoint[][] buckets;
+    private final int[] bucketSizes;
+    private int bucketIndex;
+    private int index;
+
+    // Invariant: (bucketIndex >= buckets.length) || (index < bucketsSizes[bucketIndex]).
+
+    public BucketIterator(VisibilitySweepEndpoint[][] buckets, int[] bucketSizes) {
+      assert buckets.length == bucketSizes.length;
+
+      this.buckets = buckets;
+      this.bucketSizes = bucketSizes;
+      this.bucketIndex = 0;
+      this.index = 0;
+
+      // Skip any leading empty buckets.
+      while (bucketIndex < buckets.length && index == bucketSizes[bucketIndex]) {
+        ++bucketIndex;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return bucketIndex < buckets.length;
+    }
+
+    @Override
+    public VisibilitySweepEndpoint next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      final var element = buckets[bucketIndex][index];
+
+      ++index;
+      while (bucketIndex < buckets.length && index == bucketSizes[bucketIndex]) {
+        index = 0;
+        ++bucketIndex;
+      }
+
+      return element;
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityProblem.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityProblem.java
@@ -16,18 +16,17 @@ package net.rptools.maptool.client.ui.zone.vbl;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.lib.CodeTimer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.LineSegment;
-
-record NearestWallResult(LineSegment wall, Coordinate point, double distance) {}
 
 public class VisibilityProblem {
   private static final Logger log = LogManager.getLogger(VisibilityProblem.class);
@@ -42,6 +41,16 @@ public class VisibilityProblem {
    */
   private final EndpointSet endpointSet;
 
+  // Note: we are essentially this collection as a priority queue, so we can always operate on the
+  // closest wall. However, TreeSet is faster than PriorityQueue in this case, likely since the
+  // size of the collection tends to remain quite small.
+  // Note: it's not possible to totally order all walls by distance to `origin`. But it is
+  // possible to do it for the set of open walls at any point in time, which is why we can use
+  // this structure. So it's important to remove ended walls before adding opened walls, otherwise
+  // we might momentarily violate that basic requirement of the comparison.
+  // Note: as a rule, the number of open walls is small, usually well under 50.
+  private final TreeSet<LineSegment> openWalls;
+
   /**
    * Build a new problem set.
    *
@@ -52,25 +61,42 @@ public class VisibilityProblem {
   public VisibilityProblem(Coordinate origin, Envelope visionBounds) {
     this.origin = origin;
     this.endpointSet = new EndpointSet(origin, visionBounds);
+    this.openWalls = new TreeSet<>(this::compareOpenWalls);
   }
 
   public void add(Coordinate... string) {
     add(Arrays.asList(string));
   }
 
+  /**
+   * Adds a string of vision blocking line segments into the problem space.
+   *
+   * <p>All line segments in the string must be oriented counterclockwise around the origin.
+   *
+   * <p>Internally, endpoints will be guaranteed to be unique and in a consistent orientation
+   * (counterclockwise around the origin, starting with the negative x-axis). Each segment in the
+   * string will be opened and closed by its respective endpoints.
+   *
+   * @param string The vision blocking segments to add
+   */
   public void add(List<Coordinate> string) {
     if (string.size() < 2) {
       return;
     }
 
     // Always plainly add the first point.
-
     var previous = endpointSet.add(string.get(0));
     for (int i = 1; i < string.size(); ++i) {
       var endpoint = endpointSet.add(string.get(i));
 
       previous.startsWall(endpoint);
       endpoint.endsWall(previous);
+
+      // This check is only valid because of the counter-clockwise orientation enforced above.
+      final var isOpen = endpoint.getPoint().y <= origin.y && previous.getPoint().y > origin.y;
+      if (isOpen) {
+        openWalls.add(new LineSegment(previous.getPoint(), endpoint.getPoint()));
+      }
 
       previous = endpoint;
     }
@@ -83,6 +109,18 @@ public class VisibilityProblem {
     }
   }
 
+  /**
+   * Solve the visibility polygon problem.
+   *
+   * <p>This follows Asano's algorithm as described in section 3.2 of "Efficient Computation of
+   * Visibility Polygons". The endpoints are already sorted as required, as is the initial set of
+   * open walls. As the algorithm progresses, open walls are maintained as an ordered set to enable
+   * efficient polling of the closest wall at any given point in time.
+   *
+   * @return A visibility polygon, represented as a ring of coordinates.
+   * @see <a href="https://arxiv.org/abs/1403.3905">Efficient Computation of Visibility Polygons,
+   *     arXiv:1403.3905</a>
+   */
   public @Nullable Coordinate[] solve() {
     final var timer = CodeTimer.get();
 
@@ -110,82 +148,35 @@ public class VisibilityProblem {
     // Now that we have valid geometry and a bounding box, we can continue with the sweep.
     timer.start("initialize");
     endpointSet.simplify();
-    final var endpoints = new ArrayList<>(endpointSet.getEndpoints());
+    final var endpoints = endpointSet.getEndpoints();
     // verifyEndpoints(endpoints);
+    var previousNearestWall = openWalls.getFirst();
     timer.stop("initialize");
 
-    Set<LineSegment> openWalls = new HashSet<>();
-
-    // This initial sweep just makes sure we have the correct open set to start.
-    for (final var endpoint : endpoints) {
-      if (endpoint == null) {
-        continue;
-      }
-      for (var otherEndpoint : endpoint.getStartsWalls()) {
-        openWalls.add(new LineSegment(endpoint.getPoint(), otherEndpoint.getPoint()));
-      }
-      for (var otherEndpoint : endpoint.getEndsWalls()) {
-        openWalls.remove(new LineSegment(otherEndpoint.getPoint(), endpoint.getPoint()));
-      }
-    }
-
-    // Now for the real sweep. Make sure to process the first point once more at the end to ensure
-    // the sweep covers the full 360 degrees.
-    endpoints.add(endpoints.get(0));
+    // Now for the real sweep.
+    timer.start("sweep");
     List<Coordinate> visionPoints = new ArrayList<>();
     for (final var endpoint : endpoints) {
       if (endpoint == null) {
         continue;
       }
-
-      assert !openWalls.isEmpty();
-
-      final var ray = new LineSegment(origin, endpoint.getPoint());
-      final var nearestWallResult = findNearestOpenWall(openWalls, ray);
-
-      for (var otherEndpoint : endpoint.getStartsWalls()) {
-        openWalls.add(new LineSegment(endpoint.getPoint(), otherEndpoint.getPoint()));
-      }
-      for (var otherEndpoint : endpoint.getEndsWalls()) {
-        openWalls.remove(new LineSegment(otherEndpoint.getPoint(), endpoint.getPoint()));
-      }
-
-      // Find a new nearest wall.
-      final var newNearestWallResult = findNearestOpenWall(openWalls, ray);
-
-      if (newNearestWallResult.wall() != nearestWallResult.wall()) {
-        // Implies we have changed which wall we are at. Need to figure out projections.
-
-        if (openWalls.contains(nearestWallResult.wall())) {
-          // The previous nearest wall is still open. I.e., we didn't fall of its end but
-          // encountered a new closer wall. So we project the current point to the previous
-          // nearest wall, then step to the current point.
-          visionPoints.add(nearestWallResult.point());
-          visionPoints.add(endpoint.getPoint());
-        } else {
-          // The previous nearest wall is now closed. I.e., we "fell off" it and therefore have
-          // encountered a different wall. So we step from the current point (which is on the
-          // previous wall) to the projection on the new wall.
-          visionPoints.add(endpoint.getPoint());
-          // Special case: if the two walls are adjacent, they share the current point. We don't
-          // need to add the point twice, so just skip in that case.
-          if (!endpoint.getPoint().equals(newNearestWallResult.wall().p0)) {
-            visionPoints.add(newNearestWallResult.point());
-          }
-        }
-      }
+      previousNearestWall = consumeEndpoint(endpoint, previousNearestWall, visionPoints);
     }
-    if (visionPoints.size() < 3) {
-      // This shouldn't happen, but just in case.
-      log.warn("Sweep produced too few points: {}", visionPoints);
-      return null;
-    }
-    visionPoints.add(visionPoints.get(0)); // Ensure a closed loop.
+    timer.stop("sweep");
 
+    timer.start("sanity check");
+    try {
+      if (visionPoints.size() < 3) {
+        // This shouldn't happen, but just in case.
+        log.warn("Sweep produced too few points: {}", visionPoints);
+        return null;
+      }
+    } finally {
+      timer.stop("sanity check");
+    }
     timer.start("close polygon");
-    // Ensure a closed loop.
     // TODO Are there not cases where this is already done?
-    visionPoints.add(visionPoints.get(0));
+    visionPoints.add(visionPoints.get(0)); // Ensure a closed loop.
     timer.stop("close polygon");
 
     timer.start("build result");
@@ -196,28 +187,142 @@ public class VisibilityProblem {
     }
   }
 
-  private static NearestWallResult findNearestOpenWall(
-      Set<LineSegment> openWalls, LineSegment ray) {
+  private LineSegment consumeEndpoint(
+      VisibilitySweepEndpoint endpoint,
+      LineSegment previousNearestWall,
+      List<Coordinate> visionPoints) {
     assert !openWalls.isEmpty();
 
-    @Nullable LineSegment currentNearest = null;
-    @Nullable Coordinate currentNearestPoint = null;
-    double nearestDistance = Double.MAX_VALUE;
-    for (final var openWall : openWalls) {
-      final var intersection = ray.lineIntersection(openWall);
-      if (intersection == null) {
-        continue;
-      }
+    // Note: removeAll can be slow, but not in our case with few removed elements. In fact it is
+    // almost always just removing one element.
+    for (var otherEndpoint : endpoint.getEndsWalls()) {
+      openWalls.remove(new LineSegment(otherEndpoint.getPoint(), endpoint.getPoint()));
+    }
+    for (var otherEndpoint : endpoint.getStartsWalls()) {
+      openWalls.add(new LineSegment(endpoint.getPoint(), otherEndpoint.getPoint()));
+    }
 
-      final var distance = ray.p0.distance(intersection);
-      if (distance < nearestDistance) {
-        currentNearest = openWall;
-        currentNearestPoint = intersection;
-        nearestDistance = distance;
+    // Find a new nearest wall.
+    assert !openWalls.isEmpty();
+    final var currentNearestWall = openWalls.getFirst();
+    if (currentNearestWall == previousNearestWall) {
+      return previousNearestWall;
+    }
+
+    // Implies we have changed which wall we are at. Need to figure out projections.
+    final var ray = new LineSegment(origin, endpoint.getPoint());
+    if (!ray.p1.equals(previousNearestWall.p1)) {
+      // The previous nearest wall is still open. I.e., we didn't fall of its end but
+      // encountered a new closer wall. So we project the current point to the previous
+      // nearest wall, then step to the current point.
+      assert ray.p1.equals(currentNearestWall.p0)
+          : "Uh-oh, this case should only happen if we encountered a newly opened closer wall";
+      visionPoints.add(projectOntoOpenWall(ray, previousNearestWall));
+      visionPoints.add(currentNearestWall.p0);
+    } else {
+      // The previous nearest wall is now closed. I.e., we "fell off" it and therefore have
+      // encountered a different wall. So we step from the current point (which is on the
+      // previous wall) to the projection on the new wall.
+      assert ray.p1.equals(previousNearestWall.p1)
+          : "Uh-oh, this case should only happen if we left a closed wall for something farther away";
+
+      visionPoints.add(previousNearestWall.p1);
+      // Special case: if the two walls are adjacent, they share the current point. We don't
+      // need to add the point twice, so just skip in that case.
+      if (!previousNearestWall.p1.equals(currentNearestWall.p0)) {
+        visionPoints.add(projectOntoOpenWall(ray, currentNearestWall));
       }
     }
 
-    assert currentNearest != null;
-    return new NearestWallResult(currentNearest, currentNearestPoint, nearestDistance);
+    return currentNearestWall;
+  }
+
+  /**
+   * Projects an event line ray onto an open wall.
+   *
+   * <p>Since the wall is open for the event line, the intersection will succeed.
+   *
+   * @param ray A ray representing the event line.
+   * @param wall A wall that is open according to {@code ray}.
+   * @return The point at which {@code ray} would intersect with {@code wall} if extended
+   *     indefinitely.
+   */
+  private static @Nonnull Coordinate projectOntoOpenWall(LineSegment ray, LineSegment wall) {
+    // TODO This assertion is not quite right: it's okay to project onto an about-to-be-closed wall.
+    //  assert isWallOpen(ray, wall) : String.format("Wall %s is not open for ray %s", wall, ray);
+    var intersection = ray.lineIntersection(wall);
+    assert intersection != null
+        : String.format(
+            "Unable to project ray %s onto wall %s despite the wall being open", ray, wall);
+    return intersection;
+  }
+
+  /**
+   * Compares two open walls to determine which one is closer to the origin.
+   *
+   * <p>By construction, we do not have any non-noded intersections, and as a result open walls can
+   * be totally ordered by closeness to the origin. Note though that walls cannot in general be
+   * totally ordered this way, the property only holds for open walls, with the ordering
+   * corresponding to the ordering of intersections with the event line.
+   *
+   * @param s0 The first wall to compare.
+   * @param s1 The second wall to compare.
+   * @return {@code -1} if {@code s0} is closer to {@code origin} than {@code s1}; {@code 1} if
+   *     {@code s0} is further from {@code origin} than {@code s1}; {@code 0} if {@code s0} and
+   *     {@code s1} are the same wall.
+   */
+  private int compareOpenWalls(LineSegment s0, LineSegment s1) {
+    assert s0.orientationIndex(origin) == Orientation.COUNTERCLOCKWISE
+        : String.format("Wall %s is not oriented correctly", s0);
+    assert s1.orientationIndex(origin) == Orientation.COUNTERCLOCKWISE
+        : String.format("Wall %s is not oriented correctly", s1);
+
+    if (s0 == s1) {
+      return 0;
+    }
+
+    final var pointwise = s0.compareTo(s1);
+    if (pointwise == 0) {
+      return 0;
+    }
+
+    // For orientation checks: counterclockwise indicates the tested point is nearer than the line
+    // segment, since by construction all segments are oriented counterclockwise relative to the
+    // vision origin.
+
+    // Start by trying to prove that s0 is definitely closer or further than s1.
+    var p0Orientation = Orientation.index(s0.p0, s1.p0, s1.p1);
+    var p1Orientation = Orientation.index(s0.p1, s1.p0, s1.p1);
+
+    assert p0Orientation != Orientation.COLLINEAR || p1Orientation != Orientation.COLLINEAR
+        : String.format(
+            "It should not be possible for two open walls %s and %s to be collinear with one another",
+            s0, s1);
+
+    if (p0Orientation == Orientation.COLLINEAR) {
+      // p1 is authoritative.
+      return p1Orientation == Orientation.COUNTERCLOCKWISE ? -1 : 1;
+    }
+    if (p1Orientation == Orientation.COLLINEAR) {
+      // p0 is authoritative.
+      return p0Orientation == Orientation.COUNTERCLOCKWISE ? -1 : 1;
+    }
+    if (p0Orientation == p1Orientation) {
+      // There is agreement, so we know our answer.
+      return p0Orientation == Orientation.COUNTERCLOCKWISE ? -1 : 1;
+    }
+
+    // Indefinite result (one point looks closer, one look further). So test the other segment's
+    // points. Actually only need to test one point to be sure.
+    p0Orientation = Orientation.index(s1.p0, s0.p0, s0.p1);
+    // Colinearity of one point implies colinearity of the other, otherwise we would have a definite
+    // result above. And this case can't happen in the context of the sweep algorithm.
+    assert p0Orientation != Orientation.COLLINEAR
+        : String.format(
+            "It should not be possible to get a collinear result in the fallback check for %s and %s",
+            s0, s1);
+
+    // If clockwise, this point on s1 is nearer than s0, so s1 as a whole is in front of s0.
+    return p0Orientation == Orientation.COUNTERCLOCKWISE ? 1 : -1;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilitySweepEndpoint.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilitySweepEndpoint.java
@@ -61,8 +61,16 @@ public final class VisibilitySweepEndpoint {
     startsWalls.add(end);
   }
 
+  public boolean removeStartedWall(VisibilitySweepEndpoint start) {
+    return startsWalls.remove(start);
+  }
+
   public void endsWall(VisibilitySweepEndpoint start) {
     endsWalls.add(start);
+  }
+
+  public boolean removeEndedWall(VisibilitySweepEndpoint start) {
+    return endsWalls.remove(start);
   }
 
   public double getPseudoangle() {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilitySweepEndpoint.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilitySweepEndpoint.java
@@ -27,22 +27,11 @@ import org.locationtech.jts.geom.Coordinate;
  */
 public final class VisibilitySweepEndpoint {
   private final Coordinate point;
-  private final double pseudoangle;
-  private final double distance;
   private final List<VisibilitySweepEndpoint> startsWalls = new ArrayList<>();
   private final List<VisibilitySweepEndpoint> endsWalls = new ArrayList<>();
 
-  public VisibilitySweepEndpoint(Coordinate point, Coordinate origin) {
+  public VisibilitySweepEndpoint(Coordinate point) {
     this.point = point;
-
-    final var dx = point.getX() - origin.getX();
-    final var dy = point.getY() - origin.getY();
-    final var p = dx / (Math.abs(dx) + Math.abs(dy)); // -1 .. 1 increasing with x
-    this.pseudoangle =
-        (dy <= 0)
-            ? p - 1 // -2 .. 0 increasing with x
-            : 1 - p; // 0 .. 2 decreasing with x
-    this.distance = point.distance(origin);
   }
 
   public Coordinate getPoint() {
@@ -71,14 +60,6 @@ public final class VisibilitySweepEndpoint {
 
   public boolean removeEndedWall(VisibilitySweepEndpoint start) {
     return endsWalls.remove(start);
-  }
-
-  public double getPseudoangle() {
-    return pseudoangle;
-  }
-
-  public double getDistance() {
-    return distance;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisionBlockingAccumulator.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisionBlockingAccumulator.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.client.ui.zone.vbl;
 
-import java.awt.Point;
 import net.rptools.maptool.model.Zone;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -25,8 +24,8 @@ public final class VisionBlockingAccumulator {
   private final VisibilityProblem visibilityProblem;
 
   public VisionBlockingAccumulator(
-      Point origin, Envelope visionBounds, VisibilityProblem visibilityProblem) {
-    this.origin = new Coordinate(origin.getX(), origin.getY());
+      Coordinate origin, Envelope visionBounds, VisibilityProblem visibilityProblem) {
+    this.origin = origin;
     this.visionBounds = new Envelope(visionBounds);
     this.visibilityProblem = visibilityProblem;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Final piece of #4506

### Description of the Change

A number of changes were made to the visibility sweep to improve performance:
- Avoiding JTS `Geometry` where it isn't needed. Often we weren't even relying on the general `Geometry` behaviour but were still paying a cost for it.
- The algorithm more closely follows the original idea, prefering cheap comparisons between walls and endpoints rather than heavy intersection checks.
- An improved graph representation where `VisibilitySweepEndpoint` is the nodes, and edges are merely references to other `VisibilitySweepEndpoint`.
- Skipping over blocking segments that are hidden by other segments and so cannot contribute to the result.

Altogether this brought the test case in #4506 down from ~15.5 seconds to ~2 seconds on my test machine.

### Possible Drawbacks

Should be none.

### Release Notes

- Improved fog-of-war exposure performance for long paths and complex MBL

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4642)
<!-- Reviewable:end -->
