### PR TITLE
Add a Handlebars LibraryTemplateLoader and rework file loading to support partial templates

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -35,13 +35,11 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.library.Library;
 import net.rptools.maptool.model.library.LibraryManager;
 import net.rptools.maptool.util.FunctionUtil;
+import net.rptools.maptool.util.HTMLUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Element;
-import org.jsoup.parser.Tag;
 
 public class MacroDialogFunctions extends AbstractFunction {
   private static final MacroDialogFunctions instance = new MacroDialogFunctions();
@@ -200,23 +198,7 @@ public class MacroDialogFunctions extends AbstractFunction {
             I18N.getText("macro.function.html5.invalidURI", url.toExternalForm()));
       }
 
-      htmlString = library.get().readAsString(url).get();
-
-      var document = Jsoup.parse(htmlString);
-      var head = document.select("head").first();
-      if (head != null) {
-        String baseURL = url.toExternalForm().replaceFirst("\\?.*", "");
-        baseURL = baseURL.substring(0, baseURL.lastIndexOf("/") + 1);
-        var baseElement = new Element(Tag.valueOf("base"), "").attr("href", baseURL);
-        if (head.children().isEmpty()) {
-          head.appendChild(baseElement);
-        } else {
-          head.child(0).before(baseElement);
-        }
-
-        htmlString = document.html();
-      }
-
+      htmlString = HTMLUtil.fixHTMLBase(library.get().readAsString(url).get(), url);
     } catch (InterruptedException | ExecutionException | IOException e) {
       throw new ParserException(e);
     }

--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheet.java
@@ -15,12 +15,14 @@
 package net.rptools.maptool.client.ui.sheet.stats;
 
 import java.io.IOException;
+import java.net.URL;
 import javafx.application.Platform;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.sheet.stats.StatSheetContext;
 import net.rptools.maptool.model.sheet.stats.StatSheetLocation;
