### PR TITLE
rest - return result vs ParserException

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
@@ -220,8 +220,7 @@ public class RESTfulFunctions extends AbstractFunction {
     // Execute the call and check the response...
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful() && !fullResponse) {
-        throw new ParserException(
-            I18N.getText("macro.function.rest.error.response", functionName, response.code()));
+        return I18N.getText("macro.function.rest.error.response", functionName, response.code());
       }
 
       if (fullResponse) {
@@ -231,7 +230,7 @@ public class RESTfulFunctions extends AbstractFunction {
       }
 
     } catch (IllegalArgumentException | IOException e) {
-      throw new ParserException(I18N.getText("macro.function.rest.error.unknown", functionName, e));
+      return I18N.getText("macro.function.rest.error.unknown", functionName, e);
     }
   }
 


### PR DESCRIPTION

### Identify the Bug or Feature request
Closes #2489 
`rest` commands throw parser exceptions and do not provide a `return` result that can be checked for failure.

### Description of the Change
`rest` commands that fail, will now provide a `return` of the same error previously provided through `ParserException`.
This can provide a graceful return for macro writers to check and respond accordingly.

### Possible Drawbacks
With this _feature_, macros that do not perform error checking on `rest` returns, where previously the macro would break due to the `ParserException`, will now continue execution.  This will most likely cause the macro to fail due to bad/wrong data types (eg. errors below vs expected data).

### Release Notes
Example of failures:
`[r: rest.get(url)]`
on a failure / timeout: `Unable to process function "{0}", HTTP Status Code: {1}`
on bad response: `Unable to process function "{0}", An Exception has occurred: {1} `

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4890)
<!-- Reviewable:end -->
