### PR TITLE
Return JSON on rest failure to mtscript instead of exception

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
@@ -14,8 +14,7 @@
  */
 package net.rptools.maptool.client.functions;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
+import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import java.awt.Desktop;
 import java.io.IOException;
@@ -218,9 +217,11 @@ public class RESTfulFunctions extends AbstractFunction {
       throws ParserException {
 
     // Execute the call and check the response...
+    JsonObject errjson = new JsonObject();
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful() && !fullResponse) {
-        return I18N.getText("macro.function.rest.error.response", functionName, response.code());
+        errjson.addProperty("error", response.code());
+        return errjson;
       }
 
       if (fullResponse) {
@@ -230,7 +231,8 @@ public class RESTfulFunctions extends AbstractFunction {
       }
 
     } catch (IllegalArgumentException | IOException e) {
-      return I18N.getText("macro.function.rest.error.unknown", functionName, e);
+      errjson.addProperty("error", e.toString());
+      return errjson;
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
@@ -220,8 +220,7 @@ public class RESTfulFunctions extends AbstractFunction {
     // Execute the call and check the response...
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful() && !fullResponse) {
-        throw new ParserException(
-            I18N.getText("macro.function.rest.error.response", functionName, response.code()));
+        return I18N.getText("macro.function.rest.error.response", functionName, response.code());
       }
 
       if (fullResponse) {
@@ -231,7 +230,7 @@ public class RESTfulFunctions extends AbstractFunction {
       }
 
     } catch (IllegalArgumentException | IOException e) {
-      throw new ParserException(I18N.getText("macro.function.rest.error.unknown", functionName, e));
+      return I18N.getText("macro.function.rest.error.unknown", functionName, e);
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #2489 

### Description of the Change
`rest` failures will now return a JSON in the format below
`{"error": < message or code >}` 

Examples:
`[r: rest.get("https:\\errorTest")]`
output
`{"error":java.net.UnknownHostException: No such host is known (errorTest)"}`

Deny example:
`[r: rest.get("https:\\knownGoodURL")]`
output
`{"error": "403"}`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4896)
<!-- Reviewable:end -->
