### PR TITLE
Fix hex light construction

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -479,16 +479,7 @@ public abstract class Grid implements Cloneable {
         visibleArea.add(new Area(footprintPart));
       }
       case HEX -> {
-        double x = footprint.getCenterX();
-        double y = footprint.getCenterY();
-
-        double footprintWidth = footprint.getWidth();
-        double footprintHeight = footprint.getHeight();
-        double adjustment = Math.min(footprintWidth, footprintHeight);
-        x -= adjustment / 2;
-        y -= adjustment / 2;
-
-        visibleArea = createHex(x, y, visionRange, 0);
+        visibleArea = createHex(visionRange);
       }
       default -> {
         log.error("Unhandled shape {}; treating as a circle", shape);
@@ -527,25 +518,19 @@ public abstract class Grid implements Cloneable {
     return distance;
   }
 
-  protected Area createHex(double x, double y, double radius, double rotation) {
-    GeneralPath hexPath = new GeneralPath();
+  protected Area createHex(double inRadius) {
+    double radius = inRadius * 2 / Math.sqrt(3);
 
-    for (int i = 0; i < 6; i++) {
-      if (i == 0) {
-        hexPath.moveTo(
-            x + radius * Math.cos(i * 2 * Math.PI / 6), y + radius * Math.sin(i * 2 * Math.PI / 6));
-      } else {
-        hexPath.lineTo(
-            x + radius * Math.cos(i * 2 * Math.PI / 6), y + radius * Math.sin(i * 2 * Math.PI / 6));
-      }
-    }
+    var hexPath = new Path2D.Double();
+    hexPath.moveTo(radius, 0);
+    hexPath.lineTo(radius * 0.5, inRadius);
+    hexPath.lineTo(-radius * 0.5, inRadius);
+    hexPath.lineTo(-radius, 0);
+    hexPath.lineTo(-radius * 0.5, -inRadius);
+    hexPath.lineTo(radius * 0.5, -inRadius);
+    hexPath.closePath();
 
-    if (rotation != 0) {
-      AffineTransform atArea = AffineTransform.getRotateInstance(rotation);
-      return new Area(atArea.createTransformedShape(hexPath));
-    } else {
-      return new Area(hexPath);
-    }
+    return new Area(hexPath);
   }
 
   private void fireGridChanged() {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4978

### Description of the Change

For some reason hexes had an adjustment applied based on the token footprint. But light shapes should always use `(0, 0)` as the origin, since other code will translate that to the necessary point. This PR removes that adjustment.

The other issue regarding hex size was fixed by treating the range as an inradius instead of circumradius.

Also included is a refactoring to `Grid.createHex()`. Nothing used the rotation parameter, and without that all hexes look the same aside from scale. So I removed the trig and loop and replaced it with six explicit points.

### Possible Drawbacks

Slightly different areas will be illuminated by hex lights with this change.

### Documentation Notes

For hex lights, the range measures to the edge of the hex.

### Release Notes

- Fixed a bug where hex lights on hex grids were slightly offset
- Fixed a bug where hex lights were significantly smaller than equivalent square lights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4979)
<!-- Reviewable:end -->
