### PR TITLE
Fix light offset for beams to measure counterclockwise as for cones

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -454,7 +454,7 @@ public abstract class Grid implements Cloneable {
 
         visibleArea =
             new Area(
-                AffineTransform.getRotateInstance(Math.toRadians(offsetAngle + tokenFacingAngle))
+                AffineTransform.getRotateInstance(Math.toRadians(tokenFacingAngle - offsetAngle))
                     .createTransformedShape(lineShape));
       }
       case CONE -> {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4967

### Description of the Change

This just adds a much needed minus sign to beam offsets on non-iso grids.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where beam offsets were measured clockwise on non-isometric grids.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4973)
<!-- Reviewable:end -->
