### PR TITLE
Restrict each drawable light to its lumens level

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/Illumination.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/Illumination.java
@@ -174,6 +174,24 @@ public final class Illumination {
   }
 
   /**
+   * Look up a disjoint obscured lumens level based on the lumens strength.
+   *
+   * <p>This is useful for rendering individual lights, so that the light can be constrained to the
+   * area that is actually illuminated by the light and not by any stronger light.
+   *
+   * <p>See {@link #getDisjointObscuredLumensLevels()} for more information.
+   *
+   * @param lumensStrength The strength of lumens to find.
+   * @return The {#link LumensLevel} of strength {@code lumensStrength}. If no level exists for it,
+   *     an empty optional is returned.
+   */
+  public Optional<LumensLevel> getDisjointObscuredLumensLevel(int lumensStrength) {
+    return getDisjointObscuredLumensLevels().stream()
+        .filter(level -> level.lumensStrength() == lumensStrength)
+        .findFirst();
+  }
+
+  /**
    * Get the disjoint obscured lumens levels.
    *
    * <p>Each lumens level in the result will have areas that do not intersect any other areas in any

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -61,6 +61,7 @@ import net.rptools.maptool.model.zones.TokensAdded;
 import net.rptools.maptool.model.zones.TokensChanged;
 import net.rptools.maptool.model.zones.TokensRemoved;
 import net.rptools.maptool.model.zones.TopologyChanged;
+import net.rptools.maptool.model.zones.ZoneLightingChanged;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.DrawnElementListDto;
 import net.rptools.maptool.server.proto.TopologyTypeDto;
@@ -515,6 +516,7 @@ public class Zone {
 
   public void setLightingStyle(LightingStyle lightingStyle) {
     this.lightingStyle = lightingStyle;
+    new MapToolEventBus().getMainEventBus().post(new ZoneLightingChanged(this));
   }
 
   public TokenSelection getTokenSelection() {

--- a/src/main/java/net/rptools/maptool/model/zones/ZoneLightingChanged.java
+++ b/src/main/java/net/rptools/maptool/model/zones/ZoneLightingChanged.java
@@ -1,0 +1,19 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model.zones;
+
+import net.rptools.maptool.model.Zone;
+
+public record ZoneLightingChanged(Zone zone) {}


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4936

### Description of the Change

When using the "overtop" lighting style, weak lights will no longer overlap with strong lights. This lighting style is more closely related to mechanics, and so it gets confusing when different lumens levels have overlapping colours.

When using the "environmental" lighting style, weak lights and strong lights can still overlap. This lighting style is meant to be more natural, so it's not desirable to have a hard cutoff where weak lights meet strong lights.

In either case, the interaction between darkness and light is the same: the weaker one will be cutoff by the stronger so there is no overlap.

### Possible Drawbacks

Someone may have found a use for overlapping lights in the "overtop" style, and that is being removed here.

### Documentation Notes

When using the "overtop" lighting style, each lumens level is like a separate layer for lights. Different lumens levels will not overlap with each. Instead, the strongest lumens level will "win" over weaker lumens levels. If darkness and light are tied, the darkness wins.

As an example, we can augment the default torch with lumens levels to represent bright and dim:
```
Torch - 20: circle 20+100 40#000000+50
```
If two tokens have torches, we can see that the bright areas are merged, and the dim areas are merged, but the dim areas do not overlap with the bright areas since the bright areas have a higher lumens value.
![image](https://github.com/user-attachments/assets/fe844c62-8d82-4755-88b9-cbf90997c37b)

### Release Notes

- Change light rendering so that lights of different lumens do not overlap and blend when using "overtop" lighting style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4940)
<!-- Reviewable:end -->