+import net.rptools.maptool.util.HTMLUtil;
 import net.rptools.maptool.util.HandlebarsUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,10 +41,11 @@ public class StatSheet {
    * @param content the content of the stat sheet.
    * @param location the location of the stat sheet.
    */
-  public void setContent(Token token, String content, StatSheetLocation location) {
+  public void setContent(Token token, String content, URL entry, StatSheetLocation location) {
     try {
       var statSheetContext = new StatSheetContext(token, MapTool.getPlayer(), location);
-      var output = new HandlebarsUtil<>(content).apply(statSheetContext);
+      var output =
+          HTMLUtil.fixHTMLBase(new HandlebarsUtil<>(content, entry).apply(statSheetContext), entry);
       Platform.runLater(
           () -> {
             var overlay =

--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
@@ -49,13 +49,18 @@ public class StatSheetListener {
          */
         MapTool.getFrame().hideControlPanel();
         statSheet = new StatSheet();
-        var ss = event.token().getStatSheet();
+        var ssProperties = event.token().getStatSheet();
+        var ssId = ssProperties.id();
+        var ssRecord = ssManager.getStatSheet(ssId);
         var token = event.token();
         if (MapTool.getPlayer().isGM()
             || AppUtil.playerOwns(token)
             || token.getType() != Type.NPC) {
           statSheet.setContent(
-              event.token(), ssManager.getStatSheetContent(ss.id()), ss.location());
+              event.token(),
+              ssManager.getStatSheetContent(ssId),
+              ssRecord.entry(),
+              ssProperties.location());
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/model/library/builtin/ClassPathAddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/ClassPathAddOnLibrary.java
@@ -77,11 +77,6 @@ public class ClassPathAddOnLibrary implements BuiltInLibrary {
   }
 
   @Override
-  public CompletableFuture<String> readAsHTMLContent(URL location) throws IOException {
-    return BuiltInLibrary.super.readAsHTMLContent(location);
-  }
-
-  @Override
   public CompletableFuture<InputStream> read(URL location) throws IOException {
     return addOnLibrary.read(location);
   }

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
@@ -150,7 +150,7 @@ public class StatSheetManager {
    * @throws IOException if an error occurs reading the stat sheet.
    */
   public void addStatSheet(StatSheet statSheet, Library library) throws IOException {
-    var html = library.readAsHTMLContent(statSheet.entry()).join();
+    var html = library.readAsString(statSheet.entry()).join();
     statSheets.put(statSheet, html);
   }
 

--- a/src/main/java/net/rptools/maptool/util/HTMLUtil.java
+++ b/src/main/java/net/rptools/maptool/util/HTMLUtil.java
@@ -1,0 +1,48 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.util;
+
+import java.net.URL;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+
+public class HTMLUtil {
+
+  /**
+   * Parses the HTML in the string and sets the base to the correct location.
+   *
+   * @param htmlString the HTML to parse.
+   * @param url the origin URL to set the base relative to
+   * @return the fixed-up HTML
+   */
+  public static String fixHTMLBase(String htmlString, URL url) {
+    var document = Jsoup.parse(htmlString);
+    var head = document.select("head").first();
+    if (head != null) {
+      String baseURL = url.toExternalForm().replaceFirst("\\?.*", "");
+      baseURL = baseURL.substring(0, baseURL.lastIndexOf("/") + 1);
+      var baseElement = new Element(Tag.valueOf("base"), "").attr("href", baseURL);
+      if (head.children().isEmpty()) {
+        head.appendChild(baseElement);
+      } else {
+        head.child(0).before(baseElement);
+      }
+
+      htmlString = document.html();
+    }
+    return htmlString;
+  }
+}

--- a/src/main/java/net/rptools/maptool/util/HandlebarsUtil.java
+++ b/src/main/java/net/rptools/maptool/util/HandlebarsUtil.java
@@ -20,6 +20,7 @@ import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.context.JavaBeanValueResolver;
 import com.github.jknack.handlebars.helper.AssignHelper;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
+import com.github.jknack.handlebars.helper.IncludeHelper;
 import com.github.jknack.handlebars.helper.NumberHelper;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
@@ -109,6 +110,7 @@ public class HandlebarsUtil<T> {
           .forEach(h -> handlebars.registerHelper(h.name(), h));
       NumberHelper.register(handlebars);
       handlebars.registerHelper(AssignHelper.NAME, AssignHelper.INSTANCE);
+      handlebars.registerHelper(IncludeHelper.NAME, IncludeHelper.INSTANCE);
 
       template = handlebars.compileInline(stringTemplate);
     } catch (IOException e) {

--- a/src/main/java/net/rptools/maptool/util/HandlebarsUtil.java
+++ b/src/main/java/net/rptools/maptool/util/HandlebarsUtil.java
@@ -72,8 +72,6 @@ public class HandlebarsUtil<T> {
    */
   public String apply(T bean) throws IOException {
     try {
-
-      Handlebars handlebars = new Handlebars();
       var context = Context.newBuilder(bean).resolver(JavaBeanValueResolver.INSTANCE).build();
       return template.apply(context);
     } catch (IOException e) {


### PR DESCRIPTION
### Identify the Bug or Feature request

closes https://github.com/RPTools/maptool/issues/4920

### Description of the Change

This has two major changes:

1. Moves the code for injecting the base tag to after templates have been applied instead of when they are read.

   This is necessary because the syntax for including partial templates is `{{> path}}`
   but the Jsoup code that adds the `<base>` tag normalises this strictly invalid HTML to `{{&gt; path}}`
   which makes it an invalid Handlebars template.
   
2. Adds a Handlebars [TemplateLoader](https://javadoc.io/static/com.github.jknack/handlebars/4.3.1/com/github/jknack/handlebars/io/TemplateLoader.html) that loads from lib:// URLs.

   Because the templates are already publicly exported from add-ons,
   and they can load css from other files with relative URLs
   it is natural to support loading partial templates the same way.
   
   It is implemented as a URL loader which is aware of the path of the template being loaded
   and interprets relative paths as relative to the directory.
   As-implemented, absolute paths can load content from other add-ons, but this could be prevented by adjusting the prefix and current paths.

See <https://gitlab.com/richardmaw/maptool-bar-test/-/tree/main/mtlib/library/public/sheets/basic> for an example stat sheet that uses partial templates.

### Possible Drawbacks

lib:// URIs were used to implement it as a URLTemplateLoader because handlebars.java already had a URL-based loader
and it was less intrusive to pass the URL around.

It would instead be possible to define a loader that uses a reference to the library which would have the benefit of allowing non-public templates, and bypasses the URL fetch machinery, but it may be useful to permit add-ons to depend on each other.

### Documentation Notes

In <https://wiki.rptools.info/index.php/Stat_Sheet_Tutorial> there is a comment:

> The `&` CSS selector didn't work when I created the examples, but may be available by the time you read this. It doesn't hurt to try it and see.

Which was probably due to the base tag being added before templates are parsed.

### Release Notes

- Fixed handlebars templates being mis-parsed if they were not strictly HTML.
- Added support for loading partial handlebars templates with the `{{> path}}` syntax, which includes the contents of the named partial template file in the current template. If the path is an absolute path the first component is the library namespace. If the path is a relative path it is in the same directory as the template.
- Adds the `include` helper, e.g. `{{include "foo" bar=baz}}` will include the partial template `"foo"` with the context altered to set bar to the value of baz in the current context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4921)
<!-- Reviewable:end -->
