### PR TITLE
Automatically copy relevant issue labels to Pull Requests

### DIFF
--- a/.github/workflows/copy-label-to-pr.yml
+++ b/.github/workflows/copy-label-to-pr.yml
@@ -1,6 +1,11 @@
+name: Copy Labels to PR
 on:
   pull_request:
     types: [opened]
+  permissions:
+    contents: read
+    issues: read
+    pull-requests: write
 
 jobs:
   copy-labels:

--- a/.github/workflows/copy-label-to-pr.yml
+++ b/.github/workflows/copy-label-to-pr.yml
@@ -1,0 +1,25 @@
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  copy-labels:
+    runs-on: ubuntu-latest
+    name: Copy labels from linked issues
+    steps:
+      - name: copy-labels
+        uses: michalvankodev/copy-issue-labels@v1.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels-to-include: |
+            bug
+            build-configuration
+            breaking-change
+            code-maintenance
+            dependencies
+            feature
+            ignore-for-release-note
+            performance
+            refactor
+            repo-admin
+            translations

--- a/.github/workflows/copy-label-to-pr.yml
+++ b/.github/workflows/copy-label-to-pr.yml
@@ -2,13 +2,13 @@ name: Copy Labels to PR
 on:
   pull_request:
     types: [opened]
-  permissions:
-    contents: read
-    issues: read
-    pull-requests: write
 
 jobs:
   copy-labels:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Copy labels from linked issues
     steps:


### PR DESCRIPTION


### Identify the Bug or Feature request

resolves #4743 



### Description of the Change
Adds the copy-labels action on PR push to copy relevant labels from connected issues to the PR


### Possible Drawbacks

Should be none

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4746)
<!-- Reviewable:end -->
