### PR TITLE
Magnify light source radius rather than shape

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
@@ -68,7 +68,6 @@ public class VisionOverlayRenderer {
 
   private void renderWorld(Graphics2D worldG, PlayerView view, Token token) {
     // The vision of the token is not necessarily related to the current view.
-    // final var tokenView = view.derive(Collections.singleton(token));
     final var tokenView = new PlayerView(view.getRole(), List.of(token));
 
     Area currentTokenVisionArea = zoneView.getVisibleArea(token, tokenView);

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import javax.swing.Action;
 import javax.swing.KeyStroke;
 import net.rptools.lib.FileUtil;
@@ -352,7 +353,7 @@ public abstract class Grid implements Cloneable {
    * @param scaleWithToken used to increase the area based on token footprint
    * @return Area
    */
-  public Area getShapedArea(
+  public @Nonnull Area getShapedArea(
       ShapeType shape,
       Token token,
       double range,

--- a/src/main/java/net/rptools/maptool/model/Light.java
+++ b/src/main/java/net/rptools/maptool/model/Light.java
@@ -100,16 +100,22 @@ public final class Light implements Serializable {
     return shape;
   }
 
-  public @Nonnull Area getArea(@Nonnull Token token, @Nonnull Zone zone, boolean scaleWithToken) {
+  public @Nonnull Area getArea(
+      @Nonnull Token token, @Nonnull Zone zone, double multiplier, boolean scaleWithToken) {
+    // TODO Methinks we don't apply multiplier if darkness.
     return zone.getGrid()
         .getShapedArea(
             getShape(),
             token,
-            getRadius(),
+            multiplier * getRadius(),
             getWidth(),
             getArcAngle(),
             (int) getFacingOffset(),
             scaleWithToken);
+  }
+
+  public @Nonnull Area getArea(@Nonnull Token token, @Nonnull Zone zone, boolean scaleWithToken) {
+    return getArea(token, zone, 1.0, scaleWithToken);
   }
 
   public boolean isGM() {

--- a/src/main/java/net/rptools/maptool/model/Light.java
+++ b/src/main/java/net/rptools/maptool/model/Light.java
@@ -102,12 +102,16 @@ public final class Light implements Serializable {
 
   public @Nonnull Area getArea(
       @Nonnull Token token, @Nonnull Zone zone, double multiplier, boolean scaleWithToken) {
-    // TODO Methinks we don't apply multiplier if darkness.
+    var radius = getRadius();
+    // Darkness does not get magnified.
+    if (lumens >= 0) {
+      radius *= multiplier;
+    }
     return zone.getGrid()
         .getShapedArea(
             getShape(),
             token,
-            multiplier * getRadius(),
+            radius,
             getWidth(),
             getArcAngle(),
             (int) getFacingOffset(),

--- a/src/main/java/net/rptools/maptool/model/LightSource.java
+++ b/src/main/java/net/rptools/maptool/model/LightSource.java
@@ -231,6 +231,17 @@ public final class LightSource implements Comparable<LightSource>, Serializable 
   }
 
   /* Area for all lights combined */
+  public @Nonnull Area getArea(@Nonnull Token token, @Nonnull Zone zone, double multiplier) {
+    // TODO Methinks we don't apply multiplier if not NORMAL.
+    Area area = new Area();
+    for (Light light : lightList) {
+      area.add(light.getArea(token, zone, multiplier, isScaleWithToken()));
+    }
+
+    return area;
+  }
+
+  /* Area for all lights combined */
   public @Nonnull Area getArea(@Nonnull Token token, @Nonnull Zone zone) {
     Area area = new Area();
     for (Light light : lightList) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #257

### Description of the Change

When a sight magnifier is present, we now scale the input (light radius) rather than the output (shape). This makes cone, grid, and beam lights more well-behaved since we don't scale things that should not be scaled.

### Possible Drawbacks

Light will behave a bit differently, so if someone is counting on the current behaviour they will be surprised.

### Documentation Notes

Grid lights now match the shape and size of the grid when magnified.

Beam lights extend in length when magnified, but not in width.

Code lights expand their radius when magnified, but the token footprint is not scaled up.

### Release Notes

- Fixed a bug where token footprints for cone lights would be magnified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4803)
<!-- Reviewable:end -->
