### PR TITLE
Replace token IDs on imported maps

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -77,11 +77,9 @@ import net.rptools.maptool.util.StringUtil;
 import net.rptools.parser.ParserException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 /** */
-public class ZoneRenderer extends JComponent
-    implements DropTargetListener, Comparable<ZoneRenderer> {
+public class ZoneRenderer extends JComponent implements DropTargetListener {
 
   private static final long serialVersionUID = 3832897780066104884L;
   private static final Logger log = LogManager.getLogger(ZoneRenderer.class);
@@ -3564,15 +3562,6 @@ public class ZoneRenderer extends JComponent
     // A change in grid can change the size of templates.
     flushDrawableRenderer();
     repaintDebouncer.dispatch();
-  }
-
-  //
-  // COMPARABLE
-  public int compareTo(@NotNull ZoneRenderer o) {
-    if (o != this) {
-      return (int) (zone.getCreationTime() - o.zone.getCreationTime());
-    }
-    return 0;
   }
 
   // Begin token common macro identification

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -363,12 +363,6 @@ public class Zone {
 
   public static final DrawablePaint DEFAULT_FOG = new DrawableColorPaint(Color.black);
 
-  // The zones should be ordered. We could have the server assign each zone
-  // an incrementing number as new zones are created, but that would take a lot
-  // more elegance than we really need. Instead, let's just keep track of the
-  // time when it was created. This should give us sufficient granularity, because
-  // seriously -- what's the likelihood of two GMs separately creating a new zone at exactly
-  // the same millisecond since the epoch?
   private long creationTime = System.currentTimeMillis();
 
   private GUID id = new GUID(); // Ideally would be 'final', but that complicates imported()

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -478,10 +478,6 @@ public class Zone {
     drawablesByLayer.put(Layer.BACKGROUND, backgroundDrawables);
   }
 
-  /**
-   * Note: When adding new fields to this class, make sure to update all constructors, {@link
-   * #imported()}, {@link #readResolve()}, and potentially {@link #optimize()}.
-   */
   public Zone() {
     // TODO: Was this needed?
     // setGrid(new SquareGrid());
@@ -611,16 +607,11 @@ public class Zone {
   }
 
   /**
-   * Note: When adding new fields to this class, make sure to update all constructors, {@link
-   * #imported()}, {@link #readResolve()}, and potentially {@link #optimize()}.
+   * Create a new zone with old zone's properties and with new token ids.
    *
    * <p>JFJ 2010-10-27 Don't forget that since there are new zones AND new tokens created here from
    * the old one being passed in, if you have any data that needs to transfer over, you will need to
    * manually copy it as is done below for various items.
-   */
-
-  /**
-   * Create a new zone with old zone's properties and with new token ids.
    *
    * @param zone The zone to copy.
    */
@@ -637,6 +628,7 @@ public class Zone {
   public Zone(Zone zone, boolean keepIds) {
     if (keepIds) {
       this.id = zone.getId();
+      this.creationTime = zone.creationTime;
     }
 
     backgroundPaint = zone.backgroundPaint;
@@ -755,14 +747,9 @@ public class Zone {
 
   /**
    * Should be invoked only when a Zone has been imported from an external source and needs to be
-   * cleaned up before being used. Currently this cleanup consists of allocating a new GUID, setting
-   * the creation time to `now', and resetting the initiative list (setting the related zone and
-   * clearing the model).
+   * cleaned up before being used.
    */
   public void imported() {
-    id = new GUID();
-    creationTime = System.currentTimeMillis();
-    initiativeList.setZone(this);
     initiativeList.clearModel();
   }
 

--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -320,6 +320,9 @@ public class PersistenceUtil {
         z.setName(n);
         z.imported(); // Resets creation timestamp and init panel, among other things
         z.optimize(); // Collapses overlaid or redundant drawables
+
+        // Make sure the imported zone is as fresh as possible (new IDs all the way down).
+        persistedMap.zone = new Zone(z, false);
       } else {
         // TODO: Not a map but it is something with a property.xml file in it.
         // Should we have a filetype property in there?


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4789

### Description of the Change

Zones are now copied on import. This has the effect of regenerating all IDs (the zone itself, drawings, tokens). This also reduces the expectations on `Zone#import()` as the copy constructor will take of anything that isn't destroying data.

### Possible Drawbacks

Imported maps can no longer be relied on to keep token IDs. Any maps that contain internal references to specific token IDs will no longer work as they did before and will have to be manually updated.

### Documentation Notes

Token IDs cannot be relied on when importing maps since they will be changed to unique values.

### Release Notes

- Fixed a bug where token IDs of imported maps would not be updated, causing duplicate IDs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4791)
<!-- Reviewable:end -->
