### PR TITLE
Add Label.background i18n key needed for editing text labels

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -185,6 +185,7 @@ Label.table.import  = Import Table
 Label.table.export  = Export Table
 Label.preview       = Preview
 Label.foreground    = Foreground:
+Label.background    = Background:
 Label.showbackground = Show Background:
 Label.showBorder     = Show Border
 Label.borderWidth    = Border Width


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4834 some more

### Description of the Change

The `Label.background` I18N key is needed when editing labels but was still missing. Now it is possible to edit text labels once again.


### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4846)
<!-- Reviewable:end -->
