### PR TITLE
Fix Mac OS Intel Build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
+        os: [windows-latest, ubuntu-latest, macOS-13]
         java: [ '21' ]
         distribution: ['temurin']
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
       #   /_/ /_/ /_/ \__,_/ \___/ \____//____/
       #
     - name: Copy Mac OS Release Files
-      if: matrix.os == 'macOS-latest'
+      if: matrix.os == 'macOS-13'
       run: |
         cp releases/MapTool*.dmg releases/MapTool-${{ github.event.release.tag_name }}.dmg
         cp releases/MapTool*.pkg releases/MapTool-${{ github.event.release.tag_name }}.pkg
@@ -168,7 +168,7 @@ jobs:
     - name: Upload Mac DMG Release Asset
       id: upload-release-asset-dmg
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macOS-latest'
+      if: matrix.os == 'macOS-13'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -179,7 +179,7 @@ jobs:
     - name: Upload Mac PKG Release Asset
       id: upload-release-asset-pkg
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macOS-latest'
+      if: matrix.os == 'macOS-13'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
+        os: [windows-latest, ubuntu-latest, macOS-13]
         java: [ '21' ]
         distribution: [ 'temurin']
       fail-fast: false


### PR DESCRIPTION

fixes #4892 

### Description of the Change
Change Runner back to intel for mac os builds


### Possible Drawbacks
Should be none

### Documentation Notes
Change Runner back to intel for mac os builds


### Release Notes
- Change Runner back to intel for mac os builds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4893)
<!-- Reviewable:end -->
