### PR TITLE
Fix translation of "Clear GM Auras Only" menu item

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -729,7 +729,7 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
 
   public class ClearGMAurasOnlyAction extends AbstractAction {
     public ClearGMAurasOnlyAction() {
-      super("token.popup.menu.auras.clearGM");
+      super(I18N.getText("token.popup.menu.auras.clearGM"));
     }
 
     public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4927

### Description of the Change

Fixes the use of the `"token.popup.menu.auras.clearGM"` translation key so it actually gets translated.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the "Clear GM Auras Only" menu item would show the translation key instead of the translated text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4948)
<!-- Reviewable:end -->
