### PR TITLE
Added hotkey macro button properties to metamacro functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -396,6 +396,9 @@ public class MacroFunctions extends AbstractFunction {
       } else if ("group".equalsIgnoreCase(key)) {
         mbp.setGroup(value);
       } else if ("hotkey".equalsIgnoreCase(key)) {
+        if(MacroButtonHotKeyManager.isHotkeyAssigned(value)) {
+          value = MacroButtonHotKeyManager.HOTKEYS[0];
+        }
         mbp.setHotKey(value);
       } else if ("includeLabel".equalsIgnoreCase(key)) {
         mbp.setIncludeLabel(boolVal(value));
@@ -1138,6 +1141,9 @@ public class MacroFunctions extends AbstractFunction {
         } else if ("group".equalsIgnoreCase(key)) {
           mbp.setGroup(value);
         } else if ("hotkey".equalsIgnoreCase(key)) {
+          if(MacroButtonHotKeyManager.isHotkeyAssigned(value)) {
+            value = MacroButtonHotKeyManager.HOTKEYS[0];
+          }
           mbp.setHotKey(value);
         } else if ("includeLabel".equalsIgnoreCase(key)) {
           mbp.setIncludeLabel(boolVal(value));

--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -396,7 +396,7 @@ public class MacroFunctions extends AbstractFunction {
       } else if ("group".equalsIgnoreCase(key)) {
         mbp.setGroup(value);
       } else if ("hotkey".equalsIgnoreCase(key)) {
-        if(MacroButtonHotKeyManager.isHotkeyAssigned(value)) {
+        if (MacroButtonHotKeyManager.isHotkeyAssigned(value)) {
           value = MacroButtonHotKeyManager.HOTKEYS[0];
         }
         mbp.setHotKey(value);
@@ -1141,7 +1141,7 @@ public class MacroFunctions extends AbstractFunction {
         } else if ("group".equalsIgnoreCase(key)) {
           mbp.setGroup(value);
         } else if ("hotkey".equalsIgnoreCase(key)) {
-          if(MacroButtonHotKeyManager.isHotkeyAssigned(value)) {
+          if (MacroButtonHotKeyManager.isHotkeyAssigned(value)) {
             value = MacroButtonHotKeyManager.HOTKEYS[0];
           }
           mbp.setHotKey(value);

--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -943,6 +943,7 @@ public class MacroFunctions extends AbstractFunction {
       }
       AbstractMacroPanel macroPanel =
           gmPanel ? MapTool.getFrame().getGmPanel() : MapTool.getFrame().getCampaignPanel();
+      MapTool.getFrame().updateKeyStrokes(); // ensure hotkeys are updated
       macroPanel.reset();
       return "Removed macro button "
           + label
@@ -970,6 +971,7 @@ public class MacroFunctions extends AbstractFunction {
 
     String label = mbp.getLabel();
     MapTool.serverCommand().updateTokenProperty(token, Token.Update.deleteMacro, index);
+    MapTool.getFrame().updateKeyStrokes(); // ensure hotkeys are updated
     return "Removed macro button " + label + "(index = " + index + ") from " + token.getName();
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -355,12 +355,16 @@ public class MacroFunctions extends AbstractFunction {
         mbp.setAutoExecute(boolVal(value));
       } else if ("color".equalsIgnoreCase(key)) {
         mbp.setColorKey(value);
+      } else if ("displayHotkey".equalsIgnoreCase(key)) {
+        mbp.setDisplayHotKey(boolVal(value));
       } else if ("fontColor".equalsIgnoreCase(key)) {
         mbp.setFontColorKey(value);
       } else if ("fontSize".equalsIgnoreCase(key)) {
         mbp.setFontSize(value);
       } else if ("group".equalsIgnoreCase(key)) {
         mbp.setGroup(value);
+      } else if ("hotkey".equalsIgnoreCase(key)) {
+        mbp.setHotKey(value);
       } else if ("includeLabel".equalsIgnoreCase(key)) {
         mbp.setIncludeLabel(boolVal(value));
       } else if ("sortBy".equalsIgnoreCase(key)) {
@@ -1046,20 +1050,22 @@ public class MacroFunctions extends AbstractFunction {
    */
   private String macroButtonPropertiesToString(MacroButtonProperties mbp, String delim) {
     StringBuilder sb = new StringBuilder();
+    sb.append("applyToSelected=").append(mbp.getApplyToTokens()).append(delim);
     sb.append("autoExecute=").append(mbp.getAutoExecute()).append(delim);
     sb.append("color=").append(mbp.getColorKey()).append(delim);
+    sb.append("displayHotkey=").append(mbp.getDisplayHotKey()).append(delim);
     sb.append("fontColor=").append(mbp.getFontColorKey()).append(delim);
+    sb.append("fontSize=").append(mbp.getFontSize()).append(delim);
     sb.append("group=").append(mbp.getGroup()).append(delim);
+    sb.append("hotkey=").append(mbp.getHotKey()).append(delim);
     sb.append("includeLabel=").append(mbp.getIncludeLabel()).append(delim);
-    sb.append("sortBy=").append(mbp.getSortby()).append(delim);
     sb.append("index=").append(mbp.getIndex()).append(delim);
     sb.append("label=").append(mbp.getLabel()).append(delim);
-    sb.append("fontSize=").append(mbp.getFontSize()).append(delim);
+    sb.append("maxWidth=").append(mbp.getMaxWidth()).append(delim);
     sb.append("minWidth=").append(mbp.getMinWidth()).append(delim);
     sb.append("playerEditable=").append(mbp.getAllowPlayerEdits()).append(delim);
-    sb.append("maxWidth=").append(mbp.getMaxWidth()).append(delim);
+    sb.append("sortBy=").append(mbp.getSortby()).append(delim);
     sb.append("tooltip=").append(mbp.getToolTip()).append(delim);
-    sb.append("applyToSelected=").append(mbp.getApplyToTokens()).append(delim);
     return sb.toString();
   }
 
@@ -1091,12 +1097,16 @@ public class MacroFunctions extends AbstractFunction {
           mbp.setAutoExecute(boolVal(value));
         } else if ("color".equalsIgnoreCase(key)) {
           mbp.setColorKey(value);
+        } else if ("displayHotkey".equalsIgnoreCase(key)) {
+          mbp.setDisplayHotKey(boolVal(value));
         } else if ("fontColor".equalsIgnoreCase(key)) {
           mbp.setFontColorKey(value);
         } else if ("fontSize".equalsIgnoreCase(key)) {
           mbp.setFontSize(value);
         } else if ("group".equalsIgnoreCase(key)) {
           mbp.setGroup(value);
+        } else if ("hotkey".equalsIgnoreCase(key)) {
+          mbp.setHotKey(value);
         } else if ("includeLabel".equalsIgnoreCase(key)) {
           mbp.setIncludeLabel(boolVal(value));
         } else if ("sortBy".equalsIgnoreCase(key)) {
@@ -1184,21 +1194,23 @@ public class MacroFunctions extends AbstractFunction {
    */
   private JsonObject macroButtonPropertiesToJSON(MacroButtonProperties mbp) {
     JsonObject props = new JsonObject();
+    props.addProperty("applyToSelected", mbp.getApplyToTokens());
     props.addProperty("autoExecute", mbp.getAutoExecute());
     props.addProperty("color", mbp.getColorKey());
+    props.addProperty("displayHotkey", mbp.getDisplayHotKey());
+    props.addProperty("command", mbp.getCommand());
     props.addProperty("fontColor", mbp.getFontColorKey());
+    props.addProperty("fontSize", mbp.getFontSize());
     props.addProperty("group", mbp.getGroup());
+    props.addProperty("hotkey", mbp.getHotKey());
     props.addProperty("includeLabel", mbp.getIncludeLabel());
-    props.addProperty("sortBy", mbp.getSortby());
     props.addProperty("index", mbp.getIndex());
     props.addProperty("label", mbp.getLabel());
-    props.addProperty("fontSize", mbp.getFontSize());
     props.addProperty("minWidth", mbp.getMinWidth());
-    props.addProperty("playerEditable", mbp.getAllowPlayerEdits());
-    props.addProperty("command", mbp.getCommand());
     props.addProperty("maxWidth", mbp.getMaxWidth());
+    props.addProperty("playerEditable", mbp.getAllowPlayerEdits());
+    props.addProperty("sortBy", mbp.getSortby());
     props.addProperty("tooltip", mbp.getToolTip());
-    props.addProperty("applyToSelected", mbp.getApplyToTokens());
 
     JsonArray compare = new JsonArray();
     if (mbp.getCompareGroup()) compare.add("group");

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/MacroButtonHotKeyManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/MacroButtonHotKeyManager.java
@@ -82,9 +82,11 @@ public class MacroButtonHotKeyManager {
   private static Map<KeyStroke, MacroButton> buttonsByKeyStroke =
       new HashMap<KeyStroke, MacroButton>();
   private MacroButton macroButton;
-  public static boolean isHotkeyAssigned(String hotkey){
+
+  public static boolean isHotkeyAssigned(String hotkey) {
     return buttonsByKeyStroke.containsKey(hotkey);
   }
+
   public MacroButtonHotKeyManager(MacroButton macroButton) {
     this.macroButton = macroButton;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/MacroButtonHotKeyManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/MacroButtonHotKeyManager.java
@@ -82,7 +82,9 @@ public class MacroButtonHotKeyManager {
   private static Map<KeyStroke, MacroButton> buttonsByKeyStroke =
       new HashMap<KeyStroke, MacroButton>();
   private MacroButton macroButton;
-
+  public static boolean isHotkeyAssigned(String hotkey){
+    return buttonsByKeyStroke.containsKey(hotkey);
+  }
   public MacroButtonHotKeyManager(MacroButton macroButton) {
     this.macroButton = macroButton;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #4897

### Description of the Change
included fields in metamacro functions for macro button properties "hotkey" and "displayHotkey"

### Possible Drawbacks
conflicts in hotkey settings from different sources - buyer beware

### Documentation Notes
Macro hotkeys and their display can now be set through metamacro functions.

### Release Notes
Macro hotkeys and their display can now be set through metamacro functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4970)
<!-- Reviewable:end -->
