### PR TITLE
Modify ButtonGroup drag to check for no change

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
@@ -128,7 +128,10 @@ public class ButtonGroup extends AbstractButtonGroup {
       MacroButtonProperties oldMacroProps = new MacroButtonProperties(tempProperties);
 
       // stops players from moving macros into/from the Campaign/GM panels
-      if (!MapTool.getPlayer().isGM()
+      // debounce first, ignore moves that change nothing
+      if (tempProperties.getGroup().equals(getMacroGroup())) {
+        event.dropComplete(false);
+      } else if (!MapTool.getPlayer().isGM()
           && (panelClass.equals("CampaignPanel")
               || panelClass.equals("GmPanel")
               || (data.panelClass.equals("CampaignPanel")


### PR DESCRIPTION
resolves #4883

### Description of the Change
When a macro button is dragged, logic now checks for change in button group first and exits if there is no change.

This prevents accidental small drags and drags that have no effect progressing to permission checks and further processing. 

Permission error message only presents when there is a change in the button group value.

### Possible Drawbacks
none

### Documentation Notes
Stopped permission error message for dragging macro buttons where there is no change.

### Release Notes
Stopped permission error message for dragging macro buttons where there is no change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4888)
<!-- Reviewable:end -->
