### PR TITLE
Fix onFirstInit running every time when there is JS but no MTS

### DIFF
--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
@@ -600,8 +600,8 @@ public class AddOnLibrary implements Library {
                                     if (mtScriptEventNameMap.containsKey(FIRST_INIT_EVENT)) {
                                       callMTSFunction(mtScriptEventNameMap.get(FIRST_INIT_EVENT))
                                           .join();
-                                      data.setNeedsToBeInitialized(false).join();
                                     }
+                                    data.setNeedsToBeInitialized(false).join();
                                   }
                                   if (jsEventNameMap.containsKey(INIT_EVENT)) {
                                     runJS(jsEventNameMap.get(INIT_EVENT));


### PR DESCRIPTION

### Identify the Bug or Feature request

fixes #4905



### Description of the Change
The onFirstInit event will run only as intended when there is a JavaScript but no MTScript script defined for the event instead of on every reload.


### Possible Drawbacks

Should be none

### Documentation Notes
The onFirstInit event will run only as intended when there is a JavaScript but no MTScript script defined for the event instead of on every reload.


### Release Notes
- The onFirstInit event will run only as intended when there is a JavaScript but no MTScript script defined for the event instead of on every reload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4906)
<!-- Reviewable:end -->
