### PR TITLE
Do not modify token facing when calculating light and vision

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -411,6 +411,7 @@ public abstract class Grid implements Cloneable {
     }
     int visionDistance = zone.getTokenVisionInPixels();
     double visionRange = (range == 0) ? visionDistance : range * getSize() / zone.getUnitsPerCell();
+    int tokenFacing = token.getFacingInDegrees() + 90;
 
     if (scaleWithToken) {
       double footprintWidth = token.getFootprint(this).getBounds(this).getWidth() / 2;
@@ -453,7 +454,7 @@ public abstract class Grid implements Cloneable {
         visibleArea =
             new Area(
                 AffineTransform.getRotateInstance(
-                        Math.toRadians(offsetAngle) - Math.toRadians(token.getFacing()))
+                        Math.toRadians(offsetAngle) + Math.toRadians(tokenFacing))
                     .createTransformedShape(visibleShape));
         break;
       case CONE:
@@ -475,7 +476,7 @@ public abstract class Grid implements Cloneable {
         // Rotate
         tempvisibleArea =
             tempvisibleArea.createTransformedArea(
-                AffineTransform.getRotateInstance(-Math.toRadians(token.getFacing())));
+                AffineTransform.getRotateInstance(Math.toRadians(tokenFacing)));
 
         Rectangle footprint = token.getFootprint(this).getBounds(this);
         footprint.x = -footprint.width / 2;

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -411,10 +411,12 @@ public abstract class Grid implements Cloneable {
     }
     int visionDistance = zone.getTokenVisionInPixels();
     double visionRange = (range == 0) ? visionDistance : range * getSize() / zone.getUnitsPerCell();
-    int tokenFacing = token.getFacingInDegrees() + 90;
+    /* Token facing as an angle. 0° points to the right and clockwise is positive. */
+    int tokenFacingAngle = token.getFacingInDegrees() + 90;
+    Rectangle footprint = token.getFootprint(this).getBounds(this);
 
     if (scaleWithToken) {
-      double footprintWidth = token.getFootprint(this).getBounds(this).getWidth() / 2;
+      double footprintWidth = footprint.getWidth() / 2;
 
       // Test for gridless maps
       var cellShape = getCellShape();
@@ -424,85 +426,76 @@ public abstract class Grid implements Cloneable {
       } else {
         // For grids, this will be the same, but for Hex's we'll use the smaller side depending on
         // which Hex type you choose
-        double footprintHeight = token.getFootprint(this).getBounds(this).getHeight() / 2;
+        double footprintHeight = footprint.getHeight() / 2;
         visionRange += Math.min(footprintWidth, footprintHeight);
       }
     }
 
-    Area visibleArea = new Area();
+    Area visibleArea;
     switch (shape) {
-      case CIRCLE:
+      case CIRCLE -> {
         visibleArea =
             GraphicsUtil.createLineSegmentEllipse(
                 -visionRange, -visionRange, visionRange, visionRange, CIRCLE_SEGMENTS);
-        break;
-      case GRID:
+      }
+      case GRID -> {
         visibleArea = getGridArea(token, range, scaleWithToken, visionRange);
-        break;
-      case SQUARE:
+      }
+      case SQUARE -> {
         visibleArea =
             new Area(
                 new Rectangle2D.Double(
                     -visionRange, -visionRange, visionRange * 2, visionRange * 2));
-        break;
-      case BEAM:
+      }
+      case BEAM -> {
         // Make at least 1 pixel on each side, so it's at least visible at 100% zoom.
         var pixelWidth = Math.max(2, width * getSize() / zone.getUnitsPerCell());
         Shape lineShape = new Rectangle2D.Double(0, -pixelWidth / 2, visionRange, pixelWidth);
-        Shape visibleShape = new GeneralPath(lineShape);
 
         visibleArea =
             new Area(
-                AffineTransform.getRotateInstance(
-                        Math.toRadians(offsetAngle) + Math.toRadians(tokenFacing))
-                    .createTransformedShape(visibleShape));
-        break;
-      case CONE:
+                AffineTransform.getRotateInstance(Math.toRadians(offsetAngle + tokenFacingAngle))
+                    .createTransformedShape(lineShape));
+      }
+      case CONE -> {
         Arc2D cone =
             new Arc2D.Double(
                 -visionRange,
                 -visionRange,
                 visionRange * 2,
                 visionRange * 2,
-                360.0 - (arcAngle / 2.0) + (offsetAngle * 1.0),
+                (offsetAngle - tokenFacingAngle) - arcAngle / 2.,
                 arcAngle,
                 Arc2D.PIE);
 
         // Flatten the cone to remove 'curves'
         GeneralPath path = new GeneralPath();
         path.append(cone.getPathIterator(null, 1), false);
-        Area tempvisibleArea = new Area(path);
+        visibleArea = new Area(path);
 
-        // Rotate
-        tempvisibleArea =
-            tempvisibleArea.createTransformedArea(
-                AffineTransform.getRotateInstance(Math.toRadians(tokenFacing)));
-
-        Rectangle footprint = token.getFootprint(this).getBounds(this);
-        footprint.x = -footprint.width / 2;
-        footprint.y = -footprint.height / 2;
-
-        visibleArea.add(new Area(footprint));
-        visibleArea.add(tempvisibleArea);
-        break;
-      case HEX:
-        footprint = token.getFootprint(this).getBounds(this);
+        var footprintPart = new Rectangle(footprint);
+        footprintPart.x = -footprintPart.width / 2;
+        footprintPart.y = -footprintPart.height / 2;
+        visibleArea.add(new Area(footprintPart));
+      }
+      case HEX -> {
         double x = footprint.getCenterX();
         double y = footprint.getCenterY();
 
-        double footprintWidth = token.getFootprint(this).getBounds(this).getWidth();
-        double footprintHeight = token.getFootprint(this).getBounds(this).getHeight();
+        double footprintWidth = footprint.getWidth();
+        double footprintHeight = footprint.getHeight();
         double adjustment = Math.min(footprintWidth, footprintHeight);
         x -= adjustment / 2;
         y -= adjustment / 2;
 
         visibleArea = createHex(x, y, visionRange, 0);
-        break;
-      default:
+      }
+      default -> {
+        log.error("Unhandled shape {}; treating as a circle", shape);
         visibleArea =
             GraphicsUtil.createLineSegmentEllipse(
                 -visionRange, -visionRange, visionRange * 2, visionRange * 2, CIRCLE_SEGMENTS);
-        break;
+      }
     }
 
     return visibleArea;

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -281,6 +281,7 @@ public class IsometricGrid extends Grid {
     int visionDistance = getZone().getTokenVisionInPixels();
     double visionRange =
         (range == 0) ? visionDistance : range * getSize() / getZone().getUnitsPerCell();
+    int tokenFacing = token.getFacingInDegrees() + 90;
 
     if (scaleWithToken) {
       Rectangle footprint = token.getFootprint(this).getBounds(this);
@@ -311,7 +312,7 @@ public class IsometricGrid extends Grid {
         Shape visibleShape = new Rectangle2D.Double(0, -pixelWidth / 2, visionRange, pixelWidth);
 
         // new angle, corrected for isometric view
-        double theta = Math.toRadians(offsetAngle) + Math.toRadians(token.getFacing());
+        double theta = Math.toRadians(offsetAngle) - Math.toRadians(tokenFacing);
         Point2D angleVector = new Point2D.Double(Math.cos(theta), Math.sin(theta));
         AffineTransform at = new AffineTransform();
         at.rotate(Math.PI / 4);
@@ -331,17 +332,13 @@ public class IsometricGrid extends Grid {
         visionRange = (float) Math.sin(Math.toRadians(45)) * visionRange;
         // Get the cone, use degreesFromIso to convert the facing from isometric to plan
 
-        // Area tempvisibleArea = new Area(new Arc2D.Double(-visionRange * 2, -visionRange,
-        // visionRange * 4, visionRange * 2, token.getFacing() - (arcAngle / 2.0) + (offsetAngle *
-        // 1.0), arcAngle,
-        // Arc2D.PIE));
         Arc2D cone =
             new Arc2D.Double(
                 -visionRange * 2,
                 -visionRange,
                 visionRange * 4,
                 visionRange * 2,
-                token.getFacing() - (arcAngle / 2.0) + (offsetAngle * 1.0),
+                -tokenFacing - (arcAngle / 2.0) + (offsetAngle * 1.0),
                 arcAngle,
                 Arc2D.PIE);
         GeneralPath path = new GeneralPath();

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -875,7 +875,9 @@ public class Token implements Cloneable {
 
   /**
    * This returns the rotation of the facing of the token from the default facing of down or -90.
-   * Positive for CW and negative for CCW.
+   *
+   * <p>Positive for CW and negative for CCW. The range is currently from -270° (inclusive) to +90°
+   * (exclusive), but callers should not rely on this.
    *
    * @return angle in degrees
    */


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4929

### Description of the Change

`Grid.getShapedArea()` was forcing a token facing to `0` if it did not have one. The override in `IsometricGrid` was doing the same. This PR changes it to just use a default value instead, through `Token.getFacingInDegrees()`.

Some clean up was also done on the implementation.


### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where tokens would be forced to have a facing if equipped with cone or beam lights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4955)
<!-- Reviewable:end -->
