### PR TITLE
Fix translation issues on 1.15

### DIFF
--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -185,7 +185,13 @@ Label.table.import  = Import Table
 Label.table.export  = Export Table
 Label.preview       = Preview
 Label.foreground    = Foreground:
+Label.background    = Background:
 Label.showbackground = Show Background:
+Label.showBorder     = Show Border
+Label.borderWidth    = Border Width
+Label.border.color   = Border Color
+Label.borderArc      = Border Arc
+Label.fontSize       = Font Size
 Label.layers        = Layers:
 Label.view.current  = Current View
 Label.host          = Host:
@@ -604,6 +610,19 @@ Preferences.label.access.delay.dismiss            = ToolTip Dismiss Delay
 Preferences.label.access.delay.dismiss.tooltip    = The amount of time (in milliseconds) the tooltip will remain before being removed.
 Preferences.label.access.size                     = Chat Font Size
 Preferences.label.access.size.tooltip             = Point size for all chat window text (both input and output).
+Preferences.label.access.tokenLabel                   = Token Name Label (On Map)
+Preferences.label.access.tokenLabel.size              = Font Size
+Preferences.label.access.tokenLabel.pcBackground      = PC Background
+Preferences.label.access.tokenLabel.pcForeground      = PC Foreground
+Preferences.label.access.tokenLabel.npcBackground     = NPC Background
+Preferences.label.access.tokenLabel.npcForeground     = NPC Foreground
+Preferences.label.access.tokenLabel.nonVisBackground  = Non Visible Background
+Preferences.label.access.tokenLabel.nonVisForeground  = Non Visible Foreground
+Preferences.label.access.tokenLabel.pcBorderColor     = PC Border Color
+Preferences.label.access.tokenLabel.npcBorderColor    = NPC Border Color
+Preferences.label.access.tokenLabel.nonVisBorderColor = Non Visible Border Color
+Preferences.label.access.tokenLabel.borderArc         = Border Arc
+Preferences.label.access.tokenLabel.borderSize        = Border Size
 Preferences.label.sound.system                    = Play system sounds
 Preferences.label.sound.system.tooltip            = Turn this off to prevent all sounds from within MapTool.  Needed for some Java implementations as too many sounds queued up can crash the JVM.
 Preferences.label.sound.stream                    = Play clips and streams
@@ -780,7 +799,12 @@ CampaignPropertiesDialog.tab.sight     = Sight
 CampaignPropertiesDialog.tab.light     = Light
 CampaignPropertiesDialog.tab.states    = States
 CampaignPropertiesDialog.tab.bars      = Bars
-CampaignPropertiesDialog.button.import = Import predefined
+CampaignPropertiesDialog.button.importPredefined = Import Predefined
+CampaignPropertiesDialog.button.importPredefined.tooltip = Import predefined properties and settings for the selected system
+CampaignPropertiesDialog.button.import.tooltip = Import predefined properties from a file
+CampaignPropertiesDialog.button.export.tooltip = Export campaign properties to file
+CampaignPropertiesDialog.combo.importPredefined.tooltip = System to import properties for
+CampaignPropertiesDialog.button.import = Import Predefined
 campaignPropertiesDialog.newTokenTypeName = Enter the name for the new token type
 campaignPropertiesDialog.newTokenTypeTitle = New Token Type
 campaignPropertiesDialog.newTokenTypeDefaultName = New Token Type {0}
@@ -798,6 +822,14 @@ campaignPropertiesTable.column.onStatSheet = Stat Sheet
 campaignPropertiesTable.column.gmStatSheet = GM
 campaignPropertiesTable.column.ownerStatSheet = Owner
 campaignPropertiesTable.column.defaultValue = Default
+
+campaignPropertiesTable.column.name.description = The actual name of the property, used by the application.
+campaignPropertiesTable.column.shortName.description = Short version of the property name. Used in stat-sheets and character sheets.
+campaignPropertiesTable.column.displayName.description = Display version of the property name. Used in stat-sheets and character sheets.
+campaignPropertiesTable.column.statSheet.description = Show the property on the stat-sheet.
+campaignPropertiesTable.column.gm.description = Restrict visibility to the GM view of the stat-sheet.
+campaignPropertiesTable.column.owner.description = Restrict visibility to the owner's view of the stat-sheet.
+campaignPropertiesTable.column.default.description = The default value assigned to the property.
 
 # Bar propertyType
 CampaignPropertiesDialog.combo.bars.type.twoImages      = Two Images
@@ -1114,15 +1146,23 @@ CampaignPropertiesDialog.label.mouse   = Mouseover:
 CampaignPropertiesDialog.label.order   = Order:
 CampaignPropertiesDialog.label.order.tooltip = Position in the list of states, change to move up or down the list.
 CampaignPropertiesDialog.label.else    = Everybody Else
-CampaginPropertiesDialog.label.owner   = Owner
+CampaignPropertiesDialog.label.owner   = Owner
 
 TextureChooserPanel.title = Texture
 
 TokenPropertiesPanel.label.list        = List the token properties for this token type below, one property per line:
 TokenPropertiesPanel.label.type        = Token Type
-TokenPropertiesPanel.label.statSheet   = Stat Sheet
-TokenPropertiesPanel.button.statSheetProps = Stat Sheet Properties
+TokenPropertiesPanel.label.statSheet   = Stat-Sheet
+TokenPropertiesPanel.combo.statSheet.tooltip = The default stat-sheet to use for this token type
+TokenPropertiesPanel.combo.statSheetLocation.tooltip = The default display position for the stat-sheet
+TokenPropertiesPanel.button.statSheetProps = Stat-Sheet Properties
 TokenPropertiesPanel.button.setAsDefault = Set as Default
+TokenPropertiesPanel.button.setAsDefault.tooltip = Make this the default type for all new tokens
+TokenPropertiesPanel.button.add.tooltip = Create a new token type
+TokenPropertiesPanel.button.addProperty.tooltip = Add a new property to the list
+TokenPropertiesPanel.button.deleteProperty.tooltip = Remove selected property from the list
+TokenPropertiesPanel.button.propertyUpDown.tooltip = Change the list position of the property
+TokenPropertiesPanel.button.delete.tooltip = Delete the token type and its associated properties
 TokenPropertiesPanel.defaultPropertyType = Default Property Type
 
 
@@ -1246,6 +1286,7 @@ action.commandPanel                           = Command Panel
 # In order to prevent I18N from warning that they don't exist these
 # lines have been added.
 action.commitCommand                          = Not used (action.commitCommand)
+action.newlineCommand                         = Not used (action.newlineCommand)
 action.copyTokens                             = Copy
 action.copyTokens.accel                       = C
 action.copyTokens.description                 = Copy selected tokens to an internal clipboard.


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4951

### Description of the Change

The i18n.properties file was missing a bunch of changes. This has been resolved by finding the fixes applied to `develop` and backporting them to `release-1.15`.

### Possible Drawbacks

As long as I didn't miss a key, should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where campaign properties dialog could not be opened in certain locales.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4952)
<!-- Reviewable:end -->
