### PR TITLE
Reduce number of interfaces scanned for UPnP gateways (reapply #4904)

### DIFF
--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -32,6 +32,7 @@ import net.rptools.clientserver.simple.server.ServerObserver;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolRegistry;
+import net.rptools.maptool.client.ui.StaticMessageDialog;
 import net.rptools.maptool.client.ui.connectioninfodialog.ConnectionInfoDialog;
 import net.rptools.maptool.common.MapToolConstants;
 import net.rptools.maptool.language.I18N;
@@ -388,7 +389,14 @@ public class MapToolServer {
 
     // Use UPnP to open port in router
     if (useUPnP && config != null) {
-      UPnPUtil.openPort(config.getPort());
+      MapTool.getFrame()
+          .showFilledGlassPane(
+              new StaticMessageDialog(I18N.getText("msg.info.server.upnp.discovering")));
+      try {
+        UPnPUtil.openPort(config.getPort());
+      } finally {
+        MapTool.getFrame().hideGlassPane();
+      }
     }
 
     // Registered ?

--- a/src/main/java/net/rptools/maptool/util/UPnPUtil.java
+++ b/src/main/java/net/rptools/maptool/util/UPnPUtil.java
@@ -14,9 +14,6 @@
  */
 package net.rptools.maptool.util;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Font;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InterfaceAddress;
@@ -27,13 +24,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.swing.SwingUtil;
 import net.sbbi.upnp.Discovery;
 import net.sbbi.upnp.impls.InternetGatewayDevice;
 import net.sbbi.upnp.messages.ActionResponse;
@@ -48,34 +40,6 @@ public class UPnPUtil {
   private static final Logger log = LogManager.getLogger(UPnPUtil.class);
   private static Map<InternetGatewayDevice, NetworkInterface> igds;
   private static List<InternetGatewayDevice> mappings;
-  private static JDialog dialog = null;
-  private static JPanel panel = new JPanel(new BorderLayout());
-  private static Font labelFont = new Font("Dialog", Font.BOLD, 14);
-  private static JLabel label = new JLabel("", SwingConstants.CENTER);
-
-  private static void showMessage(String device, String msg) {
-    if (dialog == null) {
-      dialog = new JDialog(MapTool.getFrame());
-      dialog.setContentPane(panel);
-      panel.add(label, BorderLayout.CENTER);
-      label.setFont(labelFont);
-    }
-    if (device == null) {
-      dialog.setVisible(false);
-    } else {
-      dialog.setTitle("Scanning device " + device);
-      label.setText(msg);
-
-      Dimension d = label.getMinimumSize();
-      d.width += 50;
-      d.height += 50;
-      label.setPreferredSize(d);
-
-      dialog.pack();
-      SwingUtil.centerOver(dialog, MapTool.getFrame());
-      dialog.setVisible(true);
-    }
-  }
 
   public static boolean findIGDs() {
     igds = new HashMap<InternetGatewayDevice, NetworkInterface>();
@@ -87,17 +51,17 @@ public class UPnPUtil {
           if (ni.isUp() && !ni.isLoopback() && !ni.isVirtual()) {
             int found = 0;
             try {
-              log.info("UPnP:  Trying interface {}", ni.getDisplayName());
+              log.info(
+                  "UPnP:  Looking for gateway devices on interface '{}' [{}]",
+                  ni.getDisplayName(),
+                  addresses);
               InternetGatewayDevice[] thisNI;
-              showMessage(
-                  ni.getDisplayName(), "Looking for gateway devices on " + ni.getDisplayName());
               thisNI =
                   InternetGatewayDevice.getDevices(
                       AppPreferences.getUpnpDiscoveryTimeout(),
                       Discovery.DEFAULT_TTL,
                       Discovery.DEFAULT_MX,
                       ni);
-              showMessage(null, null);
               if (thisNI != null) {
                 for (InternetGatewayDevice igd : thisNI) {
                   found++;
@@ -116,7 +80,6 @@ public class UPnPUtil {
                 }
               }
             } catch (IOException ex) {
-              showMessage(null, null);
               // some IO Exception occurred during communication with device
               log.warn("While searching for internet gateway devices", ex);
             }

--- a/src/main/java/net/rptools/maptool/util/UPnPUtil.java
+++ b/src/main/java/net/rptools/maptool/util/UPnPUtil.java
@@ -50,7 +50,9 @@ public class UPnPUtil {
         NetworkInterface ni = e.nextElement();
         try {
           var addresses = Collections.list(ni.getInetAddresses());
-          if (ni.isLoopback()) {
+          if (addresses.isEmpty()) {
+            log.info("UPnP:  Rejecting interface '{}' as it has no addresses", ni.getDisplayName());
+          } else if (ni.isLoopback()) {
             log.info(
                 "UPnP:  Rejecting interface '{}' [{}] as it is a loopback",
                 ni.getDisplayName(),

--- a/src/main/java/net/rptools/maptool/util/UPnPUtil.java
+++ b/src/main/java/net/rptools/maptool/util/UPnPUtil.java
@@ -20,6 +20,7 @@ import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +49,23 @@ public class UPnPUtil {
       while (e.hasMoreElements()) {
         NetworkInterface ni = e.nextElement();
         try {
-          if (ni.isUp() && !ni.isLoopback() && !ni.isVirtual()) {
+          var addresses = Collections.list(ni.getInetAddresses());
+          if (ni.isLoopback()) {
+            log.info(
+                "UPnP:  Rejecting interface '{}' [{}] as it is a loopback",
+                ni.getDisplayName(),
+                addresses);
+          } else if (ni.isVirtual()) {
+            log.info(
+                "UPnP:  Rejecting interface '{}' [{}] as it is virtual",
+                ni.getDisplayName(),
+                addresses);
+          } else if (!ni.isUp()) {
+            log.info(
+                "UPnP:  Rejecting interface '{}' [{}] as it is not up",
+                ni.getDisplayName(),
+                addresses);
+          } else {
             int found = 0;
             try {
               log.info(

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2404,6 +2404,7 @@ msg.info.stopWebEndWebPoint                   = Stopping web end point.
 # code adds that, if appropriate, based on the situation.
 msg.info.versionFile                          = CAN'T FIND VERSION FILE
 msg.info.assetsDisabled                       = The GM has disabled insertion of player assets.
+msg.info.server.upnp.discovering              = Discovering UPnP gateways...
 
 
 msg.title.exportMacro                         = Export Macro


### PR DESCRIPTION
Ports PR #4904 to `develop`.

The only notable difference is that the UPnP glass pane logic had to be moved into `MapToolServer` due to the refactorings that have taken place on `develop`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4935)
<!-- Reviewable:end -->
