### PR TITLE
Mark .form files as inputs to :instrumentForms task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,11 @@ def instrumentForms = tasks.register('instrumentForms', Sync) {
     from compileJava.destinationDirectory
     into sourceSets.main.java.destinationDirectory
 
+    def formsSet = objects.sourceDirectorySet('forms', 'IntelliJ form files')
+    formsSet.srcDirs sourceSets.main.java.sourceDirectories
+    formsSet.include '**/*.form'
+    inputs.files(formsSet.files)
+
     doLast {
         ant.echo "Instrumenting IntelliJ GUI forms"
         ant.taskdef(


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves on PR #4390 for #4389

### Description of the Change

I've noticed that the current `:instrumentForms` task does not recognize changes to IntelliJ GUI files. This makes dev iteration more clunky than it needs to be when making frequent UI changes. So the situation was only mildly improved by the previous PR.

This PR makes it so the class files are reinstrumented whenever a `.form` file is changed. This way they won't report as up-to-date unless neither Java nor form files are modified.

### Possible Drawbacks

Should be none (build only).

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4685)
<!-- Reviewable:end -->
