### PR TITLE
Make tokens more closely follow their leader

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/MeasureTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/MeasureTool.java
@@ -159,8 +159,7 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
                       .convert(new ScreenPoint(mouseX, mouseY).convertToZone(renderer));
               walker.toggleWaypoint(cp);
             } else if (gridlessPath != null) {
-              gridlessPath.addWayPoint(new ZonePoint(currentGridlessPoint));
-              gridlessPath.addPathCell(new ZonePoint(currentGridlessPoint));
+              gridlessPath.appendWaypoint(currentGridlessPoint);
             }
           }
         });
@@ -180,7 +179,7 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
       } else {
         currentGridlessPoint = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
         gridlessPath = new Path<>();
-        gridlessPath.addPathCell(new ZonePoint(currentGridlessPoint));
+        gridlessPath.appendWaypoint(currentGridlessPoint);
       }
       renderer.repaint();
       return;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.client.walker.ZoneWalker;
@@ -80,7 +81,7 @@ public class SelectionSet {
   /**
    * @return path computation.
    */
-  public Path<ZonePoint> getGridlessPath() {
+  public @Nonnull Path<ZonePoint> getGridlessPath() {
     return gridlessPath;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
@@ -77,8 +77,7 @@ public class SelectionSet {
       gridlessPath = new Path<>();
 
       currentGridlessPoint = new ZonePoint(token.getX(), token.getY());
-      gridlessPath.addWayPoint(new ZonePoint(currentGridlessPoint));
-      gridlessPath.addPathCell(new ZonePoint(currentGridlessPoint));
+      gridlessPath.appendWaypoint(currentGridlessPoint);
     }
   }
 
@@ -87,8 +86,7 @@ public class SelectionSet {
    */
   public @Nonnull Path<ZonePoint> getGridlessPath() {
     var result = gridlessPath.copy();
-    result.addWayPoint(new ZonePoint(currentGridlessPoint));
-    result.addPathCell(new ZonePoint(currentGridlessPoint));
+    result.appendWaypoint(currentGridlessPoint);
     return result;
   }
 
@@ -173,8 +171,7 @@ public class SelectionSet {
     if (walker != null && token.isSnapToGrid() && renderer.getZone().getGrid() != null) {
       walker.toggleWaypoint(renderer.getZone().getGrid().convert(location));
     } else {
-      gridlessPath.addWayPoint(location);
-      gridlessPath.addPathCell(location);
+      gridlessPath.appendWaypoint(location);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -432,7 +432,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
             }
 
             Path<? extends AbstractPoint> path =
-                set.getWalker() != null ? set.getWalker().getPath() : set.gridlessPath;
+                set.getWalker() != null ? set.getWalker().getPath() : set.getGridlessPath();
             // Jamz: add final path render here?
 
             List<GUID> filteredTokens = new ArrayList<GUID>();
@@ -1450,7 +1450,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         if (token == keyToken && token.getLayer().supportsWalker()) {
           renderPath(
               g,
-              walker != null ? walker.getPath() : set.gridlessPath,
+              walker != null ? walker.getPath() : set.getGridlessPath(),
               token.getFootprint(zone.getGrid()));
         }
 
@@ -1594,7 +1594,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       final var grid = zone.getGrid();
       tokenRectangle = token.getFootprint(grid).getBounds(grid, lastPoint);
     } else {
-      final var path = set.gridlessPath;
+      final var path = set.getGridlessPath();
       if (path.getCellPath().isEmpty()) {
         return false;
       }
@@ -1617,7 +1617,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
     double distanceTraveled = 0;
     ZonePoint lastPoint = null;
-    for (ZonePoint zp : set.gridlessPath.getCellPath()) {
+    for (ZonePoint zp : set.getGridlessPath().getCellPath()) {
       if (lastPoint == null) {
         lastPoint = zp;
         continue;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -460,17 +460,11 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
                * Lee: the problem now is to keep the precise coordinate computations for unsnapped tokens following a snapped key token. The derived path in the following section contains rounded
                * down values because the integer cell values were passed. If these were double in nature, the precision would be kept, but that would be too difficult to change at this stage...
                */
-              var endPoint = new ZonePoint(token.getX() + offsetX, token.getY() + offsetY);
-              var tokenPath =
-                  path.derive(
-                      set, keyToken, token, token.getOriginPoint(), new ZonePoint(endPoint));
+              var tokenPath = path.derive(zone.getGrid(), keyToken, token);
 
-              token.setX(endPoint.x);
-              token.setY(endPoint.y);
+              token.setX(token.getX() + offsetX);
+              token.setY(token.getY() + offsetY);
               token.setLastPath(tokenPath);
-
-              // Lee: setting originPoint to landing point
-              token.setOriginPoint(new ZonePoint(token.getX(), token.getY()));
 
               flush(token);
               MapTool.serverCommand().putToken(zone.getId(), token);

--- a/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
@@ -73,8 +74,8 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
     }
   }
 
-  public CellPoint replaceLastWaypoint(CellPoint point) {
-    return replaceLastWaypoint(
+  public void replaceLastWaypoint(CellPoint point) {
+    replaceLastWaypoint(
         point,
         false,
         Collections.singleton(TerrainModifierOperation.NONE),
@@ -86,7 +87,7 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   }
 
   @Override
-  public CellPoint replaceLastWaypoint(
+  public void replaceLastWaypoint(
       CellPoint point,
       boolean restrictMovement,
       Set<TerrainModifierOperation> terrainModifiersIgnored,
@@ -105,7 +106,7 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
     this.tokenMbl = tokenMbl;
 
     if (partialPaths.isEmpty()) {
-      return null;
+      return;
     }
     PartialPath oldPartial = partialPaths.remove(partialPaths.size() - 1);
 
@@ -115,7 +116,6 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
 
     partialPaths.add(
         new PartialPath(oldPartial.start, point, calculatePath(oldPartial.start, point)));
-    return oldPartial.end;
   }
 
   public Path<CellPoint> getPath(RenderPathWorker renderPathWorker) {
@@ -123,7 +123,7 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
     return getPath();
   }
 
-  public Path<CellPoint> getPath() {
+  public @Nonnull Path<CellPoint> getPath() {
     Path<CellPoint> path = new Path<>();
 
     synchronized (partialPaths) {

--- a/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/AbstractZoneWalker.java
@@ -128,19 +128,14 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
 
     synchronized (partialPaths) {
       if (!partialPaths.isEmpty()) {
-        path.addPathCell(partialPaths.get(0).start);
+        path.appendWaypoint(partialPaths.getFirst().start);
+
         for (PartialPath partial : partialPaths) {
-          if (partial.path.size() > 1) {
-            // Remove duplicated cells (end of a path = start of next path)
-            path.addAllPathCells(partial.path.subList(1, partial.path.size()));
+          // First point is already in (end of a path = start of next path)
+          if (!partial.path.isEmpty()) {
+            path.appendPartialPath(partial.path.subList(1, partial.path.size()));
           }
         }
-      }
-    }
-
-    for (CellPoint cp : path.getCellPath()) {
-      if (isWaypoint(cp)) {
-        path.addWayPoint(cp);
       }
     }
 
@@ -223,7 +218,6 @@ public abstract class AbstractZoneWalker implements ZoneWalker {
   protected abstract List<CellPoint> calculatePath(CellPoint start, CellPoint end);
 
   protected static class PartialPath {
-
     final CellPoint start;
     final CellPoint end;
     final List<CellPoint> path;

--- a/src/main/java/net/rptools/maptool/client/walker/NaiveWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/NaiveWalker.java
@@ -16,20 +16,11 @@ package net.rptools.maptool.client.walker;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import net.rptools.maptool.model.CellPoint;
-import net.rptools.maptool.model.TokenFootprint;
-import net.rptools.maptool.model.Zone;
 
-public class NaiveWalker extends AbstractZoneWalker {
-  public NaiveWalker(Zone zone) {
-    super(zone);
-  }
+// Like a ZoneWalker, but only supports calculatePath().
+public class NaiveWalker {
 
-  private double distance;
-
-  @Override
   public List<CellPoint> calculatePath(CellPoint start, CellPoint end) {
     List<CellPoint> list = new ArrayList<CellPoint>();
 
@@ -50,22 +41,6 @@ public class NaiveWalker extends AbstractZoneWalker {
 
       count++;
     }
-    distance = (list.size() - 1) * 5;
     return list;
-  }
-
-  public double getDistance() {
-    return distance;
-  }
-
-  @Override
-  public void setFootprint(TokenFootprint footprint) {
-    // Not needed/used here
-    System.out.println("Should not see this ever!");
-  }
-
-  @Override
-  public Map<CellPoint, Set<CellPoint>> getBlockedMoves() {
-    return null;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/ZoneWalker.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.walker;
 import java.awt.geom.Area;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Path;
@@ -29,9 +30,9 @@ public interface ZoneWalker {
 
   public void addWaypoints(CellPoint... point);
 
-  public CellPoint replaceLastWaypoint(CellPoint point);
+  public void replaceLastWaypoint(CellPoint point);
 
-  public CellPoint replaceLastWaypoint(
+  public void replaceLastWaypoint(
       CellPoint point,
       boolean restrictMovement,
       Set<TerrainModifierOperation> terrainModifiersIgnored,
@@ -45,7 +46,7 @@ public interface ZoneWalker {
 
   public double getDistance();
 
-  public Path<CellPoint> getPath();
+  public @Nonnull Path<CellPoint> getPath();
 
   public Path<CellPoint> getPath(RenderPathWorker renderPathWorker);
 

--- a/src/main/java/net/rptools/maptool/model/AbstractPoint.java
+++ b/src/main/java/net/rptools/maptool/model/AbstractPoint.java
@@ -16,7 +16,7 @@ package net.rptools.maptool.model;
 
 import net.rptools.maptool.server.proto.drawing.IntPointDto;
 
-public abstract class AbstractPoint implements Cloneable {
+public abstract sealed class AbstractPoint implements Cloneable permits ZonePoint, CellPoint {
 
   public int x;
   public int y;

--- a/src/main/java/net/rptools/maptool/model/CellPoint.java
+++ b/src/main/java/net/rptools/maptool/model/CellPoint.java
@@ -26,7 +26,7 @@ import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
  *
  * @author trevor
  */
-public class CellPoint extends AbstractPoint {
+public final class CellPoint extends AbstractPoint {
 
   public double distanceTraveled; // Only populated by AStarWalker classes to be used upstream
   public double

--- a/src/main/java/net/rptools/maptool/model/Path.java
+++ b/src/main/java/net/rptools/maptool/model/Path.java
@@ -17,9 +17,6 @@ package net.rptools.maptool.model;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.ui.zone.renderer.SelectionSet;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.client.walker.NaiveWalker;
 import net.rptools.maptool.server.proto.PathDto;
 import net.rptools.maptool.server.proto.drawing.IntPointDto;
@@ -99,203 +96,97 @@ public class Path<T extends AbstractPoint> {
     return Collections.unmodifiableList(waypointList);
   }
 
-  @SuppressWarnings("unchecked")
-  public Path<T> derive(
-      SelectionSet set,
-      Token keyToken,
-      Token followerToken,
-      ZonePoint startPoint,
-      ZonePoint endPoint) {
-
-    /*
-     * Lee: aiming to fix the following here (snapped = snapped to grid): a. fixing snapped tokens full path when following an unsnapped key token b. fixing zone point precision for unsnapped
-     * tokens following a snapped key token
-     */
-
-    Path<T> path = new Path<T>();
-    // Lee: caching
-    ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
-    Zone zone = zr.getZone();
-    Grid grid = zone.getGrid();
-
-    if (keyToken.isSnapToGrid() && !followerToken.isSnapToGrid()) {
-      ZonePoint buildVal = startPoint;
-      Path<ZonePoint> processPath = new Path<ZonePoint>();
-      for (T p : cellList) {
-        ZonePoint tempPoint = (ZonePoint) buildVal.clone();
-        processPath.cellList.add(tempPoint);
-        if (waypointList.contains(p)) {
-          processPath.waypointList.add(tempPoint);
-        }
-
-        if (buildVal.x < endPoint.x) buildVal.x += 100;
-        else if (buildVal.x > endPoint.x) buildVal.x -= 100;
-        if (buildVal.y < endPoint.y) buildVal.y += 100;
-        else if (buildVal.y > endPoint.y) buildVal.y -= 100;
-      }
-
-      path = (Path<T>) processPath;
-
-    } else if (!keyToken.isSnapToGrid() && followerToken.isSnapToGrid()) {
-      NaiveWalker nw = new NaiveWalker();
-      Path<CellPoint> processPath = new Path<CellPoint>();
-
-      CellPoint prevPoint = grid.convert(new ZonePoint(startPoint.x, startPoint.y));
-      CellPoint terminalPoint = grid.convert(endPoint);
-      CellPoint convPoint;
-
-      Path<ZonePoint> wpl = set.getGridlessPath();
-      List<T> waypointCheck = new LinkedList();
-      List<ZonePoint> cp = wpl.getCellPath();
-      ZonePoint keyStart = cp.get(0);
-      ZonePoint diffFromKey = new ZonePoint(keyStart.x - startPoint.x, keyStart.y - startPoint.y);
-
-      // Lee: list is unmodifiable, working around it
-      int indexCheck = 0;
-      for (ZonePoint zp : cp) {
-
-        if (indexCheck != 0 && indexCheck != cp.size() - 1 && !waypointCheck.contains(zp)) {
-          zp.x = zp.x + diffFromKey.x;
-          zp.y = zp.y + diffFromKey.y;
-          waypointCheck.add((T) zp);
-        }
-
-        indexCheck++;
-      }
-
-      if (!waypointCheck.isEmpty()) {
-        for (T p : waypointCheck) {
-          if (p instanceof ZonePoint) convPoint = grid.convert((ZonePoint) p);
-          else convPoint = (CellPoint) p;
-          processPath.cellList.addAll(nw.calculatePath(prevPoint, convPoint));
-          prevPoint = convPoint;
-        }
-      }
-      processPath.cellList.addAll(nw.calculatePath(prevPoint, terminalPoint));
-
-      path = (Path<T>) processPath;
-
-      for (T p : waypointCheck) {
-        if (p instanceof ZonePoint) convPoint = grid.convert((ZonePoint) p);
-        else convPoint = (CellPoint) p;
-
-        T next = (T) convPoint.clone();
-        path.waypointList.add(next);
-      }
-
-    } else {
-      AbstractPoint originPoint, tokenCell;
-      if (keyToken.isSnapToGrid()) {
-        originPoint = zone.getGrid().convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
-      } else {
-        originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
-      }
-      if (followerToken.isSnapToGrid()) {
-        tokenCell =
-            zone.getGrid().convert(new ZonePoint(followerToken.getX(), followerToken.getY()));
-      } else {
-        tokenCell = new ZonePoint(followerToken.getX(), followerToken.getY());
-      }
-
-      var cellOffsetX = originPoint.x - tokenCell.x;
-      var cellOffsetY = originPoint.y - tokenCell.y;
-
-      for (T cp : cellList) {
-        T np = (T) cp.clone();
-        np.x -= cellOffsetX;
-        np.y -= cellOffsetY;
-        path.cellList.add(np);
-      }
-
-      for (T cp : waypointList) {
-        T np = (T) cp.clone();
-        np.x -= cellOffsetX;
-        np.y -= cellOffsetY;
-        path.waypointList.add(np);
-      }
-
-      /*
-       * Not exactly sure what Lee was trying to do here?
-       * I believe he was trying to return all the "cells" a non-STG token moved though?
-       * I'll leave the code below in case someone wants to clean it up later.
-       * For now, I've restored partial logic back to 1.4.0.5 above.
-       */
-
-      /*
-      	// Lee: solo movement
-      	if (keyToken.isSnapToGrid()) {
-      		for (T cp : cellList) {
-      			T np = (T) cp.clone();
-      			np.x -= cellOffsetX;
-      			np.y -= cellOffsetY;
-      			path.addPathCell(np);
-      		}
-
-      		for (T cp : waypointList) {
-      			T np = (T) cp.clone();
-      			np.x -= cellOffsetX;
-      			np.y -= cellOffsetY;
-      			path.addWayPoint(np);
-      		}
-      	} else {
-      		Path<CellPoint> reflectedPath = new Path<CellPoint>();
-      		NaiveWalker nw = new NaiveWalker(zone);
-      		Path<ZonePoint> wpl = set.getGridlessPath();
-
-      		if (cellList.size() > 2) {
-
-      			CellPoint prevPoint = grid.convert(new ZonePoint(startPoint.x, startPoint.y));
-      			CellPoint terminalPoint = grid.convert(endPoint);
-      			CellPoint convPoint;
-
-      			// Lee: since we already have the start point
-      			((List<T>) cellList).remove(0);
-
-      			for (T p : cellList) {
-      				convPoint = grid.convert((ZonePoint) p);
-      				reflectedPath.addAllPathCells(nw.calculatePath(prevPoint, convPoint));
-      				prevPoint = convPoint;
-      			}
-
-      		} else {
-      			reflectedPath.addAllPathCells(
-      					nw.calculatePath(grid.convert(startPoint), grid.convert(endPoint)));
-      		}
-
-      		ZonePoint buildVal = startPoint;
-      		Path<ZonePoint> processPath = new Path<ZonePoint>();
-
-      		for (CellPoint p : reflectedPath.getCellPath()) {
-      			ZonePoint tempPoint = (ZonePoint) buildVal.clone();
-      			processPath.addPathCell(tempPoint);
-
-      			if (buildVal.x < endPoint.x)
-      				buildVal.x += 100;
-      			else if (buildVal.x > endPoint.x)
-      				buildVal.x -= 100;
-      			if (buildVal.y < endPoint.y)
-      				buildVal.y += 100;
-      			else if (buildVal.y > endPoint.y)
-      				buildVal.y -= 100;
-      		}
-
-      		// processPath.addWayPoint(startPoint);
-      		for (T cp : waypointList) {
-      			ZonePoint np = (ZonePoint) cp;
-      			if (np != startPoint && np != endPoint)
-      				processPath.addWayPoint(np);
-      		}
-
-      		processPath.addWayPoint(endPoint);
-
-      		// Lee: replacing the last point in derived path for the more
-      		// accurate landing point
-      		processPath.replaceLastPoint(endPoint);
-      		path = (Path<T>) processPath;
-      	}
-      */
+  /** Create a related path that can be applied to a follower token. */
+  public Path<?> derive(Grid grid, Token keyToken, Token followerToken) {
+    if (keyToken.isSnapToGrid() && followerToken.isSnapToGrid()) {
+      // Assume T = CellPoint.
+      var originCell = grid.convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
+      var tokenCell = grid.convert(new ZonePoint(followerToken.getX(), followerToken.getY()));
+      return deriveSameSnapToGrid(this, originCell.x - tokenCell.x, originCell.y - tokenCell.y);
+    } else if (!keyToken.isSnapToGrid() && !followerToken.isSnapToGrid()) {
+      // Assume T = ZonePoint.
+      var originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
+      var tokenPoint = new ZonePoint(followerToken.getX(), followerToken.getY());
+      return deriveSameSnapToGrid(this, originPoint.x - tokenPoint.x, originPoint.y - tokenPoint.y);
+    } else if (keyToken.isSnapToGrid()) {
+      // Assume T = CellPoint.
+      return deriveFromSnapToGrid(
+          (Path<CellPoint>) this,
+          grid,
+          keyToken.getX() - followerToken.getX(),
+          keyToken.getY() - followerToken.getY());
+    } else /* (!keyToken.isSnapToGrid) */ {
+      // Assume T = ZonePoint.
+      return deriveFromNotSnapToGrid(
+          (Path<ZonePoint>) this,
+          grid,
+          keyToken.getX() - followerToken.getX(),
+          keyToken.getY() - followerToken.getY());
     }
-    return path;
+  }
+
+  private static <T extends AbstractPoint> Path<T> deriveSameSnapToGrid(
+      Path<T> path, int offsetX, int offsetY) {
+    var result = new Path<T>();
+    // Not much to do here except copy the list, offsetting the follower.
+    for (T point : path.cellList) {
+      var newPoint = copyPoint(point);
+      newPoint.x -= offsetX;
+      newPoint.y -= offsetY;
+      result.cellList.add(newPoint);
+    }
+
+    for (T point : path.waypointList) {
+      var newPoint = copyPoint(point);
+      newPoint.x -= offsetX;
+      newPoint.y -= offsetY;
+      result.waypointList.add(newPoint);
+    }
+    return result;
+  }
+
+  private static Path<ZonePoint> deriveFromSnapToGrid(
+      Path<CellPoint> path, Grid grid, int zoneOffsetX, int zoneOffsetY) {
+    var result = new Path<ZonePoint>();
+    // Only use the waypoint list, otherwise we get a path full of nothing but waypoints.
+    for (CellPoint point : path.waypointList) {
+      var newPoint = grid.convert(point);
+      newPoint.x -= zoneOffsetX;
+      newPoint.y -= zoneOffsetY;
+      result.appendWaypoint(newPoint);
+    }
+
+    return result;
+  }
+
+  private static Path<CellPoint> deriveFromNotSnapToGrid(
+      Path<ZonePoint> path, Grid grid, int zoneOffsetX, int zoneOffsetY) {
+    var result = new Path<CellPoint>();
+    // The waypoints are easy: just map them to the best grid cell. But we need to fill in all the
+    // intervening points, so use a naive walker for that.
+    // The cell points of path should just be the waypoints, so just ignore them.
+
+    CellPoint previous = null;
+    for (ZonePoint point : path.waypointList) {
+      var newPoint = new ZonePoint(point);
+      newPoint.x -= zoneOffsetX;
+      newPoint.y -= zoneOffsetY;
+      var current = grid.convert(newPoint);
+
+      if (previous == null) {
+        result.appendWaypoint(current);
+        previous = current;
+        continue;
+      }
+
+      var walker = new NaiveWalker();
+      var walkerPath = walker.calculatePath(previous, current);
+      // Path will be a list: [previous, ..., current]. We already have previous, so chop that off.
+      result.appendPartialPath(walkerPath.subList(1, walkerPath.size()));
+      previous = current;
+    }
+
+    return result;
   }
 
   public static Path<?> fromDto(PathDto dto) {
@@ -313,13 +204,11 @@ public class Path<T extends AbstractPoint> {
   }
 
   public PathDto toDto() {
-    if (cellList.isEmpty()) {
-      return null;
-    }
-
     var dto = PathDto.newBuilder();
 
-    if (cellList.getFirst() instanceof CellPoint) {
+    // An empty path cannot tell what kind of points it is supposed to contain. Arbitrarily assign
+    // it as cell points.
+    if (cellList.isEmpty() || cellList.getFirst() instanceof CellPoint) {
       dto.setPointType(PathDto.PointType.CELL_POINT);
     } else {
       dto.setPointType(PathDto.PointType.ZONE_POINT);

--- a/src/main/java/net/rptools/maptool/model/Path.java
+++ b/src/main/java/net/rptools/maptool/model/Path.java
@@ -126,7 +126,7 @@ public class Path<T extends AbstractPoint> {
       path = (Path<T>) processPath;
 
     } else if (!keyToken.isSnapToGrid() && followerToken.isSnapToGrid()) {
-      NaiveWalker nw = new NaiveWalker(zone);
+      NaiveWalker nw = new NaiveWalker();
       Path<CellPoint> processPath = new Path<CellPoint>();
 
       CellPoint prevPoint = grid.convert(new ZonePoint(startPoint.x, startPoint.y));

--- a/src/main/java/net/rptools/maptool/model/Path.java
+++ b/src/main/java/net/rptools/maptool/model/Path.java
@@ -104,8 +104,6 @@ public class Path<T extends AbstractPoint> {
       SelectionSet set,
       Token keyToken,
       Token followerToken,
-      int cellOffsetX,
-      int cellOffsetY,
       ZonePoint startPoint,
       ZonePoint endPoint) {
 
@@ -182,12 +180,26 @@ public class Path<T extends AbstractPoint> {
         else convPoint = (CellPoint) p;
 
         T next = (T) convPoint.clone();
-        next.x -= cellOffsetX;
-        next.y -= cellOffsetY;
         path.waypointList.add(next);
       }
 
     } else {
+      AbstractPoint originPoint, tokenCell;
+      if (keyToken.isSnapToGrid()) {
+        originPoint = zone.getGrid().convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
+      } else {
+        originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
+      }
+      if (followerToken.isSnapToGrid()) {
+        tokenCell =
+            zone.getGrid().convert(new ZonePoint(followerToken.getX(), followerToken.getY()));
+      } else {
+        tokenCell = new ZonePoint(followerToken.getX(), followerToken.getY());
+      }
+
+      var cellOffsetX = originPoint.x - tokenCell.x;
+      var cellOffsetY = originPoint.y - tokenCell.y;
+
       for (T cp : cellList) {
         T np = (T) cp.clone();
         np.x -= cellOffsetX;

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -51,7 +51,6 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.swing.SwingUtil;
-import net.rptools.maptool.client.ui.zone.renderer.SelectionSet;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
@@ -1278,33 +1277,6 @@ public class Token implements Cloneable {
     }
 
     return tokenOrigin;
-  }
-
-  /*
-   * Lee: changing this to apply new X and Y values (as end point) for the token BEFORE its path is
-   * computed. Path to be saved will be computed here instead of in ZoneRenderer
-   */
-  public void applyMove(
-      SelectionSet set,
-      Path<? extends AbstractPoint> followerPath,
-      int xOffset,
-      int yOffset,
-      Token keyToken,
-      int cellOffX,
-      int cellOffY) {
-    setX(x + xOffset);
-    setY(y + yOffset);
-    lastPath =
-        followerPath != null
-            ? followerPath.derive(
-                set,
-                keyToken,
-                this,
-                cellOffX,
-                cellOffY,
-                getOriginPoint(),
-                new ZonePoint(getX(), getY()))
-            : null;
   }
 
   public void setLastPath(Path<? extends AbstractPoint> path) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -242,8 +242,6 @@ public class Token implements Cloneable {
   private int lastY;
   private Path<? extends AbstractPoint> lastPath;
 
-  // Lee: for use in added path calculations
-  private transient ZonePoint tokenOrigin = null;
   private boolean snapToScale = true; // Whether the scaleX and scaleY represent snap-to-grid
   // measurements
 
@@ -1264,19 +1262,6 @@ public class Token implements Cloneable {
   public void setY(int y) {
     lastY = this.y;
     this.y = y;
-  }
-
-  // Lee: added functions necessary for path computations
-  public void setOriginPoint(ZonePoint p) {
-    tokenOrigin = p;
-  }
-
-  public ZonePoint getOriginPoint() {
-    if (tokenOrigin == null) {
-      tokenOrigin = new ZonePoint(getX(), getY());
-    }
-
-    return tokenOrigin;
   }
 
   public void setLastPath(Path<? extends AbstractPoint> path) {

--- a/src/main/java/net/rptools/maptool/model/ZonePoint.java
+++ b/src/main/java/net/rptools/maptool/model/ZonePoint.java
@@ -14,7 +14,7 @@
  */
 package net.rptools.maptool.model;
 
-public class ZonePoint extends AbstractPoint {
+public final class ZonePoint extends AbstractPoint {
   public ZonePoint(int x, int y) {
     super(x, y);
   }

--- a/src/test/java/net/rptools/maptool/model/PathTest.java
+++ b/src/test/java/net/rptools/maptool/model/PathTest.java
@@ -1,0 +1,681 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class PathTest {
+  @Test
+  @DisplayName("Test that a new path is empty")
+  public void testNewPath() {
+    var path = new Path<>();
+
+    assertTrue(path.getCellPath().isEmpty());
+    assertTrue(path.getWayPointList().isEmpty());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending a waypoint to an empty path results in a path with one cell and one waypoint")
+  public void testSingletonPath() {
+    var path = new Path<ZonePoint>();
+    var point = new ZonePoint(1, 3);
+
+    path.appendWaypoint(point);
+
+    assertIterableEquals(List.of(point), path.getCellPath());
+    assertIterableEquals(List.of(point), path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending a partial path to an empty path sets the first and last point as waypoints")
+  public void testAddingPartialPathToEmptyPath() {
+    var path = new Path<ZonePoint>();
+    var partialPath =
+        List.of(new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0));
+
+    path.appendPartialPath(partialPath);
+
+    assertIterableEquals(partialPath, path.getCellPath());
+    var expectedWaypoints = List.of(new ZonePoint(1, 3), new ZonePoint(4, 0));
+    assertIterableEquals(expectedWaypoints, path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending an singleton partial path to an empty path adds the single point as the only cell and waypoint in the result")
+  public void testAddingSingletonPartialPathToEmptyPath() {
+    var path = new Path<ZonePoint>();
+    var partialPath = List.of(new ZonePoint(1, 3));
+
+    path.appendPartialPath(partialPath);
+
+    assertIterableEquals(partialPath, path.getCellPath());
+    assertIterableEquals(partialPath, path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending a partial path to a singleton path extends the path and adds only the last point as a waypoint")
+  public void testAddingPartialPathToSingletonPath() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+
+    var expectedCellPoints =
+        List.of(
+            new ZonePoint(0, 4),
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(4, 0));
+    assertIterableEquals(expectedCellPoints, path.getCellPath());
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0));
+    assertIterableEquals(expectedWaypoints, path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending a partial path to a non-empty path extends the path and adds only the last point as a waypoint")
+  public void testAddingPartialPathToPath() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+
+    path.appendPartialPath(
+        List.of(new ZonePoint(5, -1), new ZonePoint(6, -2), new ZonePoint(7, -3)));
+
+    var expectedCellPoints =
+        List.of(
+            new ZonePoint(0, 4),
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(4, 0),
+            new ZonePoint(5, -1),
+            new ZonePoint(6, -2),
+            new ZonePoint(7, -3));
+    assertIterableEquals(expectedCellPoints, path.getCellPath());
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0), new ZonePoint(7, -3));
+    assertIterableEquals(expectedWaypoints, path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending an empty partial path to a non-empty path does not modify the path")
+  public void testAddingEmptyPartialPathToPath() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+
+    path.appendPartialPath(List.of());
+
+    var expectedCellPoints =
+        List.of(
+            new ZonePoint(0, 4),
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(4, 0));
+    assertIterableEquals(expectedCellPoints, path.getCellPath());
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0));
+    assertIterableEquals(expectedWaypoints, path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName(
+      "Test that appending an singleton partial path to a non-empty path adds the single point as a cell and as a waypoint")
+  public void testAddingSingletonPartialPathToPath() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+
+    path.appendPartialPath(List.of(new ZonePoint(5, -1)));
+
+    var expectedCellPoints =
+        List.of(
+            new ZonePoint(0, 4),
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(4, 0),
+            new ZonePoint(5, -1));
+    assertIterableEquals(expectedCellPoints, path.getCellPath());
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0), new ZonePoint(5, -1));
+    assertIterableEquals(expectedWaypoints, path.getWayPointList());
+  }
+
+  @Test
+  @DisplayName("Test that copying a path returns an equivalent path with unique point objects")
+  public void testCopyPath() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+
+    var copy = path.copy();
+
+    var expectedCellPoints =
+        List.of(
+            new ZonePoint(0, 4),
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(4, 0));
+    assertIterableEquals(expectedCellPoints, copy.getCellPath());
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0));
+    assertIterableEquals(expectedWaypoints, copy.getWayPointList());
+
+    for (int i = 0; i < path.getCellPath().size(); ++i) {
+      var originalPoint = path.getCellPath().get(i);
+      var copyPoint = copy.getCellPath().get(i);
+      assertNotSame(originalPoint, copyPoint);
+    }
+    for (int i = 0; i < path.getWayPointList().size(); ++i) {
+      var originalPoint = path.getWayPointList().get(i);
+      var copyPoint = copy.getWayPointList().get(i);
+      assertNotSame(originalPoint, copyPoint);
+    }
+  }
+
+  @Test
+  @DisplayName("Test that isWaypoint() agrees with getWaypointList()")
+  public void testIsWaypoint() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+    path.appendPartialPath(
+        List.of(new ZonePoint(5, -1), new ZonePoint(6, -2), new ZonePoint(7, -3)));
+
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0), new ZonePoint(7, -3));
+    for (var waypoint : expectedWaypoints) {
+      assertTrue(
+          path.isWaypoint(waypoint),
+          () -> String.format("Point %s should be a waypoint", waypoint));
+    }
+    var expectedNotWaypoints =
+        List.of(
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(5, -1),
+            new ZonePoint(6, -2));
+    for (var notWaypoint : expectedNotWaypoints) {
+      assertFalse(
+          path.isWaypoint(notWaypoint),
+          () -> String.format("Point %s should not be a waypoint", notWaypoint));
+    }
+  }
+
+  @Test
+  @DisplayName("Test that an empty path can be converted to a DTO and back")
+  public void testEmptyDto() {
+    var path = new Path<ZonePoint>();
+
+    var dto = path.toDto();
+    var newPath = Path.fromDto(dto);
+
+    assertTrue(newPath.getCellPath().isEmpty());
+    assertTrue(newPath.getWayPointList().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Test that a path of ZonePoint can be converted to and from a DTO")
+  public void testDtoZonePoint() {
+    var path = new Path<ZonePoint>();
+    path.appendWaypoint(new ZonePoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new ZonePoint(1, 3), new ZonePoint(2, 2), new ZonePoint(3, 1), new ZonePoint(4, 0)));
+    path.appendPartialPath(
+        List.of(new ZonePoint(5, -1), new ZonePoint(6, -2), new ZonePoint(7, -3)));
+
+    var dto = path.toDto();
+    var newPath = Path.fromDto(dto);
+
+    var expectedCellPoints =
+        List.of(
+            new ZonePoint(0, 4),
+            new ZonePoint(1, 3),
+            new ZonePoint(2, 2),
+            new ZonePoint(3, 1),
+            new ZonePoint(4, 0),
+            new ZonePoint(5, -1),
+            new ZonePoint(6, -2),
+            new ZonePoint(7, -3));
+    assertIterableEquals(expectedCellPoints, newPath.getCellPath());
+
+    var expectedWaypoints = List.of(new ZonePoint(0, 4), new ZonePoint(4, 0), new ZonePoint(7, -3));
+    assertIterableEquals(expectedWaypoints, newPath.getWayPointList());
+
+    // Make sure we didn't confuse the point type.
+    for (var cell : newPath.getCellPath()) {
+      assertInstanceOf(ZonePoint.class, cell);
+    }
+    for (var waypoint : newPath.getWayPointList()) {
+      assertInstanceOf(ZonePoint.class, waypoint);
+    }
+  }
+
+  @Test
+  @DisplayName("Test that a path of CellPoint can be converted to and from a DTO")
+  public void testDtoCellPoint() {
+    var path = new Path<CellPoint>();
+    path.appendWaypoint(new CellPoint(0, 4));
+    path.appendPartialPath(
+        List.of(
+            new CellPoint(1, 3), new CellPoint(2, 2), new CellPoint(3, 1), new CellPoint(4, 0)));
+    path.appendPartialPath(
+        List.of(new CellPoint(5, -1), new CellPoint(6, -2), new CellPoint(7, -3)));
+
+    var dto = path.toDto();
+    var newPath = Path.fromDto(dto);
+
+    var expectedCellPoints =
+        List.of(
+            new CellPoint(0, 4),
+            new CellPoint(1, 3),
+            new CellPoint(2, 2),
+            new CellPoint(3, 1),
+            new CellPoint(4, 0),
+            new CellPoint(5, -1),
+            new CellPoint(6, -2),
+            new CellPoint(7, -3));
+    assertIterableEquals(expectedCellPoints, newPath.getCellPath());
+
+    var expectedWaypoints = List.of(new CellPoint(0, 4), new CellPoint(4, 0), new CellPoint(7, -3));
+    assertIterableEquals(expectedWaypoints, newPath.getWayPointList());
+
+    // Make sure we didn't confuse the point type.
+    for (var cell : newPath.getCellPath()) {
+      assertInstanceOf(CellPoint.class, cell);
+    }
+    for (var waypoint : newPath.getWayPointList()) {
+      assertInstanceOf(CellPoint.class, waypoint);
+    }
+  }
+
+  // TODO @Nested for derived tests.
+
+  @Nested
+  class DerivedPathTests {
+    @Test
+    @DisplayName(
+        "Test that a non-snap-to-grid follower path is properly derived from a non-snap-to-grid leader path")
+    public void testDeriveNonStgFollowingNonStg() {
+      var path = new Path<ZonePoint>();
+      path.appendWaypoint(new ZonePoint(52, 427));
+      path.appendPartialPath(
+          List.of(
+              new ZonePoint(116, 364),
+              new ZonePoint(231, 290),
+              new ZonePoint(342, 172),
+              new ZonePoint(429, 65)));
+      path.appendPartialPath(
+          List.of(new ZonePoint(502, -91), new ZonePoint(628, -171), new ZonePoint(756, -272)));
+      var grid = mock(Grid.class);
+      var leaderToken = mock(Token.class);
+      when(leaderToken.isSnapToGrid()).thenReturn(false);
+      // Position agrees with start of path.
+      when(leaderToken.getX()).thenReturn(52);
+      when(leaderToken.getY()).thenReturn(427);
+      var followerToken = mock(Token.class);
+      when(followerToken.isSnapToGrid()).thenReturn(false);
+      // Offset a bit from the leader.
+      when(followerToken.getX()).thenReturn(1012);
+      when(followerToken.getY()).thenReturn(1184);
+
+      var derived = path.derive(grid, leaderToken, followerToken);
+
+      // All points are used, even though in practice non-STG tokens only have waypoints.
+      var expectedCellPoints =
+          List.of(
+              new ZonePoint(1012, 1184),
+              new ZonePoint(1076, 1121),
+              new ZonePoint(1191, 1047),
+              new ZonePoint(1302, 929),
+              new ZonePoint(1389, 822),
+              new ZonePoint(1462, 666),
+              new ZonePoint(1588, 586),
+              new ZonePoint(1716, 485));
+      assertIterableEquals(expectedCellPoints, derived.getCellPath());
+      var expectedWaypoints =
+          List.of(new ZonePoint(1012, 1184), new ZonePoint(1389, 822), new ZonePoint(1716, 485));
+      assertIterableEquals(expectedWaypoints, derived.getWayPointList());
+
+      for (var cell : derived.getCellPath()) {
+        assertInstanceOf(ZonePoint.class, cell);
+      }
+      for (var waypoint : derived.getWayPointList()) {
+        assertInstanceOf(ZonePoint.class, waypoint);
+      }
+    }
+
+    @Test
+    @DisplayName(
+        "Test that a snap-to-grid follower path is properly derived from a snap-to-grid leader path")
+    public void testDeriveStgFollowingStg() {
+      var path = new Path<CellPoint>();
+      path.appendWaypoint(new CellPoint(0, 4));
+      path.appendPartialPath(
+          List.of(
+              new CellPoint(1, 3), new CellPoint(2, 2), new CellPoint(3, 1), new CellPoint(4, 0)));
+      path.appendPartialPath(
+          List.of(new CellPoint(5, -1), new CellPoint(6, -2), new CellPoint(7, -3)));
+      var grid = mock(Grid.class);
+      when(grid.convert(new ZonePoint(52, 427))).thenReturn(new CellPoint(0, 4));
+      when(grid.convert(new ZonePoint(1012, 1184))).thenReturn(new CellPoint(10, 11));
+
+      var leaderToken = mock(Token.class);
+      when(leaderToken.isSnapToGrid()).thenReturn(true);
+      // Position agrees with start of path.
+      when(leaderToken.getX()).thenReturn(52);
+      when(leaderToken.getY()).thenReturn(427);
+      var followerToken = mock(Token.class);
+      when(followerToken.isSnapToGrid()).thenReturn(true);
+      // Offset a bit from the leader.
+      when(followerToken.getX()).thenReturn(1012);
+      when(followerToken.getY()).thenReturn(1184);
+
+      var derived = path.derive(grid, leaderToken, followerToken);
+
+      // All points are used, even though in practice non-STG tokens only have waypoints.
+      var expectedCellPoints =
+          List.of(
+              new CellPoint(10, 11),
+              new CellPoint(11, 10),
+              new CellPoint(12, 9),
+              new CellPoint(13, 8),
+              new CellPoint(14, 7),
+              new CellPoint(15, 6),
+              new CellPoint(16, 5),
+              new CellPoint(17, 4));
+      assertIterableEquals(expectedCellPoints, derived.getCellPath());
+      var expectedWaypoints =
+          List.of(new CellPoint(10, 11), new CellPoint(14, 7), new CellPoint(17, 4));
+      assertIterableEquals(expectedWaypoints, derived.getWayPointList());
+
+      for (var cell : derived.getCellPath()) {
+        assertInstanceOf(CellPoint.class, cell);
+      }
+      for (var waypoint : derived.getWayPointList()) {
+        assertInstanceOf(CellPoint.class, waypoint);
+      }
+    }
+
+    @Test
+    @DisplayName(
+        "Test that a non-snap-to-grid follower path is properly derived from a snap-to-grid leader path")
+    public void testDeriveNonStgFollowingStg() {
+      var path = new Path<CellPoint>();
+      path.appendWaypoint(new CellPoint(0, 4));
+      path.appendPartialPath(
+          List.of(
+              new CellPoint(1, 3), new CellPoint(2, 2), new CellPoint(3, 1), new CellPoint(4, 0)));
+      path.appendPartialPath(
+          List.of(new CellPoint(5, -1), new CellPoint(6, -2), new CellPoint(7, -3)));
+      var grid = mock(Grid.class);
+      when(grid.convert(new CellPoint(0, 4))).thenReturn(new ZonePoint(0, 400));
+      when(grid.convert(new CellPoint(1, 3))).thenReturn(new ZonePoint(100, 300));
+      when(grid.convert(new CellPoint(2, 2))).thenReturn(new ZonePoint(200, 200));
+      when(grid.convert(new CellPoint(3, 1))).thenReturn(new ZonePoint(300, 100));
+      when(grid.convert(new CellPoint(4, 0))).thenReturn(new ZonePoint(400, 0));
+      when(grid.convert(new CellPoint(5, -1))).thenReturn(new ZonePoint(500, -100));
+      when(grid.convert(new CellPoint(6, -2))).thenReturn(new ZonePoint(600, -200));
+      when(grid.convert(new CellPoint(7, -3))).thenReturn(new ZonePoint(700, -300));
+      var leaderToken = mock(Token.class);
+      when(leaderToken.isSnapToGrid()).thenReturn(true);
+      // Position agrees with start of path.
+      when(leaderToken.getX()).thenReturn(52);
+      when(leaderToken.getY()).thenReturn(427);
+      var followerToken = mock(Token.class);
+      when(followerToken.isSnapToGrid()).thenReturn(false);
+      // Offset a bit from the leader.
+      when(followerToken.getX()).thenReturn(1012);
+      when(followerToken.getY()).thenReturn(1184);
+
+      var derived = path.derive(grid, leaderToken, followerToken);
+
+      // Only the waypoints are used.
+      var expectedCellPoints =
+          List.of(new ZonePoint(960, 1157), new ZonePoint(1360, 757), new ZonePoint(1660, 457));
+      assertIterableEquals(expectedCellPoints, derived.getCellPath());
+      var expectedWaypoints = expectedCellPoints;
+      assertIterableEquals(expectedWaypoints, derived.getWayPointList());
+
+      for (var cell : derived.getCellPath()) {
+        assertInstanceOf(ZonePoint.class, cell);
+      }
+      for (var waypoint : derived.getWayPointList()) {
+        assertInstanceOf(ZonePoint.class, waypoint);
+      }
+    }
+
+    @Test
+    @DisplayName(
+        "Test that a snap-to-grid follower path is properly derived from a non-snap-to-grid leader path")
+    public void testDeriveStgFollowingNonStg() {
+      var path = new Path<ZonePoint>();
+      path.appendWaypoint(new ZonePoint(52, 427));
+      path.appendPartialPath(
+          List.of(
+              new ZonePoint(116, 364),
+              new ZonePoint(231, 290),
+              new ZonePoint(342, 172),
+              new ZonePoint(429, 65)));
+      path.appendPartialPath(
+          List.of(new ZonePoint(502, -91), new ZonePoint(628, -171), new ZonePoint(756, -272)));
+      var grid = mock(Grid.class);
+      when(grid.convert(new ZonePoint(1012, 1184))).thenReturn(new CellPoint(10, 11));
+      when(grid.convert(new ZonePoint(1389, 822))).thenReturn(new CellPoint(13, 8));
+      when(grid.convert(new ZonePoint(1716, 485))).thenReturn(new CellPoint(17, 4));
+      var leaderToken = mock(Token.class);
+      when(leaderToken.isSnapToGrid()).thenReturn(false);
+      // Position agrees with start of path.
+      when(leaderToken.getX()).thenReturn(52);
+      when(leaderToken.getY()).thenReturn(427);
+      var followerToken = mock(Token.class);
+      when(followerToken.isSnapToGrid()).thenReturn(true);
+      // Offset a bit from the leader.
+      when(followerToken.getX()).thenReturn(1012);
+      when(followerToken.getY()).thenReturn(1184);
+
+      var derived = path.derive(grid, leaderToken, followerToken);
+
+      // Only waypoints are used directly. The rest are interpolated.
+      var expectedCellPoints =
+          List.of(
+              new CellPoint(10, 11),
+              new CellPoint(11, 10),
+              new CellPoint(12, 9),
+              new CellPoint(13, 8),
+              new CellPoint(14, 7),
+              new CellPoint(15, 6),
+              new CellPoint(16, 5),
+              new CellPoint(17, 4));
+      assertIterableEquals(expectedCellPoints, derived.getCellPath());
+      var expectedWaypoints =
+          List.of(new CellPoint(10, 11), new CellPoint(13, 8), new CellPoint(17, 4));
+      assertIterableEquals(expectedWaypoints, derived.getWayPointList());
+
+      for (var cell : derived.getCellPath()) {
+        assertInstanceOf(CellPoint.class, cell);
+      }
+      for (var waypoint : derived.getWayPointList()) {
+        assertInstanceOf(CellPoint.class, waypoint);
+      }
+    }
+
+    @Test
+    @DisplayName(
+        "Test that a snap-to-grid follower path is properly derived from a non-snap-to-grid leader path using the naive walk")
+    public void testDeriveStgFollowingNonStgWithDifferentSlope() {
+      var path = new Path<ZonePoint>();
+      path.appendWaypoint(new ZonePoint(52, 427));
+      path.appendWaypoint(new ZonePoint(889, 838));
+      path.appendWaypoint(new ZonePoint(445, -238));
+      var grid = mock(Grid.class);
+      when(grid.convert(new ZonePoint(1012, 1184))).thenReturn(new CellPoint(10, 11));
+      when(grid.convert(new ZonePoint(1849, 1595))).thenReturn(new CellPoint(18, 15));
+      when(grid.convert(new ZonePoint(1405, 519))).thenReturn(new CellPoint(14, 5));
+      var leaderToken = mock(Token.class);
+      when(leaderToken.isSnapToGrid()).thenReturn(false);
+      // Position agrees with start of path.
+      when(leaderToken.getX()).thenReturn(52);
+      when(leaderToken.getY()).thenReturn(427);
+      var followerToken = mock(Token.class);
+      when(followerToken.isSnapToGrid()).thenReturn(true);
+      // Offset a bit from the leader.
+      when(followerToken.getX()).thenReturn(1012);
+      when(followerToken.getY()).thenReturn(1184);
+
+      var derived = path.derive(grid, leaderToken, followerToken);
+
+      // Only waypoints are used directly. The rest are interpolated.
+      var expectedCellPoints =
+          List.of(
+              new CellPoint(10, 11),
+              new CellPoint(11, 12),
+              new CellPoint(12, 13),
+              new CellPoint(13, 14),
+              new CellPoint(14, 15),
+              new CellPoint(15, 15),
+              new CellPoint(16, 15),
+              new CellPoint(17, 15),
+              new CellPoint(18, 15),
+              new CellPoint(17, 14),
+              new CellPoint(16, 13),
+              new CellPoint(15, 12),
+              new CellPoint(14, 11),
+              new CellPoint(14, 10),
+              new CellPoint(14, 9),
+              new CellPoint(14, 8),
+              new CellPoint(14, 7),
+              new CellPoint(14, 6),
+              new CellPoint(14, 5));
+      assertIterableEquals(expectedCellPoints, derived.getCellPath());
+      var expectedWaypoints =
+          List.of(new CellPoint(10, 11), new CellPoint(18, 15), new CellPoint(14, 5));
+      assertIterableEquals(expectedWaypoints, derived.getWayPointList());
+
+      for (var cell : derived.getCellPath()) {
+        assertInstanceOf(CellPoint.class, cell);
+      }
+      for (var waypoint : derived.getWayPointList()) {
+        assertInstanceOf(CellPoint.class, waypoint);
+      }
+    }
+
+    @Test
+    @DisplayName(
+        "Test that a snap-to-grid leader's derived path does not include extra waypoints when the path crosses the start or endpoint")
+    public void testStgPathCrossingItself() {
+      // Previous implementations of derive() would add waypoints anywhere along a path if the
+      // position was a waypoint. So a path that crosses itself could be given many more waypoints
+      // than were actually set. We don't do that anymore, and this test ensures it.
+
+      var path = new Path<CellPoint>();
+      path.appendWaypoint(new CellPoint(0, 0));
+      path.appendPartialPath(
+          List.of(
+              new CellPoint(1, 0), new CellPoint(2, 0), new CellPoint(3, 0), new CellPoint(4, 0)));
+      path.appendPartialPath(
+          List.of(
+              new CellPoint(3, 1), new CellPoint(2, 2), new CellPoint(1, 3), new CellPoint(0, 4)));
+      path.appendPartialPath(
+          List.of(
+              new CellPoint(0, 3),
+              new CellPoint(0, 2),
+              new CellPoint(0, 1),
+              // Note: this point is also the first point in the path.
+              new CellPoint(0, 0),
+              new CellPoint(0, -1),
+              new CellPoint(0, -2)));
+      path.appendPartialPath(
+          List.of(
+              new CellPoint(1, -1),
+              // Note: this last point crosses through the first partial path.
+              new CellPoint(2, 0)));
+      var grid = mock(Grid.class);
+      when(grid.convert(new ZonePoint(50, 50))).thenReturn(new CellPoint(0, 0));
+      var leaderToken = mock(Token.class);
+      when(leaderToken.isSnapToGrid()).thenReturn(true);
+      // Position agrees with start of path.
+      when(leaderToken.getX()).thenReturn(50);
+      when(leaderToken.getY()).thenReturn(50);
+
+      var derived = path.derive(grid, leaderToken, leaderToken);
+
+      // All points are used, even though in practice non-STG tokens only have waypoints.
+      var expectedCellPoints =
+          List.of(
+              new CellPoint(0, 0),
+              new CellPoint(1, 0),
+              new CellPoint(2, 0),
+              new CellPoint(3, 0),
+              new CellPoint(4, 0),
+              new CellPoint(3, 1),
+              new CellPoint(2, 2),
+              new CellPoint(1, 3),
+              new CellPoint(0, 4),
+              new CellPoint(0, 3),
+              new CellPoint(0, 2),
+              new CellPoint(0, 1),
+              new CellPoint(0, 0),
+              new CellPoint(0, -1),
+              new CellPoint(0, -2),
+              new CellPoint(1, -1),
+              new CellPoint(2, 0));
+      assertIterableEquals(expectedCellPoints, derived.getCellPath());
+      var expectedWaypoints =
+          List.of(
+              // Important that these are exactly the waypoints set, in the orer they were set.
+              new CellPoint(0, 0),
+              // Note: No (2, 0) waypoint here.
+              new CellPoint(4, 0),
+              new CellPoint(0, 4),
+              // Note: New (0, 0) waypoint here.
+              new CellPoint(0, -2),
+              new CellPoint(2, 0));
+      assertIterableEquals(expectedWaypoints, derived.getWayPointList());
+
+      for (var cell : derived.getCellPath()) {
+        assertInstanceOf(CellPoint.class, cell);
+      }
+      for (var waypoint : derived.getWayPointList()) {
+        assertInstanceOf(CellPoint.class, waypoint);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4813

### Description of the Change

#### Bug fix

A new approach is taken for deriving follower paths from leader paths. The general idea is that the waypoints in the follower path should follow the waypoints of the leader path, regardless of which tokens are STG or not. In most cases this is exact, but in the case of a STG token following a non-STG leader the waypoints are snapped to grid cells after being calculated. When both tokens are STG or both are not, the follower path will precisely follow the leader path even between waypoints (so pathfinding is accounted for). In the other cases, only the waypoints are considered, and intervening points may be interpolated.

#### Refactoring

There is a supporting refactor to `Path` to make the above idea solid. `Path` now has an invariant that makes sure the waypoint list and cell list make sense together:
1. if either list is empty, both are empty
2. if not empty, the lists have the same first and last point.
3. All waypoints are guaranteed to appear in the cell list in the same order, but possibly with extra cells interposed.

To do this, callers are only allowed to append to the path, not otherwise modify it. And they no longer add cells and waypoints separately. Instead they can either:
1. Append a single point to be treated as both cell and waypoint.
2. Append a partial path whose last point is treated as a waypoint.

Only `SelectionSet` and `MeasureTool` really had a problem with that, and specifically for gridless paths. They were easily fixed by having them handle their own current point instead of hijacking the `Path` to do it for them.

New unit tests are included that fully cover `Path` aside from `readResolve()`.

### Possible Drawbacks

Serialized paths will not obey the new rules. This shouldn't really be an issue, but it does mean that if a user loads up an campaign, hit "Show Path" on a follower token, the paths they see won't match what they see if they tried the same drag that produced it originally.

### Documentation Notes

Follower tokens try to follow the leader token as closely as possible when dragging.

### Release Notes

- Fixed a bugs where follower tokens would take different paths to the destination than the leader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4817)
<!-- Reviewable:end -->
