### PR TITLE
Fix for missing translation keys

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -141,7 +141,7 @@ public class AppActions {
   public static final Action NEXT_TOKEN =
       new ZoneClientAction() {
         {
-          init("menu.nextToken");
+          init("action.nextToken");
         }
 
         @Override

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
@@ -29,7 +29,6 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.events.MapToolEventBus;
-import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.drawing.AbstractTemplate;
 import net.rptools.maptool.model.drawing.DrawablesGroup;
@@ -56,16 +55,10 @@ public class DrawPanelTreeModel implements TreeModel {
       return byLayer.get(layer);
     }
 
-    private final String displayName;
     private final Zone.Layer layer;
 
     private View(Zone.Layer layer) {
-      this.displayName = I18N.getText("panel.DrawExplorer.View." + layer.name());
       this.layer = layer;
-    }
-
-    public String getDisplayName() {
-      return displayName;
     }
 
     public Zone.Layer getLayer() {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1248,6 +1248,7 @@ action.commandPanel                           = Command Panel
 # In order to prevent I18N from warning that they don't exist these
 # lines have been added.
 action.commitCommand                          = Not used (action.commitCommand)
+action.newlineCommand                         = Not used (action.newlineCommand)
 action.copyTokens                             = Copy
 action.copyTokens.accel                       = C
 action.copyTokens.description                 = Copy selected tokens to an internal clipboard.

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1420,6 +1420,7 @@ action.saveMapAs                              = &Export Map...
 action.saveMapAs.description                  = Save a map to an external file.
 action.saveMessageHistory                     = Save Chat Log &History...
 action.saveMessageHistory.description         = Save the contents of your chat log, including whispers.
+action.nextToken                              = Select next token
 # Tool
 action.sendChat                               = C&hat
 action.sendChat.accel                         = ENTER


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #2042

### Description of the Change

Some translation keys in `DrawPanelTreeModel` were being looked up but not used. These have been removed since the keys no longer exist.

A couple of app actions have keys that simply weren't present in the i18n file. New entries were added to address that.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where certain nonexistent translations would be looked up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4807)
<!-- Reviewable:end -->
