### PR TITLE
Fix onChangeSelection and related events for inactive tabbed frames

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrame.java
@@ -310,7 +310,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
   /** Run all callback macros for "onChangeSelection". */
   public static void doSelectedChanged() {
     for (HTMLFrame frame : frames.values()) {
-      if (frame.isVisible()) {
+      if (!frame.isHidden()) {
         HTMLPanelContainer.selectedChanged(frame.macroCallbacks);
       }
     }
@@ -319,7 +319,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
   /** Run all callback macros for "onChangeImpersonated". */
   public static void doImpersonatedChanged() {
     for (HTMLFrame frame : frames.values()) {
-      if (frame.isVisible()) {
+      if (!frame.isHidden()) {
         HTMLPanelContainer.impersonatedChanged(frame.macroCallbacks);
       }
     }
@@ -333,7 +333,7 @@ public class HTMLFrame extends DockableFrame implements HTMLPanelContainer {
   public static void doTokenChanged(Token token) {
     if (token != null) {
       for (HTMLFrame frame : frames.values()) {
-        if (frame.isVisible()) {
+        if (!frame.isHidden()) {
           HTMLPanelContainer.tokenChanged(token, frame.macroCallbacks);
         }
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4709

### Description of the Change

As an AWT component, inactive tabbed frames are considered not visible, so the existing check did not accomodate these. As a JIDE component they are considered not hidden, so we use that property instead.

### Possible Drawbacks

If anyone is counting on inactive tabs not generating events, this will shock them.

### Documentation Notes

Frames can generate `onChangeSelection`, `onChangeToken`, and `onChangeImpersonated` even when not the active tab.

### Release Notes

- Fixed a bug where hidden tabbed frames would not generate `onChange*` events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4810)
<!-- Reviewable:end -->
