### PR TITLE
Apply changes made to token properties in the campaign settings when pressing "Ok"

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -213,6 +213,7 @@ public class CampaignPropertiesDialog extends JDialog {
       MapTool.getFrame()
           .showFilledGlassPane(
               new StaticMessageDialog("campaignPropertiesDialog.tokenTypeNameRename"));
+      tokenPropertiesPanel.finalizeCellEditing();
       tokenPropertiesPanel
           .getRenameTypes()
           .forEach(

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -87,6 +87,12 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     campaign.setDefaultTokenPropertyType(defaultPropertyType);
   }
 
+  public void finalizeCellEditing() {
+    if (getTokenPropertiesTable().isEditing()) {
+      getTokenPropertiesTable().getCellEditor().stopCellEditing();
+    }
+  }
+
   public JList getTokenTypeList() {
     JList list = (JList) getComponent("tokenTypeList");
     if (list == null) {
@@ -285,6 +291,11 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
         e ->
             EventQueue.invokeLater(
                 () -> {
+                  JTable propertiesTable = getTokenPropertiesTable();
+                  if (propertiesTable.isEditing()) {
+                    TableCellEditor cellEditor = propertiesTable.getCellEditor();
+                    cellEditor.stopCellEditing();
+                  }
                   var model = getTokenPropertiesTableModel();
                   model.addProperty();
                 }));

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -255,6 +255,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     var button = getPropertyMoveUpButton();
     button.addActionListener(
         l -> {
+          finalizeCellEditing();
           var selectedRow = getTokenPropertiesTable().getSelectedRow();
           if (selectedRow <= 0) {
             return;
@@ -272,6 +273,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     var button = getPropertyMoveDownButton();
     button.addActionListener(
         l -> {
+          finalizeCellEditing();
           var selectedRow = getTokenPropertiesTable().getSelectedRow();
           if (selectedRow < 0 || selectedRow >= getTokenPropertiesTable().getRowCount() - 1) {
             return;
@@ -291,11 +293,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
         e ->
             EventQueue.invokeLater(
                 () -> {
-                  JTable propertiesTable = getTokenPropertiesTable();
-                  if (propertiesTable.isEditing()) {
-                    TableCellEditor cellEditor = propertiesTable.getCellEditor();
-                    cellEditor.stopCellEditing();
-                  }
+                  finalizeCellEditing();
                   var model = getTokenPropertiesTableModel();
                   model.addProperty();
                 }));
@@ -308,6 +306,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
         e ->
             EventQueue.invokeLater(
                 () -> {
+                  finalizeCellEditing();
                   var model = getTokenPropertiesTableModel();
                   model.deleteProperty(getTokenPropertiesTable().getSelectedRow());
                 }));


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes 4710

### Description of the Change
When editing a cell in the campaign settings token table by double clicking on a Cell in the JTable,
a TableCellEditor is created, that enables changing the value of the cell. This editor needs to be closed 
to apply the changes. By default this is done, by clicking inside the JTable again, outside of the currently selected cell,
or programmatically by calling `JTable().getCellEditor().stopCellEditing()`.
The public method `finalizeCellEditing()` was added to the `TokenPropertiesManagementPanel` that checks, if the
JTable is in edit mode and if yes, calls `stopCellEditing()`.
The method now can be called when pressing the "Ok" button in the `CampaignPropertiesDialog` to first apply the changes before closing the campaign editor.
The call is also added to functions `initPropertyMoveUpButton` and `initPropertyMoveDownButton` for moving, 
`initPropertyDeleteButton` for deleting a property and 
`initPropertyAddButton` for adding properties
because doing that will also cause problems with duplicated entries and OutOfBoundsExceptions.

### Possible Drawbacks
No drawbacks known

### Documentation Notes
N/A

### Release Notes
- Fixes an issue with losing changes made to campaign tokens by pressing the "Ok" button without clicking somewhere else first.
- Fixes a crash when trying to delete a token while simultaneously editing a property of that token.
- Fixes a problem with moving a token while simultaneously editing a property of that token. This created a duplicate of the token with the old properties and added unrelated data to the token currently edited.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4863)
<!-- Reviewable:end -->
