### PR TITLE
Correctly centre map labels and fix colors for some old labels that had wrong coloring.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1220,7 +1220,9 @@ public class ZoneRenderer extends JComponent
       timer.start("labels-1.1");
       ScreenPoint sp = ScreenPoint.fromZonePointRnd(this, zp.x, zp.y);
       var dim = flabel.getDimensions(g, label.getLabel());
-      Rectangle bounds = flabel.render(g, (int) sp.x, (int) sp.y, label.getLabel());
+      Rectangle bounds =
+          flabel.render(
+              g, (int) (sp.x - dim.width / 2), (int) (sp.y - dim.height / 2), label.getLabel());
       labelLocationList.add(new LabelLocation(bounds, label));
       timer.stop("labels-1.1");
     }

--- a/src/main/java/net/rptools/maptool/model/transform/campaign/LabelFontAndBGTransform.java
+++ b/src/main/java/net/rptools/maptool/model/transform/campaign/LabelFontAndBGTransform.java
@@ -28,10 +28,22 @@ public class LabelFontAndBGTransform implements ModelVersionTransformation {
   /** The end label tag that we want to replace. */
   private static final String endLabelTag = "</net.rptools.maptool.model.Label>";
 
+  /** The pattern that we want o match for 0 foreground color. */
+  private static final String replace0ForegroundTags =
+      "<foregroundColor>0</foregroundColor>[^<]*" + endLabelTag;
+
+  /**
+   * The foreground color that we want to use for the label where the legacy foreground color is 0.
+   */
+  private static final Color legacyForegroundColor = new Color(0.0f, 0.0f, 0.0f, 1.0f);
+
+  private static final String foreground0Replacement =
+      "<foregroundColor>" + legacyForegroundColor.getRGB() + "</foregroundColor>\n" + endLabelTag;
+
   /** The background color that we want to use for the new label tag. */
   private static final Color legacyBackgroundColor = new Color(0.82f, 0.82f, 0.82f, 1.0f);
 
-  /** The replacement string that we want to use for the end label tag. */
+  /** The replacement string that we want to use for the new label tag. */
   private static final String replacement =
       "<backgroundColor>"
           + legacyBackgroundColor.getRGB()
@@ -54,8 +66,13 @@ public class LabelFontAndBGTransform implements ModelVersionTransformation {
   /** The pattern that we want to use to match the end label tag. */
   private static final Pattern pattern = Pattern.compile(endLabelTag, Pattern.DOTALL);
 
+  /** The pattern that we want to use to match the legacy foreground color of 0. */
+  private static final Pattern replace0Foreground =
+      Pattern.compile(replace0ForegroundTags, Pattern.DOTALL);
+
   @Override
   public String transform(String xml) {
-    return pattern.matcher(xml).replaceAll(replacement);
+    String replace0 = replace0Foreground.matcher(xml).replaceAll(foreground0Replacement);
+    return pattern.matcher(replace0).replaceAll(replacement);
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request
Fixes #4706



### Description of the Change
Labels are not being centred correctly, so I have updated the rendering to fix their locations.



### Possible Drawbacks

This means labels created with RC1 will be in the wrong place with the next release.
Since the sizes of labels are different there will not be a pixel perfect match of locations for the labels but they will be centred in same location and their bounds will be very close to before 1.15.

### Documentation Notes
Fixes rendering locations of labels

#### Pre 1.15
<img width="419" alt="CleanShot 2024-03-10 at 11 41 52@2x" src="https://github.com/RPTools/maptool/assets/73173/2b70b801-758f-4990-b7c6-da675532f8c2">


#### Fixes
<img width="416" alt="CleanShot 2024-03-10 at 13 25 47@2x" src="https://github.com/RPTools/maptool/assets/73173/b7a17ae1-9839-41e0-931b-b8c1066e68e8">



### Release Notes
- Fix centering of

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4716)
<!-- Reviewable:end -->
