### PR TITLE
Go back to calling MapTool.setCampaign()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -643,7 +643,7 @@ public class ClientMessageHandler implements MessageHandler {
     EventQueue.invokeLater(
         () -> {
           Campaign campaign = Campaign.fromDto(msg.getCampaign());
-          client.setCampaign(campaign);
+          MapTool.setCampaign(campaign);
 
           // Hide the "Connecting" overlay
           MapTool.getFrame().hideGlassPane();
@@ -1048,7 +1048,7 @@ public class ClientMessageHandler implements MessageHandler {
     var loaded = updatePlayerStatusMsg.getLoaded();
 
     Player player =
-        MapTool.getPlayerList().stream()
+        client.getPlayerList().stream()
             .filter(x -> x.getName().equals(playerName))
             .findFirst()
             .orElse(null);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes PR #4771

### Description of the Change

As part of my cleanup in the previous PR, I switched `ClientMessageHandler` from calling `MapTool.setCampaign()` to directly calling `MapToolClient.setCampaign()`. This is a mistake since - for now anyways - `MapTool.setCampaign()` still does a few important things that are separate from `MapToolClient`. This new PR addresses that.

### Possible Drawbacks

Only upsides :slightly_smiling_face: 

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4774)
<!-- Reviewable:end -->
