### PR TITLE
Fix hexagon geometry

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -84,7 +84,7 @@ public abstract class Grid implements Cloneable {
   }
 
   protected Object readResolve() {
-    cellShape = createCellShape(getSize());
+    cellShape = createCellShape();
     return this;
   }
 
@@ -274,7 +274,12 @@ public abstract class Grid implements Cloneable {
     return null;
   }
 
-  protected abstract Area createCellShape(int size);
+  /**
+   * Build the shape of a cell for the current grid size.
+   *
+   * @return The cell shape.
+   */
+  protected abstract Area createCellShape();
 
   /**
    * @param offsetX The grid's x offset component
@@ -339,7 +344,7 @@ public abstract class Grid implements Cloneable {
    */
   public void setSize(int size) {
     this.size = constrainSize(size);
-    cellShape = createCellShape(size);
+    cellShape = createCellShape();
     fireGridChanged();
   }
 
@@ -838,7 +843,7 @@ public abstract class Grid implements Cloneable {
    * @return the {@link Area} conforming to the current grid layout for the given radius
    */
   protected Area createGridArea(int gridRadius) {
-    final Area cellArea = new Area(createCellShape(getSize()));
+    final Area cellArea = new Area(getCellShape());
     final Set<Point> points = generateRadius(gridRadius);
     Area gridArea = new Area();
 
@@ -945,7 +950,7 @@ public abstract class Grid implements Cloneable {
     grid.offsetX = dto.getOffsetX();
     grid.offsetY = dto.getOffsetY();
     grid.size = dto.getSize();
-    grid.cellShape = grid.createCellShape(grid.size);
+    grid.cellShape = grid.createCellShape();
 
     return grid;
   }

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -518,7 +518,7 @@ public abstract class Grid implements Cloneable {
   }
 
   private void fireGridChanged() {
-    gridShapeCache.clear();
+    getGridShapeCache().clear();
     new MapToolEventBus().getMainEventBus().post(new GridChanged(this.zone));
   }
 

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -92,7 +92,7 @@ public abstract class Grid implements Cloneable {
     return gridShapeCache;
   }
 
-  protected synchronized void setGridShapeCache(int gridRadius, Area newGridArea) {
+  private synchronized void setGridShapeCache(int gridRadius, Area newGridArea) {
     final AffineTransform at = new AffineTransform();
     final double gridScale = (double) MAX_GRID_SIZE / getSize();
     at.scale(gridScale, gridScale);
@@ -848,8 +848,6 @@ public abstract class Grid implements Cloneable {
       gridArea.add(cellArea.createTransformedArea(at));
     }
 
-    setGridShapeCache(gridRadius, gridArea);
-
     return gridArea;
   }
 
@@ -923,7 +921,8 @@ public abstract class Grid implements Cloneable {
     // Or if the flag is enabled, recreate cache
     if (DeveloperOptions.Toggle.IgnoreGridShapeCache.isEnabled()
         || !getGridShapeCache().containsKey(gridRadius)) {
-      createGridArea(gridRadius);
+      var newArea = createGridArea(gridRadius);
+      setGridShapeCache(gridRadius, newArea);
     }
 
     double rescale = getSize() / (double) MAX_GRID_SIZE;

--- a/src/main/java/net/rptools/maptool/model/GridlessGrid.java
+++ b/src/main/java/net/rptools/maptool/model/GridlessGrid.java
@@ -158,7 +158,7 @@ public class GridlessGrid extends Grid {
   }
 
   @Override
-  protected Area createCellShape(int size) {
+  protected Area createCellShape() {
     // Doesn't do this
     return null;
   }

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -126,9 +126,7 @@ public abstract class HexGrid extends Grid {
   }
 
   @Override
-  protected Area createCellShape(int size) {
-    // don't use size. it has already been used to set the minorRadius
-    // and will only introduce a rounding error.
+  protected Area createCellShape() {
     var hex = new GeneralPath();
     hex.moveTo(0, minorRadius);
     hex.lineTo(edgeProjection, 0);

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -500,12 +500,6 @@ public abstract class HexGrid extends Grid {
     BiConsumer<Double, Double> lineTo =
         isHexHorizontal() ? ((x, y) -> path.lineTo(y, x)) : ((x, y) -> path.lineTo(x, y));
 
-    // The coordinate system we have to work in is a bit weird. First off all, we don't measure from
-    // the center of the origin cell, but from its top-left (northwest) corner. Secondly, the cell
-    // offset of the grid is applied to the result, so we have to account for them as well.
-    // This is written from the perspective of a vertical hex, but swapping the coordinates is
-    // enough to make the horizontal equivalent.
-
     var x = edgeLength / 2 + edgeProjection;
     var y = -gridRadius * 2 * minorRadius;
     moveTo.accept(x, y);

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -230,10 +230,10 @@ public abstract class HexGrid extends Grid {
   private GeneralPath createHalfShape(
       double minorRadius, double edgeProjection, double edgeLength) {
     GeneralPath hex = new GeneralPath();
-    hex.moveTo(0, (int) minorRadius);
-    hex.lineTo((int) edgeProjection, 0);
-    hex.lineTo((int) (edgeProjection + edgeLength), 0);
-    hex.lineTo((int) (edgeProjection + edgeLength + edgeProjection), (int) minorRadius);
+    hex.moveTo(0, minorRadius);
+    hex.lineTo(edgeProjection, 0);
+    hex.lineTo(edgeProjection + edgeLength, 0);
+    hex.lineTo(edgeProjection + edgeLength + edgeProjection, minorRadius);
 
     orientHex(hex);
     return hex;

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -604,29 +604,6 @@ public abstract class HexGrid extends Grid {
     return getGridAreaFromCache(gridRadius).createTransformedArea(getGridOffset(token));
   }
 
-  @Override
-  protected AffineTransform getGridOffset(Token token) {
-    // Adjust to grid if token is an even number of grid cells
-    double footprintWidth = token.getFootprint(this).getBounds(this).getWidth();
-    double footprintHeight = token.getFootprint(this).getBounds(this).getHeight();
-    double shortFootprintSide = Math.min(footprintWidth, footprintHeight);
-
-    final AffineTransform at = new AffineTransform();
-
-    if ((shortFootprintSide / getSize()) % 2 == 0) {
-      double coordinateOffsetV = getCellOffsetV();
-      double coordinateOffsetU = -0.5 * (edgeProjection + edgeLength);
-      if (isHexHorizontal()) {
-        // Swap x and y;
-        at.translate(coordinateOffsetV, coordinateOffsetU);
-      } else {
-        at.translate(coordinateOffsetU, coordinateOffsetV);
-      }
-    }
-
-    return at;
-  }
-
   protected abstract OffsetTranslator getOffsetTranslator();
 
   public static HexGrid fromDto(HexGridDto dto) {

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -211,18 +211,19 @@ public abstract class HexGrid extends Grid {
   }
 
   private void setDimensions(int size, double diameter) {
+    // Update internal variables to agree with the new dimensions.
     minorRadius = size / 2.;
-
-    // We get degenerate hexes below this, so constrain things.
-    diameter = Math.max(diameter, minorRadius);
-
     hexRatio = size / diameter;
+    // Since we're just scaling a regular hexagon, these simple relations still hold.
+    edgeLength = diameter / 2;
+    edgeProjection = edgeLength / 2;
 
-    // In order to get edges of equal length while obeying the circumradius and inradius, this is
-    // the quadratic to solve: $3 * edge^2 + 2*diameter * edge - (size^2 + diameter^2) = 0$
-    // That gets us to ...
-    edgeLength = (-diameter + 2 * Math.sqrt(diameter * diameter + 0.75 * size * size)) / 3.;
-    edgeProjection = (diameter - edgeLength) / 2;
+    // If we instead wanted equal edge lengths, we have to solve this equation:
+    // $3 * edge^2 + 2*diameter * edge - (size^2 + diameter^2) = 0$
+    // Giving:
+    // edgeLength = (-diameter + 2 * Math.sqrt(diameter * diameter + 0.75 * size * size)) / 3.
+    // and:
+    // edgeProjection = (diameter - edgeLength) / 2
   }
 
   private GeneralPath createHalfShape(

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -527,8 +527,6 @@ public abstract class HexGrid extends Grid {
       gridArea.add(createHex(getSize(), -getSize(), hexRadius, Math.toRadians(90)));
     }
 
-    setGridShapeCache(gridRadius, gridArea);
-
     return gridArea;
   }
 

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -189,9 +189,8 @@ public abstract class HexGrid extends Grid {
   }
 
   protected Object readResolve() {
-    super.readResolve();
     setDimensions(getSize(), getSize() / hexRatio);
-    return this;
+    return super.readResolve();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -626,9 +626,9 @@ public abstract class HexGrid extends Grid {
       double coordinateOffsetU = -0.5 * (edgeProjection + edgeLength);
       if (isHexHorizontal()) {
         // Swap x and y;
-        at.translate(coordinateOffsetU, coordinateOffsetV);
-      } else {
         at.translate(coordinateOffsetV, coordinateOffsetU);
+      } else {
+        at.translate(coordinateOffsetU, coordinateOffsetV);
       }
     }
 

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -191,6 +191,7 @@ public abstract class HexGrid extends Grid {
   }
 
   protected Object readResolve() {
+    super.readResolve();
     setDimensions(getSize(), getSize() / hexRatio);
     return this;
   }

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -156,30 +156,20 @@ public class HexGridHorizontal extends HexGrid {
       movementKeys = new HashMap<KeyStroke, Action>(12); // parameter is 9/0.75 (load factor)
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD7, 0), new MovementKey(callback, -1, -1));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, 0), new
-      // MovementKey(callback, 0, -1));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, 0), new MovementKey(callback, 1, -1));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, 0), new MovementKey(callback, -1, 0));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD5, 0), new
-      // MovementKey(callback, 0, 0));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, 0), new MovementKey(callback, 1, 0));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, 0), new MovementKey(callback, -1, 1));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, 0), new
-      // MovementKey(callback, 0, 1));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, 0), new MovementKey(callback, 1, 1));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0), new MovementKey(callback, -1, 0));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0), new MovementKey(callback, 1, 0));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), new MovementKey(callback, 0,
-      // -1));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), new MovementKey(callback,
-      // 0, 1));
     }
     actionMap.putAll(movementKeys);
   }
@@ -234,7 +224,7 @@ public class HexGridHorizontal extends HexGrid {
   }
 
   @Override
-  protected Dimension setCellOffset() {
+  public Dimension getCellOffset() {
     return new Dimension((int) getCellOffsetV(), (int) getCellOffsetU());
   }
 

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -305,28 +305,4 @@ public class HexGridHorizontal extends HexGrid {
     double mapY = ((newX + newY) * heightHalf) + heightHalf;
     return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
   }
-
-  @Override
-  protected AffineTransform getGridOffset(Token token) {
-    // Adjust to grid if token is an even number of grid cells
-    double footprintWidth = token.getFootprint(this).getBounds(this).getWidth();
-    double footprintHeight = token.getFootprint(this).getBounds(this).getHeight();
-    double shortFootprintSide = Math.min(footprintWidth, footprintHeight);
-
-    final AffineTransform at = new AffineTransform();
-    final double coordinateOffsetX;
-    final double coordinateOffsetY;
-
-    if ((shortFootprintSide / getSize()) % 2 != 0) {
-      coordinateOffsetX = -getCellWidth();
-      coordinateOffsetY = getCellOffsetU() * 2;
-    } else {
-      coordinateOffsetX = getCellWidth() * -1.5;
-      coordinateOffsetY = getCellHeight() * -1.375;
-    }
-
-    at.translate(coordinateOffsetX, coordinateOffsetY);
-
-    return at;
-  }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -305,4 +305,20 @@ public class HexGridHorizontal extends HexGrid {
     double mapY = ((newX + newY) * heightHalf) + heightHalf;
     return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
   }
+
+  @Override
+  protected AffineTransform getGridOffset(Token token) {
+    // Adjust to grid if token is an even number of grid cells
+    double footprintWidth = token.getFootprint(this).getBounds(this).getWidth();
+
+    final AffineTransform at = new AffineTransform();
+
+    if ((footprintWidth / getSize()) % 2 == 0) {
+      double coordinateOffsetV = getCellOffsetV();
+      double coordinateOffsetU = -0.5 * (edgeProjection + edgeLength);
+      at.translate(coordinateOffsetV, coordinateOffsetU);
+    }
+
+    return at;
+  }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -18,6 +18,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -273,5 +274,21 @@ public class HexGridVertical extends HexGrid {
     double mapY = (newY - newX) * getVRadius();
     double mapX = ((newX + newY) * heightHalf) + heightHalf;
     return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
+  }
+
+  @Override
+  protected AffineTransform getGridOffset(Token token) {
+    // Adjust to grid if token is an even number of grid cells
+    double footprintHeight = token.getFootprint(this).getBounds(this).getHeight();
+
+    final AffineTransform at = new AffineTransform();
+
+    if ((footprintHeight / getSize()) % 2 == 0) {
+      double coordinateOffsetV = getCellOffsetV();
+      double coordinateOffsetU = -0.5 * (edgeProjection + edgeLength);
+      at.translate(coordinateOffsetU, coordinateOffsetV);
+    }
+
+    return at;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -18,7 +18,6 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
-import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -274,29 +273,5 @@ public class HexGridVertical extends HexGrid {
     double mapY = (newY - newX) * getVRadius();
     double mapX = ((newX + newY) * heightHalf) + heightHalf;
     return new ZonePoint((int) (mapX) + getOffsetX(), (int) (mapY) + getOffsetY());
-  }
-
-  @Override
-  protected AffineTransform getGridOffset(Token token) {
-    // Adjust to grid if token is an even number of grid cells
-    double footprintWidth = token.getFootprint(this).getBounds(this).getWidth();
-    double footprintHeight = token.getFootprint(this).getBounds(this).getHeight();
-    double shortFootprintSide = Math.min(footprintWidth, footprintHeight);
-
-    final AffineTransform at = new AffineTransform();
-    final double coordinateOffsetX;
-    final double coordinateOffsetY;
-
-    if ((shortFootprintSide / getSize()) % 2 == 0) {
-      coordinateOffsetX = getCellWidth() * -1.375;
-      coordinateOffsetY = getCellHeight() * -1.5;
-    } else {
-      coordinateOffsetX = -getCellWidth();
-      coordinateOffsetY = getCellOffsetV() * 2;
-    }
-
-    at.translate(coordinateOffsetX, coordinateOffsetY);
-
-    return at;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -79,11 +79,6 @@ public class HexGridVertical extends HexGrid {
   }
 
   @Override
-  public boolean isHexVertical() {
-    return true;
-  }
-
-  @Override
   protected synchronized Map<Integer, Area> getGridShapeCache() {
     return gridShapeCache;
   }
@@ -153,22 +148,12 @@ public class HexGridVertical extends HexGrid {
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD8, 0), new MovementKey(callback, 0, -h));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD9, 0), new MovementKey(callback, w, -h));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD4, 0), new
-      // MovementKey(callback, -1, 0));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD5, 0), new
-      // MovementKey(callback, 0, 0));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD6, 0), new
-      // MovementKey(callback, 1, 0));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD1, 0), new MovementKey(callback, -w, h));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD2, 0), new MovementKey(callback, 0, h));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_NUMPAD3, 0), new MovementKey(callback, w, h));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0), new MovementKey(callback,
-      // -1, 0));
-      //			movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0), new MovementKey(callback,
-      // 1, 0));
       movementKeys.put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), new MovementKey(callback, 0, -h));
       movementKeys.put(
           KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), new MovementKey(callback, 0, h));
@@ -215,7 +200,7 @@ public class HexGridVertical extends HexGrid {
   }
 
   @Override
-  protected Dimension setCellOffset() {
+  public Dimension getCellOffset() {
     return new Dimension((int) getCellOffsetU(), (int) getCellOffsetV());
   }
 

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -241,9 +241,13 @@ public class IsometricGrid extends Grid {
   }
 
   @Override
-  protected Area createCellShape(int size) {
-    int x[] = {size, size * 2, size, 0};
-    int y[] = {0, size / 2, size, size / 2};
+  protected Area createCellShape() {
+    return createCellShape(getSize());
+  }
+
+  private Area createCellShape(int size) {
+    int[] x = {size, size * 2, size, 0};
+    int[] y = {0, size / 2, size, size / 2};
     return new Area(new Polygon(x, y, 4));
   }
 
@@ -400,7 +404,7 @@ public class IsometricGrid extends Grid {
         footprint.x = -footprint.width / 2;
         footprint.y = -footprint.height / 2;
         // convert the cell footprint to an area
-        Area cellShape = getZone().getGrid().createCellShape(footprint.height);
+        Area cellShape = createCellShape(footprint.height);
         // convert the area to isometric view
         AffineTransform mtx = new AffineTransform();
         mtx.translate(-footprint.width / 2, -footprint.height / 2);
@@ -432,7 +436,7 @@ public class IsometricGrid extends Grid {
     footprint.x = -footprint.width / 2;
     footprint.y = -footprint.height / 2;
     // convert the cell footprint to an area
-    Area cellShape = getZone().getGrid().createCellShape(footprint.height);
+    Area cellShape = createCellShape(footprint.height);
     // convert the area to isometric view
     AffineTransform mtx = new AffineTransform();
     mtx.translate(bounds.getBounds().getX(), bounds.getBounds().getY());

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -249,7 +249,8 @@ public class SquareGrid extends Grid {
   }
 
   @Override
-  protected Area createCellShape(int size) {
+  protected Area createCellShape() {
+    var size = getSize();
     return new Area(new Rectangle(0, 0, size, size));
   }
 

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2105,6 +2105,8 @@ public class Zone {
       playerAlias = null;
     }
 
+    grid.setZone(this);
+
     // 1.3b76 -> 1.3b77
     // adding the exposed area for Individual FOW
     if (exposedAreaMeta == null) {

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -598,14 +598,6 @@ message IsometricGridDto {}
 message HexGridDto {
   bool vertical = 1;
   double hex_ratio = 2;
-  double edge_projection = 3;
-  double minor_radius = 4;
-  double edge_length = 5;
-  double scaled_edge_projection = 6;
-  double scaled_minor_radius = 7;
-  double scaled_edge_length = 8;
-  double last_scale = 9;
-  IntPointDto cellOffset = 10;
 }
 
 enum TokenUpdateDto {

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -583,7 +583,6 @@ message GridDto {
   int32 offset_x = 1;
   int32 offset_y = 2;
   int32 size = 3;
-  AreaDto cell_shape = 4;
   oneof type {
     SquareGridDto square_grid = 5;
     GridlessGridDto gridless_grid = 6;


### PR DESCRIPTION
#### Identify the Bug or Feature request

Fixes #2840
Fixes #4830

### Description of the Change

A number of underlying problems with hex grid have been fixed:
- The edge projection was not updated when the cell dimensions were changed, leading to all sorts of discrepancies the more the grid is modified. Now it is always updated when dimensions change.
- The math in a few places assumed a scaled version of a regular hex while other places assumed an equal edge length. These can't generally be true at the same time, which caused some graphical inaccuracies as well as #2840. These places have now been generalized to work for any shape hex, and we have also committed to not using equal-length edges since it has its own subtleties.
- The shape cache for hex grids was not being cleared when the grid changed, leading to some odd artifacts depending on when the cache was populated (#4830).

With the above, whatever the users sets in the "2nd Size" input is kept and is reflected in the map. Previously, typing in 100 x 400 would change the second size and result in this:
![image](https://github.com/RPTools/maptool/assets/7492219/88f8ea83-4167-4f96-a8ef-13d8a14a5808)
Now the 400 is kept and we see this:
![image](https://github.com/RPTools/maptool/assets/7492219/a9e966c5-0226-4d5b-9ae1-2f6ece0c30ef)

Some general grid clean up is included as well:
- Grids, and especially hex grids, used to serialize way too much. Most of the fields are now `transient`, with only size, offset, and for hex grids also their "aspect ratio" and orientation being serialized. The DTOs now include only these fields as well.
- Hex grid shapes are now built as a `Path2D` and filled in as an `Area` instead of merging together a bunch of individual cells. This avoids precision issues (gaps) without needing to scale up the cell size. It avoids any possibility of holes in the result, and avoids hex grid lights bleeding over the cell edges.
- The way grid offsets work for hex grids is a little different now. For some reason we were offseting by more than a cell size only for other code to compensate for that. Now we offset by only a fraction of a cell.

### Possible Drawbacks

If loading an existing campaign with really stretched out hex grids, snap-to-grid tokens will not end up in the same cell as before. Since the cell dimensions were not accurate before, the conversion between a tokens real position and its cell has changed.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the 2nd Size for hex grids would not remain as the user set it.
- Fixed a bug where grid lights on adjusted hex grids could contain gaps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4831)
<!-- Reviewable:end -->
