### PR TITLE
Fix NPE in Set Facing tool

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -642,7 +642,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equalsIgnoreCase("getTokenFacing")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
       Token token = FunctionUtil.getTokenFromParam(resolver, functionName, parameters, 0, 1);
-      if (token.getFacing() == null) {
+      if (!token.hasFacing()) {
         return ""; // XXX Should be -1 instead of a string?
       }
       return BigDecimal.valueOf(token.getFacing());

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -16,7 +16,6 @@ package net.rptools.maptool.client.tool;
 
 import java.awt.dnd.DragSource;
 import java.awt.event.*;
-import java.awt.geom.AffineTransform;
 import java.util.Map;
 import java.util.Set;
 import javax.swing.*;
@@ -322,62 +321,10 @@ public abstract class DefaultTool extends Tool
         if (!AppUtil.playerOwns(token)) {
           continue;
         }
-        Integer facing = token.getFacing();
-        if (facing == null) {
-          facing = -90; // natural alignment
-        }
+
+        int facing = token.getFacing();
         if (SwingUtil.isControlDown(e)) {
-          // Modify on the fly the rotation point
-          if (e.isAltDown()) {
-            int x = token.getX();
-            int y = token.getY();
-            int w = token.getWidth();
-            int h = token.getHeight();
-
-            double xc = x + w / 2;
-            double yc = y + h / 2;
-
-            facing += e.getWheelRotation() > 0 ? 5 : -5;
-            token.setFacing(facing);
-            int a = token.getFacingInDegrees();
-            double r = Math.toRadians(a);
-
-            System.out.println("Angle: " + a);
-            System.out.println("Origin x,y: " + x + ", " + y);
-            System.out.println("Origin bounds: " + token.getBounds(renderer.getZone()));
-            // System.out.println("Anchor x,y: " + token.getAnchor().x + ", " +
-            // token.getAnchor().y);
-
-            // x = (int) ((x + w) - w * Math.cos(r));
-            // y = (int) (y - w * Math.sin(r));
-
-            // double x1 = (x - xc) * Math.cos(r) - (y - yc) * Math.sin(r) + xc;
-            // double y1 = (y - yc) * Math.cos(r) + (x - xc) * Math.sin(r) + yc;
-
-            // x = (int) (x * Math.cos(r) - y * Math.sin(r));
-            // y = (int) (y * Math.cos(r) + x * Math.sin(r));
-
-            AffineTransform at = new AffineTransform();
-            at.translate(x, y);
-            at.rotate(r, x + w, y);
-
-            x = (int) at.getTranslateX();
-            y = (int) at.getTranslateY();
-
-            // token.setX(x);
-            // token.setY(y);
-            // renderer.flush(token);
-            // MapTool.serverCommand().putToken(getZone().getId(), token);
-
-            // token.setX(0);
-            // token.setY(0);
-
-            System.out.println("New x,y: " + x + ", " + y);
-            System.out.println("New bounds: " + token.getBounds(renderer.getZone()).toString());
-
-          } else {
-            facing += e.getWheelRotation() > 0 ? 5 : -5;
-          }
+          facing += e.getWheelRotation() > 0 ? 5 : -5;
         } else {
           int[] facingArray = getZone().getGrid().getFacingAngles();
           int facingIndex = TokenUtil.getIndexNearestTo(facingArray, facing);

--- a/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
@@ -72,7 +72,7 @@ public class FacingTool extends DefaultTool {
                 if (token == null) {
                   continue;
                 }
-                token.setFacing(null);
+                token.removeFacing();
                 renderer.flush(token);
               }
               // Go back to the pointer tool

--- a/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
@@ -127,15 +127,6 @@ public class FacingTool extends DefaultTool {
       }
       token.setFacing(degrees);
 
-      // Old Logic
-      // if (renderer.getZone().hasFog()
-      //        && ((AppPreferences.getAutoRevealVisionOnGMMovement() &&
-      // MapTool.getPlayer().isGM()))
-      //    || MapTool.getServerPolicy().isAutoRevealOnMovement()) {
-      //  visibleArea = renderer.getZoneView().getVisibleArea(token);
-      //  remoteSelected.add(token.getId());
-      //  renderer.getZone().exposeArea(visibleArea, token);
-      // }
       boolean revealFog = false;
       if (renderer.getZone().hasFog()) {
         if (ownerReveal && token.isOwner(name)) revealFog = true;
@@ -168,8 +159,14 @@ public class FacingTool extends DefaultTool {
       if (token == null) {
         continue;
       }
-      // Send the facing to other players
-      MapTool.serverCommand().updateTokenProperty(token, Token.Update.setFacing, token.getFacing());
+
+      // Send the facing (or lack thereof) to other players
+      if (!token.hasFacing()) {
+        MapTool.serverCommand().updateTokenProperty(token, Token.Update.removeFacing);
+      } else {
+        MapTool.serverCommand()
+            .updateTokenProperty(token, Token.Update.setFacing, token.getFacing());
+      }
     }
     // Go back to the pointer tool
     resetTool();

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1092,11 +1092,8 @@ public class PointerTool extends DefaultTool {
       if (!AppUtil.playerOwns(token)) {
         continue;
       }
-      Integer facing = token.getFacing();
-      // TODO: this should really be a per grid setting
-      if (facing == null) {
-        facing = -90; // natural alignment
-      }
+
+      int facing = token.getFacing();
       if (freeRotate) {
         facing += direction * 5;
       } else {

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
@@ -1046,7 +1045,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
           if (token.hasFacing() && token.getShape() == Token.TokenShape.TOP_DOWN) {
             // untested when anchor != (0,0)
             // rotate the resize image with the stamp.
-            double theta = Math.toRadians(-token.getFacing() - 90);
+            double theta = Math.toRadians(token.getFacingInDegrees());
             double anchorX =
                 -scaledWidth / 2 + resizeImg.getWidth() - (token.getAnchor().x * scale);
             double anchorY =
@@ -1303,7 +1302,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
       // theta is the rotation angle clockwise from the positive x-axis to compensate for the +ve
       // y-axis pointing downwards in zone space and an unrotated token has facing of -90.
       // theta == 0 => token has default rotation.
-      int theta = -Objects.requireNonNullElse(tokenBeingResized.getFacing(), -90) - 90;
+      int theta = tokenBeingResized.getFacingInDegrees();
       double radians = Math.toRadians(theta);
       this.down = new Vector2(-Math.sin(radians), Math.cos(radians));
       this.right = new Vector2(Math.cos(radians), Math.sin(radians));

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -693,7 +693,7 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
       for (GUID tokenGUID : selectedTokenSet) {
         Token token = renderer.getZone().getToken(tokenGUID);
-        token.setFacing(null);
+        token.removeFacing();
         MapTool.serverCommand().putToken(renderer.getZone().getId(), token);
       }
       renderer.repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1496,7 +1496,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
         if (token.hasFacing() && token.getShape() == Token.TokenShape.TOP_DOWN) {
           at.rotate(
-              Math.toRadians(-token.getFacing() - 90),
+              Math.toRadians(token.getFacingInDegrees()),
               scaledWidth / 2 - token.getAnchor().x * scale - offsetx,
               scaledHeight / 2
                   - token.getAnchor().y * scale
@@ -2191,7 +2191,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         double sy = scaledHeight / 2 + y - (token.getAnchor().y * scale);
         tokenBounds.transform(
             AffineTransform.getRotateInstance(
-                Math.toRadians(-token.getFacing() - 90), sx, sy)); // facing
+                Math.toRadians(token.getFacingInDegrees()), sx, sy)); // facing
         // defaults
         // to
         // down,
@@ -2394,7 +2394,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         // (token.getAnchor().y * scale) - offsety);
 
         at.rotate(
-            Math.toRadians(-token.getFacing() - 90),
+            Math.toRadians(token.getFacingInDegrees()),
             location.scaledWidth / 2 - (token.getAnchor().x * scale) - offsetx,
             location.scaledHeight / 2 - (token.getAnchor().y * scale) - offsety);
         // facing defaults to down, or -90 degrees
@@ -2502,9 +2502,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         Token.TokenShape tokenType = token.getShape();
         switch (tokenType) {
           case FIGURE:
-            if (token.getHasImageTable()
-                && token.hasFacing()
-                && AppPreferences.getForceFacingArrow() == false) {
+            if (token.getHasImageTable() && AppPreferences.getForceFacingArrow() == false) {
               break;
             }
             Shape arrow = getFigureFacingArrow(token.getFacing(), footprintBounds.width / 2);
@@ -2719,7 +2717,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
           // Rotated
           clippedG.translate(sp.x, sp.y);
           clippedG.rotate(
-              Math.toRadians(-token.getFacing() - 90),
+              Math.toRadians(token.getFacingInDegrees()),
               width / 2 - (token.getAnchor().x * scale),
               height / 2 - (token.getAnchor().y * scale)); // facing defaults to down, or -90
           // degrees
@@ -3376,7 +3374,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
           MapTool.getCampaign().getLookupTableMap().get(token.getImageTableName());
       if (lookupTable != null) {
         try {
-          LookupEntry result = lookupTable.getLookup(token.getFacing().toString());
+          LookupEntry result = lookupTable.getLookup(Integer.toString(token.getFacing()));
           if (result != null) {
             image = ImageManager.getImage(result.getImageId(), this);
           }

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -406,9 +406,6 @@ public abstract class Grid implements Cloneable {
                     -visionRange, -visionRange, visionRange * 2, visionRange * 2));
         break;
       case BEAM:
-        if (token.getFacing() == null) {
-          token.setFacing(0);
-        }
         // Make at least 1 pixel on each side, so it's at least visible at 100% zoom.
         var pixelWidth = Math.max(2, width * getSize() / zone.getUnitsPerCell());
         Shape lineShape = new Rectangle2D.Double(0, -pixelWidth / 2, visionRange, pixelWidth);
@@ -421,10 +418,6 @@ public abstract class Grid implements Cloneable {
                     .createTransformedShape(visibleShape));
         break;
       case CONE:
-        if (token.getFacing() == null) {
-          token.setFacing(0);
-        }
-
         Arc2D cone =
             new Arc2D.Double(
                 -visionRange,

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -351,9 +351,6 @@ public class IsometricGrid extends Grid {
         visibleArea = new Area(new Polygon(x, y, 4));
         break;
       case BEAM:
-        if (token.getFacing() == null) {
-          token.setFacing(0);
-        }
         var pixelWidth = Math.max(2, width * getSize() / getZone().getUnitsPerCell());
         Shape visibleShape = new Rectangle2D.Double(0, -pixelWidth / 2, visionRange, pixelWidth);
 
@@ -374,9 +371,6 @@ public class IsometricGrid extends Grid {
 
         break;
       case CONE:
-        if (token.getFacing() == null) {
-          token.setFacing(0);
-        }
         // Rotate the vision range by 45 degrees for isometric view
         visionRange = (float) Math.sin(Math.toRadians(45)) * visionRange;
         // Get the cone, use degreesFromIso to convert the facing from isometric to plan

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -848,12 +848,16 @@ public class Token implements Cloneable {
     return facing != null;
   }
 
-  public void setFacing(Integer facing) {
-    while (facing != null && (facing > 180 || facing < -179)) {
+  public void setFacing(int facing) {
+    while (facing > 180 || facing < -179) {
       facing += facing > 180 ? -360 : 0;
       facing += facing < -179 ? 360 : 0;
     }
     this.facing = facing;
+  }
+
+  public void removeFacing() {
+    this.facing = null;
   }
 
   /**
@@ -864,8 +868,9 @@ public class Token implements Cloneable {
    *
    * @return null or angle in degrees
    */
-  public Integer getFacing() {
-    return facing;
+  public int getFacing() {
+    // -90° is natural alignment. TODO This should really be a per grid setting
+    return facing == null ? -90 : facing;
   }
 
   /**
@@ -874,24 +879,8 @@ public class Token implements Cloneable {
    *
    * @return angle in degrees
    */
-  public Integer getFacingInDegrees() {
-    if (facing == null) {
-      return 0;
-    } else {
-      return -(facing + 90);
-    }
-  }
-
-  public Integer getFacingInRealDegrees() {
-    if (facing == null) {
-      return 270;
-    }
-
-    if (facing >= 0) {
-      return facing;
-    } else {
-      return facing + 360;
-    }
+  public int getFacingInDegrees() {
+    return -getFacing() - 90;
   }
 
   public boolean getHasSight() {
@@ -2728,7 +2717,7 @@ public class Token implements Cloneable {
         setFacing(parameters.get(0).getIntValue());
         break;
       case removeFacing:
-        setFacing(null);
+        removeFacing();
         break;
       case clearAllOwners:
         clearAllOwners();


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4956

### Description of the Change

The Set Facing tool now handles the case where a token has no facing at the end of the operation (see changes in `FacingTool.mousePressed()`).

The rest of the changes are easy cleanup related to facing, but don't affect functionality:
- Use `Token.hasFacing()` instead of `Token.getFacing() == null`
- Use `Token.getFacingInDegrees()` where it helps.
- Provide `Token.removeFacing()` to clear facing rather than using `Token.setFacing(null)`.
- Move the default -90° angle into `Token.getFacing()`
- Remove all nullability of facing in `Token`'s API.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the Set Facing tool would throw an error if the mouse never moved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4957)
<!-- Reviewable:end -->
