### PR TITLE
Update crowdin.yml to extend translation file suffix with locale

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
   - source: /src/main/resources/net/rptools/maptool/language/i18n.properties
-    translation: /%original_path%/%file_name%_%two_letters_code%.%file_extension%
+    translation: /%original_path%/%file_name%_%locale_with_underscore%.%file_extension%


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #4344

### Description of the Change
Currently Crowdin returns one file for each language using a a two letter code; e.g. _jp, _es, _en
This falls down when there are multiple locale translations that use the same code.
Changing the crowdin.yml export mask from: 
`translation: /%original_path%/%file_name%_%two_letters_code%.%file_extension%`
to:
`translation: /%original_path%/%file_name%_%locale_with_underscore%.%file_extension%`
should resolve the issue.

### Possible Drawbacks
none foreseeable if it works as expected, otherwise, tragic mayhem.

### Documentation Notes
Translation file import fix

### Release Notes
Translation file import fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4792)
<!-- Reviewable:end -->
