### PR TITLE
Added ability to load MRU campaign at startup

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -116,6 +116,11 @@ public class AppPreferences {
   /** Represents the key used to access the most recently used campaigns for the menu option. */
   private static final String KEY_MRU_CAMPAIGNS = "mruCampaigns";
 
+  /** Represents the key used to load the most recent campaign on launch. Defaults to false */
+  private static final String KEY_LOAD_MRU_CAMPAIGN_AT_START = "loadMRUCampaignAtStart";
+
+  private static final boolean DEFAULT_LOAD_MRU_CAMPAIGN_AT_START = false;
+
   /** Represents the key used to save the paint textures to the preferences. */
   private static final String KEY_SAVED_PAINT_TEXTURES = "savedTextures";
 
@@ -1341,6 +1346,14 @@ public class AppPreferences {
 
   public static void setAllowExternalMacroAccess(boolean value) {
     prefs.putBoolean(KEY_ALLOW_EXTERNAL_MACRO_ACCESS, value);
+  }
+
+  public static boolean getLoadMRUCampaignAtStart() {
+    return prefs.getBoolean(KEY_LOAD_MRU_CAMPAIGN_AT_START, DEFAULT_LOAD_MRU_CAMPAIGN_AT_START);
+  }
+
+  public static void setLoadMRUCampaignAtStart(boolean value) {
+    prefs.putBoolean(KEY_LOAD_MRU_CAMPAIGN_AT_START, value);
   }
 
   public static WalkerMetric getMovementMetric() {

--- a/src/main/java/net/rptools/maptool/client/AutoSaveManager.java
+++ b/src/main/java/net/rptools/maptool/client/AutoSaveManager.java
@@ -170,13 +170,15 @@ public class AutoSaveManager {
   }
 
   /** Check to see if autosave recovery is necessary. */
-  public void check() {
+  public boolean check() {
     if (AUTOSAVE_FILE.exists()) {
       boolean okay;
       okay = MapTool.confirm("msg.confirm.recoverAutosave", AUTOSAVE_FILE.lastModified());
       if (okay) {
         AppActions.loadCampaign(AUTOSAVE_FILE);
+        return true;
       }
     }
+    return false;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1264,12 +1264,27 @@ public class MapTool {
 
   private static void postInitialize() {
     // Check to see if there is an autosave file from MT crashing
-    getAutoSaveManager().check();
+    boolean recover = getAutoSaveManager().check();
 
-    if (!loadCampaignOnStartPath.isEmpty()) {
-      File campaignFile = new File(loadCampaignOnStartPath);
-      if (campaignFile.exists()) {
-        AppActions.loadCampaign(campaignFile);
+    if (!recover) {
+      File campaignFile;
+      // if not loading auto-save, load campaign from command-line arguments
+      if (!loadCampaignOnStartPath.isEmpty()) {
+        campaignFile = new File(loadCampaignOnStartPath);
+        if (campaignFile.exists()) {
+          AppActions.loadCampaign(campaignFile);
+        }
+      }
+      // alternately load MRU campaign if preference set
+      else if (AppPreferences.getLoadMRUCampaignAtStart()) {
+        try {
+          campaignFile = AppPreferences.getMruCampaigns().getFirst();
+          if (campaignFile.exists()) {
+            AppActions.loadCampaign(campaignFile);
+          }
+        } catch (NoSuchElementException nse) {
+          log.info("MRU Campaign not loaded. List is empty.");
+        }
       }
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/Scale.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Scale.java
@@ -127,7 +127,6 @@ public class Scale implements Serializable {
 
   private void setZoomLevel(int zoomLevel) {
     this.zoomLevel = Math.clamp(zoomLevel, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
-    System.out.println(this.zoomLevel);
     setScaleFromZoomLevel();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -442,6 +442,9 @@ public class PreferencesDialog extends JDialog {
   /** Checkbox for showing the token label border. */
   private final JCheckBox showLabelBorderCheckBox;
 
+  // ** Checkbox for loading the most recently used campaign on startup */
+  private final JCheckBox loadMRUcheckbox;
+
   /**
    * Array of LocalizedComboItems representing the default grid types for the preferences dialog.
    * Each item in the array consists of a grid type and its corresponding localized display name.
@@ -664,7 +667,7 @@ public class PreferencesDialog extends JDialog {
     allowExternalMacroAccessCheckBox = panel.getCheckBox("allowExternalMacroAccessCheckBox");
     fileSyncPath = panel.getTextField("fileSyncPath");
     fileSyncPathButton = (JButton) panel.getButton("fileSyncPathButton");
-
+    loadMRUcheckbox = (JCheckBox) panel.getCheckBox("loadMRUcheckbox");
     final var installDirTextField = (JTextField) panel.getComponent("InstallDirTextField");
     installDirTextField.setText(AppUtil.getInstallDirectory().toString());
 
@@ -976,6 +979,8 @@ public class PreferencesDialog extends JDialog {
           }
         });
 
+    loadMRUcheckbox.addActionListener(
+        e -> AppPreferences.setLoadMRUCampaignAtStart(loadMRUcheckbox.isSelected()));
     allowExternalMacroAccessCheckBox.addActionListener(
         e ->
             AppPreferences.setAllowExternalMacroAccess(
@@ -1551,6 +1556,7 @@ public class PreferencesDialog extends JDialog {
     defaultUsername.setText(AppPreferences.getDefaultUserName());
     // initEnableServerSyncCheckBox.setSelected(AppPreferences.getInitEnableServerSync());
     autoSaveSpinner.setValue(AppPreferences.getAutoSaveIncrement());
+    loadMRUcheckbox.setSelected(AppPreferences.getLoadMRUCampaignAtStart());
     newMapsHaveFOWCheckBox.setSelected(AppPreferences.getNewMapsHaveFOW());
     tokensPopupWarningWhenDeletedCheckBox.setSelected(AppPreferences.getTokensWarnWhenDeleted());
     tokensStartSnapToGridCheckBox.setSelected(AppPreferences.getTokensStartSnapToGrid());

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -906,7 +906,7 @@
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.accessibility"/>
             </constraints>
             <properties>
-              <visible value="true"/>
+              <visible value="false"/>
             </properties>
             <border type="none"/>
             <children>
@@ -1220,7 +1220,7 @@
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.application"/>
             </constraints>
             <properties>
-              <visible value="false"/>
+              <visible value="true"/>
             </properties>
             <border type="none"/>
             <children>
@@ -1592,7 +1592,7 @@
                 <properties/>
                 <border type="none"/>
                 <children>
-                  <grid id="392e4" layout-manager="GridLayoutManager" row-count="5" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="392e4" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="0" right="0"/>
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -1720,6 +1720,26 @@
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Label.minute"/>
+                        </properties>
+                      </component>
+                      <component id="c8b47" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.loadMRU"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.loadMRU.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="577b7" class="javax.swing.JCheckBox" default-binding="true">
+                        <constraints>
+                          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <label value=""/>
+                          <name value="loadMRUcheckbox"/>
+                          <text value=""/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.loadMRU.tooltip"/>
                         </properties>
                       </component>
                     </children>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -734,6 +734,8 @@ PreferencesDialog.themeChangeWarningTitle         = Theme Change.
 Preferences.combo.themes.filter.all               = All
 Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
+Preferences.label.loadMRU                         = Load last campaign on start
+Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = You must enter a numeric port.
 ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.


### PR DESCRIPTION


### Identify the Bug or Feature request
resolves #4869

### Description of the Change
Added preference to load the most recently used campaign at startup.

Startup now loads in the order:
1. Auto-save recovery, or
2. Command-line option -F <path to campaign>, or
3. <if preference set> Most recent campaign, or
4. Blank campaign.

- Added pref KEY_LOAD_MRU_CAMPAIGN_AT_START
- Changed AutoSaveManager.check() from void to boolean. 
- Changed command-line campaign load to only execute when not recovering auto-save. 
- (unrelated) Removed annoying Scale.setZoomLevel  "System.out.println(this.zoomLevel);" that has been bugging me.

### Possible Drawbacks
Buggy campaign locking MapTool on load. Can be worked around by launching with command-line options -F or waiting for auto-save to trigger recover auto-save on next launch.

### Documentation Notes
- Added preference to launch most recent campaign at startup.

### Release Notes
- Added preference to launch most recent campaign at startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4870)
<!-- Reviewable:end -->
