### PR TITLE
Fix darkness in GM views

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/DarknessRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/DarknessRenderer.java
@@ -37,7 +37,7 @@ public class DarknessRenderer {
   }
 
   public void render(Graphics2D g2d, PlayerView view) {
-    if (!view.isGMView()) {
+    if (view.isGMView()) {
       return;
     }
     final Area darkness = zoneView.getIllumination(view).getDarkenedArea();


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4941

### Description of the Change

Fixes the view check in the darkness renderer so that darkness is rendered as black for players, not GMs.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where coloured darkness would render as black for GMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4942)
<!-- Reviewable:end -->
