### PR TITLE
Pass zones to templates so they don't have to look them up

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -251,7 +251,7 @@ public class DrawingFunctions extends AbstractFunction {
     dinfo.addProperty("name", d.getName());
     dinfo.addProperty("layer", el.getDrawable().getLayer().name());
     dinfo.addProperty("type", getDrawbleType(d));
-    dinfo.add("bounds", boundsToJSON(d));
+    dinfo.add("bounds", boundsToJSON(map, d));
     dinfo.addProperty("penColor", paintToString(el.getPen().getPaint()));
     dinfo.addProperty("fillColor", paintToString(el.getPen().getBackgroundPaint()));
     dinfo.addProperty("opacity", el.getPen().getOpacity());
@@ -262,12 +262,12 @@ public class DrawingFunctions extends AbstractFunction {
     return dinfo;
   }
 
-  private JsonObject boundsToJSON(AbstractDrawing d) {
+  private JsonObject boundsToJSON(Zone map, AbstractDrawing d) {
     JsonObject binfo = new JsonObject();
-    binfo.addProperty("x", d.getBounds().x);
-    binfo.addProperty("y", d.getBounds().y);
-    binfo.addProperty("width", d.getBounds().width);
-    binfo.addProperty("height", d.getBounds().height);
+    binfo.addProperty("x", d.getBounds(map).x);
+    binfo.addProperty("y", d.getBounds(map).y);
+    binfo.addProperty("width", d.getBounds(map).width);
+    binfo.addProperty("height", d.getBounds(map).height);
     return binfo;
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
@@ -108,7 +108,7 @@ public class DrawingMiscFunctions extends DrawingFunctions {
   private JsonArray getCrossedPoints(final Zone map, final DrawnElement de, final String pathStr) {
     List<Map<String, Integer>> pathPoints = convertJSONStringToList(pathStr);
     JsonArray returnPoints = new JsonArray();
-    Area a = de.getDrawable().getArea();
+    Area a = de.getDrawable().getArea(map);
     int cnt = 0;
     Point previousPoint = new Point();
     for (Map<String, Integer> entry : pathPoints) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
@@ -34,7 +34,6 @@ import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.tool.DefaultTool;
 import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
-import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.Zone.Layer;
@@ -220,8 +219,7 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
   }
 
   protected Area getTokenTopology(Zone.TopologyType topologyType) {
-    List<Token> topologyTokens =
-        MapTool.getFrame().getCurrentZoneRenderer().getZone().getTokensWithTopology(topologyType);
+    List<Token> topologyTokens = getZone().getTokensWithTopology(topologyType);
 
     Area tokenTopology = new Area();
     for (Token topologyToken : topologyTokens) {
@@ -326,11 +324,12 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
    * Render a drawable on a zone. This method consolidates all of the calls to the server in one
    * place so that it is easier to keep them in sync.
    *
-   * @param zoneId Id of the zone where the <code>drawable</code> is being drawn.
    * @param pen The pen used to draw.
    * @param drawable What is being drawn.
    */
-  protected void completeDrawable(GUID zoneId, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
+    var zone = getZone();
+
     if (!hasPaint(pen)) {
       return;
     }
@@ -348,11 +347,10 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
     MapToolUtil.uploadTexture(pen.getBackgroundPaint());
 
     // Tell the local/server to render the drawable.
-    MapTool.serverCommand().draw(zoneId, pen, drawable);
+    MapTool.serverCommand().draw(zone.getId(), pen, drawable);
 
     // Allow it to be undone
-    Zone z = MapTool.getFrame().getCurrentZoneRenderer().getZone();
-    z.addDrawable(pen, drawable);
+    zone.addDrawable(pen, drawable);
   }
 
   private boolean hasPaint(Pen pen) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
@@ -333,7 +333,7 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
     if (!hasPaint(pen)) {
       return;
     }
-    if (drawable.getBounds() == null) {
+    if (drawable.getBounds(zone) == null) {
       return;
     }
     if (MapTool.getPlayer().isGM()) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingTool.java
@@ -117,7 +117,7 @@ public abstract class AbstractDrawingTool extends DefaultTool implements ZoneOve
     AffineTransform transform = getPaintTransform(renderer);
     AffineTransform oldTransform = g.getTransform();
     g.transform(transform);
-    drawing.draw(g, pen);
+    drawing.draw(renderer.getZone(), g, pen);
     g.setTransform(oldTransform);
   }
 

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractLineTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractLineTool.java
@@ -95,7 +95,7 @@ public abstract class AbstractLineTool extends AbstractDrawingTool {
     if (isBackgroundFill(e) && line.getPoints().size() > 2) {
       drawable = new ShapeDrawable(getPolygon(trimLine));
     }
-    completeDrawable(renderer.getZone().getId(), getPen(), drawable);
+    completeDrawable(getPen(), drawable);
 
     line = null;
     currentX = -1;

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
@@ -93,7 +93,7 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
       var drawable = element.getDrawable();
       var id = drawable.getId();
       ZonePoint pos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
-      if (drawable.getBounds().contains(pos.x, pos.y)) {
+      if (drawable.getBounds(zone).contains(pos.x, pos.y)) {
         if (!selectedDrawings.contains(id)) selectedDrawings.add(id);
         else selectedDrawings.remove(id);
         break;
@@ -116,7 +116,7 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
   }
 
   private void drawBox(Graphics2D g, DrawnElement element) {
-    var box = element.getDrawable().getBounds();
+    var box = element.getDrawable().getBounds(getZone());
     var pen = element.getPen();
 
     var scale = renderer.getScale();

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondExposeTool.java
@@ -70,7 +70,7 @@ public class DiamondExposeTool extends DiamondTool {
       return;
     }
     Zone zone = MapTool.getCampaign().getZone(zoneId);
-    Area area = new Area(drawable.getArea());
+    Area area = new Area(drawable.getArea(zone));
     Set<GUID> selectedToks = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
     if (pen.isEraser()) {
       zone.hideArea(area, selectedToks);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondExposeTool.java
@@ -63,15 +63,15 @@ public class DiamondExposeTool extends DiamondTool {
   }
 
   @Override
-  protected void completeDrawable(GUID zoneId, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     if (!MapTool.getPlayer().isGM()) {
       MapTool.showError("msg.error.fogexpose");
       MapTool.getFrame().refresh();
       return;
     }
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
+    Zone zone = getZone();
     Area area = new Area(drawable.getArea(zone));
-    Set<GUID> selectedToks = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
+    Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {
       zone.hideArea(area, selectedToks);
       MapTool.serverCommand().hideFoW(zone.getId(), area, selectedToks);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondTool.java
@@ -76,7 +76,7 @@ public class DiamondTool extends AbstractDrawingTool implements MouseMotionListe
           return;
         }
         // ToolHelper.drawDiamondMeasurement(renderer, null, diamond);
-        completeDrawable(renderer.getZone().getId(), getPen(), new ShapeDrawable(diamond, false));
+        completeDrawable(getPen(), new ShapeDrawable(diamond, false));
         diamond = null;
       }
       setIsEraser(isEraser(e));

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DiamondTopologyTool.java
@@ -78,7 +78,7 @@ public class DiamondTopologyTool extends AbstractDrawingTool implements MouseMot
           renderer.repaint();
           return;
         }
-        Area area = new ShapeDrawable(diamond, false).getArea();
+        Area area = new ShapeDrawable(diamond, false).getArea(getZone());
         if (isEraser(e)) {
           getZone().removeTopology(area);
           MapTool.serverCommand()

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawnTextTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawnTextTool.java
@@ -239,7 +239,7 @@ public class DrawnTextTool extends AbstractDrawingTool implements MouseMotionLis
     textPane = null;
 
     // Tell everybody else
-    completeDrawable(renderer.getZone().getId(), getPen(), label);
+    completeDrawable(getPen(), label);
     resetTool();
   }
 

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/FreehandExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/FreehandExposeTool.java
@@ -76,18 +76,18 @@ public class FreehandExposeTool extends FreehandTool implements MouseMotionListe
 
     if (line == null) return; // Escape has been pressed
     addPoint(e);
-    completeDrawable(renderer.getZone().getId(), getPen(), line);
+    completeDrawable(getPen(), line);
     resetTool();
   }
 
   @Override
-  protected void completeDrawable(GUID zoneId, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     if (!MapTool.getPlayer().isGM()) {
       MapTool.showError("msg.error.fogexpose");
       MapTool.getFrame().refresh();
       return;
     }
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
+    Zone zone = getZone();
 
     Area area = null;
     if (drawable instanceof LineSegment) {
@@ -96,7 +96,7 @@ public class FreehandExposeTool extends FreehandTool implements MouseMotionListe
     if (drawable instanceof ShapeDrawable) {
       area = new Area(((ShapeDrawable) drawable).getShape());
     }
-    Set<GUID> selectedToks = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
+    Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {
       zone.hideArea(area, selectedToks);
       MapTool.serverCommand().hideFoW(zone.getId(), area, selectedToks);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/LineCellTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/LineCellTemplateTool.java
@@ -107,7 +107,7 @@ public class LineCellTemplateTool extends RadiusCellTemplateTool {
       g.setTransform(newTransform);
       ZonePoint vertex = template.getVertex();
       ZonePoint pathVertex = ((LineCellTemplate) template).getPathVertex();
-      template.draw(g, pen);
+      template.draw(renderer.getZone(), g, pen);
       Paint paint = pen.getPaint() != null ? pen.getPaint().getPaint() : null;
       paintCursor(g, paint, pen.getThickness(), vertex);
       if (pathVertex != null) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/LineTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/LineTemplateTool.java
@@ -116,7 +116,7 @@ public class LineTemplateTool extends RadiusTemplateTool implements PropertyChan
       g.setTransform(newTransform);
       ZonePoint vertex = template.getVertex();
       ZonePoint pathVertex = ((LineTemplate) template).getPathVertex();
-      template.draw(g, pen);
+      template.draw(renderer.getZone(), g, pen);
       Paint paint = pen.getPaint() != null ? pen.getPaint().getPaint() : null;
       paintCursor(g, paint, pen.getThickness(), vertex);
       if (pathVertex != null) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/OvalExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/OvalExposeTool.java
@@ -78,7 +78,7 @@ public class OvalExposeTool extends OvalTool {
     }
     Zone zone = getZone();
 
-    Rectangle bounds = drawable.getBounds();
+    Rectangle bounds = drawable.getBounds(zone);
     Area area = new Area(new Ellipse2D.Double(bounds.x, bounds.y, bounds.width, bounds.height));
     Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/OvalExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/OvalExposeTool.java
@@ -70,17 +70,17 @@ public class OvalExposeTool extends OvalTool {
   }
 
   @Override
-  protected void completeDrawable(GUID zoneId, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     if (!MapTool.getPlayer().isGM()) {
       MapTool.showError("msg.error.fogexpose");
       MapTool.getFrame().refresh();
       return;
     }
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
+    Zone zone = getZone();
 
     Rectangle bounds = drawable.getBounds();
     Area area = new Area(new Ellipse2D.Double(bounds.x, bounds.y, bounds.width, bounds.height));
-    Set<GUID> selectedToks = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
+    Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {
       zone.hideArea(area, selectedToks);
       MapTool.serverCommand().hideFoW(zone.getId(), area, selectedToks);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/OvalTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/OvalTool.java
@@ -100,7 +100,6 @@ public class OvalTool extends AbstractDrawingTool implements MouseMotionListener
         }
 
         completeDrawable(
-            renderer.getZone().getId(),
             getPen(),
             new ShapeDrawable(new Ellipse2D.Float(oval.x, oval.y, oval.width, oval.height), true));
         oval = null;

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonExposeTool.java
@@ -77,22 +77,22 @@ public class PolygonExposeTool extends PolygonTool implements MouseMotionListene
 
     if (line == null) return; // Escape has been pressed
     addPoint(e);
-    completeDrawable(renderer.getZone().getId(), getPen(), line);
+    completeDrawable(getPen(), line);
     resetTool();
   }
 
   @Override
-  protected void completeDrawable(GUID zoneId, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     if (!MapTool.getPlayer().isGM()) {
       MapTool.showError("msg.error.fogexpose");
       MapTool.getFrame().refresh();
       return;
     }
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
+    Zone zone = getZone();
 
     Polygon polygon = getPolygon((LineSegment) drawable);
     Area area = new Area(polygon);
-    Set<GUID> selectedToks = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
+    Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {
       zone.hideArea(area, selectedToks);
       MapTool.serverCommand().hideFoW(zone.getId(), area, selectedToks);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonTool.java
@@ -17,7 +17,6 @@ package net.rptools.maptool.client.tool.drawing;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.event.MouseMotionListener;
-import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.LineSegment;
 import net.rptools.maptool.model.drawing.Pen;
@@ -40,9 +39,9 @@ public class PolygonTool extends LineTool implements MouseMotionListener {
   }
 
   @Override
-  protected void completeDrawable(GUID zoneGUID, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     LineSegment line = (LineSegment) drawable;
-    super.completeDrawable(zoneGUID, pen, new ShapeDrawable(getPolygon(line)));
+    super.completeDrawable(pen, new ShapeDrawable(getPolygon(line)));
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/PolygonTopologyTool.java
@@ -25,7 +25,6 @@ import java.awt.geom.Path2D;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
-import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.LineSegment;
@@ -74,7 +73,7 @@ public class PolygonTopologyTool extends LineTool implements MouseMotionListener
   }
 
   @Override
-  protected void completeDrawable(GUID zoneGUID, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     Area area = new Area();
 
     if (drawable instanceof LineSegment) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
@@ -412,7 +412,7 @@ public class RadiusCellTemplateTool extends AbstractDrawingTool implements Mouse
       template.setRadius(getRadiusAtMouse(e));
       ZonePoint vertex = template.getVertex();
       ZonePoint newPoint = new ZonePoint(vertex.x, vertex.y);
-      completeDrawable(renderer.getZone().getId(), getPen(), template);
+      completeDrawable(getPen(), template);
       setIsEraser(false);
       resetTool(newPoint);
     }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
@@ -217,7 +217,6 @@ public class RadiusCellTemplateTool extends AbstractDrawingTool implements Mouse
     } // endif
     template = createBaseTemplate();
     template.setVertex(vertex);
-    template.setZoneId(renderer.getZone().getId());
     controlOffset = null;
     renderer.repaint();
   }
@@ -354,7 +353,6 @@ public class RadiusCellTemplateTool extends AbstractDrawingTool implements Mouse
   @Override
   protected void detachFrom(ZoneRenderer renderer) {
     super.detachFrom(renderer);
-    template.setZoneId(null);
     renderer.repaint();
   }
 
@@ -363,7 +361,6 @@ public class RadiusCellTemplateTool extends AbstractDrawingTool implements Mouse
    */
   @Override
   protected void attachTo(ZoneRenderer renderer) {
-    template.setZoneId(renderer.getZone().getId());
     renderer.repaint();
     super.attachTo(renderer);
   }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
@@ -313,7 +313,7 @@ public class RadiusCellTemplateTool extends AbstractDrawingTool implements Mouse
       AffineTransform newTransform = g.getTransform();
       newTransform.concatenate(getPaintTransform(renderer));
       g.setTransform(newTransform);
-      template.draw(g, pen);
+      template.draw(renderer.getZone(), g, pen);
       Paint paint = pen.getPaint() != null ? pen.getPaint().getPaint() : null;
       paintCursor(g, paint, pen.getThickness(), template.getVertex());
       g.setTransform(old);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
@@ -415,7 +415,7 @@ public class RadiusTemplateTool extends AbstractDrawingTool implements MouseMoti
       template.setRadius(getRadiusAtMouse(e));
       ZonePoint vertex = template.getVertex();
       ZonePoint newPoint = new ZonePoint(vertex.x, vertex.y);
-      completeDrawable(renderer.getZone().getId(), getPen(), template);
+      completeDrawable(getPen(), template);
       setIsEraser(false);
       resetTool(newPoint);
     }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
@@ -316,7 +316,7 @@ public class RadiusTemplateTool extends AbstractDrawingTool implements MouseMoti
       AffineTransform newTransform = g.getTransform();
       newTransform.concatenate(getPaintTransform(renderer));
       g.setTransform(newTransform);
-      template.draw(g, pen);
+      template.draw(renderer.getZone(), g, pen);
       Paint paint = pen.getPaint() != null ? pen.getPaint().getPaint() : null;
       paintCursor(g, paint, pen.getThickness(), template.getVertex());
       g.setTransform(old);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
@@ -220,7 +220,6 @@ public class RadiusTemplateTool extends AbstractDrawingTool implements MouseMoti
     } // endif
     template = createBaseTemplate();
     template.setVertex(vertex);
-    template.setZoneId(renderer.getZone().getId());
     controlOffset = null;
     renderer.repaint();
   }
@@ -357,7 +356,6 @@ public class RadiusTemplateTool extends AbstractDrawingTool implements MouseMoti
   @Override
   protected void detachFrom(ZoneRenderer renderer) {
     super.detachFrom(renderer);
-    template.setZoneId(null);
     renderer.repaint();
   }
 
@@ -366,7 +364,6 @@ public class RadiusTemplateTool extends AbstractDrawingTool implements MouseMoti
    */
   @Override
   protected void attachTo(ZoneRenderer renderer) {
-    template.setZoneId(renderer.getZone().getId());
     renderer.repaint();
     super.attachTo(renderer);
   }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleExposeTool.java
@@ -72,7 +72,7 @@ public class RectangleExposeTool extends RectangleTool {
     }
     Zone zone = getZone();
 
-    Rectangle bounds = drawable.getBounds();
+    Rectangle bounds = drawable.getBounds(zone);
     Area area = new Area(bounds);
     Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleExposeTool.java
@@ -64,17 +64,17 @@ public class RectangleExposeTool extends RectangleTool {
   }
 
   @Override
-  protected void completeDrawable(GUID zoneId, Pen pen, Drawable drawable) {
+  protected void completeDrawable(Pen pen, Drawable drawable) {
     if (!MapTool.getPlayer().isGM()) {
       MapTool.showError("msg.error.fogexpose");
       MapTool.getFrame().refresh();
       return;
     }
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
+    Zone zone = getZone();
 
     Rectangle bounds = drawable.getBounds();
     Area area = new Area(bounds);
-    Set<GUID> selectedToks = MapTool.getFrame().getCurrentZoneRenderer().getSelectedTokenSet();
+    Set<GUID> selectedToks = renderer.getSelectedTokenSet();
     if (pen.isEraser()) {
       zone.hideArea(area, selectedToks);
       MapTool.serverCommand().hideFoW(zone.getId(), area, selectedToks);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RectangleTool.java
@@ -94,7 +94,7 @@ public class RectangleTool extends AbstractDrawingTool implements MouseMotionLis
           rectangle.height *= 2;
         }
         // System.out.println("Adding Rectangle to zone: " + rectangle);
-        completeDrawable(renderer.getZone().getId(), getPen(), new ShapeDrawable(rectangle, false));
+        completeDrawable(getPen(), new ShapeDrawable(rectangle, false));
         rectangle = null;
       }
       setIsEraser(isEraser(e));

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1181,11 +1181,13 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
               tree.addSelectionInterval(rowIndex, rowIndex);
               if (row instanceof DrawnElement && e.getClickCount() == 2) {
                 DrawnElement de = (DrawnElement) row;
+                var renderer = getCurrentZoneRenderer();
+                var zone = renderer.getZone();
                 getCurrentZoneRenderer()
                     .centerOn(
                         new ZonePoint(
-                            (int) de.getDrawable().getBounds().getCenterX(),
-                            (int) de.getDrawable().getBounds().getCenterY()));
+                            (int) de.getDrawable().getBounds(zone).getCenterX(),
+                            (int) de.getDrawable().getBounds(zone).getCenterY()));
               }
               /*
                * int[] treeRows = tree.getSelectionRows(); java.util.Arrays.sort(treeRows); drawablesPanel.clearSelectedIds(); for (int i = 0; i < treeRows.length; i++) { TreePath p =

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -279,14 +279,14 @@ public class DrawPanelPopupMenu extends JPopupMenu {
         // only bother doing stuff if more than one selected
         List<DrawnElement> drawableList = renderer.getZone().getAllDrawnElements();
         Iterator<DrawnElement> iter = drawableList.iterator();
-        Area a = elementUnderMouse.getDrawable().getArea();
+        Area a = elementUnderMouse.getDrawable().getArea(renderer.getZone());
         while (iter.hasNext()) {
           DrawnElement de = iter.next();
           if (selectedDrawSet.contains(de.getDrawable().getId())) {
             renderer.getZone().removeDrawable(de.getDrawable().getId());
             MapTool.serverCommand().undoDraw(renderer.getZone().getId(), de.getDrawable().getId());
             de.getDrawable().setLayer(elementUnderMouse.getDrawable().getLayer());
-            if (!de.equals(elementUnderMouse)) a.add(de.getDrawable().getArea());
+            if (!de.equals(elementUnderMouse)) a.add(de.getDrawable().getArea(renderer.getZone()));
           }
         }
         Shape s = a;

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
@@ -80,7 +80,7 @@ public class DrawablesPanel extends JComponent {
           }
           if (drawableList.size() > 0) {
             Collections.reverse(drawableList);
-            Rectangle bounds = getBounds(drawableList);
+            Rectangle bounds = getBounds(zone, drawableList);
             double scale =
                 (double) Math.min(MAX_PANEL_SIZE, getSize().width) / (double) bounds.width;
             if ((bounds.height * scale) > MAX_PANEL_SIZE)
@@ -147,13 +147,16 @@ public class DrawablesPanel extends JComponent {
     return backBuffer;
   }
 
-  private Rectangle getBounds(List<DrawnElement> drawableList) {
+  private Rectangle getBounds(Zone zone, List<DrawnElement> drawableList) {
     Rectangle bounds = null;
     for (DrawnElement element : drawableList) {
       // Empty drawables are created by right clicking during the draw process
       // and need to be skipped.
-      if (element.getDrawable().getBounds() == null) continue;
-      Rectangle drawnBounds = new Rectangle(element.getDrawable().getBounds());
+      Rectangle drawnBounds = element.getDrawable().getBounds(zone);
+      if (drawnBounds == null) {
+        continue;
+      }
+      drawnBounds = new Rectangle(drawnBounds);
       // Handle pen size
       Pen pen = element.getPen();
       int penSize = pen.getForegroundMode() == Pen.MODE_TRANSPARENT ? 0 : (int) pen.getThickness();

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
@@ -85,7 +85,7 @@ public class DrawablesPanel extends JComponent {
                 (double) Math.min(MAX_PANEL_SIZE, getSize().width) / (double) bounds.width;
             if ((bounds.height * scale) > MAX_PANEL_SIZE)
               scale = (double) Math.min(MAX_PANEL_SIZE, getSize().height) / (double) bounds.height;
-            g.drawImage(drawDrawables(drawableList, bounds, scale, onlyCuts), 0, 0, null);
+            g.drawImage(drawDrawables(zone, drawableList, bounds, scale, onlyCuts), 0, 0, null);
           }
         }
       }
@@ -93,7 +93,11 @@ public class DrawablesPanel extends JComponent {
   }
 
   private BufferedImage drawDrawables(
-      List<DrawnElement> drawableList, Rectangle viewport, double scale, boolean showEraser) {
+      Zone zone,
+      List<DrawnElement> drawableList,
+      Rectangle viewport,
+      double scale,
+      boolean showEraser) {
     BufferedImage backBuffer =
         new BufferedImage(
             (int) (viewport.width * scale),
@@ -126,11 +130,17 @@ public class DrawablesPanel extends JComponent {
       if (drawable instanceof DrawablesGroup) {
         g.drawImage(
             drawDrawables(
-                ((DrawablesGroup) drawable).getDrawableList(), new Rectangle(viewport), 1, false),
+                zone,
+                ((DrawablesGroup) drawable).getDrawableList(),
+                new Rectangle(viewport),
+                1,
+                false),
             viewport.x,
             viewport.y,
             null);
-      } else drawable.draw(g, pen);
+      } else {
+        drawable.draw(zone, g, pen);
+      }
       g.setComposite(oldComposite);
     }
     g.dispose();

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -883,7 +883,7 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
       }
 
       Drawable drawable = element.getDrawable();
-      Rectangle drawnBounds = new Rectangle(drawable.getBounds());
+      Rectangle drawnBounds = new Rectangle(drawable.getBounds(zone));
 
       // Handle pen size
       // This slightly over-estimates the size of the pen, but we want to

--- a/src/main/java/net/rptools/maptool/client/ui/zone/DiskBasedPartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/DiskBasedPartitionedDrawableRenderer.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import javax.imageio.ImageIO;
 import net.rptools.lib.FileUtil;
 import net.rptools.maptool.client.AppUtil;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawnElement;
 import net.rptools.maptool.model.drawing.Pen;
@@ -45,6 +46,7 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
   private static final BufferedImage NO_IMAGE = new BufferedImage(1, 1, Transparency.OPAQUE);
   private static final int CHUNK_SIZE = 256;
 
+  private final Zone zone;
   private final Map<String, BufferedImage> chunkMap = new HashMap<String, BufferedImage>();
 
   private double lastScale;
@@ -67,7 +69,8 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
     }
   }
 
-  public DiskBasedPartitionedDrawableRenderer() {
+  public DiskBasedPartitionedDrawableRenderer(Zone zone) {
+    this.zone = zone;
     flush();
   }
 
@@ -230,7 +233,7 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
       // if (gridx == 0 && gridy == 1) {
       // System.out.println("draw");
       // }
-      drawable.draw(g, pen);
+      drawable.draw(zone, g, pen);
       g.setComposite(oldComposite);
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/DiskBasedPartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/DiskBasedPartitionedDrawableRenderer.java
@@ -196,7 +196,7 @@ public class DiskBasedPartitionedDrawableRenderer implements DrawableRenderer {
     for (DrawnElement element : drawableList) {
       Drawable drawable = element.getDrawable();
 
-      Rectangle2D drawnBounds = drawable.getBounds();
+      Rectangle2D drawnBounds = drawable.getBounds(zone);
       Rectangle2D chunkBounds =
           new Rectangle(
               (int) (gridx * (CHUNK_SIZE / scale)),

--- a/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
@@ -29,6 +29,7 @@ import java.util.*;
 import net.rptools.lib.CodeTimer;
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.maptool.client.DeveloperOptions;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawablesGroup;
 import net.rptools.maptool.model.drawing.DrawnElement;
@@ -44,6 +45,7 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
   private static final int CHUNK_SIZE = 256;
   private static List<BufferedImage> unusedChunkList = new LinkedList<BufferedImage>();
 
+  private final Zone zone;
   private final Set<String> noImageSet = new HashSet<String>();
   private final List<Tuple> chunkList = new LinkedList<Tuple>();
   private int maxChunks;
@@ -55,6 +57,10 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
   private int verticalChunkCount;
 
   private boolean dirty = false;
+
+  public PartitionedDrawableRenderer(Zone zone) {
+    this.zone = zone;
+  }
 
   public void flush() {
     int unusedSize = unusedChunkList.size();
@@ -280,7 +286,7 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
         Graphics2D g2 = image.createGraphics();
         g2.drawImage(groupImage, 0, 0, CHUNK_SIZE, CHUNK_SIZE, null);
         g2.dispose();
-      } else drawable.draw(g, pen);
+      } else drawable.draw(zone, g, pen);
       g.setComposite(oldComposite);
       timer.stop("createChunk:Draw");
     }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
@@ -224,12 +224,13 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
     for (DrawnElement element : drawableList) {
       timer.start("createChunk:calculate");
       Drawable drawable = element.getDrawable();
-      if (drawable.getBounds() == null) {
+      Rectangle drawableBounds = drawable.getBounds(zone);
+      if (drawableBounds == null) {
         timer.stop("createChunk:calculate");
         continue;
       }
 
-      Rectangle2D drawnBounds = new Rectangle(drawable.getBounds());
+      Rectangle2D drawnBounds = new Rectangle(drawableBounds);
       Rectangle2D chunkBounds =
           new Rectangle(
               (int) (gridx * (CHUNK_SIZE / scale)),

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -107,8 +107,7 @@ public class ZoneRenderer extends JComponent
   private final SelectionModel selectionModel;
 
   private Scale zoneScale;
-  private final Map<Zone.Layer, DrawableRenderer> drawableRenderers =
-      CollectionUtil.newFilledEnumMap(Zone.Layer.class, layer -> new PartitionedDrawableRenderer());
+  private final Map<Zone.Layer, DrawableRenderer> drawableRenderers;
   private final List<ZoneOverlay> overlayList = new ArrayList<ZoneOverlay>();
   private final Map<Zone.Layer, List<TokenLocation>> tokenLocationMap =
       new HashMap<Zone.Layer, List<TokenLocation>>();
@@ -172,6 +171,10 @@ public class ZoneRenderer extends JComponent
     this.zone = zone;
     zoneView = new ZoneView(zone);
     setZoneScale(new Scale());
+
+    drawableRenderers =
+        CollectionUtil.newFilledEnumMap(
+            Zone.Layer.class, layer -> new PartitionedDrawableRenderer(zone));
 
     var renderHelper = new RenderHelper(this, tempBufferPool);
     this.compositor = new ZoneCompositor();

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2087,7 +2087,7 @@ public class Zone {
     for (ListIterator<DrawnElement> drawnIter = list.listIterator(); drawnIter.hasNext(); ) {
       DrawnElement drawn = drawnIter.next();
       // Are we covered ourselves ?
-      Area drawnArea = drawn.getDrawable().getArea();
+      Area drawnArea = drawn.getDrawable().getArea(this);
       if (drawnArea == null) {
         continue;
       }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -37,7 +37,6 @@ import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.InitiativeList.TokenInitiative;
 import net.rptools.maptool.model.Token.TerrainModifierOperation;
-import net.rptools.maptool.model.drawing.AbstractTemplate;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
@@ -665,7 +664,6 @@ public class Zone {
     for (final var entry : drawablesByLayer.entrySet()) {
       entry.getValue().addAll(zone.drawablesByLayer.get(entry.getKey()));
     }
-    validateTemplateZoneIds();
 
     if (!zone.labels.isEmpty()) {
       for (GUID guid : zone.labels.keySet()) {
@@ -1507,17 +1505,6 @@ public class Zone {
     undo.addDrawable(pen, drawable);
   }
 
-  private void validateTemplateZoneIds() {
-    // Classes that extend Abstract template have a zone id so we need to make sure to update it
-    for (var list : drawablesByLayer.values()) {
-      for (var de : list) {
-        if (de.getDrawable() instanceof AbstractTemplate at) {
-          at.setZoneId(id);
-        }
-      }
-    }
-  }
-
   public boolean canUndo() {
     return undo.canUndo();
   }
@@ -2220,7 +2207,6 @@ public class Zone {
     drawablesByLayer.put(Layer.GM, gmDrawables);
     drawablesByLayer.put(Layer.OBJECT, objectDrawables);
     drawablesByLayer.put(Layer.BACKGROUND, backgroundDrawables);
-    validateTemplateZoneIds();
 
     return this;
   }
@@ -2347,8 +2333,6 @@ public class Zone {
     zone.tokenSelection = TokenSelection.valueOf(dto.getTokenSelection().name());
     zone.height = dto.getHeight();
     zone.width = dto.getWidth();
-
-    zone.validateTemplateZoneIds();
 
     return zone;
   }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2088,7 +2088,7 @@ public class Zone {
       DrawnElement drawn = drawnIter.next();
       // Are we covered ourselves ?
       Area drawnArea = drawn.getDrawable().getArea(this);
-      if (drawnArea == null) {
+      if (drawnArea.isEmpty()) {
         continue;
       }
       // The following is over-zealous optimization. Lines (1-dimensional) should be kept.

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -47,12 +47,8 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
     this.id = id;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see maptool.model.drawing.Drawable#draw(java.awt.Graphics2D, maptool.model.drawing.Pen)
-   */
-  public void draw(Graphics2D g, Pen pen) {
+  @Override
+  public void draw(Zone zone, Graphics2D g, Pen pen) {
     if (pen == null) {
       pen = Pen.DEFAULT;
     }
@@ -72,7 +68,7 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
         // **** Legacy support for 1.1
         g.setColor(new Color(pen.getBackgroundColor()));
       }
-      drawBackground(g);
+      drawBackground(zone, g);
     }
     if (pen.getForegroundMode() == Pen.MODE_SOLID) {
       if (pen.getPaint() != null) {
@@ -81,15 +77,15 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
         // **** Legacy support for 1.1
         g.setColor(new Color(pen.getColor()));
       }
-      draw(g);
+      draw(zone, g);
     }
     g.setComposite(oldComposite);
     g.setStroke(oldStroke);
   }
 
-  protected abstract void draw(Graphics2D g);
+  protected abstract void draw(Zone zone, Graphics2D g);
 
-  protected abstract void drawBackground(Graphics2D g);
+  protected abstract void drawBackground(Zone zone, Graphics2D g);
 
   @VisibleForTesting
   protected Campaign getCampaign() {

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
@@ -19,7 +19,6 @@ import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Line2D;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
@@ -183,15 +182,15 @@ public abstract class AbstractTemplate extends AbstractDrawing {
   /**
    * Paint the border or area of the template
    *
+   * @param zone The zone that is being painted
    * @param g Where to paint
    * @param border Paint the border?
    * @param area Paint the area?
    */
-  protected void paint(Graphics2D g, boolean border, boolean area) {
+  protected void paint(Zone zone, Graphics2D g, boolean border, boolean area) {
     if (radius == 0) {
       return;
     }
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
     if (zone == null) {
       return;
     }
@@ -331,25 +330,20 @@ public abstract class AbstractTemplate extends AbstractDrawing {
    * Overridden AbstractDrawing Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractDrawing#draw(java.awt.Graphics2D)
-   */
   @Override
-  protected void draw(Graphics2D g) {
-    paint(g, true, false);
+  protected void draw(Zone zone, Graphics2D g) {
+    paint(zone, g, true, false);
   }
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractDrawing#drawBackground(java.awt.Graphics2D)
-   */
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
 
     // Adjust alpha automatically
     Composite old = g.getComposite();
-    if (old != AlphaComposite.Clear)
+    if (old != AlphaComposite.Clear) {
       g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, DEFAULT_BG_ALPHA));
-    paint(g, false, true);
+    }
+    paint(zone, g, false, true);
     g.setComposite(old);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
@@ -41,9 +41,6 @@ public abstract class AbstractTemplate extends AbstractDrawing {
   /** The location of the vertex where painting starts. */
   private ZonePoint vertex = new ZonePoint(0, 0);
 
-  /** The id of the zone where this drawable is painted. */
-  private GUID zoneId;
-
   protected AbstractTemplate() {}
 
   protected AbstractTemplate(GUID id) {
@@ -159,24 +156,6 @@ public abstract class AbstractTemplate extends AbstractDrawing {
    */
   public void setVertex(ZonePoint vertex) {
     this.vertex = vertex;
-  }
-
-  /**
-   * Get the zoneId for this RadiusTemplate.
-   *
-   * @return Returns the current value of zoneId.
-   */
-  public GUID getZoneId() {
-    return zoneId;
-  }
-
-  /**
-   * Set the value of zoneId for this RadiusTemplate.
-   *
-   * @param zoneId The zoneId to set.
-   */
-  public void setZoneId(GUID zoneId) {
-    this.zoneId = zoneId;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -21,6 +21,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -175,7 +176,7 @@ public class BlastTemplate extends ConeTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     return renderer.getArea(zone);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -175,8 +175,8 @@ public class BlastTemplate extends ConeTemplate {
   }
 
   @Override
-  public Area getArea() {
-    return renderer.getArea();
+  public Area getArea(Zone zone) {
+    return renderer.getArea(zone);
   }
 
   public int getOffsetX() {

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -88,7 +88,7 @@ public class BlastTemplate extends ConeTemplate {
    *-------------------------------------------------------------------------------------------*/
 
   @Override
-  public Rectangle getBounds() {
+  public Rectangle getBounds(Zone zone) {
     Rectangle r = new Rectangle(renderer.getShape().getBounds());
     // We don't know pen width, so add some padding to account for it
     r.x -= 5;

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -167,7 +167,6 @@ public class BlastTemplate extends ConeTemplate {
     var dto = BlastTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto())
         .setDirection(getDirection().name())

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -160,23 +160,17 @@ public class BlastTemplate extends ConeTemplate {
    * Overridden AbstractDrawing Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractDrawing#draw(java.awt.Graphics2D)
-   */
   @Override
-  protected void draw(Graphics2D g) {
-    renderer.draw(g);
+  protected void draw(Zone zone, Graphics2D g) {
+    renderer.draw(zone, g);
   }
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractDrawing#drawBackground(java.awt.Graphics2D)
-   */
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     Composite old = g.getComposite();
     if (old != AlphaComposite.Clear)
       g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, DEFAULT_BG_ALPHA));
-    renderer.drawBackground(g);
+    renderer.drawBackground(zone, g);
     g.setComposite(old);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -21,6 +21,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -142,7 +143,7 @@ public class BurstTemplate extends RadiusTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     return renderer.getArea(zone);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -142,8 +142,8 @@ public class BurstTemplate extends RadiusTemplate {
   }
 
   @Override
-  public Area getArea() {
-    return renderer.getArea();
+  public Area getArea(Zone zone) {
+    return renderer.getArea(zone);
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -112,7 +112,7 @@ public class BurstTemplate extends RadiusTemplate {
   }
 
   @Override
-  public Rectangle getBounds() {
+  public Rectangle getBounds(Zone zone) {
     Rectangle r = new Rectangle(renderer.getShape().getBounds());
     // We don't know pen width, so add some padding to account for it
     r.x -= 5;

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -116,7 +116,6 @@ public class BurstTemplate extends RadiusTemplate {
     var dto = BurstTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto());
 

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -126,24 +126,18 @@ public class BurstTemplate extends RadiusTemplate {
    * Overridden AbstractDrawing Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractDrawing#draw(java.awt.Graphics2D)
-   */
   @Override
-  protected void draw(Graphics2D g) {
-    renderer.draw(g);
-    vertexRenderer.draw(g);
+  protected void draw(Zone zone, Graphics2D g) {
+    renderer.draw(zone, g);
+    vertexRenderer.draw(zone, g);
   }
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractDrawing#drawBackground(java.awt.Graphics2D)
-   */
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     Composite old = g.getComposite();
     if (old != AlphaComposite.Clear)
       g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, DEFAULT_BG_ALPHA));
-    renderer.drawBackground(g);
+    renderer.drawBackground(zone, g);
     g.setComposite(old);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -307,11 +307,7 @@ public class ConeTemplate extends RadiusTemplate {
   }
 
   @Override
-  public Area getArea() {
-    if (getZoneId() == null) {
-      return new Area();
-    }
-    Zone zone = getCampaign().getZone(getZoneId());
+  public Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -336,7 +336,6 @@ public class ConeTemplate extends RadiusTemplate {
     var dto = ConeTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto())
         .setDirection(getDirection().name());

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -19,7 +19,6 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
 import javax.annotation.Nonnull;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
@@ -258,21 +257,9 @@ public class ConeTemplate extends RadiusTemplate {
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
-    if (MapTool.getCampaign().getZone(getZoneId()) == null) {
-      // How does this happen ?! Anyway, try to use the current zone (since that's what we're
-      // drawing anyway, seems reasonable
-      if (MapTool.getFrame().getCurrentZoneRenderer() == null) {
-        // Wha?!
-        return new Rectangle();
-      }
-      setZoneId(MapTool.getFrame().getCurrentZoneRenderer().getZone().getId());
-    }
-
-    int gridSize = MapTool.getCampaign().getZone(getZoneId()).getGrid().getSize();
+  @Override
+  public Rectangle getBounds(Zone zone) {
+    int gridSize = zone.getGrid().getSize();
     int quadrantSize = getRadius() * gridSize + BOUNDS_PADDING;
 
     // Find the x,y loc

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -18,6 +18,7 @@ import com.google.protobuf.StringValue;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -307,7 +308,7 @@ public class ConeTemplate extends RadiusTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/Cross.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Cross.java
@@ -45,7 +45,7 @@ public class Cross extends AbstractDrawing {
 
   @Override
   public @Nonnull Area getArea(Zone zone) {
-    return new Area(getBounds());
+    return new Area(getBounds(zone));
   }
 
   @Override
@@ -62,13 +62,8 @@ public class Cross extends AbstractDrawing {
     return DrawableDto.newBuilder().setCrossDrawable(dto).build();
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public java.awt.Rectangle getBounds() {
-
+  @Override
+  public java.awt.Rectangle getBounds(Zone zone) {
     if (bounds == null) {
       int x = Math.min(startPoint.x, endPoint.x);
       int y = Math.min(startPoint.y, endPoint.y);

--- a/src/main/java/net/rptools/maptool/model/drawing/Cross.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Cross.java
@@ -20,6 +20,7 @@ import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.geom.Area;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.CrossDrawableDto;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
@@ -86,7 +87,8 @@ public class Cross extends AbstractDrawing {
     return endPoint;
   }
 
-  protected void draw(Graphics2D g) {
+  @Override
+  protected void draw(Zone zone, Graphics2D g) {
 
     int minX = Math.min(startPoint.x, endPoint.x);
     int minY = Math.min(startPoint.y, endPoint.y);
@@ -104,7 +106,8 @@ public class Cross extends AbstractDrawing {
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldAA);
   }
 
-  protected void drawBackground(Graphics2D g) {
+  @Override
+  protected void drawBackground(Zone zone, Graphics2D g) {
     int minX = Math.min(startPoint.x, endPoint.x);
     int minY = Math.min(startPoint.y, endPoint.y);
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Cross.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Cross.java
@@ -19,6 +19,7 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
@@ -43,7 +44,7 @@ public class Cross extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     return new Area(getBounds());
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Cross.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Cross.java
@@ -42,7 +42,8 @@ public class Cross extends AbstractDrawing {
     endPoint = new Point(endX, endY);
   }
 
-  public Area getArea() {
+  @Override
+  public Area getArea(Zone zone) {
     return new Area(getBounds());
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -34,7 +34,7 @@ public interface Drawable {
 
   java.awt.Rectangle getBounds();
 
-  Area getArea();
+  Area getArea(Zone zone);
 
   GUID getId();
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.LogManager;
  */
 public interface Drawable {
 
-  void draw(Graphics2D g, Pen pen);
+  void draw(Zone zone, Graphics2D g, Pen pen);
 
   java.awt.Rectangle getBounds();
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -33,7 +33,7 @@ public interface Drawable {
 
   void draw(Zone zone, Graphics2D g, Pen pen);
 
-  java.awt.Rectangle getBounds();
+  java.awt.Rectangle getBounds(Zone zone);
 
   @Nonnull
   Area getArea(Zone zone);

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -127,7 +127,6 @@ public interface Drawable {
         var dto = drawableDto.getRadiusCellTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new RadiusCellTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -139,7 +138,6 @@ public interface Drawable {
         var dto = drawableDto.getLineCellTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new LineCellTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -155,7 +153,6 @@ public interface Drawable {
         var dto = drawableDto.getRadiusTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new RadiusTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -167,7 +164,6 @@ public interface Drawable {
         var dto = drawableDto.getBurstTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new BurstTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -179,7 +175,6 @@ public interface Drawable {
         var dto = drawableDto.getConeTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new ConeTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -192,7 +187,6 @@ public interface Drawable {
         var dto = drawableDto.getBlastTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new BlastTemplate(id, dto.getOffsetX(), dto.getOffsetY());
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -205,7 +199,6 @@ public interface Drawable {
         var dto = drawableDto.getLineTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new LineTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
@@ -224,7 +217,6 @@ public interface Drawable {
         var dto = drawableDto.getWallTemplate();
         var id = GUID.valueOf(dto.getId());
         var drawable = new WallTemplate(id);
-        drawable.setZoneId(GUID.valueOf(dto.getZoneId()));
         drawable.setRadius(dto.getRadius());
         var vertex = dto.getVertex();
         drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.model.drawing;
 import java.awt.Graphics2D;
 import java.awt.geom.Area;
 import java.util.ArrayList;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -34,6 +35,7 @@ public interface Drawable {
 
   java.awt.Rectangle getBounds();
 
+  @Nonnull
   Area getArea(Zone zone);
 
   GUID getId();

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -19,6 +19,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
 import java.util.List;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
@@ -65,18 +66,18 @@ public class DrawablesGroup extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea(Zone zone) {
-    Area area = null;
+  public @Nonnull Area getArea(Zone zone) {
+    Area area = new Area();
     for (DrawnElement element : drawableList) {
       boolean isEraser = element.getPen().isEraser();
-      if (area == null) {
-        if (!isEraser) area = new Area(element.getDrawable().getArea(zone));
-      } else {
-        if (isEraser) {
+
+      if (isEraser) {
+        // Optimization: erasing from nothing is a no-op.
+        if (!area.isEmpty()) {
           area.subtract(element.getDrawable().getArea(zone));
-        } else {
-          area.add(element.getDrawable().getArea(zone));
         }
+      } else {
+        area.add(element.getDrawable().getArea(zone));
       }
     }
     return area;

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -46,10 +46,10 @@ public class DrawablesGroup extends AbstractDrawing {
   }
 
   @Override
-  public Rectangle getBounds() {
+  public Rectangle getBounds(Zone zone) {
     Rectangle bounds = null;
     for (DrawnElement element : drawableList) {
-      Rectangle drawnBounds = new Rectangle(element.getDrawable().getBounds());
+      Rectangle drawnBounds = new Rectangle(element.getDrawable().getBounds(zone));
       // Handle pen size
       Pen pen = element.getPen();
       int penSize = (int) (pen.getThickness() / 2 + 1);

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -65,17 +65,17 @@ public class DrawablesGroup extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea() {
+  public Area getArea(Zone zone) {
     Area area = null;
     for (DrawnElement element : drawableList) {
       boolean isEraser = element.getPen().isEraser();
       if (area == null) {
-        if (!isEraser) area = new Area(element.getDrawable().getArea());
+        if (!isEraser) area = new Area(element.getDrawable().getArea(zone));
       } else {
         if (isEraser) {
-          area.subtract(element.getDrawable().getArea());
+          area.subtract(element.getDrawable().getArea(zone));
         } else {
-          area.add(element.getDrawable().getArea());
+          area.add(element.getDrawable().getArea(zone));
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -20,6 +20,7 @@ import java.awt.Rectangle;
 import java.awt.geom.Area;
 import java.util.List;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.DrawablesGroupDto;
 
@@ -93,15 +94,15 @@ public class DrawablesGroup extends AbstractDrawing {
   }
 
   @Override
-  protected void draw(Graphics2D g) {
+  protected void draw(Zone zone, Graphics2D g) {
     // This should never be called
     for (DrawnElement element : drawableList) {
-      element.getDrawable().draw(g, element.getPen());
+      element.getDrawable().draw(zone, g, element.getPen());
     }
   }
 
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     // This should never be called
   }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
@@ -19,6 +19,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import javax.swing.CellRendererPane;
 import net.rptools.maptool.client.swing.TwoToneTextPane;
 import net.rptools.maptool.client.tool.drawing.DrawnTextTool;
@@ -99,8 +100,8 @@ public class DrawnLabel extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea(Zone zone) {
-    return null;
+  public @Nonnull Area getArea(Zone zone) {
+    return new Area();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
@@ -37,7 +37,7 @@ import net.rptools.maptool.server.proto.drawing.DrawnLabelDto;
 public class DrawnLabel extends AbstractDrawing {
 
   /** The bounds of the display rectangle */
-  private Rectangle bounds = new Rectangle();
+  private Rectangle bounds;
 
   /** Text being painted. */
   private String text;
@@ -92,10 +92,8 @@ public class DrawnLabel extends AbstractDrawing {
   @Override
   protected void drawBackground(Zone zone, Graphics2D g) {}
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
+  @Override
+  public Rectangle getBounds(Zone zone) {
     return bounds;
   }
 
@@ -109,7 +107,7 @@ public class DrawnLabel extends AbstractDrawing {
     var dto = DrawnLabelDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setBounds(Mapper.map(getBounds()))
+        .setBounds(Mapper.map(bounds))
         .setText(getText())
         .setFont(getFont());
 

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
@@ -98,8 +98,8 @@ public class DrawnLabel extends AbstractDrawing {
     return bounds;
   }
 
-  public Area getArea() {
-    // TODO Auto-generated method stub
+  @Override
+  public Area getArea(Zone zone) {
     return null;
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
@@ -23,6 +23,7 @@ import javax.swing.CellRendererPane;
 import net.rptools.maptool.client.swing.TwoToneTextPane;
 import net.rptools.maptool.client.tool.drawing.DrawnTextTool;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.DrawnLabelDto;
@@ -78,11 +79,7 @@ public class DrawnLabel extends AbstractDrawing {
     return font;
   }
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#draw(java.awt.Graphics2D,
-   *     net.rptools.maptool.model.drawing.Pen)
-   */
-  public void draw(Graphics2D aG) {
+  public void draw(Zone zone, Graphics2D aG) {
     if (renderer == null) {
       renderer = new CellRendererPane();
       textPane = DrawnTextTool.createTextPane(bounds, null, font);
@@ -92,7 +89,7 @@ public class DrawnLabel extends AbstractDrawing {
   }
 
   @Override
-  protected void drawBackground(Graphics2D g) {}
+  protected void drawBackground(Zone zone, Graphics2D g) {}
 
   /**
    * @see net.rptools.maptool.model.drawing.Drawable#getBounds()

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -112,20 +112,9 @@ public class LineCellTemplate extends AbstractTemplate {
     if (!noPaint[3]) paintCloseHorizontalBorder(g, xOff, yOff, gridSize, getQuadrant());
   }
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractTemplate#paint(java.awt.Graphics2D, boolean,
-   *     boolean)
-   */
   @Override
-  protected void paint(Graphics2D g, boolean border, boolean area) {
-    if (MapTool.getCampaign().getZone(getZoneId()) == null) {
-      return;
-    }
-    // Need to paint? We need a line and to translate the painting
-    if (pathVertex == null) {
-      return;
-    }
-    if (getRadius() == 0) {
+  protected void paint(Zone zone, Graphics2D g, boolean border, boolean area) {
+    if (zone == null) {
       return;
     }
     final var path = getPath();
@@ -134,7 +123,7 @@ public class LineCellTemplate extends AbstractTemplate {
     }
 
     // Paint each element in the path
-    int gridSize = MapTool.getCampaign().getZone(getZoneId()).getGrid().getSize();
+    int gridSize = zone.getGrid().getSize();
     ListIterator<CellPoint> i = path.listIterator();
     while (i.hasNext()) {
       CellPoint p = i.next();

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -401,7 +401,7 @@ public class LineCellTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -447,7 +447,6 @@ public class LineCellTemplate extends AbstractTemplate {
     var dto = LineCellTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto());
 

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.ListIterator;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -343,12 +342,9 @@ public class LineCellTemplate extends AbstractTemplate {
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
+  @Override
+  public Rectangle getBounds(Zone zone) {
     // Get all of the numbers needed for the calculation
-    final var zone = MapTool.getCampaign().getZone(getZoneId());
     if (zone == null) {
       return new Rectangle();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -401,13 +401,16 @@ public class LineCellTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea() {
-    Zone zone = MapTool.getCampaign().getZone(getZoneId());
-
-    final var path = getPath();
-    if (path == null || zone == null || getRadius() == 0 || pathVertex == null) {
+  public Area getArea(Zone zone) {
+    if (zone == null) {
       return new Area();
     }
+
+    final var path = getPath();
+    if (path == null) {
+      return new Area();
+    }
+
     // Create an area by merging all the squares along the path
     Area result = new Area();
     int gridSize = zone.getGrid().getSize();

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -23,6 +23,7 @@ import java.awt.geom.Area;
 import java.awt.geom.GeneralPath;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -75,11 +76,11 @@ public class LineSegment extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     if (area == null) {
       area = createLineArea();
     }
-    return area;
+    return Objects.requireNonNullElseGet(area, Area::new);
   }
 
   @Override
@@ -97,7 +98,9 @@ public class LineSegment extends AbstractDrawing {
   }
 
   private Area createLineArea() {
-    if (points.size() < 1) return null;
+    if (points.size() < 1) {
+      return null;
+    }
     GeneralPath gp = null;
     for (Point point : points) {
       if (gp == null) {
@@ -116,7 +119,7 @@ public class LineSegment extends AbstractDrawing {
     width = ((BasicStroke) g.getStroke()).getLineWidth();
     squareCap = ((BasicStroke) g.getStroke()).getEndCap() == BasicStroke.CAP_SQUARE;
     Area area = getArea(zone);
-    if (area != null) g.fill(area);
+    g.fill(area);
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -74,7 +74,8 @@ public class LineSegment extends AbstractDrawing {
     return points;
   }
 
-  public Area getArea() {
+  @Override
+  public Area getArea(Zone zone) {
     if (area == null) {
       area = createLineArea();
     }
@@ -114,7 +115,7 @@ public class LineSegment extends AbstractDrawing {
   protected void draw(Zone zone, Graphics2D g) {
     width = ((BasicStroke) g.getStroke()).getLineWidth();
     squareCap = ((BasicStroke) g.getStroke()).getEndCap() == BasicStroke.CAP_SQUARE;
-    Area area = getArea();
+    Area area = getArea(zone);
     if (area != null) g.fill(area);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.LineSegmentDrawableDto;
@@ -110,7 +111,7 @@ public class LineSegment extends AbstractDrawing {
   }
 
   @Override
-  protected void draw(Graphics2D g) {
+  protected void draw(Zone zone, Graphics2D g) {
     width = ((BasicStroke) g.getStroke()).getLineWidth();
     squareCap = ((BasicStroke) g.getStroke()).getEndCap() == BasicStroke.CAP_SQUARE;
     Area area = getArea();
@@ -118,7 +119,7 @@ public class LineSegment extends AbstractDrawing {
   }
 
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     // do nothing
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -127,12 +127,8 @@ public class LineSegment extends AbstractDrawing {
     // do nothing
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
+  @Override
+  public Rectangle getBounds(Zone zone) {
     if (lastPointCount == points.size()) {
       return cachedBounds;
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -118,22 +118,18 @@ public class LineTemplate extends AbstractTemplate {
     if (!noPaint[3]) paintCloseHorizontalBorder(g, xOff, yOff, gridSize, getQuadrant());
   }
 
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractTemplate#paint(java.awt.Graphics2D, boolean,
-   *     boolean)
-   */
   @Override
-  protected void paint(Graphics2D g, boolean border, boolean area) {
-    if (MapTool.getCampaign().getZone(getZoneId()) == null) {
+  protected void paint(Zone zone, Graphics2D g, boolean border, boolean area) {
+    if (zone == null) {
       return;
     }
     // Need to paint? We need a line and to translate the painting
-    if (pathVertex == null) return;
-    if (getRadius() == 0) return;
-    if (calcPath() == null) return;
+    if (pathVertex == null || getRadius() == 0 || calcPath() == null) {
+      return;
+    }
 
     // Paint each element in the path
-    int gridSize = MapTool.getCampaign().getZone(getZoneId()).getGrid().getSize();
+    int gridSize = zone.getGrid().getSize();
     ListIterator<CellPoint> i = path.listIterator();
     while (i.hasNext()) {
       CellPoint p = i.next();

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -24,6 +24,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.CellPoint;
@@ -448,7 +449,7 @@ public class LineTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     if (path == null) {
       calcPath();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -448,11 +448,10 @@ public class LineTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea() {
+  public Area getArea(Zone zone) {
     if (path == null) {
       calcPath();
     }
-    Zone zone = MapTool.getCampaign().getZone(getZoneId());
     if (path == null || zone == null || getRadius() == 0 || pathVertex == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.ListIterator;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.client.AppState;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -381,15 +380,13 @@ public class LineTemplate extends AbstractTemplate {
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
+  @Override
+  public Rectangle getBounds(Zone zone) {
     // Get all of the numbers needed for the calculation
-    if (MapTool.getCampaign().getZone(getZoneId()) == null) {
+    if (zone == null) {
       return new Rectangle();
     }
-    int gridSize = MapTool.getCampaign().getZone(getZoneId()).getGrid().getSize();
+    int gridSize = zone.getGrid().getSize();
     ZonePoint vertex = getVertex();
 
     // Find the point that is farthest away in the path, then adjust
@@ -403,7 +400,7 @@ public class LineTemplate extends AbstractTemplate {
       }
     }
     for (CellPoint pt : path) {
-      ZonePoint p = MapTool.getCampaign().getZone(getZoneId()).getGrid().convert(pt);
+      ZonePoint p = zone.getGrid().convert(pt);
       p = new ZonePoint(vertex.x + p.x, vertex.y + p.y);
 
       if (minp == null) {

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -476,7 +476,6 @@ public class LineTemplate extends AbstractTemplate {
     var dto = LineTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto())
         .setMouseSlopeGreater(isMouseSlopeGreater())

--- a/src/main/java/net/rptools/maptool/model/drawing/Oval.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Oval.java
@@ -19,6 +19,7 @@ import java.awt.Graphics2D;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.OvalDrawableDto;
@@ -40,7 +41,7 @@ public class Oval extends Rectangle {
   }
 
   @Override
-  protected void draw(Graphics2D g) {
+  protected void draw(Zone zone, Graphics2D g) {
     int minX = Math.min(startPoint.x, endPoint.x);
     int minY = Math.min(startPoint.y, endPoint.y);
 
@@ -51,7 +52,7 @@ public class Oval extends Rectangle {
   }
 
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     int minX = Math.min(startPoint.x, endPoint.x);
     int minY = Math.min(startPoint.y, endPoint.y);
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Oval.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Oval.java
@@ -63,7 +63,7 @@ public class Oval extends Rectangle {
   }
 
   @Override
-  public Area getArea() {
+  public Area getArea(Zone zone) {
     java.awt.Rectangle r = getBounds();
     return new Area(new Ellipse2D.Double(r.x, r.y, r.width, r.height));
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/Oval.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Oval.java
@@ -18,6 +18,7 @@ import com.google.protobuf.StringValue;
 import java.awt.Graphics2D;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
@@ -63,7 +64,7 @@ public class Oval extends Rectangle {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     java.awt.Rectangle r = getBounds();
     return new Area(new Ellipse2D.Double(r.x, r.y, r.width, r.height));
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/Oval.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Oval.java
@@ -65,7 +65,7 @@ public class Oval extends Rectangle {
 
   @Override
   public @Nonnull Area getArea(Zone zone) {
-    java.awt.Rectangle r = getBounds();
+    java.awt.Rectangle r = getBounds(zone);
     return new Area(new Ellipse2D.Double(r.x, r.y, r.width, r.height));
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -278,7 +278,6 @@ public class RadiusCellTemplate extends AbstractTemplate {
     var dto = RadiusCellTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto());
 

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -17,10 +17,8 @@ package net.rptools.maptool.model.drawing;
 import com.google.protobuf.StringValue;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.Shape;
 import java.awt.geom.Area;
 import javax.annotation.Nonnull;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
@@ -34,13 +32,6 @@ import net.rptools.maptool.server.proto.drawing.RadiusCellTemplateDto;
  * @author naciron
  */
 public class RadiusCellTemplate extends AbstractTemplate {
-
-  /** Renderer for the blast. The {@link Shape} is just a rectangle. */
-  private final ShapeDrawable renderer = new ShapeDrawable(new Rectangle());
-
-  /** Renderer for the blast. The {@link Shape} is just a rectangle. */
-  private final ShapeDrawable vertexRenderer = new ShapeDrawable(new Rectangle());
-
   public RadiusCellTemplate() {}
 
   public RadiusCellTemplate(GUID id) {
@@ -237,40 +228,6 @@ public class RadiusCellTemplate extends AbstractTemplate {
   }
 
   /**
-   * This methods adjusts the rectangle in the renderer to match the new radius, vertex, or
-   * direction. Due to the fact that it is impossible to draw to the cardinal directions evenly when
-   * the radius is an even number and still stay in the squares, that case isn't allowed.
-   */
-  private void adjustShape() {
-    if (getZoneId() == null) return;
-    Zone zone;
-    if (MapTool.isHostingServer()) {
-      zone = MapTool.getServer().getCampaign().getZone(getZoneId());
-    } else {
-      zone = MapTool.getCampaign().getZone(getZoneId());
-    }
-    if (zone == null) return;
-
-    int gridSize = zone.getGrid().getSize();
-    Rectangle r = (Rectangle) vertexRenderer.getShape();
-    r.setBounds(getVertex().x, getVertex().y, gridSize, gridSize);
-    r = (Rectangle) renderer.getShape();
-    r.setBounds(getVertex().x, getVertex().y, gridSize, gridSize);
-    r.x -= getRadius() * gridSize;
-    r.y -= getRadius() * gridSize;
-    r.width = r.height = (getRadius() * 2 + 1) * gridSize;
-  }
-
-  /**
-   * @see net.rptools.maptool.model.drawing.AbstractTemplate#setRadius(int)
-   */
-  @Override
-  public void setRadius(int squares) {
-    super.setRadius(squares);
-    adjustShape();
-  }
-
-  /**
    * Get the distance to a specific coordinate.
    *
    * @param x delta-X of the coordinate.
@@ -283,16 +240,6 @@ public class RadiusCellTemplate extends AbstractTemplate {
     if (x > y) distance = x + (y / 2) + 1 + (y & 1);
     else distance = y + (x / 2) + 1 + (x & 1);
     return distance;
-  }
-
-  /**
-   * @see
-   *     net.rptools.maptool.model.drawing.AbstractTemplate#setVertex(net.rptools.maptool.model.ZonePoint)
-   */
-  @Override
-  public void setVertex(ZonePoint vertex) {
-    super.setVertex(vertex);
-    adjustShape();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -219,15 +219,8 @@ public class RadiusCellTemplate extends AbstractTemplate {
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
-    if (getZoneId() == null) {
-      // This avoids a NPE when loading up a campaign
-      return new Rectangle();
-    }
-    Zone zone = MapTool.getCampaign().getZone(getZoneId());
+  @Override
+  public Rectangle getBounds(Zone zone) {
     if (zone == null) {
       return new Rectangle();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -150,20 +150,13 @@ public class RadiusCellTemplate extends AbstractTemplate {
     }
   }
 
-  /**
-   * Paint the border or area of the template
-   *
-   * @param g Where to paint
-   * @param border Paint the border?
-   * @param area Paint the area?
-   */
-  protected void paint(Graphics2D g, boolean border, boolean area) {
+  @Override
+  protected void paint(Zone zone, Graphics2D g, boolean border, boolean area) {
     int radius = getRadius();
-    GUID zoneId = getZoneId();
 
-    if (radius == 0) return;
-    Zone zone = MapTool.getCampaign().getZone(zoneId);
-    if (zone == null) return;
+    if (zone == null || radius == 0) {
+      return;
+    }
 
     // Find the proper distance
     int gridSize = zone.getGrid().getSize();
@@ -175,8 +168,12 @@ public class RadiusCellTemplate extends AbstractTemplate {
         int yOff = y * gridSize;
 
         // Template specific painting
-        if (border) paintBorder(g, x, y, xOff, yOff, gridSize, getDistance(x, y));
-        if (area) paintArea(g, x, y, xOff, yOff, gridSize, getDistance(x, y));
+        if (border) {
+          paintBorder(g, x, y, xOff, yOff, gridSize, getDistance(x, y));
+        }
+        if (area) {
+          paintArea(g, x, y, xOff, yOff, gridSize, getDistance(x, y));
+        }
       } // endfor
     } // endfor
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -302,11 +302,7 @@ public class RadiusCellTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea() {
-    if (getZoneId() == null) {
-      return new Area();
-    }
-    Zone zone = getCampaign().getZone(getZoneId());
+  public Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -19,6 +19,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -302,7 +303,7 @@ public class RadiusCellTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
@@ -17,9 +17,7 @@ package net.rptools.maptool.model.drawing;
 import com.google.protobuf.StringValue;
 import java.awt.*;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
-import java.awt.geom.PathIterator;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -137,15 +135,8 @@ public class RadiusTemplate extends AbstractTemplate {
         vertex.x - quadrantSize, vertex.y - quadrantSize, quadrantSize * 2, quadrantSize * 2);
   }
 
-  public PathIterator getPathIterator() {
-    return getArea().getPathIterator(new AffineTransform());
-  }
-
-  public Area getArea() {
-    if (getZoneId() == null) {
-      return new Area();
-    }
-    Zone zone = getCampaign().getZone(getZoneId());
+  @Override
+  public Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
@@ -159,7 +159,6 @@ public class RadiusTemplate extends AbstractTemplate {
     var dto = RadiusTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto());
 

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
@@ -19,7 +19,6 @@ import java.awt.*;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
 import javax.annotation.Nonnull;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
@@ -117,15 +116,8 @@ public class RadiusTemplate extends AbstractTemplate {
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public Rectangle getBounds() {
-    if (getZoneId() == null) {
-      // This avoids a NPE when loading up a campaign
-      return new Rectangle();
-    }
-    Zone zone = MapTool.getCampaign().getZone(getZoneId());
+  @Override
+  public Rectangle getBounds(Zone zone) {
     if (zone == null) {
       return new Rectangle();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
@@ -18,6 +18,7 @@ import com.google.protobuf.StringValue;
 import java.awt.*;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -136,7 +137,7 @@ public class RadiusTemplate extends AbstractTemplate {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     if (zone == null) {
       return new Area();
     }

--- a/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
@@ -45,7 +45,7 @@ public class Rectangle extends AbstractDrawing {
 
   @Override
   public @Nonnull Area getArea(Zone zone) {
-    return new Area(getBounds());
+    return new Area(getBounds(zone));
   }
 
   @Override
@@ -62,12 +62,8 @@ public class Rectangle extends AbstractDrawing {
     return DrawableDto.newBuilder().setRectangleDrawable(dto).build();
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
-  public java.awt.Rectangle getBounds() {
+  @Override
+  public java.awt.Rectangle getBounds(Zone zone) {
     if (bounds == null) {
       int x = Math.min(startPoint.x, endPoint.x);
       int y = Math.min(startPoint.y, endPoint.y);

--- a/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
@@ -42,7 +42,8 @@ public class Rectangle extends AbstractDrawing {
     endPoint = new Point(endX, endY);
   }
 
-  public Area getArea() {
+  @Override
+  public Area getArea(Zone zone) {
     return new Area(getBounds());
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
@@ -20,6 +20,7 @@ import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.geom.Area;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.RectangleDrawableDto;
@@ -85,7 +86,7 @@ public class Rectangle extends AbstractDrawing {
   }
 
   @Override
-  protected void draw(Graphics2D g) {
+  protected void draw(Zone zone, Graphics2D g) {
     int minX = Math.min(startPoint.x, endPoint.x);
     int minY = Math.min(startPoint.y, endPoint.y);
 
@@ -99,7 +100,7 @@ public class Rectangle extends AbstractDrawing {
   }
 
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     int minX = Math.min(startPoint.x, endPoint.x);
     int minY = Math.min(startPoint.y, endPoint.y);
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
@@ -19,6 +19,7 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
@@ -43,7 +44,7 @@ public class Rectangle extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     return new Area(getBounds());
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -50,13 +50,13 @@ public class ShapeDrawable extends AbstractDrawing {
     return useAntiAliasing;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see net.rptools.maptool.model.drawing.Drawable#getBounds()
-   */
   public java.awt.Rectangle getBounds() {
     return shape.getBounds();
+  }
+
+  @Override
+  public java.awt.Rectangle getBounds(Zone zone) {
+    return getBounds();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -20,6 +20,7 @@ import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.Area;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.ShapeDrawableDto;
@@ -77,14 +78,14 @@ public class ShapeDrawable extends AbstractDrawing {
   }
 
   @Override
-  protected void draw(Graphics2D g) {
+  protected void draw(Zone zone, Graphics2D g) {
     Object oldAA = applyAA(g);
     g.draw(shape);
     restoreAA(g, oldAA);
   }
 
   @Override
-  protected void drawBackground(Graphics2D g) {
+  protected void drawBackground(Zone zone, Graphics2D g) {
     Object oldAA = applyAA(g);
     g.fill(shape);
     restoreAA(g, oldAA);

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -19,6 +19,7 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.Area;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.server.Mapper;
@@ -59,7 +60,7 @@ public class ShapeDrawable extends AbstractDrawing {
   }
 
   @Override
-  public Area getArea(Zone zone) {
+  public @Nonnull Area getArea(Zone zone) {
     return new Area(shape);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -58,7 +58,8 @@ public class ShapeDrawable extends AbstractDrawing {
     return shape.getBounds();
   }
 
-  public Area getArea() {
+  @Override
+  public Area getArea(Zone zone) {
     return new Area(shape);
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/WallTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/WallTemplate.java
@@ -80,7 +80,6 @@ public class WallTemplate extends LineTemplate {
     var dto = WallTemplateDto.newBuilder();
     dto.setId(getId().toString())
         .setLayer(getLayer().name())
-        .setZoneId(getZoneId().toString())
         .setRadius(getRadius())
         .setVertex(getVertex().toDto())
         .setMouseSlopeGreater(isMouseSlopeGreater())

--- a/src/main/proto/drawing_dto.proto
+++ b/src/main/proto/drawing_dto.proto
@@ -57,66 +57,60 @@ message WallTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
-  bool mouse_slope_greater = 7;
-  IntPointDto path_vertex = 8;
-  bool double_wide = 9;
-  repeated IntPointDto points = 10;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
+  bool mouse_slope_greater = 6;
+  IntPointDto path_vertex = 7;
+  bool double_wide = 8;
+  repeated IntPointDto points = 9;
 }
 
 message LineTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
-  bool mouse_slope_greater = 7;
-  string quadrant = 8;
-  IntPointDto path_vertex = 9;
-  bool double_wide = 10;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
+  bool mouse_slope_greater = 6;
+  string quadrant = 7;
+  IntPointDto path_vertex = 8;
+  bool double_wide = 9;
 }
 
 message BlastTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
-  string direction = 7;
-  int32 offset_x = 8;
-  int32 offset_y = 9;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
+  string direction = 6;
+  int32 offset_x = 7;
+  int32 offset_y = 8;
 }
 
 message ConeTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
-  string direction = 7;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
+  string direction = 6;
 }
 
 message BurstTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
 }
 
 message RadiusTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
 }
 
 message LineCellTemplateDto {
@@ -133,9 +127,8 @@ message RadiusCellTemplateDto {
   string id = 1;
   string layer = 2;
   google.protobuf.StringValue name = 3;
-  string zoneId = 4;
-  IntPointDto vertex = 5;
-  int32 radius = 6;
+  IntPointDto vertex = 4;
+  int32 radius = 5;
 }
 
 message DrawablesGroupDto {

--- a/src/test/java/net/rptools/maptool/model/drawing/ConeTemplateAreaTest.java
+++ b/src/test/java/net/rptools/maptool/model/drawing/ConeTemplateAreaTest.java
@@ -37,7 +37,6 @@ public class ConeTemplateAreaTest {
     coneTemplate.setVertex(vertex);
     coneTemplate.setRadius(radius);
     coneTemplate.setDirection(direction);
-    coneTemplate.setZoneId(testZone.getId());
 
     coneTemplate = Mockito.spy(coneTemplate);
     Mockito.when(coneTemplate.getCampaign()).thenReturn(testCampaign);

--- a/src/test/java/net/rptools/maptool/model/drawing/ConeTemplateAreaTest.java
+++ b/src/test/java/net/rptools/maptool/model/drawing/ConeTemplateAreaTest.java
@@ -47,9 +47,16 @@ public class ConeTemplateAreaTest {
   @Test
   @DisplayName("Test getArea function on cone drawing template")
   void testRDrawingArea() throws Exception {
+    Campaign testCampaign = new Campaign();
+    Zone testZone = new Zone();
+    Grid testGrid = new SquareGrid();
+    testGrid.setSize(50);
+    testZone.setGrid(testGrid);
+    testCampaign.putZone(testZone);
+
     ConeTemplate coneTemplate =
         testConeTemplate(new ZonePoint(50, 50), 3, AbstractTemplate.Direction.EAST);
-    Area area = coneTemplate.getArea();
+    Area area = coneTemplate.getArea(testZone);
     // This should look like the following:
     //
     // □■□

--- a/src/test/java/net/rptools/maptool/model/drawing/RadiusTemplateAreaTest.java
+++ b/src/test/java/net/rptools/maptool/model/drawing/RadiusTemplateAreaTest.java
@@ -37,7 +37,6 @@ public class RadiusTemplateAreaTest {
     radiusTemplate.setName("test");
     radiusTemplate.setVertex(vertex);
     radiusTemplate.setRadius(radius);
-    radiusTemplate.setZoneId(testZone.getId());
 
     radiusTemplate = Mockito.spy(radiusTemplate);
     Mockito.when(radiusTemplate.getCampaign()).thenReturn(testCampaign);

--- a/src/test/java/net/rptools/maptool/model/drawing/RadiusTemplateAreaTest.java
+++ b/src/test/java/net/rptools/maptool/model/drawing/RadiusTemplateAreaTest.java
@@ -47,8 +47,15 @@ public class RadiusTemplateAreaTest {
   @Test
   @DisplayName("Test getArea function on radius drawing template")
   void testRadiusDrawingArea() throws Exception {
+    Campaign testCampaign = new Campaign();
+    Zone testZone = new Zone();
+    Grid testGrid = new SquareGrid();
+    testGrid.setSize(50);
+    testZone.setGrid(testGrid);
+    testCampaign.putZone(testZone);
+
     RadiusTemplate radiusTemplate = testRadiusTemplate(new ZonePoint(50, 50), 1);
-    Area area = radiusTemplate.getArea();
+    Area area = radiusTemplate.getArea(testZone);
     assertFalse(area.isEmpty());
     // Radius is 1, so it should be a 2x2 square.
     // With a gridsize of 50, that's 100x100, with the ul origin at 0,0
@@ -56,7 +63,7 @@ public class RadiusTemplateAreaTest {
 
     // And now a slightly bigger radius
     radiusTemplate = testRadiusTemplate(new ZonePoint(50, 50), 2);
-    area = radiusTemplate.getArea();
+    area = radiusTemplate.getArea(testZone);
     // This one contains the same squares as above, + 2 more on each edge
     assert (area.contains(new Rectangle(0, 0, 100, 100)));
     // The full list of all 12 points a radius 2 template should contain


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4524
Fixes #4527

### Description of the Change

The main idea with this change is to fix #4527 by passing a `Zone` to templates rather than requiring them to look the zone up themselves. This is done by adding a `Zone` parameter to these `Drawable` methods, and other related methods:
- `draw()`
- `getBounds()`
- `getArea()`

Regular drawings ignore the new parameter, but templates require it in order to scale properly without relying on global state.

There were some remaining zone lookups in `RadiusCellTemplate`, `BlastTemplate`, and `BurstTemplate`. These all delegated to a `ShapeDrawable` as a renderer, and keeping that renderer in sync with the template state required knowledge of the zone when modifying the template. But these renderer did not add any value to these templates -- `RadiusCellTemplate` didn't use its renderer, while `BlastTemplate` and `BurstTemplate` were just as well to draw their own shape. Removing these and the need for maintaining extra state is the resolution to #4524.

With those changes done, templates no longer require their zone ID in any way. So that is now removed from `AbstractTemplate` and the associated DTOs. This simplifies other parts of the code (e.g., `Zone` deserialization) as we don't have to worry about updating template zone IDs.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where burst and blast templates would not scale when changing the the map grid size.
- Fixed a bug where templates would disappear if duplicated to another map and then the duplicate was deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4753)
<!-- Reviewable:end -->
