### PR TITLE
hasLightSource & Campaign Panel drag-drop bug fix 

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
@@ -187,6 +187,7 @@ public class TokenLightFunctions extends AbstractFunction {
             return true;
           }
         }
+        return false;
       }
     }
     if (lightSourcesMap.containsKey(category)) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
@@ -128,7 +128,10 @@ public class ButtonGroup extends AbstractButtonGroup {
       MacroButtonProperties oldMacroProps = new MacroButtonProperties(tempProperties);
 
       // stops players from moving macros into/from the Campaign/GM panels
-      if (!MapTool.getPlayer().isGM()
+      // debounce first, ignore moves that change nothing
+      if (tempProperties.getGroup().equals(getMacroGroup())) {
+        event.dropComplete(false);
+      } else if (!MapTool.getPlayer().isGM()
           && (panelClass.equals("CampaignPanel")
               || panelClass.equals("GmPanel")
               || (data.panelClass.equals("CampaignPanel")


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4885 
fixes #4883 (@bubblobill fix)

### Description of the Change
`[r: hasLightSource("*","none")]` returns `0` as expected.
_See other examples in bug report_

This mimics what v1.14.3 and older version would return

### Possible Drawbacks
None

### Release Notes
- Fixed issue where `hasLightSource` would return an error instead of `0`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4887)
<!-- Reviewable:end -->
