### PR TITLE
Updated dice systems to handle exploding dice limits

### DIFF
--- a/src/main/java/net/rptools/dicelib/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/dicelib/expression/ExpressionParser.java
@@ -95,15 +95,25 @@ public class ExpressionParser {
         new String[] {"\\b(\\d+)[dD](\\d+)[eE][sS](\\d+)\\b", "explodingSuccess($1, $2, $3)"},
         new String[] {"\\b[dD](\\d+)[eE][sS](\\d+)\\b", "explodingSuccess(1, $1, $2)"},
         new String[] {"\\b(\\d+)[eE][sS](\\d+)\\b", "explodingSuccess($1, 6, $2)"},
+        new String[] {
+          "\\b(\\d+)[dD](\\d+)[eE](\\d+)[sS](\\d+)\\b", "explodingSuccess($1, $2, $4, $3)"
+        },
+        new String[] {"\\b[dD](\\d+)[eE](\\d+)[sS](\\d+)\\b", "explodingSuccess(1, $1, $3, $2)"},
+        new String[] {"\\b(\\d+)[eE](\\d+)[sS](\\d+)\\b", "explodingSuccess($1, 6, $3, $2)"},
 
         // show max while exploding
         new String[] {"\\b(\\d+)[dD](\\d+)[oO]\\b", "openTest($1, $2)"},
         new String[] {"\\b[dD](\\d+)[oO]\\b", "openTest(1, $1)"},
         new String[] {"\\b(\\d+)[oO]\\b", "openTest($1, 6)"},
+        new String[] {"\\b(\\d+)[dD](\\d+)[oO](\\d+)\\b", "openTest($1, $2, $3)"},
+        new String[] {"\\b[dD](\\d+)[oO](\\d+)\\b", "openTest(1, $1, $2)"},
+        new String[] {"\\b(\\d+)[oO](\\d+)\\b", "openTest($1, 6, $2)"},
 
         // explode
         new String[] {"\\b(\\d+)[dD](\\d+)[eE]\\b", "explode($1, $2)"},
         new String[] {"\\b[dD](\\d+)[eE]\\b", "explode(1, $1)"},
+        new String[] {"\\b(\\d+)[dD](\\d+)[eE](\\d+)\\b", "explode($1, $2, $3)"},
+        new String[] {"\\b[dD](\\d+)[eE](\\d+)\\b", "explode(1, $1, $2)"},
 
         // hero
         new String[] {"\\b(\\d+[.]\\d+)[dD](\\d+)[hH]\\b", "hero($1, $2)"},

--- a/src/main/java/net/rptools/dicelib/expression/function/DiceHelper.java
+++ b/src/main/java/net/rptools/dicelib/expression/function/DiceHelper.java
@@ -45,6 +45,11 @@ public class DiceHelper {
     return rolls + "Successes: " + successes;
   }
 
+  public static String explodingSuccessDice(int times, int sides, int target)
+      throws EvaluationException {
+    return explodingSuccessDice(times, sides, target, -1);
+  }
+
   public static String openTestDice(int times, int sides, int limit) throws EvaluationException {
     String rolls = "Dice: ";
     int max = 0;
@@ -55,6 +60,10 @@ public class DiceHelper {
       if (currentRoll > max) max = currentRoll;
     }
     return rolls + "Maximum: " + max;
+  }
+
+  public static String openTestDice(int times, int sides) throws EvaluationException {
+    return openTestDice(times, sides, -1);
   }
 
   public static int fudgeDice(int times) {
@@ -208,6 +217,10 @@ public class DiceHelper {
     }
 
     return result;
+  }
+
+  public static int explodeDice(int times, int sides) throws EvaluationException {
+    return explodeDice(times, sides, -1);
   }
 
   public static int countSuccessDice(int times, int sides, int success) {

--- a/src/main/java/net/rptools/dicelib/expression/function/DiceHelper.java
+++ b/src/main/java/net/rptools/dicelib/expression/function/DiceHelper.java
@@ -32,25 +32,25 @@ public class DiceHelper {
     return result;
   }
 
-  public static String explodingSuccessDice(int times, int sides, int target)
+  public static String explodingSuccessDice(int times, int sides, int target, int limit)
       throws EvaluationException {
     String rolls = "Dice: ";
     int successes = 0;
 
     for (int i = 0; i < times; i++) {
-      int currentRoll = explodeDice(1, sides);
+      int currentRoll = explodeDice(1, sides, limit);
       rolls += currentRoll + ", ";
       if (currentRoll >= target) successes++;
     }
     return rolls + "Successes: " + successes;
   }
 
-  public static String openTestDice(int times, int sides) throws EvaluationException {
+  public static String openTestDice(int times, int sides, int limit) throws EvaluationException {
     String rolls = "Dice: ";
     int max = 0;
 
     for (int i = 0; i < times; i++) {
-      int currentRoll = explodeDice(1, sides);
+      int currentRoll = explodeDice(1, sides, limit);
       rolls += currentRoll + ", ";
       if (currentRoll > max) max = currentRoll;
     }
@@ -186,17 +186,25 @@ public class DiceHelper {
     return result;
   }
 
-  public static int explodeDice(int times, int sides) throws EvaluationException {
+  public static int explodeDice(int times, int sides, int limit) throws EvaluationException {
     int result = 0;
+    boolean infiniteExplode = limit <= 0;
 
     if (sides == 0 || sides == 1) throw new EvaluationException("Number of sides must be > 1");
 
     RunData runData = RunData.getCurrent();
 
     for (int i = 0; i < times; i++) {
-      int roll = runData.randomInt(sides);
-      if (roll == sides) times++;
-      result += roll;
+      int thisDieRolls = 0;
+      boolean endRolling = false;
+      while (!endRolling && (thisDieRolls < limit || infiniteExplode)) {
+        int roll = runData.randomInt(sides);
+        thisDieRolls++;
+        if (roll != sides) {
+          endRolling = true;
+        }
+        result += roll;
+      }
     }
 
     return result;

--- a/src/main/java/net/rptools/dicelib/expression/function/ExplodeDice.java
+++ b/src/main/java/net/rptools/dicelib/expression/function/ExplodeDice.java
@@ -24,7 +24,7 @@ import net.rptools.parser.function.EvaluationException;
 public class ExplodeDice extends AbstractNumberFunction {
 
   public ExplodeDice() {
-    super(2, 2, false, "explode");
+    super(2, 3, false, "explode");
   }
 
   @Override
@@ -34,7 +34,11 @@ public class ExplodeDice extends AbstractNumberFunction {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();
     int sides = ((BigDecimal) parameters.get(n++)).intValue();
+    int limit = -1;
+    if (parameters.size() > 2) {
+      limit = ((BigDecimal) parameters.get(n++)).intValue();
+    }
 
-    return new BigDecimal(DiceHelper.explodeDice(times, sides));
+    return new BigDecimal(DiceHelper.explodeDice(times, sides, limit));
   }
 }

--- a/src/main/java/net/rptools/dicelib/expression/function/ExplodingSuccessDice.java
+++ b/src/main/java/net/rptools/dicelib/expression/function/ExplodingSuccessDice.java
@@ -24,7 +24,7 @@ import net.rptools.parser.function.EvaluationException;
 public class ExplodingSuccessDice extends AbstractNumberFunction {
 
   public ExplodingSuccessDice() {
-    super(3, 3, true, "explodingSuccess");
+    super(3, 4, true, "explodingSuccess");
   }
 
   @Override
@@ -35,7 +35,11 @@ public class ExplodingSuccessDice extends AbstractNumberFunction {
     int times = ((BigDecimal) parameters.get(n++)).intValue();
     int sides = ((BigDecimal) parameters.get(n++)).intValue();
     int target = ((BigDecimal) parameters.get(n++)).intValue();
+    int limit = -1;
+    if (parameters.size() > 3) {
+      limit = ((BigDecimal) parameters.get(n++)).intValue();
+    }
 
-    return DiceHelper.explodingSuccessDice(times, sides, target);
+    return DiceHelper.explodingSuccessDice(times, sides, target, limit);
   }
 }

--- a/src/main/java/net/rptools/dicelib/expression/function/OpenTestDice.java
+++ b/src/main/java/net/rptools/dicelib/expression/function/OpenTestDice.java
@@ -24,7 +24,7 @@ import net.rptools.parser.function.EvaluationException;
 public class OpenTestDice extends AbstractNumberFunction {
 
   public OpenTestDice() {
-    super(2, 2, true, "openTest");
+    super(2, 3, true, "openTest");
   }
 
   @Override
@@ -34,7 +34,11 @@ public class OpenTestDice extends AbstractNumberFunction {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();
     int sides = ((BigDecimal) parameters.get(n++)).intValue();
+    int limit = -1;
+    if (parameters.size() > 2) {
+      limit = ((BigDecimal) parameters.get(n++)).intValue();
+    }
 
-    return DiceHelper.openTestDice(times, sides);
+    return DiceHelper.openTestDice(times, sides, limit);
   }
 }

--- a/src/test/java/net/rptools/dicelib/expression/function/DiceHelperTest.java
+++ b/src/test/java/net/rptools/dicelib/expression/function/DiceHelperTest.java
@@ -59,7 +59,7 @@ public class DiceHelperTest {
     RunData.setCurrent(new RunData(null));
     RunData.setSeed(102312L);
 
-    assertEquals(23, DiceHelper.explodeDice(4, 6));
+    assertEquals(23, DiceHelper.explodeDice(4, 6, -1));
   }
 
   @Test
@@ -68,7 +68,7 @@ public class DiceHelperTest {
       RunData.setCurrent(new RunData(null));
       RunData.setSeed(102312L);
 
-      assertEquals(23, DiceHelper.explodeDice(4, 1));
+      assertEquals(23, DiceHelper.explodeDice(4, 1, -1));
       fail("Expected EvaluationException");
     } catch (EvaluationException e) {
     }


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #4643


### Description of the Change
Adds limiting parameters to exploding dice functions and expressions

### Possible Drawbacks
None

### Documentation Notes
XdYeL and explode(times, sides, limit)
XdYeLsT and explodingSuccess(times, sides, target, limit)
XdYoL and openTest(times, sides, limit)
(Wiki will need updates to several pages)

### Release Notes
Added limiting parameters to exploding dice functions and expressions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4644)
<!-- Reviewable:end -->
