### PR TITLE
Fix issue with vision bounds not including the vision origin

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/EndpointSet.java
@@ -53,9 +53,9 @@ public class EndpointSet {
 
   private final int[] bucketSizes;
 
-  public EndpointSet(Coordinate origin, Envelope bounds) {
+  public EndpointSet(Coordinate origin) {
     this.origin = origin;
-    this.envelope = new Envelope(bounds);
+    this.envelope = new Envelope();
 
     this.buckets = new VisibilitySweepEndpoint[BUCKET_COUNT][];
     Arrays.setAll(this.buckets, i -> new VisibilitySweepEndpoint[32]);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityProblem.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibilityProblem.java
@@ -48,6 +48,14 @@ public class VisibilityProblem {
   private final EndpointSet endpointSet;
 
   /**
+   * Bounds on the vision and origin.
+   *
+   * <p>This will be used to guarantee that we have endpoints in every direction around the origin,
+   * and that we avoid infinite results.
+   */
+  private final Envelope bounds;
+
+  /**
    * The set of walls that are intersected by the current event line.
    *
    * <p>This set is ordered by distance to {@link #origin}, where the distance is measured along the
@@ -66,7 +74,9 @@ public class VisibilityProblem {
    */
   public VisibilityProblem(Coordinate origin, Envelope visionBounds) {
     this.origin = origin;
-    this.endpointSet = new EndpointSet(origin, visionBounds);
+    this.endpointSet = new EndpointSet(origin);
+    this.bounds = new Envelope(visionBounds);
+    this.bounds.expandToInclude(origin);
     this.openWalls = new TreeSet<>(this::compareOpenWalls);
   }
 
@@ -145,6 +155,7 @@ public class VisibilityProblem {
 
     timer.start("add bounds");
     final var envelope = endpointSet.getBounds();
+    envelope.expandToInclude(this.bounds);
     // Exact expansion distance doesn't matter, we just don't want the boundary walls to overlap
     // endpoints from real walls.
     envelope.expandBy(1.0);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4637

### Description of the Change
The vision sweep is only well-behaved if it has bounds surrounding the origin. It is not enough that we use the vision bounds since certain cases may not guarantee that the vision shape include the vision origin. So we now make sure to explicitly expand the sweep bounds to include the origin.

Also some separation of concerns: `EndpointSet` has no reason to know anything about vision, not even just to provide initial bounds. So now it only tracks the bounding box of its contents and nothing else.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where non-STG tokens with small rid vision or lights could generate errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4645)
<!-- Reviewable:end -->
