### PR TITLE
Give DrawnElement a copy constructor

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -662,7 +662,16 @@ public class Zone {
     playerAlias = zone.playerAlias;
 
     for (final var entry : drawablesByLayer.entrySet()) {
-      entry.getValue().addAll(zone.drawablesByLayer.get(entry.getKey()));
+      final var otherDrawables = zone.drawablesByLayer.get(entry.getKey());
+      final var thisDrawables = entry.getValue();
+
+      for (final var element : otherDrawables) {
+        final var copy = new DrawnElement(element);
+        if (!keepIds) {
+          copy.getDrawable().setId(new GUID());
+        }
+        thisDrawables.add(copy);
+      }
     }
 
     if (!zone.labels.isEmpty()) {

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -33,8 +33,12 @@ import net.rptools.maptool.model.Zone;
  * implementing classes.
  */
 public abstract class AbstractDrawing implements Drawable, ImageObserver {
-  /** The unique identifier for this drawable. It is immutable. */
-  private final GUID id;
+  /**
+   * The unique identifier for this drawable.
+   *
+   * <p>It should not typically be changed except to give copies a new ID.
+   */
+  private GUID id;
 
   private String layer;
   private String name;
@@ -45,6 +49,13 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
 
   protected AbstractDrawing(GUID id) {
     this.id = id;
+  }
+
+  protected AbstractDrawing(AbstractDrawing other) {
+    // The only thing we don't preserve is the ID.
+    this.id = other.id;
+    this.layer = other.layer;
+    this.name = other.name;
   }
 
   @Override
@@ -99,6 +110,11 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
    */
   public GUID getId() {
     return id;
+  }
+
+  @Override
+  public void setId(GUID guid) {
+    this.id = guid;
   }
 
   public void setLayer(Zone.Layer layer) {

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
@@ -47,6 +47,12 @@ public abstract class AbstractTemplate extends AbstractDrawing {
     super(id);
   }
 
+  protected AbstractTemplate(AbstractTemplate other) {
+    super(other);
+    this.radius = other.radius;
+    this.vertex = new ZonePoint(other.vertex);
+  }
+
   /*---------------------------------------------------------------------------------------------
    * Class Variables
    *-------------------------------------------------------------------------------------------*/

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -22,6 +22,7 @@ import java.awt.geom.Area;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.server.proto.drawing.BlastTemplateDto;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 
@@ -187,5 +188,19 @@ public class BlastTemplate extends ConeTemplate {
     if (getName() != null) dto.setName(StringValue.of(getName()));
 
     return DrawableDto.newBuilder().setBlastTemplate(dto).build();
+  }
+
+  public static BlastTemplate fromDto(BlastTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new BlastTemplate(id, dto.getOffsetX(), dto.getOffsetY());
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    drawable.setDirection(AbstractTemplate.Direction.valueOf(dto.getDirection()));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -48,9 +48,20 @@ public class BlastTemplate extends ConeTemplate {
     this.offsetY = offsetY;
   }
 
+  public BlastTemplate(BlastTemplate other) {
+    super(other);
+    this.offsetX = other.offsetX;
+    this.offsetY = other.offsetY;
+  }
+
   /*---------------------------------------------------------------------------------------------
    * Instance Methods
    *-------------------------------------------------------------------------------------------*/
+
+  @Override
+  public Drawable copy() {
+    return new BlastTemplate(this);
+  }
 
   private Rectangle makeShape(Zone zone) {
     if (zone == null) {

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -41,9 +41,18 @@ public class BurstTemplate extends RadiusTemplate {
     super(id);
   }
 
+  public BurstTemplate(BurstTemplate other) {
+    super(other);
+  }
+
   /*---------------------------------------------------------------------------------------------
    * Instance Methods
    *-------------------------------------------------------------------------------------------*/
+
+  @Override
+  public Drawable copy() {
+    return new BurstTemplate(this);
+  }
 
   private Rectangle makeVertexShape(Zone zone) {
     int gridSize = zone.getGrid().getSize();

--- a/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BurstTemplate.java
@@ -22,6 +22,7 @@ import java.awt.geom.Area;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.server.proto.drawing.BurstTemplateDto;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 
@@ -131,5 +132,18 @@ public class BurstTemplate extends RadiusTemplate {
     if (getName() != null) dto.setName(StringValue.of(getName()));
 
     return DrawableDto.newBuilder().setBurstTemplate(dto).build();
+  }
+
+  public static BurstTemplate fromDto(BurstTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new BurstTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -350,4 +350,18 @@ public class ConeTemplate extends RadiusTemplate {
 
     return DrawableDto.newBuilder().setConeTemplate(dto).build();
   }
+
+  public static ConeTemplate fromDto(ConeTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new ConeTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    drawable.setDirection(AbstractTemplate.Direction.valueOf(dto.getDirection()));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -35,16 +35,6 @@ import net.rptools.maptool.server.proto.drawing.DrawableDto;
  */
 public class ConeTemplate extends RadiusTemplate {
 
-  public ConeTemplate() {}
-
-  public ConeTemplate(GUID id) {
-    super(id);
-  }
-
-  /*---------------------------------------------------------------------------------------------
-   * Instance Variables
-   *-------------------------------------------------------------------------------------------*/
-
   /**
    * The dirction to paint. The ne,se,nw,sw paint a quadrant and the n,w,e,w paint along the spine
    * of the selected vertex. Saved as a string as a hack to get around the hessian library's problem
@@ -52,9 +42,25 @@ public class ConeTemplate extends RadiusTemplate {
    */
   private String direction = Direction.SOUTH_EAST.name();
 
+  public ConeTemplate() {}
+
+  public ConeTemplate(GUID id) {
+    super(id);
+  }
+
+  public ConeTemplate(ConeTemplate other) {
+    super(other);
+    this.direction = other.direction;
+  }
+
   /*---------------------------------------------------------------------------------------------
    * Instance Methods
    *-------------------------------------------------------------------------------------------*/
+
+  @Override
+  public Drawable copy() {
+    return new ConeTemplate(this);
+  }
 
   /**
    * Get the direction for this ConeTemplate.

--- a/src/main/java/net/rptools/maptool/model/drawing/Cross.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Cross.java
@@ -43,6 +43,18 @@ public class Cross extends AbstractDrawing {
     endPoint = new Point(endX, endY);
   }
 
+  public Cross(Cross other) {
+    super(other);
+
+    this.startPoint = new Point(other.startPoint);
+    this.endPoint = new Point(other.endPoint);
+  }
+
+  @Override
+  public Drawable copy() {
+    return new Cross(this);
+  }
+
   @Override
   public @Nonnull Area getArea(Zone zone) {
     return new Area(getBounds(zone));

--- a/src/main/java/net/rptools/maptool/model/drawing/Cross.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Cross.java
@@ -74,6 +74,19 @@ public class Cross extends AbstractDrawing {
     return DrawableDto.newBuilder().setCrossDrawable(dto).build();
   }
 
+  public static Cross fromDto(CrossDrawableDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var startPoint = dto.getStartPoint();
+    var endPoint = dto.getEndPoint();
+    var drawable =
+        new Cross(id, startPoint.getX(), startPoint.getY(), endPoint.getX(), endPoint.getY());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
+
   @Override
   public java.awt.Rectangle getBounds(Zone zone) {
     if (bounds == null) {

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
  * @author drice
  */
 public interface Drawable {
+  Drawable copy();
 
   void draw(Zone zone, Graphics2D g, Pen pen);
 
@@ -39,6 +40,8 @@ public interface Drawable {
   Area getArea(Zone zone);
 
   GUID getId();
+
+  void setId(GUID guid);
 
   Zone.Layer getLayer();
 

--- a/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Drawable.java
@@ -16,13 +16,9 @@ package net.rptools.maptool.model.drawing;
 
 import java.awt.Graphics2D;
 import java.awt.geom.Area;
-import java.util.ArrayList;
 import javax.annotation.Nonnull;
-import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
-import net.rptools.maptool.model.ZonePoint;
-import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import org.apache.logging.log4j.LogManager;
 
@@ -50,198 +46,27 @@ public interface Drawable {
   DrawableDto toDto();
 
   static Drawable fromDto(DrawableDto drawableDto) {
-    switch (drawableDto.getDrawableTypeCase()) {
-      case SHAPE_DRAWABLE -> {
-        var dto = drawableDto.getShapeDrawable();
-        var shape = Mapper.map(dto.getShape());
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new ShapeDrawable(id, shape, dto.getUseAntiAliasing());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case RECTANGLE_DRAWABLE -> {
-        var dto = drawableDto.getRectangleDrawable();
-        var id = GUID.valueOf(dto.getId());
-        var startPoint = dto.getStartPoint();
-        var endPoint = dto.getEndPoint();
-        var drawable =
-            new Rectangle(
-                id, startPoint.getX(), startPoint.getY(), endPoint.getX(), endPoint.getY());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case OVAL_DRAWABLE -> {
-        var dto = drawableDto.getOvalDrawable();
-        var id = GUID.valueOf(dto.getId());
-        var startPoint = dto.getStartPoint();
-        var endPoint = dto.getEndPoint();
-        var drawable =
-            new Oval(id, startPoint.getX(), startPoint.getY(), endPoint.getX(), endPoint.getY());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case CROSS_DRAWABLE -> {
-        var dto = drawableDto.getCrossDrawable();
-        var id = GUID.valueOf(dto.getId());
-        var startPoint = dto.getStartPoint();
-        var endPoint = dto.getEndPoint();
-        var drawable =
-            new Cross(id, startPoint.getX(), startPoint.getY(), endPoint.getX(), endPoint.getY());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case DRAWN_LABEL -> {
-        var dto = drawableDto.getDrawnLabel();
-        var id = GUID.valueOf(dto.getId());
-        var bounds = dto.getBounds();
-        var drawable =
-            new DrawnLabel(id, dto.getText(), Mapper.map(dto.getBounds()), dto.getFont());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case LINE_SEGMENT -> {
-        var dto = drawableDto.getLineSegment();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new LineSegment(id, dto.getWidth(), dto.getSquareCap());
-        var points = drawable.getPoints();
-        var pointDtos = dto.getPointsList();
-        pointDtos.forEach(p -> points.add(Mapper.map(p)));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case DRAWABLES_GROUP -> {
-        var dto = drawableDto.getDrawablesGroup();
-        var id = GUID.valueOf(dto.getId());
-        var elements = new ArrayList<DrawnElement>();
-        var elementDtos = dto.getDrawnElementsList();
-        elementDtos.forEach(e -> elements.add(DrawnElement.fromDto(e)));
-        var drawable = new DrawablesGroup(id, elements);
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case RADIUS_CELL_TEMPLATE -> {
-        var dto = drawableDto.getRadiusCellTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new RadiusCellTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case LINE_CELL_TEMPLATE -> {
-        var dto = drawableDto.getLineCellTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new LineCellTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        var pathVertex = dto.getPathVertex();
-        drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
-        if (dto.hasName()) {
-          drawable.setName(dto.getName().getValue());
-        }
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case RADIUS_TEMPLATE -> {
-        var dto = drawableDto.getRadiusTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new RadiusTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case BURST_TEMPLATE -> {
-        var dto = drawableDto.getBurstTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new BurstTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case CONE_TEMPLATE -> {
-        var dto = drawableDto.getConeTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new ConeTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        drawable.setDirection(AbstractTemplate.Direction.valueOf(dto.getDirection()));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case BLAST_TEMPLATE -> {
-        var dto = drawableDto.getBlastTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new BlastTemplate(id, dto.getOffsetX(), dto.getOffsetY());
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        drawable.setDirection(AbstractTemplate.Direction.valueOf(dto.getDirection()));
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case LINE_TEMPLATE -> {
-        var dto = drawableDto.getLineTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new LineTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        if (!dto.getQuadrant().isEmpty()) {
-          drawable.setQuadrant(AbstractTemplate.Quadrant.valueOf(dto.getQuadrant()));
-        }
-        drawable.setMouseSlopeGreater(dto.getMouseSlopeGreater());
-        var pathVertex = dto.getPathVertex();
-        drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
-        drawable.setDoubleWide(dto.getDoubleWide());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-        return drawable;
-      }
-      case WALL_TEMPLATE -> {
-        var dto = drawableDto.getWallTemplate();
-        var id = GUID.valueOf(dto.getId());
-        var drawable = new WallTemplate(id);
-        drawable.setRadius(dto.getRadius());
-        var vertex = dto.getVertex();
-        drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
-        drawable.setMouseSlopeGreater(dto.getMouseSlopeGreater());
-        var pathVertex = dto.getPathVertex();
-        drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
-        drawable.setDoubleWide(dto.getDoubleWide());
-        if (dto.hasName()) drawable.setName(dto.getName().getValue());
-        drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
-
-        var cellpoints = new ArrayList<CellPoint>();
-        for (var point : dto.getPointsList())
-          cellpoints.add(new CellPoint(point.getX(), point.getY()));
-        drawable.setPath(cellpoints);
-
-        return drawable;
-      }
+    return switch (drawableDto.getDrawableTypeCase()) {
+      case SHAPE_DRAWABLE -> ShapeDrawable.fromDto(drawableDto.getShapeDrawable());
+      case RECTANGLE_DRAWABLE -> Rectangle.fromDto(drawableDto.getRectangleDrawable());
+      case OVAL_DRAWABLE -> Oval.fromDto(drawableDto.getOvalDrawable());
+      case CROSS_DRAWABLE -> Cross.fromDto(drawableDto.getCrossDrawable());
+      case DRAWN_LABEL -> DrawnLabel.fromDto(drawableDto.getDrawnLabel());
+      case LINE_SEGMENT -> LineSegment.fromDto(drawableDto.getLineSegment());
+      case DRAWABLES_GROUP -> DrawablesGroup.fromDto(drawableDto.getDrawablesGroup());
+      case RADIUS_CELL_TEMPLATE -> RadiusCellTemplate.fromDto(drawableDto.getRadiusCellTemplate());
+      case LINE_CELL_TEMPLATE -> LineCellTemplate.fromDto(drawableDto.getLineCellTemplate());
+      case RADIUS_TEMPLATE -> RadiusTemplate.fromDto(drawableDto.getRadiusTemplate());
+      case BURST_TEMPLATE -> BurstTemplate.fromDto(drawableDto.getBurstTemplate());
+      case CONE_TEMPLATE -> ConeTemplate.fromDto(drawableDto.getConeTemplate());
+      case BLAST_TEMPLATE -> BlastTemplate.fromDto(drawableDto.getBlastTemplate());
+      case LINE_TEMPLATE -> LineTemplate.fromDto(drawableDto.getLineTemplate());
+      case WALL_TEMPLATE -> WallTemplate.fromDto(drawableDto.getWallTemplate());
       default -> {
         LogManager.getLogger(Drawable.class)
             .warn("unknown DrawableDto type: " + drawableDto.getDrawableTypeCase());
-        return null;
+        yield null;
       }
-    }
+    };
   }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -109,6 +109,19 @@ public class DrawablesGroup extends AbstractDrawing {
     return DrawableDto.newBuilder().setDrawablesGroup(dto).build();
   }
 
+  public static DrawablesGroup fromDto(DrawablesGroupDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var elements = new ArrayList<DrawnElement>();
+    var elementDtos = dto.getDrawnElementsList();
+    elementDtos.forEach(e -> elements.add(DrawnElement.fromDto(e)));
+    var drawable = new DrawablesGroup(id, elements);
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
+
   @Override
   protected void draw(Zone zone, Graphics2D g) {
     // This should never be called

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablesGroup.java
@@ -18,6 +18,7 @@ import com.google.protobuf.StringValue;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
@@ -39,6 +40,20 @@ public class DrawablesGroup extends AbstractDrawing {
   public DrawablesGroup(GUID id, List<DrawnElement> drawableList) {
     super(id);
     this.drawableList = drawableList;
+  }
+
+  public DrawablesGroup(DrawablesGroup other) {
+    super(other);
+
+    this.drawableList = new ArrayList<>(other.drawableList.size());
+    for (final var element : other.drawableList) {
+      this.drawableList.add(new DrawnElement(element));
+    }
+  }
+
+  @Override
+  public Drawable copy() {
+    return new DrawablesGroup(this);
   }
 
   public List<DrawnElement> getDrawableList() {

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnElement.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnElement.java
@@ -27,6 +27,10 @@ public class DrawnElement {
     this.pen = pen;
   }
 
+  public DrawnElement(DrawnElement other) {
+    this(other.drawable.copy(), new Pen(other.pen));
+  }
+
   public Drawable getDrawable() {
     return drawable;
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
@@ -127,4 +127,15 @@ public class DrawnLabel extends AbstractDrawing {
 
     return DrawableDto.newBuilder().setDrawnLabel(dto).build();
   }
+
+  public static DrawnLabel fromDto(DrawnLabelDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var bounds = dto.getBounds();
+    var drawable = new DrawnLabel(id, dto.getText(), Mapper.map(dto.getBounds()), dto.getFont());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnLabel.java
@@ -72,6 +72,18 @@ public class DrawnLabel extends AbstractDrawing {
     font = aFont;
   }
 
+  public DrawnLabel(DrawnLabel other) {
+    super(other);
+    this.bounds = new Rectangle(other.bounds);
+    this.text = other.text;
+    this.font = other.font;
+  }
+
+  @Override
+  public Drawable copy() {
+    return new DrawnLabel(this);
+  }
+
   public String getText() {
     return text;
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -470,4 +470,19 @@ public class LineCellTemplate extends AbstractTemplate {
 
     return DrawableDto.newBuilder().setLineCellTemplate(dto).build();
   }
+
+  public static LineCellTemplate fromDto(LineCellTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new LineCellTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    var pathVertex = dto.getPathVertex();
+    drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineCellTemplate.java
@@ -58,6 +58,11 @@ public class LineCellTemplate extends AbstractTemplate {
     super(id);
   }
 
+  public LineCellTemplate(LineCellTemplate other) {
+    super(other);
+    this.pathVertex = new ZonePoint(other.pathVertex);
+  }
+
   /*---------------------------------------------------------------------------------------------
    * Overridden AbstractTemplate Methods
    *-------------------------------------------------------------------------------------------*/
@@ -341,6 +346,11 @@ public class LineCellTemplate extends AbstractTemplate {
   /*---------------------------------------------------------------------------------------------
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
+
+  @Override
+  public Drawable copy() {
+    return new LineCellTemplate(this);
+  }
 
   @Override
   public Rectangle getBounds(Zone zone) {

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -53,6 +53,21 @@ public class LineSegment extends AbstractDrawing {
     this.squareCap = squareCap;
   }
 
+  public LineSegment(LineSegment other) {
+    super(other);
+    this.width = other.width;
+    this.squareCap = other.squareCap;
+
+    for (final var point : other.points) {
+      this.points.add(new Point(point));
+    }
+  }
+
+  @Override
+  public Drawable copy() {
+    return new LineSegment(this);
+  }
+
   @SuppressWarnings("ConstantValue")
   private Object readResolve() {
     if (width == null) {

--- a/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineSegment.java
@@ -112,6 +112,19 @@ public class LineSegment extends AbstractDrawing {
     return DrawableDto.newBuilder().setLineSegment(dto).build();
   }
 
+  public static LineSegment fromDto(LineSegmentDrawableDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new LineSegment(id, dto.getWidth(), dto.getSquareCap());
+    var points = drawable.getPoints();
+    var pointDtos = dto.getPointsList();
+    pointDtos.forEach(p -> points.add(Mapper.map(p)));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
+
   private Area createLineArea() {
     if (points.size() < 1) {
       return null;

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -520,4 +520,24 @@ public class LineTemplate extends AbstractTemplate {
 
     return DrawableDto.newBuilder().setLineTemplate(dto).build();
   }
+
+  public static LineTemplate fromDto(LineTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new LineTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    if (!dto.getQuadrant().isEmpty()) {
+      drawable.setQuadrant(AbstractTemplate.Quadrant.valueOf(dto.getQuadrant()));
+    }
+    drawable.setMouseSlopeGreater(dto.getMouseSlopeGreater());
+    var pathVertex = dto.getPathVertex();
+    drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
+    drawable.setDoubleWide(dto.getDoubleWide());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/LineTemplate.java
@@ -72,6 +72,30 @@ public class LineTemplate extends AbstractTemplate {
     super(id);
   }
 
+  public LineTemplate(LineTemplate other) {
+    super(other);
+
+    this.doubleWide = other.doubleWide;
+    this.pathVertex = new ZonePoint(other.pathVertex);
+
+    if (other.path != null) {
+      this.path = new ArrayList<>(other.path.size());
+      for (final var cellPoint : other.path) {
+        this.path.add(new CellPoint(cellPoint));
+      }
+    }
+
+    if (other.pool != null) {
+      this.pool = new ArrayList<>(other.pool.size());
+      for (final var cellPoint : other.pool) {
+        this.pool.add(new CellPoint(cellPoint));
+      }
+    }
+
+    this.quadrant = other.quadrant;
+    this.mouseSlopeGreater = other.mouseSlopeGreater;
+  }
+
   /*---------------------------------------------------------------------------------------------
    * Overridden AbstractTemplate Methods
    *-------------------------------------------------------------------------------------------*/
@@ -379,6 +403,11 @@ public class LineTemplate extends AbstractTemplate {
   /*---------------------------------------------------------------------------------------------
    * Drawable Interface Methods
    *-------------------------------------------------------------------------------------------*/
+
+  @Override
+  public Drawable copy() {
+    return new LineTemplate(this);
+  }
 
   @Override
   public Rectangle getBounds(Zone zone) {

--- a/src/main/java/net/rptools/maptool/model/drawing/Oval.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Oval.java
@@ -41,6 +41,15 @@ public class Oval extends Rectangle {
     super(id, x, y, width, height);
   }
 
+  public Oval(Oval other) {
+    super(other);
+  }
+
+  @Override
+  public Drawable copy() {
+    return new Oval(this);
+  }
+
   @Override
   protected void draw(Zone zone, Graphics2D g) {
     int minX = Math.min(startPoint.x, endPoint.x);

--- a/src/main/java/net/rptools/maptool/model/drawing/Oval.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Oval.java
@@ -89,4 +89,17 @@ public class Oval extends Rectangle {
 
     return DrawableDto.newBuilder().setOvalDrawable(dto).build();
   }
+
+  public static Oval fromDto(OvalDrawableDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var startPoint = dto.getStartPoint();
+    var endPoint = dto.getEndPoint();
+    var drawable =
+        new Oval(id, startPoint.getX(), startPoint.getY(), endPoint.getX(), endPoint.getY());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -294,4 +294,17 @@ public class RadiusCellTemplate extends AbstractTemplate {
 
     return DrawableDto.newBuilder().setRadiusCellTemplate(dto).build();
   }
+
+  public static RadiusCellTemplate fromDto(RadiusCellTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new RadiusCellTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusCellTemplate.java
@@ -38,6 +38,15 @@ public class RadiusCellTemplate extends AbstractTemplate {
     super(id);
   }
 
+  public RadiusCellTemplate(RadiusCellTemplate other) {
+    super(other);
+  }
+
+  @Override
+  public Drawable copy() {
+    return new RadiusCellTemplate(this);
+  }
+
   /**
    * Paint the border at a specific radius.
    *

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
@@ -175,4 +175,17 @@ public class RadiusTemplate extends AbstractTemplate {
 
     return DrawableDto.newBuilder().setRadiusTemplate(dto).build();
   }
+
+  public static RadiusTemplate fromDto(RadiusTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new RadiusTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/RadiusTemplate.java
@@ -40,6 +40,15 @@ public class RadiusTemplate extends AbstractTemplate {
     super(id);
   }
 
+  public RadiusTemplate(RadiusTemplate other) {
+    super(other);
+  }
+
+  @Override
+  public Drawable copy() {
+    return new RadiusTemplate(this);
+  }
+
   /**
    * Paint the border at a specific radius.
    *

--- a/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
@@ -43,6 +43,17 @@ public class Rectangle extends AbstractDrawing {
     endPoint = new Point(endX, endY);
   }
 
+  public Rectangle(Rectangle other) {
+    super(other);
+    this.startPoint = new Point(other.startPoint);
+    this.endPoint = new Point(other.endPoint);
+  }
+
+  @Override
+  public Drawable copy() {
+    return new Rectangle(this);
+  }
+
   @Override
   public @Nonnull Area getArea(Zone zone) {
     return new Area(getBounds(zone));

--- a/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Rectangle.java
@@ -73,6 +73,19 @@ public class Rectangle extends AbstractDrawing {
     return DrawableDto.newBuilder().setRectangleDrawable(dto).build();
   }
 
+  public static Rectangle fromDto(RectangleDrawableDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var startPoint = dto.getStartPoint();
+    var endPoint = dto.getEndPoint();
+    var drawable =
+        new Rectangle(id, startPoint.getX(), startPoint.getY(), endPoint.getX(), endPoint.getY());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
+
   @Override
   public java.awt.Rectangle getBounds(Zone zone) {
     if (bounds == null) {

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -99,6 +99,17 @@ public class ShapeDrawable extends AbstractDrawing {
     return DrawableDto.newBuilder().setShapeDrawable(dto).build();
   }
 
+  public static ShapeDrawable fromDto(ShapeDrawableDto dto) {
+    var shape = Mapper.map(dto.getShape());
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new ShapeDrawable(id, shape, dto.getUseAntiAliasing());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+    return drawable;
+  }
+
   @Override
   protected void draw(Zone zone, Graphics2D g) {
     Object oldAA = applyAA(g);

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -16,9 +16,11 @@ package net.rptools.maptool.model.drawing;
 
 import com.google.protobuf.StringValue;
 import java.awt.Graphics2D;
+import java.awt.Polygon;
 import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.Area;
+import java.awt.geom.RectangularShape;
 import javax.annotation.Nonnull;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -44,6 +46,24 @@ public class ShapeDrawable extends AbstractDrawing {
 
   public ShapeDrawable(Shape shape) {
     this(shape, true);
+  }
+
+  public ShapeDrawable(ShapeDrawable other) {
+    super(other);
+    this.useAntiAliasing = other.useAntiAliasing;
+    this.shape =
+        switch (other.shape) {
+            // Covers Rectangle, Ellipse2D, etc.
+          case RectangularShape r -> (Shape) r.clone();
+          case Polygon p -> new Polygon(p.xpoints, p.ypoints, p.npoints);
+          case Area a -> new Area(a);
+          default -> other.shape; // Assume anything else cannot be copied but is also okay.
+        };
+  }
+
+  @Override
+  public Drawable copy() {
+    return new ShapeDrawable(this);
   }
 
   public boolean getUseAntiAliasing() {

--- a/src/main/java/net/rptools/maptool/model/drawing/WallTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/WallTemplate.java
@@ -40,6 +40,15 @@ public class WallTemplate extends LineTemplate {
     setPathVertex(new ZonePoint(0, 0));
   }
 
+  public WallTemplate(WallTemplate other) {
+    super(other);
+  }
+
+  @Override
+  public Drawable copy() {
+    return new WallTemplate(this);
+  }
+
   /**
    * @see net.rptools.maptool.model.drawing.AbstractTemplate#getRadius()
    */

--- a/src/main/java/net/rptools/maptool/model/drawing/WallTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/WallTemplate.java
@@ -15,9 +15,11 @@
 package net.rptools.maptool.model.drawing;
 
 import com.google.protobuf.StringValue;
+import java.util.ArrayList;
 import java.util.List;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.server.proto.drawing.DrawableDto;
 import net.rptools.maptool.server.proto.drawing.WallTemplateDto;
@@ -100,5 +102,29 @@ public class WallTemplate extends LineTemplate {
     for (var point : getPath()) dto.addPoints(point.toDto());
 
     return DrawableDto.newBuilder().setWallTemplate(dto).build();
+  }
+
+  public static WallTemplate fromDto(WallTemplateDto dto) {
+    var id = GUID.valueOf(dto.getId());
+    var drawable = new WallTemplate(id);
+    drawable.setRadius(dto.getRadius());
+    var vertex = dto.getVertex();
+    drawable.setVertex(new ZonePoint(vertex.getX(), vertex.getY()));
+    drawable.setMouseSlopeGreater(dto.getMouseSlopeGreater());
+    var pathVertex = dto.getPathVertex();
+    drawable.setPathVertex(new ZonePoint(pathVertex.getX(), pathVertex.getY()));
+    drawable.setDoubleWide(dto.getDoubleWide());
+    if (dto.hasName()) {
+      drawable.setName(dto.getName().getValue());
+    }
+    drawable.setLayer(Zone.Layer.valueOf(dto.getLayer()));
+
+    var cellpoints = new ArrayList<CellPoint>();
+    for (var point : dto.getPointsList()) {
+      cellpoints.add(new CellPoint(point.getX(), point.getY()));
+    }
+    drawable.setPath(cellpoints);
+
+    return drawable;
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #2433
Properly fixes #4526

### Description of the Change

`DrawnElement` now has a copy constructor that will copy the underlying `Drawable` and `Pen`. `Pen` already has a copy constructor, but `Drawable` did not have anything for this. So a new `Drawable.copy()` method is added, with concrete child classes deciding how they should be copied. For practical reasons, this is always implemented via copy constructors.

The above is mostly straightforward, but `ShapeDrawable` is a unique case. It wraps a general `Shape`, but not all `Shape` implementations are easily copied. So for this we do case work on the type of the shape: the common cases of `Area`, `Polygon`, and `RectangularShape` (covering `Rectangle`, `Ellipse2D` and more), are handled explicitly. There shouldn't be other type encountered in `ShapeDrawable`, but to cover our bases we simply do a shallow a copy if some unknown `Shape` implementation is found.

In the copy constructor of `Zone`, each drawing is copied using the new `DrawnElement` copy constructor. If `keepIDs` is `false`, a new GUID will also be generated and set for each copy.

Finally, I took the opportunity to refactor `Drawable.fromDto()` so that each concrete class has its own `fromDto()` method, with `Drawable.fromDto()` doing nothing but delegating base on type case. I find this easier to read with the `toDto()` and `fromDto()` methods for each type sitting right next to each other.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where modify a drawing on a copy of a map would affect the original drawing on the original map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4763)
<!-- Reviewable:end -->
