### PR TITLE
Swap hex grid icons in Rod's theme

### DIFF
--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/gridHorizontalHex.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/gridHorizontalHex.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <g transform="matrix(1,0,0,1,-133,-38)">
-        <g id="gridHorizontalHex" transform="matrix(1,0,0,1,-359.667,38)">
+    <g transform="matrix(1,0,0,1,-133,-19)">
+        <g id="gridVerticalHex" transform="matrix(1,0,0,1,-359.667,19)">
             <rect x="492.667" y="0" width="16" height="16" style="fill:none;"/>
-            <g transform="matrix(6.94752e-17,1.13462,-1.13462,6.94752e-17,509.593,-109.627)">
+            <g transform="matrix(1.13462,0,0,1.13462,383.04,-0.926736)">
                 <path d="M103.671,2.579L108.251,5.224L108.251,10.512L103.671,13.156L99.092,10.512L99.092,5.224L103.671,2.579Z" style="fill:rgb(110,110,110);"/>
             </g>
         </g>

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/gridVerticalHex.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/gridVerticalHex.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <g transform="matrix(1,0,0,1,-133,-19)">
-        <g id="gridVerticalHex" transform="matrix(1,0,0,1,-359.667,19)">
+    <g transform="matrix(1,0,0,1,-133,-38)">
+        <g id="gridHorizontalHex" transform="matrix(1,0,0,1,-359.667,38)">
             <rect x="492.667" y="0" width="16" height="16" style="fill:none;"/>
-            <g transform="matrix(1.13462,0,0,1.13462,383.04,-0.926736)">
+            <g transform="matrix(6.94752e-17,1.13462,-1.13462,6.94752e-17,509.593,-109.627)">
                 <path d="M103.671,2.579L108.251,5.224L108.251,10.512L103.671,13.156L99.092,10.512L99.092,5.224L103.671,2.579Z" style="fill:rgb(110,110,110);"/>
             </g>
         </g>


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4811

### Description of the Change

The horizontal and vertical hex icons are swapped so the image matches the name.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the icons for the two hex grid variants were swapped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4812)
<!-- Reviewable:end -->
