### PR TITLE
Call finalizeCellEditing() before switching tokenTypes to make sure t…

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -430,6 +430,9 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
                   getTokenTypeList().getSelectedValue() == null
                       ? null
                       : getTokenTypeList().getSelectedValue().toString();
+
+              finalizeCellEditing();
+
               if (propertyType == null) {
                 reset();
                 getPropertyAddButton().setEnabled(false);


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4650

### Description of the Change
When switching to another token type, the underlying table data changes. The TableCellEditor is tied to a specific cell though and if it is not closed before changing the underlying data, that can cause data loss and/or NullReferenceExceptions.
The solution is to use the finalizeCellEditing method to close and apply the data before switching the table data.

### Possible Drawbacks
No drawbacks known

### Release Notes
- fix crash when trying to switch token types while editing the data of a token.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4865)
<!-- Reviewable:end -->
