### PR TITLE
Remove the unique light sources feature

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -674,16 +674,10 @@ public class ServerCommandClientImpl implements ServerCommand {
 
   @Override
   public void updateTokenProperty(Token token, Token.Update update, LightSource value) {
-    if (update == Token.Update.createUniqueLightSource) {
-      // This case requires sending the full light source definition.
-      updateTokenProperty(
-          token, update, TokenPropertyValueDto.newBuilder().setLightSource(value.toDto()).build());
-    } else {
-      updateTokenProperty(
-          token,
-          update,
-          TokenPropertyValueDto.newBuilder().setLightSourceId(value.getId().toString()).build());
-    }
+    updateTokenProperty(
+        token,
+        update,
+        TokenPropertyValueDto.newBuilder().setLightSourceId(value.getId().toString()).build());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
@@ -15,19 +15,14 @@
 package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import java.awt.Color;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.*;
-import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -37,22 +32,8 @@ import net.rptools.parser.function.AbstractFunction;
 public class TokenLightFunctions extends AbstractFunction {
   private static final TokenLightFunctions instance = new TokenLightFunctions();
 
-  private static final String TOKEN_CATEGORY = "$unique";
-
   private TokenLightFunctions() {
-    super(
-        0,
-        5,
-        "hasLightSource",
-        "clearLights",
-        "setLight",
-        "getLights",
-        "createUniqueLightSource",
-        "updateUniqueLightSource",
-        "deleteUniqueLightSource",
-        "getUniqueLightSource",
-        "getUniqueLightSources",
-        "getUniqueLightSourceNames");
+    super(0, 5, "hasLightSource", "clearLights", "setLight", "getLights");
   }
 
   public static TokenLightFunctions getInstance() {
@@ -95,49 +76,6 @@ public class TokenLightFunctions extends AbstractFunction {
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 2, 3);
       return getLights(token, type, delim);
     }
-    if (functionName.equalsIgnoreCase("createUniqueLightSource")) {
-      FunctionUtil.blockUntrustedMacro(functionName);
-      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
-
-      JsonObject lightSource = FunctionUtil.paramAsJsonObject(functionName, parameters, 0);
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return createUniqueLightSource(lightSource, token, false).getName();
-    }
-    if (functionName.equalsIgnoreCase("updateUniqueLightSource")) {
-      FunctionUtil.blockUntrustedMacro(functionName);
-      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
-
-      JsonObject lightSource = FunctionUtil.paramAsJsonObject(functionName, parameters, 0);
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return createUniqueLightSource(lightSource, token, true).getName();
-    }
-    if (functionName.equalsIgnoreCase("deleteUniqueLightSource")) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
-
-      String name = parameters.get(0).toString();
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      deleteUniqueLightSource(name, token);
-      return "";
-    }
-    if (functionName.equalsIgnoreCase("getUniqueLightSource")) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
-
-      String name = parameters.get(0).toString();
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 1, 2);
-      return Objects.requireNonNullElse(getUniqueLightSource(name, token), "");
-    }
-    if (functionName.equalsIgnoreCase("getUniqueLightSources")) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
-
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      return getUniqueLightSources(token);
-    }
-    if (functionName.equalsIgnoreCase("getUniqueLightSourceNames")) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
-
-      Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      return getUniqueLightSourceNames(token);
-    }
     return null;
   }
 
