### PR TITLE
Chat background colour fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -36,6 +36,7 @@ import net.rptools.maptool.client.ui.chat.SmileyChatTranslationRuleGroup;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrameFactory;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
+import net.rptools.maptool.client.ui.theme.ThemeSupport;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.*;
@@ -82,7 +83,6 @@ public class CommandPanel extends JPanel {
   public CommandPanel() {
     setLayout(new BorderLayout());
     setBorder(BorderFactory.createLineBorder(Color.gray));
-
     add(BorderLayout.SOUTH, createSouthPanel());
     add(BorderLayout.CENTER, getMessagePanel());
     initializeSmilies();
@@ -607,6 +607,10 @@ public class CommandPanel extends JPanel {
       commandTextArea.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
       commandTextArea.setPreferredSize(new Dimension(50, 40)); // XXX should be resizable
       commandTextArea.setFont(new Font("sans-serif", 0, AppPreferences.getFontSize()));
+      if (!ThemeSupport.shouldUseThemeColorsForChat()) {
+        commandTextArea.setBackground(Color.WHITE);
+        commandTextArea.setForeground(Color.BLACK);
+      }
       commandTextArea.addKeyListener(new ChatTypingListener());
       SwingUtil.useAntiAliasing(commandTextArea);
 

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
@@ -71,6 +71,9 @@ public class MessagePanel extends JPanel {
     textPane.setEditorKit(new MessagePanelEditorKit());
     if (ThemeSupport.shouldUseThemeColorsForChat()) {
       textPane.setUI(new javax.swing.plaf.basic.BasicEditorPaneUI());
+    } else {
+      textPane.setBackground(new Color(253, 253, 254));
+      textPane.setForeground(Color.BLACK);
     }
     textPane.addComponentListener(
         new ComponentListener() {
@@ -149,13 +152,19 @@ public class MessagePanel extends JPanel {
     new MapToolEventBus().getMainEventBus().register(this);
     // Create the style
     StyleSheet style = document.getStyleSheet();
-    var defColor =
+    var fgColour =
         ThemeSupport.shouldUseThemeColorsForChat()
             ? MessageUtil.getDefaultForegroundHex()
             : "black";
+    var bgColour =
+        ThemeSupport.shouldUseThemeColorsForChat()
+            ? MessageUtil.getDefaultBackgroundHex()
+            : "#fdfdfe";
     var mainCss =
-        "body {color: "
-            + defColor
+        "body {background-color: "
+            + bgColour
+            + "; color: "
+            + fgColour
             + " ; font-family: sans-serif; font-size: "
             + AppPreferences.getFontSize()
             + "pt}";

--- a/src/main/java/net/rptools/maptool/util/MessageUtil.java
+++ b/src/main/java/net/rptools/maptool/util/MessageUtil.java
@@ -191,6 +191,11 @@ public class MessageUtil {
     return String.format("#%06X", color.getRGB() & 0x00FFFFFF);
   }
 
+  public static String getDefaultBackgroundHex() {
+    var color = UIManager.getColor("Panel.background");
+    return String.format("#%06X", color.getRGB() & 0x00FFFFFF);
+  }
+
   public static String getDefaultForegroundHex() {
     var color = UIManager.getColor("Panel.foreground");
     return String.format("#%06X", color.getRGB() & 0x00FFFFFF);


### PR DESCRIPTION
fixes #4733

### Description of the Change
Default chat background was picking up theme background when option shouldUseThemeColorsForChat was not selected.
Hinging on ThemeSupport.shouldUseThemeColorsForChat();
Default text colour set to black, and
Default background colour set to white.
Applied to chat output and command input sub-panels.

### Possible Drawbacks
none

### Documentation Notes
Fixed issue with default chat background using dark themes.

### Release Notes
Fixed issue with default chat background using dark themes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4734)
<!-- Reviewable:end -->
