### PR TITLE
Add a cover VBL icon to Rod Takehara icon theme

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
@@ -432,6 +432,8 @@ public class RessourceManager {
           put(Icons.TOOLBAR_TOPOLOGY_TYPE_PIT_ON, ROD_ICONS + "ribbon/Draw Pit VBL.svg");
           put(Icons.TOOLBAR_TOPOLOGY_TYPE_VBL_OFF, ROD_ICONS + "ribbon/Draw Wall VBL.svg");
           put(Icons.TOOLBAR_TOPOLOGY_TYPE_VBL_ON, ROD_ICONS + "ribbon/Draw Wall VBL.svg");
+          put(Icons.TOOLBAR_TOPOLOGY_TYPE_COVER_OFF, ROD_ICONS + "ribbon/Draw Cover VBL.svg");
+          put(Icons.TOOLBAR_TOPOLOGY_TYPE_COVER_ON, ROD_ICONS + "ribbon/Draw Cover VBL.svg");
           put(Icons.TOOLBAR_VOLUME_OFF, ROD_ICONS + "ribbon/Mute - OFF.svg");
           put(Icons.TOOLBAR_VOLUME_ON, ROD_ICONS + "ribbon/Mute - ON.svg");
           put(Icons.TOOLBAR_ZONE, ROD_ICONS + "ribbon/Select Map.svg");

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Cover VBL.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Cover VBL.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100%"
+   height="100%"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg4"
+   sodipodi:docname="Draw Cover VBL.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:serif="http://www.serif.com/"><defs
+   id="defs4" /><sodipodi:namedview
+   id="namedview4"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="true"
+   inkscape:zoom="64"
+   inkscape:cx="6.1484375"
+   inkscape:cy="8.8828125"
+   inkscape:window-width="2560"
+   inkscape:window-height="1412"
+   inkscape:window-x="1440"
+   inkscape:window-y="557"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg4"><inkscape:grid
+     id="grid4"
+     units="px"
+     originx="0"
+     originy="0"
+     spacingx="1"
+     spacingy="1"
+     empcolor="#0099e5"
+     empopacity="0.30196078"
+     color="#0099e5"
+     opacity="0.14901961"
+     empspacing="5"
+     dotted="false"
+     gridanglex="30"
+     gridanglez="30"
+     visible="true" /></sodipodi:namedview>
+    <g
+   transform="translate(-189.99999,-135)"
+   id="g4-6"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+        <g
+   id="Draw-Wall-VBL-7"
+   serif:id="Draw Wall VBL"
+   transform="translate(100,133)"
+   inkscape:label="Draw-Wall-VBL">
+            <rect
+   x="90"
+   y="0"
+   width="16"
+   height="16"
+   style="fill:none"
+   id="rect1-5" />
+            <g
+   transform="translate(-71.71,-167.606)"
+   id="g2-3">
+                <rect
+   x="173.70999"
+   y="175.606"
+   width="2"
+   height="4.9999971"
+   style="fill:#6e6e6e;stroke-width:0.707106"
+   id="rect2-5" /><rect
+   x="163.71001"
+   y="175.606"
+   width="2"
+   height="5"
+   style="clip-rule:evenodd;fill:#6e6e6e;fill-rule:evenodd;stroke-width:0.707107;stroke-linejoin:round;stroke-miterlimit:2"
+   id="rect2-3-6" />
+            </g>
+            <g
+   transform="matrix(1,0,0,1.08656,-71.71,-183.067)"
+   id="g3-2">
+                <rect
+   x="163.70999"
+   y="175.84546"
+   width="12"
+   height="1.841"
+   style="fill:#6e6e6e"
+   id="rect3-9" />
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #3732

### Description of the Change

Adds an icon for Cover VBL that is consistent with the Rod Takehara icon theme.

In the toolbar, the icon looks like this:
![image](https://github.com/RPTools/maptool/assets/7492219/8f410b0a-3bd1-4f7a-86d5-e207d6e13604)

### Possible Drawbacks

If folks don't find the icon intuitive, it could lead to confusion.

### Documentation Notes

N/A

### Release Notes

- Added a modern icon for Cover VBL to the Rod Takehara icon theme.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4737)
<!-- Reviewable:end -->
