### PR TITLE
Keep selected token property in view when moving it up or down a big property table

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -256,7 +256,8 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     button.addActionListener(
         l -> {
           finalizeCellEditing();
-          var selectedRow = getTokenPropertiesTable().getSelectedRow();
+          JTable propertiesTable = getTokenPropertiesTable();
+          var selectedRow = propertiesTable.getSelectedRow();
           if (selectedRow <= 0) {
             return;
           }
@@ -264,7 +265,8 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
           var model = getTokenPropertiesTableModel();
           model.movePropertyUp(selectedRow);
           --selectedRow;
-          getTokenPropertiesTable().setRowSelectionInterval(selectedRow, selectedRow);
+          propertiesTable.setRowSelectionInterval(selectedRow, selectedRow);
+          propertiesTable.scrollRectToVisible(propertiesTable.getCellRect(selectedRow, 0, true));
         });
     button.setEnabled(false);
   }
@@ -274,15 +276,17 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     button.addActionListener(
         l -> {
           finalizeCellEditing();
-          var selectedRow = getTokenPropertiesTable().getSelectedRow();
-          if (selectedRow < 0 || selectedRow >= getTokenPropertiesTable().getRowCount() - 1) {
+          JTable propertiesTable = getTokenPropertiesTable();
+          var selectedRow = propertiesTable.getSelectedRow();
+          if (selectedRow < 0 || selectedRow >= propertiesTable.getRowCount() - 1) {
             return;
           }
 
           var model = getTokenPropertiesTableModel();
           model.movePropertyDown(selectedRow);
           ++selectedRow;
-          getTokenPropertiesTable().setRowSelectionInterval(selectedRow, selectedRow);
+          propertiesTable.setRowSelectionInterval(selectedRow, selectedRow);
+          propertiesTable.scrollRectToVisible(propertiesTable.getCellRect(selectedRow, 0, true));
         });
     button.setEnabled(false);
   }
@@ -294,8 +298,12 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
             EventQueue.invokeLater(
                 () -> {
                   finalizeCellEditing();
+                  JTable propertiesTable = getTokenPropertiesTable();
                   var model = getTokenPropertiesTableModel();
                   model.addProperty();
+                  int count = model.getRowCount();
+                  propertiesTable.scrollRectToVisible(
+                      propertiesTable.getCellRect(count - 1, 0, true));
                 }));
     button.setEnabled(false);
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4711 

### Description of the Change
To keep a specific table row in the view rect, JTable must be instructed which row needs to be visible
i.e. by calling `JTable.scrollRectToVisible()`. 
To get the rect, one can ask JTable for the rect of a row by calling `JTable.getCellRect(rowNumber, columnNumber, true)`.
This call has been added to:
- `TokenPropertiesManagementPanel.initPropertyMoveUpButton()`
- `TokenPropertiesManagementPanel.initPropertyMoveDownButton()`
- `TokenPropertiesManagementPanel.initPropertyAddButton()`

### Possible Drawbacks
No drawbacks known

### Documentation Notes
N/A

### Release Notes
- Token properties in the campaign settings are kept visible when moving them up or down a big table.
- When adding a new property in a big table, it automatically scrolls to the new entry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4864)
<!-- Reviewable:end -->
