### PR TITLE
Enforce valid frame rate cap values

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -1286,11 +1286,21 @@ public class AppPreferences {
   }
 
   public static void setFrameRateCap(int cap) {
+    if (cap <= 0) {
+      // The provided value is invalid. Change to default instead.
+      cap = DEFAULT_FRAME_RATE_CAP;
+    }
     prefs.putInt(KEY_FRAME_RATE_CAP, cap);
   }
 
   public static int getFrameRateCap() {
-    return prefs.getInt(KEY_FRAME_RATE_CAP, DEFAULT_FRAME_RATE_CAP);
+    int result = prefs.getInt(KEY_FRAME_RATE_CAP, DEFAULT_FRAME_RATE_CAP);
+    if (result <= 0) {
+      // An invalid value is stored. Fix that.
+      result = DEFAULT_FRAME_RATE_CAP;
+      setFrameRateCap(result);
+    }
+    return result;
   }
 
   public static void setUpnpDiscoveryTimeout(int timeout) {

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -939,14 +939,20 @@ public class PreferencesDialog extends JDialog {
               protected void storeNumericValue(Integer value) {
                 AppPreferences.setFrameRateCap(value);
 
+                // AppPreferences may have rejected the value, so read it back.
+                final var cap = AppPreferences.getFrameRateCap();
                 for (final var renderer : MapTool.getFrame().getZoneRenderers()) {
-                  renderer.setFrameRateCap(value);
+                  renderer.setFrameRateCap(cap);
                 }
               }
 
               @Override
               protected Integer convertString(String value) throws ParseException {
-                return StringUtil.parseInteger(value);
+                final var result = StringUtil.parseInteger(value);
+                if (result <= 0) {
+                  throw new ParseException("Frame rate cap must be positive", 0);
+                }
+                return result;
               }
             });
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4730

### Description of the Change

We no longer allow frame rates that aren't positive integers. This is enforced in two ways:
- In the Preferences dialog, by validating that the value is positive. This is mainly done in the hopes that validation errors will one day be signaled to the user somehow, though today it is currently a silent failure.
- In `AppPreferences`, by using the default value wherever an invalid value is encountered. This lets all components be able to rely on `AppPreferences.getFrameRateCap()` to return a useable value.

### Possible Drawbacks

This can lead to confusion since invalid values are silently ignored in the Preferences dialog (this is already the case for invalid values in this field and others). The Preferences dialog deserves some TLC regarding validation.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where it was possible to set invalid frame rates of zero or less.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4732)
<!-- Reviewable:end -->
