### PR TITLE
Missing tooltip for import predefined button added.

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -783,6 +783,7 @@ CampaignPropertiesDialog.tab.light     = Light
 CampaignPropertiesDialog.tab.states    = States
 CampaignPropertiesDialog.tab.bars      = Bars
 CampaignPropertiesDialog.button.import = Import predefined
+CampaignPropertiesDialog.button.import.tooltip = Import predefined properties and settings for the selected system
 campaignPropertiesDialog.newTokenTypeName = Enter the name for the new token type
 campaignPropertiesDialog.newTokenTypeTitle = New Token Type
 campaignPropertiesDialog.newTokenTypeDefaultName = New Token Type {0}


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4823

### Description of the Change
Tooltip got lost in numerous commits. Putting it back in.


### Possible Drawbacks
n/a
### Documentation Notes
n/a
### Release Notes
n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4824)
<!-- Reviewable:end -->