@@ -146,8 +84,7 @@ public class TokenLightFunctions extends AbstractFunction {
    *
    * @param token The token to get the light sources for.
    * @param category The category to get the light sources for. If "*" then the light sources for
-   *     all categories will be returned. If "$unique" then the light sources defined on the token
-   *     will be returned.
+   *     all categories will be returned.
    * @param delim the delimiter for the list.
    * @return a string list containing the lights that are on.
    * @throws ParserException if the light type can't be found.
@@ -159,23 +96,11 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     if (category.equals("*")) {
-      // Look up on both token and campaign.
-      for (LightSource ls : token.getUniqueLightSources()) {
-        if (token.hasLightSource(ls)) {
-          lightList.add(ls.getName());
-        }
-      }
       for (Map<GUID, LightSource> lsMap : lightSourcesMap.values()) {
         for (LightSource ls : lsMap.values()) {
           if (token.hasLightSource(ls)) {
             lightList.add(ls.getName());
           }
-        }
-      }
-    } else if (TOKEN_CATEGORY.equals(category)) {
-      for (LightSource ls : token.getUniqueLightSources()) {
-        if (token.hasLightSource(ls)) {
-          lightList.add(ls.getName());
         }
       }
     } else if (lightSourcesMap.containsKey(category)) {
@@ -202,8 +127,7 @@ public class TokenLightFunctions extends AbstractFunction {
    * Sets the light value for a token.
    *
    * @param token the token to set the light for.
-   * @param category the category of the light source. Use "$unique" for light sources defined on
-   *     the token.
+   * @param category the category of the light source.
    * @param name the name of the light source.
    * @param val the value to set for the light source, 0 for off non 0 for on.
    * @return 0 if the light was not found, otherwise 1;
@@ -216,9 +140,7 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     Iterable<LightSource> sources;
-    if (TOKEN_CATEGORY.equals(category)) {
-      sources = token.getUniqueLightSources();
-    } else if (lightSourcesMap.containsKey(category)) {
+    if (lightSourcesMap.containsKey(category)) {
       sources = lightSourcesMap.get(category).values();
     } else {
       throw new ParserException(
@@ -241,7 +163,6 @@ public class TokenLightFunctions extends AbstractFunction {
    * Checks to see if the token has a light source. The token is checked to see if it has a light
    * source with the name in the second parameter from the category in the first parameter. A "*"
    * for category indicates all categories are checked; a "*" for name indicates all names are
-   * checked. The "$unique" category indicates that only light sources defined on the token are
    * checked.
    *
    * @param token the token to check.
@@ -260,12 +181,6 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     if ("*".equals(category)) {
-      // Look up on both token and campaign.
-      for (LightSource ls : token.getUniqueLightSources()) {
-        if (ls.getName().equals(name) && token.hasLightSource(ls)) {
-          return true;
-        }
-      }
       for (Map<GUID, LightSource> lsMap : lightSourcesMap.values()) {
         for (LightSource ls : lsMap.values()) {
           if (ls.getName().equals(name) && token.hasLightSource(ls)) {
@@ -273,13 +188,8 @@ public class TokenLightFunctions extends AbstractFunction {
           }
         }
       }
-    } else if (TOKEN_CATEGORY.equals(category)) {
-      for (LightSource ls : token.getUniqueLightSources()) {
-        if ((ls.getName().equals(name) || "*".equals(name)) && token.hasLightSource(ls)) {
-          return true;
-        }
-      }
-    } else if (lightSourcesMap.containsKey(category)) {
+    }
+    if (lightSourcesMap.containsKey(category)) {
       for (LightSource ls : lightSourcesMap.get(category).values()) {
         if ((ls.getName().equals(name) || "*".equals(name)) && token.hasLightSource(ls)) {
           return true;
@@ -291,220 +201,5 @@ public class TokenLightFunctions extends AbstractFunction {
     }
 
     return false;
-  }
-
-  private static LightSource createUniqueLightSource(
-      JsonObject lightSourceDef, Token token, boolean isUpdate) throws ParserException {
-    if (!lightSourceDef.has("name")) {
-      throw new ParserException(I18N.getText("The light source must have a name."));
-    }
-    final String name = lightSourceDef.get("name").getAsString();
-
-    // Modifications require the light source to exist. Creation requires it to not exists.
-    final Optional<LightSource> existingSource =
-        token.getUniqueLightSources().stream()
-            .filter(source -> name.equals(source.getName()))
-            .findFirst();
-    if (isUpdate && existingSource.isEmpty()) {
-      throw new ParserException(
-          I18N.getText(
-              "Light source %s is not defined for token %s", name, token.getId().toString()));
-    }
-    if (!isUpdate && existingSource.isPresent()) {
-      throw new ParserException(
-          I18N.getText(
-              "Light source %s is already defined for token %s", name, token.getId().toString()));
-    }
-
-    final LightSource.Type type =
-        lightSourceDef.has("type")
-            ? LightSource.Type.valueOf(lightSourceDef.get("type").getAsString().toUpperCase())
-            : LightSource.Type.NORMAL;
-    final boolean scaleWithToken =
-        lightSourceDef.has("scale") ? lightSourceDef.get("scale").getAsBoolean() : false;
-    final boolean ignoresVBL =
-        lightSourceDef.has("ignores-vbl")
-            ? lightSourceDef.get("ignores-vbl").getAsBoolean()
-            : false;
-    final JsonArray lightDefs =
-        lightSourceDef.has("lights") ? lightSourceDef.getAsJsonArray("lights") : new JsonArray();
-
-    final var lights = new ArrayList<Light>();
-    for (final var light : lightDefs) {
-      lights.add(parseLightJson(light.getAsJsonObject(), type));
-    }
-
-    final var lightSource =
-        LightSource.createRegular(
-            name,
-            existingSource.isPresent() ? existingSource.get().getId() : new GUID(),
-            type,
-            scaleWithToken,
-            ignoresVBL,
-            lights);
-    token.addUniqueLightSource(lightSource);
-    MapTool.serverCommand()
-        .updateTokenProperty(token, Token.Update.createUniqueLightSource, lightSource);
-    return lightSource;
-  }
-
-  private static void deleteUniqueLightSource(String name, Token token) {
-    final var sourcesToRemove = new ArrayList<LightSource>();
-    for (final LightSource source : token.getUniqueLightSources()) {
-      if (name.equals(source.getName())) {
-        sourcesToRemove.add(source);
-      }
-    }
-
-    for (final LightSource source : sourcesToRemove) {
-      token.removeUniqueLightSource(source.getId());
-      MapTool.serverCommand()
-          .updateTokenProperty(token, Token.Update.deleteUniqueLightSource, source);
-    }
-  }
-
-  private static JsonObject getUniqueLightSource(String name, Token token) {
-    for (final LightSource source : token.getUniqueLightSources()) {
-      if (name.equals(source.getName())) {
-        return lightSourceToJson(source);
-      }
-    }
-
-    return null;
-  }
-
-  private static JsonArray getUniqueLightSources(Token token) {
-    final var result = new JsonArray();
-
-    for (final LightSource source : token.getUniqueLightSources()) {
-      result.add(lightSourceToJson(source));
-    }
-
-    return result;
-  }
-
-  private static JsonArray getUniqueLightSourceNames(Token token) {
-    final var result = new JsonArray();
-
-    for (final LightSource source : token.getUniqueLightSources()) {
-      result.add(source.getName());
-    }
-
-    return result;
-  }
-
-  private static Light parseLightJson(JsonObject lightDef, LightSource.Type lightSourceType)
-      throws ParserException {
-    if (!lightDef.has("range")) {
-      throw new ParserException(I18N.getText("A range must be provided for each light"));
-    }
-    final var range = lightDef.get("range").getAsDouble();
-
-    final var shape =
-        lightDef.has("shape")
-            ? ShapeType.valueOf(lightDef.get("shape").getAsString())
-            : ShapeType.CIRCLE;
-    // Beams permit the field "width", cones permit the field "arc", and both permit "offset".
-    // But no other shape permits these fields.
-    if (shape != ShapeType.BEAM) {
-      if (lightDef.has("width")) {
-        throw new ParserException(I18N.getText("Width provided but the shape is not a beam"));
-      }
-    }
-    if (shape != ShapeType.CONE) {
-      if (lightDef.has("arc")) {
-        throw new ParserException(I18N.getText("Arc provided but the shape is not a cone"));
-      }
-    }
-    if (shape != ShapeType.CONE && shape != ShapeType.BEAM) {
-      if (lightDef.has("offset")) {
-        throw new ParserException(
-            I18N.getText("Facing offset provided but the shape is not a cone"));
-      }
-    }
-    final var width = lightDef.has("width") ? lightDef.get("width").getAsDouble() : 0;
-    final var offset = lightDef.has("offset") ? lightDef.get("offset").getAsDouble() : 0;
-    final var arc = lightDef.has("arc") ? lightDef.get("arc").getAsDouble() : 0;
-
-    // Auras permit the gmOnly and ownerOnly flags, but no other type accepts them.
-    if (lightSourceType != LightSource.Type.AURA) {
-      if (lightDef.has("gmOnly")) {
-        throw new ParserException(I18N.getText("gmOnly flag provided but the type is not an aura"));
-      }
-      if (lightDef.has("ownerOnly")) {
-        throw new ParserException(
-            I18N.getText("ownerOnly flag provided but the type is not an aura"));
-      }
-    }
-    final var gmOnly = lightDef.has("gmOnly") ? !lightDef.get("gmOnly").getAsBoolean() : false;
-    final var ownerOnly =
-        lightDef.has("ownerOnly") ? !lightDef.get("ownerOnly").getAsBoolean() : false;
-
-    final DrawableColorPaint colorPaint;
-    if (lightDef.has("color")) {
-      var colorString = lightDef.get("color").getAsString();
-      if (!colorString.startsWith("#")) {
-        // Make sure it is parsed as a hex color string, not something else.
-        colorString = "#" + colorString;
-      }
-
-      colorPaint = new DrawableColorPaint(Color.decode(colorString));
-    } else {
-      colorPaint = null;
-    }
-
-    final var lumens = lightDef.has("lumens") ? lightDef.get("lumens").getAsInt() : 100;
-    if (lumens == 0) {
-      throw new ParserException(I18N.getText("Lumens must be non-zero."));
-    }
-
-    return new Light(shape, offset, range, width, arc, colorPaint, lumens, gmOnly, ownerOnly);
-  }
-
-  private static JsonObject lightSourceToJson(LightSource source) {
-    final var lightSourceDef = new JsonObject();
-    lightSourceDef.addProperty("name", source.getName());
-    lightSourceDef.addProperty("type", source.getType().toString());
-    lightSourceDef.addProperty("scale", source.isScaleWithToken());
-    lightSourceDef.addProperty("ignores-vbl", source.isIgnoresVBL());
-
-    final var lightDefs = new JsonArray();
-    for (final Light light : source.getLightList()) {
-      lightDefs.add(lightToJson(source, light));
-    }
-    lightSourceDef.add("lights", lightDefs);
-    return lightSourceDef;
-  }
-
-  private static JsonObject lightToJson(LightSource source, Light light) {
-    final var lightDef = new JsonObject();
-    lightDef.addProperty("shape", light.getShape().toString());
-
-    if (light.getShape() == ShapeType.BEAM) {
-      lightDef.addProperty("offset", light.getFacingOffset());
-      lightDef.addProperty("width", light.getWidth());
-    }
-
-    if (light.getShape() == ShapeType.CONE) {
-      lightDef.addProperty("offset", light.getFacingOffset());
-      lightDef.addProperty("arc", light.getArcAngle());
-    }
-
-    if (source.getType() == LightSource.Type.AURA) {
-      lightDef.addProperty("gmOnly", light.isGM());
-      lightDef.addProperty("ownerOnly", light.isOwnerOnly());
-    }
-
-    lightDef.addProperty("range", light.getRadius());
-    if (light.getPaint() instanceof DrawableColorPaint paint) {
-      lightDef.addProperty("color", toHex(paint.getColor()));
-    }
-    lightDef.addProperty("lumens", light.getLumens());
-
-    return lightDef;
-  }
-
-  private static String toHex(int rgb) {
-    return String.format("#%06X", rgb & 0x00FFFFFF);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -142,15 +142,6 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       menu.addSeparator();
     }
 
-    // Add unique light sources for the token.
-    {
-      JMenu subMenu = createLightCategoryMenu("Unique", tokenUnderMouse.getUniqueLightSources());
-      if (subMenu.getItemCount() != 0) {
-        menu.add(subMenu);
-        menu.addSeparator();
-      }
-    }
-
     for (Entry<String, Map<GUID, LightSource>> entry :
         MapTool.getCampaign().getLightSourcesMap().entrySet()) {
       JMenu subMenu = createLightCategoryMenu(entry.getKey(), entry.getValue().values());

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -87,7 +87,6 @@ import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
 import net.rptools.maptool.util.ExtractHeroLab;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.ImageManager;
-import net.rptools.maptool.util.LightSyntax;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
@@ -173,10 +172,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     EnumSet.allOf(TerrainModifierOperation.class).forEach(operationModel::addElement);
   }
 
-  public void initUniqueLightSourcesTextPane() {
-    setUniqueLightSourcesEnabled(MapTool.getPlayer().isGM());
-  }
-
   public void initJtsMethodComboBox() {
     getJtsMethodComboBox().setModel(new DefaultComboBoxModel<>(JTS_SimplifyMethodType.values()));
   }
@@ -205,8 +200,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     getRootPane().setDefaultButton(getOKButton());
     setGmNotesEnabled(MapTool.getPlayer().isGM());
     getComponent("@GMName").setEnabled(MapTool.getPlayer().isGM());
-
-    setUniqueLightSourcesEnabled(MapTool.getPlayer().isGM());
 
     dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
@@ -377,9 +370,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                 .stream()
                 .mapToInt(Integer::valueOf)
                 .toArray());
-
-    getUniqueLightSourcesTextPane()
-        .setText(new LightSyntax().stringifyLights(token.getUniqueLightSources()));
 
     // Jamz: Init the Topology tab...
     JTabbedPane tabbedPane = getTabbedPane();
@@ -719,15 +709,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     return (JList<TerrainModifierOperation>) getComponent("terrainModifiersIgnored");
   }
 
-  public void setUniqueLightSourcesEnabled(boolean enabled) {
-    getUniqueLightSourcesTextPane().setEnabled(enabled);
-    getLabel("uniqueLightSourcesLabel").setEnabled(enabled);
-  }
-
-  public JTextPane getUniqueLightSourcesTextPane() {
-    return (JTextPane) getComponent("uniqueLightSources");
-  }
-
   public JLabel getLibTokenURIErrorLabel() {
     return (JLabel) getComponent("Label.LibURIError");
   }
@@ -801,14 +782,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     token.setTerrainModifiersIgnored(
         new HashSet<>(getTerrainModifiersIgnoredList().getSelectedValuesList()));
-
-    var uniqueLightSources =
-        new LightSyntax()
-            .parseLights(getUniqueLightSourcesTextPane().getText(), token.getUniqueLightSources());
-    token.removeAllUniqueLightsources();
-    for (var lightSource : uniqueLightSources.values()) {
-      token.addUniqueLightSource(lightSource);
-    }
 
     // Get the states
     Component[] stateComponents = getStatesPanel().getComponents();

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -550,7 +550,7 @@
               </vspacer>
             </children>
           </grid>
-          <grid id="3a658" layout-manager="GridLayoutManager" row-count="10" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="3a658" layout-manager="GridLayoutManager" row-count="9" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="4" left="4" bottom="4" right="4"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="EditTokenDialog.tab.config"/>
@@ -710,7 +710,7 @@
               <grid id="d2ea5" layout-manager="GridLayoutManager" row-count="2" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="9" column="0" row-span="1" col-span="9" vsize-policy="2" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="8" column="0" row-span="1" col-span="9" vsize-policy="2" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -937,40 +937,14 @@
                   <name value="statSheetLocationComboBox"/>
                 </properties>
               </component>
-              <component id="86a4f" class="javax.swing.JLabel">
-                <constraints>
-                  <grid row="7" column="0" row-span="1" col-span="6" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <labelFor value="c3057"/>
-                  <name value="uniqueLightSourcesLabel"/>
-                  <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.uniqueLightSources"/>
-                </properties>
-              </component>
-              <scrollpane id="45ccf">
-                <constraints>
-                  <grid row="8" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                    <preferred-size width="-1" height="100"/>
-                  </grid>
-                </constraints>
-                <properties>
-                  <background color="-1"/>
-                  <name value="uniqueLights"/>
-                </properties>
-                <border type="none"/>
-                <children>
-                  <component id="c3057" class="javax.swing.JTextPane">
-                    <constraints/>
-                    <properties>
-                      <background color="-1"/>
-                      <name value="uniqueLightSources"/>
-                    </properties>
-                  </component>
-                </children>
-              </scrollpane>
               <vspacer id="57cb0">
                 <constraints>
                   <grid row="6" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </vspacer>
+              <vspacer id="341a0">
+                <constraints>
+                  <grid row="7" column="5" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
             </children>

--- a/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
@@ -35,7 +35,7 @@ public class LightSourceIconOverlay implements ZoneOverlay {
       if (token.hasLightSources()) {
         boolean foundNormalLight = false;
         for (AttachedLightSource attachedLightSource : token.getLightSources()) {
-          LightSource lightSource = attachedLightSource.resolve(token, MapTool.getCampaign());
+          LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
           if (lightSource != null && lightSource.getType() == LightSource.Type.NORMAL) {
             foundNormalLight = true;
             break;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -77,7 +77,7 @@ public class ZoneView {
 
   private void addLightSourceToken(Token token, Set<Player.Role> roles) {
     for (AttachedLightSource als : token.getLightSources()) {
-      LightSource lightSource = als.resolve(token, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource == null) {
         continue;
       }
@@ -315,8 +315,7 @@ public class ZoneView {
     final var result = new ArrayList<ContributedLight>();
 
     for (final var attachedLightSource : lightSourceToken.getLightSources()) {
-      LightSource lightSource =
-          attachedLightSource.resolve(lightSourceToken, MapTool.getCampaign());
+      LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
       if (lightSource == null) {
         continue;
       }
@@ -693,7 +692,7 @@ public class ZoneView {
                 Point p = FogUtil.calculateVisionCenter(token, zone);
 
                 for (AttachedLightSource als : token.getLightSources()) {
-                  LightSource lightSource = als.resolve(token, MapTool.getCampaign());
+                  LightSource lightSource = als.resolve(MapTool.getCampaign());
                   if (lightSource == null) {
                     continue;
                   }

--- a/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
+++ b/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
@@ -31,8 +31,8 @@ public final class AttachedLightSource {
    * Get the ID of the attached light source.
    *
    * <p>If you're trying to use this to look up a {@link net.rptools.maptool.model.LightSource},
-   * consider using {@link #resolve(Token, Campaign)} instead. If you're trying to compare to
-   * another {@code GUID}, consider using {@link #matches(GUID)}.
+   * consider using {@link #resolve(Campaign)} instead. If you're trying to compare to another
+   * {@code GUID}, consider using {@link #matches(GUID)}.
    *
    * @return The ID of the attached light source.
    */
@@ -41,19 +41,13 @@ public final class AttachedLightSource {
   }
 
   /**
-   * Obtain the attached {@code LightSource} from the token or campaign.
+   * Obtain the attached {@code LightSource} from the campaign.
    *
-   * @param token The token in which to look up light source IDs.
    * @param campaign The campaign in which to look up light source IDs.
    * @return The {@code LightSource} referenced by this {@code AttachedLightSource}, or {@code null}
    *     if no such light source exists.
    */
-  public @Nullable LightSource resolve(Token token, Campaign campaign) {
-    final var uniqueLightSource = token.getUniqueLightSource(lightSourceId);
-    if (uniqueLightSource != null) {
-      return uniqueLightSource;
-    }
-
+  public @Nullable LightSource resolve(Campaign campaign) {
     for (Map<GUID, LightSource> map : campaign.getLightSourcesMap().values()) {
       if (map.containsKey(lightSourceId)) {
         return map.get(lightSourceId);

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -212,8 +212,6 @@ public class Token implements Cloneable {
     setPortraitImage,
     setCharsheetImage,
     setLayout,
-    createUniqueLightSource,
-    deleteUniqueLightSource,
     clearLightSources,
     removeLightSource,
     addLightSource,
@@ -337,8 +335,6 @@ public class Token implements Cloneable {
 
   private MD5Key charsheetImage;
   private MD5Key portraitImage;
-
-  private Map<GUID, LightSource> uniqueLightSources = new LinkedHashMap<>();
 
   /**
    * All light sources attached to the token.
@@ -485,7 +481,6 @@ public class Token implements Cloneable {
     ownerType = token.ownerType;
     ownerList.addAll(token.ownerList);
 
-    uniqueLightSources.putAll(token.uniqueLightSources);
     lightSourceList.addAll(token.lightSourceList);
 
     state.putAll(token.state);
@@ -917,26 +912,6 @@ public class Token implements Cloneable {
     return imageTableName;
   }
 
-  public @Nonnull Collection<LightSource> getUniqueLightSources() {
-    return uniqueLightSources.values();
-  }
-
-  public @Nullable LightSource getUniqueLightSource(GUID lightSourceId) {
-    return uniqueLightSources.getOrDefault(lightSourceId, null);
-  }
-
-  public void addUniqueLightSource(LightSource source) {
-    uniqueLightSources.put(source.getId(), source);
-  }
-
-  public void removeUniqueLightSource(GUID lightSourceId) {
-    uniqueLightSources.remove(lightSourceId);
-  }
-
-  public void removeAllUniqueLightsources() {
-    uniqueLightSources.clear();
-  }
-
   public void addLightSource(GUID lightSourceId) {
     if (lightSourceList.stream().anyMatch(source -> source.matches(lightSourceId))) {
       // Avoid duplicates.
@@ -948,7 +923,7 @@ public class Token implements Cloneable {
   public void removeLightSourceType(LightSource.Type lightType) {
     for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
       AttachedLightSource als = i.next();
-      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource != null && lightSource.getType() == lightType) {
         i.remove();
       }
@@ -958,7 +933,7 @@ public class Token implements Cloneable {
   public void removeGMAuras() {
     for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
       AttachedLightSource als = i.next();
-      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -973,7 +948,7 @@ public class Token implements Cloneable {
   public void removeOwnerOnlyAuras() {
     for (ListIterator<AttachedLightSource> i = lightSourceList.listIterator(); i.hasNext(); ) {
       AttachedLightSource als = i.next();
-      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -987,7 +962,7 @@ public class Token implements Cloneable {
 
   public boolean hasOwnerOnlyAuras() {
     for (AttachedLightSource als : lightSourceList) {
-      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -1002,7 +977,7 @@ public class Token implements Cloneable {
 
   public boolean hasGMAuras() {
     for (AttachedLightSource als : lightSourceList) {
-      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource != null) {
         List<Light> lights = lightSource.getLightList();
         for (Light light : lights) {
@@ -1017,7 +992,7 @@ public class Token implements Cloneable {
 
   public boolean hasLightSourceType(LightSource.Type lightType) {
     for (AttachedLightSource als : lightSourceList) {
-      LightSource lightSource = als.resolve(this, MapTool.getCampaign());
+      LightSource lightSource = als.resolve(MapTool.getCampaign());
       if (lightSource != null && lightSource.getType() == lightType) {
         return true;
       }
@@ -2561,9 +2536,6 @@ public class Token implements Cloneable {
     if (ownerList == null) {
       ownerList = new HashSet<>();
     }
-    if (uniqueLightSources == null) {
-      uniqueLightSources = new LinkedHashMap<>();
-    }
 
     // Remove null and duplicate attached light sources.
     List<AttachedLightSource> lightSources =
@@ -2883,14 +2855,6 @@ public class Token implements Cloneable {
         setSizeScale(parameters.get(0).getDoubleValue());
         setAnchor(parameters.get(1).getIntValue(), parameters.get(2).getIntValue());
         break;
-      case createUniqueLightSource:
-        lightChanged = true;
-        addUniqueLightSource(LightSource.fromDto(parameters.get(0).getLightSource()));
-        break;
-      case deleteUniqueLightSource:
-        lightChanged = true;
-        removeUniqueLightSource(GUID.valueOf(parameters.get(0).getLightSourceId()));
-        break;
       case clearLightSources:
         if (hasLightSources()) {
           lightChanged = true;
@@ -3024,10 +2988,6 @@ public class Token implements Cloneable {
         dto.hasCharsheetImage() ? new MD5Key(dto.getCharsheetImage().getValue()) : null;
     token.portraitImage =
         dto.hasPortraitImage() ? new MD5Key(dto.getPortraitImage().getValue()) : null;
-
-    dto.getUniqueLightSourcesList().stream()
-        .map(LightSource::fromDto)
-        .forEach(source -> token.uniqueLightSources.put(source.getId(), source));
     token.lightSourceList.addAll(
         dto.getLightSourcesList().stream()
             .map(AttachedLightSource::fromDto)
@@ -3155,8 +3115,6 @@ public class Token implements Cloneable {
     if (portraitImage != null) {
       dto.setPortraitImage(StringValue.of(portraitImage.toString()));
     }
-    dto.addAllUniqueLightSources(
-        uniqueLightSources.values().stream().map(LightSource::toDto).collect(Collectors.toList()));
     dto.addAllLightSources(
         lightSourceList.stream().map(AttachedLightSource::toDto).collect(Collectors.toList()));
     if (sightType != null) {

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -346,7 +346,6 @@ message TokenDto {
   bool is_flipped_iso = 47;
   google.protobuf.StringValue charsheet_image = 48;
   google.protobuf.StringValue portrait_image = 49;
-  repeated LightSourceDto unique_light_sources = 72;
   repeated AttachedLightSourceDto light_sources = 50;
   google.protobuf.StringValue sight_type = 51;
   bool has_sight = 52;
@@ -650,8 +649,6 @@ enum TokenUpdateDto {
     setPortraitImage = 43;
     setCharsheetImage = 44;
     setLayout = 45;
-    createUniqueLightSource = 46;
-    deleteUniqueLightSource = 47;
     clearLightSources = 48;
     removeLightSource = 49;
     addLightSource = 50;

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Has Sight:
 EditTokenDialog.label.terrain.mod        = Terrain Modifier:
 EditTokenDialog.label.terrain.mod.tooltip= Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 = 1).
 EditTokenDialog.label.image              = Image Table:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources:
 EditTokenDialog.label.opacity            = Token Opacity:
 EditTokenDialog.label.opacity.tooltip    = Change the opacity of the token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_cs.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_cs.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Has Sight\:
 EditTokenDialog.label.terrain.mod        = Terrain Modifier\:
 EditTokenDialog.label.terrain.mod.tooltip= Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 \= 1).
 EditTokenDialog.label.image              = Image Table\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Token Opacity\:
 EditTokenDialog.label.opacity.tooltip    = Change the opacity of the token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_da.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_da.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Har syn\:
 EditTokenDialog.label.terrain.mod        = Terræn ændring\:
 EditTokenDialog.label.terrain.mod.tooltip= Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 \= 1).
 EditTokenDialog.label.image              = Billede tabel\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Polet gennemsigtighed\:
 EditTokenDialog.label.opacity.tooltip    = Ændr polettens gennemsigtighed.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_de.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_de.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Hat Sicht\:
 EditTokenDialog.label.terrain.mod        = Geländemodifikator\:
 EditTokenDialog.label.terrain.mod.tooltip= Kosten für die Bewegung anderer Spielmarken anpassen, um sich über oder durch diese Spielmarke zu bewegen. Standardmultiplikator von 1 ist keine Änderung (1 * 1 \= 1).
 EditTokenDialog.label.image              = Bildtabelle\:
-EditTokenDialog.label.uniqueLightSources = Eindeutige Lichtquellen\:
 EditTokenDialog.label.opacity            = Deckkraft dieser Spielmarke\:
 EditTokenDialog.label.opacity.tooltip    = Ändere die Deckkraft der Spielmarke.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_es.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_es.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Has Sight\:
 EditTokenDialog.label.terrain.mod        = Terrain Modifier\:
 EditTokenDialog.label.terrain.mod.tooltip= Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 \= 1).
 EditTokenDialog.label.image              = Image Table\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Token Opacity\:
 EditTokenDialog.label.opacity.tooltip    = Change the opacity of the token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Peut voir\:
 EditTokenDialog.label.terrain.mod        = Modifieur de terrain\:
 EditTokenDialog.label.terrain.mod.tooltip= Ajuster le coût de déplacement des autres pions pour pouvoir passer sur ce jeton. Le multiplicateur par défaut de 1 équivaut à aucun changement (1 * 1 \= 1).
 EditTokenDialog.label.image              = Tableau image\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Opacité du pion\:
 EditTokenDialog.label.opacity.tooltip    = Change l'opacité du pion.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_it.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_it.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Ha Vista\:
 EditTokenDialog.label.terrain.mod        = Modificatore Terreno\:
 EditTokenDialog.label.terrain.mod.tooltip= Aggiusta il costo di movimento degli altri token che potrebbero muoversi sopra o attraverso questo token. Il moltiplicatore predefinito 1 significa nessuna modifica (1 * 1 \= 1).
 EditTokenDialog.label.image              = Tabella Immagine\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Opacità Token\:
 EditTokenDialog.label.opacity.tooltip    = Modifica l'opacità del token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_ja.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ja.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = 視覚あり：
 EditTokenDialog.label.terrain.mod        = 地形修正：
 EditTokenDialog.label.terrain.mod.tooltip= 他のトークンが、このトークン上に入る、または通り抜けるために必要な移動コストの修正値。初期値は1倍で修正されない（1×1＝1）。
 EditTokenDialog.label.image              = 画像ロール表：
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = トークン透明度：
 EditTokenDialog.label.opacity.tooltip    = トークンの不透明度を変更する。
 EditTokenDialog.label.opacity.100        = 100％

--- a/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Heeft zicht\:
 EditTokenDialog.label.terrain.mod        = Terrein Aanpassen\:
 EditTokenDialog.label.terrain.mod.tooltip= Pas de bewegingskosten aan van een token die over (of door) dit token heen beweegd. Standaard vermenigvuldiger is 1 wat gelijk is aan geen aanpassing (1 * 1 \= 1).
 EditTokenDialog.label.image              = Afbeelding tabel\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Token Transparantie\:
 EditTokenDialog.label.opacity.tooltip    = Wijzig de transparantie van het token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Ma Wzrok\:
 EditTokenDialog.label.terrain.mod        = Modyfikator Terenu\:
 EditTokenDialog.label.terrain.mod.tooltip= Dostosuj mnożnik ruchu, inne tokeny mogą przechodzić przez ten token. Domyślny mnożnik to 1.
 EditTokenDialog.label.image              = Tabela Obrazów\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Krycie Żetonu\:
 EditTokenDialog.label.opacity.tooltip    = Zmienia nieprzezroczystość żetonu.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_pt.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pt.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Tem Visão\:
 EditTokenDialog.label.terrain.mod        = Modificador de Terreno\:
 EditTokenDialog.label.terrain.mod.tooltip= Ajusta o custo de movimentação que outros tokens terão ao passar por este token. O multiplicador padrão de 1 é igual a nenhuma alteração (1 * 1 \= 1).
 EditTokenDialog.label.image              = Tabela de imagem\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Opacidade do token\:
 EditTokenDialog.label.opacity.tooltip    = Alterar a opacidade do token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Имеет зрение\:
 EditTokenDialog.label.terrain.mod        = Модификатор местности\:
 EditTokenDialog.label.terrain.mod.tooltip= Отрегулируйте стоимость движения других токенов для перемещения по этому токену. По умолчанию мультипликатор 1 равный нет изменений (1 * 1 \= 1).
 EditTokenDialog.label.image              = Таблица изображений\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Прозрачность токенов\:
 EditTokenDialog.label.opacity.tooltip    = Изменить прозрачность токена.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Har syn\:
 EditTokenDialog.label.terrain.mod        = Terrängmodifierare\:
 EditTokenDialog.label.terrain.mod.tooltip= Adjust the cost of movement other tokens will may to move over or through this token. Default multiplier of 1 equals no change (1 * 1 \= 1).
 EditTokenDialog.label.image              = Bildtabell\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Tokens opacitet\:
 EditTokenDialog.label.opacity.tooltip    = Ändra opaciteten på token.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = Поле зору\:
 EditTokenDialog.label.terrain.mod        = Модифікатор террейну\:
 EditTokenDialog.label.terrain.mod.tooltip= Відрегулюйте вартість переміщення через (на) цей токен для інших токенів. Множник за замовчуванням 1 і не змінюється (1 * 1 \= 1).
 EditTokenDialog.label.image              = Таблиця зображення\:
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = Непрозорість токену\:
 EditTokenDialog.label.opacity.tooltip    = Змінити ступінь непрозорості токену.
 EditTokenDialog.label.opacity.100        = 100%

--- a/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
@@ -281,7 +281,6 @@ EditTokenDialog.label.sight.has          = 有视觉：
 EditTokenDialog.label.terrain.mod        = 地形修正：
 EditTokenDialog.label.terrain.mod.tooltip= 调整其他指示物穿过或在此指示物之上时的移动消耗。1为默认乘数且无变化 (1 * 1 \= 1)。
 EditTokenDialog.label.image              = 图像表：
-EditTokenDialog.label.uniqueLightSources = Unique Light Sources\:
 EditTokenDialog.label.opacity            = 指示物不透明度：
 EditTokenDialog.label.opacity.tooltip    = 更改指示物的不透明度。
 EditTokenDialog.label.opacity.100        = 100%


### PR DESCRIPTION
### Identify the Bug or Feature request

#331, #3087

### Description of the Change

With some open questions about how lights should evolve (e.g., #4598, #4599), I don't want unique light sources to tie us down to the current state of things. So I'm removing the feature from MT 1.15 to give us a chance to address some of these fundamentals.

### Possible Drawbacks

No unique lights in 1.15 :cry: 

### Documentation Notes

Documentation from PRs #4356 and and #4553 no longer apply to 1.15

### Release Notes

- Removed unique lights feature

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4673)
<!-- Reviewable:end -->
