### PR TITLE
Include `token types` in `getInfo("campaign")`

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -371,6 +371,10 @@ public class getInfoFunction extends AbstractFunction {
     }
     cinfo.add("tables", tinfo);
 
+    JsonArray ttinfo = new JsonArray();
+    c.getTokenTypes().forEach(ttinfo::add);
+    cinfo.add("token types", ttinfo);
+
     JsonObject llinfo = new JsonObject();
     for (String ltype : c.getLightSourcesMap().keySet()) {
       JsonArray ltinfo = new JsonArray();


### PR DESCRIPTION
closes #4694 

### Description of the Change

A `token types` array added to `getInfo("campaign")`

### Possible Drawbacks
none

### Release Notes
`getInfo("campaign")` will now include `token types` array of the token types found under Campaign Properties - Token Properties tab

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4697)
<!-- Reviewable:end -->
