### PR TITLE
Rework javascript getProperty API to handle missing properties better

### DIFF
--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -121,6 +121,21 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   }
 
   @HostAccess.Export
+  public String getRawProperty(String name) {
+    boolean trusted = JSScriptEngine.inTrustedContext();
+    String playerId = MapTool.getPlayer().getName();
+    if (trusted || token.isOwner(playerId)) {
+      Object val = this.token.getProperty(name);
+      // Short-circuit to returning null so we don't return "null"
+      if (val == null) {
+        return null;
+      }
+      return "" + val;
+    }
+    return null;
+  }
+
+  @HostAccess.Export
   public String getProperty(String name) {
     boolean trusted = JSScriptEngine.inTrustedContext();
     String playerId = MapTool.getPlayer().getName();
@@ -130,6 +145,7 @@ public class JSAPIToken implements MapToolJSAPIInterface {
       // since it's not useful to return nulls and require
       // javascript to have to handle defaults when getInfo isn't even bound,
       // especially when the value gets unset if it matches the default.
+      // Evaluation is not performed automatically, use getEvaluatedProperty for that.
       if (val == null) {
         List<TokenProperty> propertyList =
             MapTool.getCampaign()
@@ -150,6 +166,17 @@ public class JSAPIToken implements MapToolJSAPIInterface {
       return "" + val;
     }
     return null;
+  }
+
+  @HostAccess.Export
+  public String getEvaluatedProperty(String name) {
+    boolean trusted = JSScriptEngine.inTrustedContext();
+    String playerId = MapTool.getPlayer().getName();
+    if (trusted || token.isOwner(playerId)) {
+      Object val = this.token.getEvaluatedProperty(name);
+      return "" + val;
+    }
+    return "";
   }
 
   @HostAccess.Export


### PR DESCRIPTION
### Identify the Bug or Feature request

closes https://github.com/RPTools/maptool/issues/3028

### Description of the Change

This changes the javascript `getProperty` function to look up the value in the campaign property type defaults if it's missing, and return `null` instead of `"null"` if you don't have permission to get that token's properties or the campaign doesn't have that property either, for improved ergonomics of null-handling in javascript.

This also adds `getRawProperty` which returns `null` if it's not set, and `getEvaluatedProperty` which may evaluate the value as a macro.

### Possible Drawbacks

If users of getProperty were checking for the value being missing with something like:

```javascript
let value = token.getProperty(name);
if (value == "null") {
    value = "10";
}
```

then this will now end up with value being `null`.

`getProperty` is the most desirable name for the most common operation. It's possible that most campaigns use properties that should be evaluated so should use the shorter name, and the form of `getProperty` that only falls back to the default value should be called something like `getUnevaluatedProperty` or `getDefaultedProperty`.

### Release Notes

* Made `token.getProperty` return `null` instead of the string `"null"` when properties are missing or not permitted to be read.
* Make `token.getProperty` return the default value for the token type if the value was not set on the token.
* Added `token.getRawProperty` for uses that shouldn't fall back to defaults and `token.getEvaluatedProperty` for uses that should use calculated defaults.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4900)
<!-- Reviewable:end -->
