### PR TITLE
Add read timeouts to server sockets

### DIFF
--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
@@ -16,6 +16,7 @@ package net.rptools.clientserver.simple.connection;
 
 import java.io.*;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -161,6 +162,9 @@ public class SocketConnection extends AbstractConnection implements Connection {
           try {
             byte[] message = SocketConnection.this.readMessage(in);
             SocketConnection.this.dispatchCompressedMessage(message);
+          } catch (SocketTimeoutException e) {
+            log.warn("Lost client {}", SocketConnection.this.getId(), e);
+            return;
           } catch (IOException e) {
             log.error(e);
             return;

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/SocketServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/SocketServer.java
@@ -17,6 +17,7 @@ package net.rptools.clientserver.simple.server;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.TimeUnit;
 import net.rptools.clientserver.simple.connection.SocketConnection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -103,6 +104,9 @@ public class SocketServer extends AbstractServer {
       while (!stopRequested) {
         try {
           Socket s = socket.accept();
+          // Client heartbeat frequency is 20 seconds, so a minute should permit two or three
+          // heartbeats to come in if still connected.
+          s.setSoTimeout((int) TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES));
           log.debug("Client connecting ...");
 
           String id = nextClientId(s);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #774

### Description of the Change

On the server side, sockets now have a 1 minute read timeout. This gives plenty of time for heartbeats to come in and "reset" the timeout, while not allowing the server to hold onto stale connections forever.

### Possible Drawbacks

I guess if the network is really haywire this could lead to forced disconnects.

### Documentation Notes

Connections to servers automatically time out after one minute.

### Release Notes

- Fixed a bug where servers would hang onto connections indefinitely if the client goes away without closing the connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4805)
<!-- Reviewable:end -->
