### PR TITLE
Check windows based on hidden status, not showing

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -3339,7 +3339,7 @@ public class AppActions {
 
     @Override
     public boolean isSelected() {
-      return MapTool.getFrame().getFrame(mtFrame).isShowing();
+      return !MapTool.getFrame().getFrame(mtFrame).isHidden();
     }
 
     @Override
@@ -3350,7 +3350,7 @@ public class AppActions {
     @Override
     protected void executeAction() {
       DockableFrame frame = MapTool.getFrame().getFrame(mtFrame);
-      if (frame.isShowing()) {
+      if (!frame.isHidden()) {
         MapTool.getFrame().getDockingManager().hideFrame(mtFrame.name());
       } else {
         MapTool.getFrame().getDockingManager().showFrame(mtFrame.name());


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #1030

### Description of the Change

In the _Window_ menu, windows now have a check whenever they are open. The old check is based on `isShowing()`, an AWT property that checks whether the component happens to be visible on screen (e.g., not hidden behind anything else). The new check is based on `isHidden()`, a JIDE concept that checks whether a frame is hidden by the docking manager's `hideFrame()`.

This also means windows can be closed from the _Window_ menu even if they aren't the active tab.

A similar use of `isShowing()` for _Tool > Chat_ seems to be intentional so I've left it in place.

### Possible Drawbacks

None.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where windows would not be checked in the _Window_ menu if not the active window in a tab group.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4804)
<!-- Reviewable:end -->
