### PR TITLE
Update weisj/jsvg to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -425,7 +425,7 @@ dependencies {
     implementation 'com.formdev:flatlaf:3.3'
     implementation 'com.formdev:flatlaf-intellij-themes:3.3'
     implementation 'com.formdev:flatlaf-extras:3.3'
-    implementation 'com.github.weisj:jsvg:1.3.0-jb.5'
+    implementation 'com.github.weisj:jsvg:1.3.0'
     implementation 'com.formdev:flatlaf-jide-oss:3.3'
 
     // JS support for macros


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes dependabot PR #4669

### Description of the Change

Version `1.3.0-jb.5` does not include the `SVGLoader` class that FlatLaf-extras depends on. This prevents MapTool from running. Version `1.3.0` works as expected.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4672)
<!-- Reviewable:end -->
