### PR TITLE
Fixed ButtonGroup drag event drop checks #4959

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroup.java
@@ -128,8 +128,8 @@ public class ButtonGroup extends AbstractButtonGroup {
       MacroButtonProperties oldMacroProps = new MacroButtonProperties(tempProperties);
 
       // stops players from moving macros into/from the Campaign/GM panels
-      // debounce first, ignore moves that change nothing
-      if (tempProperties.getGroup().equals(getMacroGroup())) {
+      // debounce first, ignore moves to the same group in the same panel
+      if (tempProperties.getGroup().equals(getMacroGroup()) && data.panelClass.equals(panelClass)) {
         event.dropComplete(false);
       } else if (!MapTool.getPlayer().isGM()
           && (panelClass.equals("CampaignPanel")


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #4959

### Description of the Change
Previous change #4888 to fix #4883 was to exit early if there was no change in a button's group.
This resulted in early exits when dragging into different panels using the same group name.
Added a check to only exit where there is no change in the group on the same panel.

### Possible Drawbacks
None foreseen, but I thought that last time

### Documentation Notes
Improved checks for dragging macro button 

### Release Notes
Fixed issue with dragging macro buttons to macro groups with the same name on other panels

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4963)
<!-- Reviewable:end -->
