### PR TITLE
Do not run the InfoTextSwingWorker on the EDT thread

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/SysInfoDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/SysInfoDialog.java
@@ -47,7 +47,7 @@ public class SysInfoDialog {
     infoTextArea.setWrapStyleWord(true);
     infoTextArea.setFont(new Font("Monospaced", Font.PLAIN, 13));
     infoTextArea.setText(I18N.getText("action.gatherDebugInfoWait"));
-    EventQueue.invokeLater(new InfoTextSwingWorker());
+    new InfoTextSwingWorker().execute();
 
     JScrollPane scrollPane = new JScrollPane(infoTextArea);
     scrollPane.setHorizontalScrollBarPolicy(31);

--- a/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
-import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
 import net.rptools.maptool.model.Token.TerrainModifierOperation;
@@ -37,7 +36,6 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   protected Area tokenPitVbl;
   protected Area tokenCoverVbl;
   protected Area tokenMbl;
-  protected RenderPathWorker renderPathWorker;
 
   public AbstractZoneWalker(Zone zone) {
     this.zone = zone;
@@ -116,11 +114,6 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
     partialPaths.add(
         new PartialPath(oldPartial.start, point, calculatePath(oldPartial.start, point)));
     return oldPartial.end;
-  }
-
-  public Path<CellPoint> getPath(RenderPathWorker renderPathWorker) {
-    this.renderPathWorker = renderPathWorker;
-    return getPath();
   }
 
   public Path<CellPoint> getPath() {

--- a/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
@@ -17,7 +17,6 @@ package net.rptools.maptool.client.walker;
 import java.awt.geom.Area;
 import java.util.Map;
 import java.util.Set;
-import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
 import net.rptools.maptool.model.Token.TerrainModifierOperation;
@@ -46,8 +45,6 @@ public interface ZoneWalker {
   public double getDistance();
 
   public Path<CellPoint> getPath();
-
-  public Path<CellPoint> getPath(RenderPathWorker renderPathWorker);
 
   public CellPoint getLastPoint();
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4801

### Description of the Change

This changes the data gathering task for Gather Debug Information... to run on a background thread rather than the EDT thread. The dialog as a result now shows the text "Gathering information, please wait..." until the dialog is populated, rather than being blank. The dialog also no longer hangs indefinitely.

The reason we previously got away with running that task on the EDT thread is that `SwingWorker` would always run the `done()` method after the internal `FutureTask<>` completes, so the `get()` method would have a result to return. But since Java 21, it runs `done()` as part of the `FutureTask<>` callback if running on the EDT thread, i.e., it runs `done()` before the task completes. The `get()` call therefore blocks as it has no result yet, and the task is blocked from completing and providing those results.

I audited the rest of our `SwingWorker` tasks, but they are all run via `.execute()` and thus are safe from this issue. Only one task (`RenderPathWorker`) is run in a dfiferent manner, but it is on its own non-EDT executor. One unnecessary usage of that worker was found and removed though.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where Gather Debug Information... would permanently hang MapTool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4802)
<!-- Reviewable:end -->
