### PR TITLE
Handle NPE when grid tool is open and map is removed

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -536,9 +536,13 @@ public class ClientMessageHandler implements MessageHandler {
           int color = msg.getColor();
 
           var zone = MapTool.getCampaign().getZone(zoneGUID);
-          zone.getGrid().setSize(size);
-          zone.getGrid().setOffset(xOffset, yOffset);
-          zone.setGridColor(color);
+          // Sometimes these messages can come in as a zone is being removed, so we can't rely on
+          // its existence
+          if (zone != null) {
+            zone.getGrid().setSize(size);
+            zone.getGrid().setOffset(xOffset, yOffset);
+            zone.setGridColor(color);
+          }
 
           MapTool.getFrame().refresh();
         });

--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -416,10 +416,12 @@ public class ServerMessageHandler implements MessageHandler {
     EventQueue.invokeLater(
         () -> {
           Zone zone = server.getCampaign().getZone(GUID.valueOf(msg.getZoneGuid()));
-          Grid grid = zone.getGrid();
-          grid.setSize(msg.getSize());
-          grid.setOffset(msg.getXOffset(), msg.getYOffset());
-          zone.setGridColor(msg.getColor());
+          if (zone != null) {
+            Grid grid = zone.getGrid();
+            grid.setSize(msg.getSize());
+            grid.setOffset(msg.getXOffset(), msg.getYOffset());
+            zone.setGridColor(msg.getColor());
+          }
         });
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4523

### Description of the Change

When the Adjust Grid tool is detached from a zone, it first attempts to write out its state to the zone. This doesn't work if the zone is being removed since the zone is likely to be gone by the time the updated is received. So we now check in the message handlers whether the zone is still around before applying the updates.

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where leaving the Adjust Grid tool open and switching campaigns would throw an error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4754)
<!-- Reviewable:end -->
