### PR TITLE
Update template rendering when the Adjust Grid tool is used

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
@@ -37,10 +37,12 @@ import net.rptools.maptool.client.swing.ColorWell;
 import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.tool.DefaultTool;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
+import net.rptools.maptool.model.zones.GridChanged;
 
 /** */
 public class GridTool extends DefaultTool {
@@ -75,7 +77,8 @@ public class GridTool extends DefaultTool {
     controlPanel = new AbeillePanel(new AdjustGridControlPanelView().getRootComponent());
 
     gridSizeSpinner = (JSpinner) controlPanel.getComponent("gridSize");
-    gridSizeSpinner.setModel(new SpinnerNumberModel());
+    gridSizeSpinner.setModel(
+        new SpinnerNumberModel(100, Grid.MIN_GRID_SIZE, Grid.MAX_GRID_SIZE, 1));
     gridSizeSpinner.addChangeListener(new UpdateGridListener());
 
     gridOffsetXTextField = (JTextField) controlPanel.getComponent("offsetX");
@@ -175,6 +178,8 @@ public class GridTool extends DefaultTool {
     grid.setOffset(getInt(gridOffsetXTextField, 0), getInt(gridOffsetYTextField, 0));
     zone.setGridColor(colorWell.getColor().getRGB());
     grid.setSize(Math.max((Integer) gridSizeSpinner.getValue(), Grid.MIN_GRID_SIZE));
+
+    new MapToolEventBus().getMainEventBus().post(new GridChanged(zone));
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -3557,6 +3557,9 @@ public class ZoneRenderer extends JComponent
     if (event.zone() != this.zone) {
       return;
     }
+
+    // A change in grid can change the size of templates.
+    flushDrawableRenderer();
     repaintDebouncer.dispatch();
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4525

### Description of the Change

Templates are scaled according to the size of the grid, so when the grid is changed the size of templates might change. Since templates are handled the same as any drawable, we must rerender drawables when the grid size changes. This PR does this by flushing the drawable renderers on `GridChanged` events, and by firing these events when the Adjust Grid tool modifies the grid.

As before, the changes to the grid are only done locally. Only once the tool is closed will the changes be sent to the server, which will update the templates on the other clients.

I also included a change to constrain the adjust grid tool to the min and max size for grids.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where templates would not scale with the grid until an user update was made.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4755)
<!-- Reviewable:end -->
