### PR TITLE
Persist new public keys in the player database when using Easy Connect

### DIFF
--- a/src/main/java/net/rptools/maptool/server/ServerHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ServerHandshake.java
@@ -309,8 +309,9 @@ public class ServerHandshake implements Handshake, MessageHandler {
           playerDb.setRole(pl.getName(), p.role());
           setPlayer(playerDatabase.getPlayer(pl.getName()));
         }
-        playerDb.commitChanges();
       }
+      playerDb.commitChanges();
+
       var publicKeyAddedMsgBuilder = PublicKeyAddedMsg.newBuilder();
       publicKeyAddedMsgBuilder.setPublicKey(p.publicKey());
       sendMessage(HandshakeMsg.newBuilder().setPublicKeyAddedMsg(publicKeyAddedMsgBuilder).build());


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4779

### Description of the Change

Commits the player database whenever new keys are added as part of Easy Connect. Previously we only committed if the player was already known, but now we do it regardless.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where Easy Connect clients were forgotten after server restart.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4780)
<!-- Reviewable:end -->
