### PR TITLE
Add clear lights menu items only once

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -120,24 +120,33 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
   protected JMenu createLightSourceMenu() {
     JMenu menu = new JMenu(I18N.getText("panel.MapExplorer.View.LIGHT_SOURCES"));
 
-    if (tokenUnderMouse.hasLightSources()) {
-      menu.add(new ClearLightAction());
+    boolean hasAnyLights = false;
+    boolean hasLights = false;
+    boolean hasAuras = false;
+    boolean hasGmAuras = false;
+    boolean hasOwnerOnlyAuras = false;
 
-      ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
-      for (GUID tokenGUID : selectedTokenSet) {
-        Token token = renderer.getZone().getToken(tokenGUID);
-        if (token.hasLightSourceType(LightSource.Type.NORMAL)) {
-          menu.add(new ClearLightsOnlyAction());
-        }
-        if (token.hasLightSourceType(LightSource.Type.AURA)) {
-          menu.add(new ClearAurasOnlyAction());
-        }
-        if (token.hasGMAuras()) {
-          menu.add(new ClearGMAurasOnlyAction());
-        }
-        if (token.hasOwnerOnlyAuras()) {
-          menu.add(new ClearOwnerAurasOnlyAction());
-        }
+    for (GUID tokenGUID : selectedTokenSet) {
+      Token token = renderer.getZone().getToken(tokenGUID);
+      hasAnyLights |= token.hasLightSources();
+      hasLights |= token.hasLightSourceType(LightSource.Type.NORMAL);
+      hasAuras |= token.hasLightSourceType(LightSource.Type.AURA);
+      hasGmAuras |= token.hasGMAuras();
+      hasOwnerOnlyAuras |= token.hasOwnerOnlyAuras();
+    }
+    if (hasAnyLights) {
+      menu.add(new ClearLightAction());
+      if (hasLights) {
+        menu.add(new ClearLightsOnlyAction());
+      }
+      if (hasAuras) {
+        menu.add(new ClearAurasOnlyAction());
+      }
+      if (hasGmAuras) {
+        menu.add(new ClearGMAurasOnlyAction());
+      }
+      if (hasOwnerOnlyAuras) {
+        menu.add(new ClearOwnerAurasOnlyAction());
       }
       menu.addSeparator();
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4933

### Description of the Change

If multiple tokens are selected, add each "clear lights" menu item only use. Also, add these menu items if any of the selected tokens have the corresponding light sources, not just if the clicked token has light sources.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the "Clear lights" and related context menu items would be added repeatedly for each selected token.
- Fixed a bug where the "Clear lights only" and related context menu items would not be added if the the clicked token did not have light sources but other selected tokens did.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4949)
<!-- Reviewable:end -->
