### PR TITLE
Fix the splash screen to show on its own

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -659,6 +659,7 @@ public class MapTool {
     assetTransferManager.addConsumerListener(new AssetTransferHandler());
 
     setClientFrame(new MapToolFrame(menuBar));
+    taskbarFlasher = new TaskBarFlasher(clientFrame);
 
     try {
       playerZoneListener = new PlayerZoneListener();
@@ -1281,8 +1282,6 @@ public class MapTool {
 
     // fire up autosaves
     getAutoSaveManager().start();
-
-    taskbarFlasher = new TaskBarFlasher(clientFrame);
 
     // Jamz: After preferences are loaded, Asset Tree and ImagePanel are out of sync,
     // so after frame is all done loading we sync them back up.

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -84,6 +84,7 @@ import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.TextMessage;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZoneFactory;
+import net.rptools.maptool.model.library.LibraryManager;
 import net.rptools.maptool.model.library.url.LibraryURLStreamHandler;
 import net.rptools.maptool.model.player.LocalPlayer;
 import net.rptools.maptool.model.player.Player;
@@ -639,6 +640,7 @@ public class MapTool {
   private static void initialize() {
     // First time
     AppSetup.install();
+    LibraryManager.init();
 
     // Clean up after ourselves
     FileUtil.delete(AppUtil.getAppHome("tmp"), 2);
@@ -661,6 +663,7 @@ public class MapTool {
     try {
       playerZoneListener = new PlayerZoneListener();
       zoneLoadedListener = new ZoneLoadedListener();
+
       Campaign cmpgn = CampaignFactory.createBasicCampaign();
       startPersonalServer(cmpgn);
     } catch (Exception e) {
@@ -1750,8 +1753,10 @@ public class MapTool {
     EventQueue.invokeLater(
         () -> {
           initialize();
+
           EventQueue.invokeLater(
               () -> {
+                log.info("VISIBLE!");
                 clientFrame.setVisible(true);
                 splash.hideSplashScreen();
                 EventQueue.invokeLater(MapTool::postInitialize);

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1755,7 +1755,6 @@ public class MapTool {
 
           EventQueue.invokeLater(
               () -> {
-                log.info("VISIBLE!");
                 clientFrame.setVisible(true);
                 splash.hideSplashScreen();
                 EventQueue.invokeLater(MapTool::postInitialize);

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -228,6 +228,8 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   private final DragImageGlassPane dragImageGlassPane = new DragImageGlassPane();
 
+  private boolean dockingConfigured = false;
+
   private final class KeyListenerDeleteDraw implements KeyListener {
     private final JTree tree;
 
@@ -455,8 +457,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     restorePreferences();
     updateKeyStrokes();
 
-    // This will cause the frame to be set to visible (BAD jide, BAD! No cookie for you!)
-    configureDocking();
+    initializeFrames();
 
     new WindowPreferences(AppConstants.APP_NAME, "mainFrame", this);
     chatTyperTimers = new ChatNotificationTimers();
@@ -545,8 +546,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   }
 
   private void configureDocking() {
-    initializeFrames();
-
     getDockingManager().setProfileKey(DOCKING_PROFILE_NAME);
     getDockingManager().setOutlineMode(com.jidesoft.docking.DockingManager.PARTIAL_OUTLINE_MODE);
     getDockingManager().setUsePref(false);
@@ -617,6 +616,16 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
       }
     }
     /* /Issue #2485 */
+  }
+
+  @Override
+  public void setVisible(boolean b) {
+    if (!dockingConfigured) {
+      dockingConfigured = true;
+      configureDocking();
+    }
+
+    super.setVisible(b);
   }
 
   public DockableFrame getFrame(MTFrame frame) {

--- a/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
@@ -74,7 +74,7 @@ public class LibraryManager {
   private static final AddOnSlashCommandManager addOnSlashCommandManager =
       new AddOnSlashCommandManager();
 
-  static {
+  public static void init() {
     libraryTokenManager.init();
     builtInLibraryManager.loadBuiltIns();
     new MapToolEventBus().getMainEventBus().register(addOnSlashCommandManager);

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheet.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheet.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.model.sheet.stats;
 
 import java.net.URL;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -28,4 +29,36 @@ import java.util.Set;
  * @param namespace The namespace of the add-on that provides the spreadsheet.
  */
 public record StatSheet(
-    String name, String description, URL entry, Set<String> propertyTypes, String namespace) {}
+    String name, String description, URL entry, Set<String> propertyTypes, String namespace) {
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof StatSheet other)) {
+      return false;
+    }
+    if (!Objects.equals(name, other.name)) {
+      return false;
+    }
+    if (!Objects.equals(description, other.description)) {
+      return false;
+    }
+    if (!Objects.equals(propertyTypes, other.propertyTypes)) {
+      return false;
+    }
+    if (!Objects.equals(namespace, other.namespace)) {
+      return false;
+    }
+
+    // Finally the URLs
+    var thisUrl = entry == null ? null : entry.toString();
+    var otherUrl = other.entry == null ? null : other.entry.toString();
+
+    return Objects.equals(thisUrl, otherUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    // Hash the URL as a string. E.g., we don't need hostname resolution just for a hashcode.
+    return Objects.hash(
+        name, description, entry == null ? null : entry.toString(), propertyTypes, namespace);
+  }
+}


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4782

### Description of the Change

Mainly this change delays the JIDE layout load until we want the frame to be made visible. This avoids JIDE foisting a visible frame on us.

Also noticed there were some delays due to built in libraries. Sometimes we would get really unlucky and these would take a long time to load and would do so while we're trying to make our frame visible. To avoid this, we now explicitly init the `LibraryManager` early in the startup process. Also we no longer hash URLs in `StatSheet` because that does things like hostname lookups.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the main frame and splash screen were both shown during startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4783)
<!-- Reviewable:end -->
