### PR TITLE
Decompose `Grid.getShapedArea()` so we can reuse logic between grids

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -527,17 +527,6 @@ public class Zone {
     this.tokenSelection = tokenSelection;
   }
 
-  /**
-   * @return the distance in map pixels at a 1:1 zoom
-   */
-  public int getTokenVisionInPixels() {
-    if (tokenVisionDistance == 0) {
-      // TODO: This is here to provide transition between pre 1.3b19 an 1.3b19. Remove later
-      tokenVisionDistance = DEFAULT_TOKEN_VISION_DISTANCE;
-    }
-    return Double.valueOf(tokenVisionDistance * grid.getSize() / getUnitsPerCell()).intValue();
-  }
-
   public void setFogPaint(DrawablePaint paint) {
     fogPaint = paint;
   }
@@ -2101,6 +2090,11 @@ public class Zone {
   // Backward compatibility
   @SuppressWarnings("ConstantConditions")
   protected Object readResolve() {
+    if (tokenVisionDistance == 0) {
+      // 1.3b19
+      tokenVisionDistance = DEFAULT_TOKEN_VISION_DISTANCE;
+    }
+
     if ("".equals(playerAlias) || name.equals(playerAlias)) {
       // Don't keep redundant player aliases around. The display name will default to the name if
       // no player alias is set.


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4980

### Description of the Change

This refactors `Grid.getShapedArea()` for more consistency between grid types. The main goal was to allow `IsometricGrid` to reuse the main logic and transform the results rather than having to duplicate and specialize most of the logic for its unique circumstance.

With this change, isometric grid lighting behaves the same as for other grid types, save for the footprint area and 45° difference in the meaning of token facing. This means hex lights render as hexes, and beams are properly foreshortened. It also means no special logic for the other shapes, so we can be more confident that those will remain consistent into the future.

### Possible Drawbacks

None. Unless folks want to complain about hexes being hexagonal.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where hex lights were rendered as circles on isometric grids
- Fixed a bug where beam lights were not foreshortened on isometric grids

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4981)
<!-- Reviewable:end -->
