### PR TITLE
Do not disclose GM maps to players in status UI

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
@@ -56,11 +56,11 @@ public class PlayersLoadingStatusBar extends JLabel {
         new StringBuilder(I18N.getText("ConnectionStatusPanel.playersLoadedZone", loaded, total));
 
     for (Player player : players) {
+      // GMs can see everyone's zone, players can only see each other's.
+      var showZone = MapTool.getPlayer().isGM() || !player.isGM();
+
       String text;
-      if (player.isGM()) {
-        // Don't display zone information.
-        text = player.toString();
-      } else {
+      if (showZone) {
         var zone =
             player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
         text =
@@ -70,6 +70,8 @@ public class PlayersLoadingStatusBar extends JLabel {
                     : "connections.playerIsLoadingZone",
                 player.toString(),
                 zone == null ? null : zone.getDisplayName());
+      } else {
+        text = player.toString();
       }
 
       sb.append("\n");

--- a/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
@@ -56,14 +56,22 @@ public class PlayersLoadingStatusBar extends JLabel {
         new StringBuilder(I18N.getText("ConnectionStatusPanel.playersLoadedZone", loaded, total));
 
     for (Player player : players) {
-      var zone =
-          player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
+      String text;
+      if (player.isGM()) {
+        // Don't display zone information.
+        text = player.toString();
+      } else {
+        var zone =
+            player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
+        text =
+            I18N.getText(
+                player.getLoaded()
+                    ? "connections.playerIsInZone"
+                    : "connections.playerIsLoadingZone",
+                player.toString(),
+                zone == null ? null : zone.getDisplayName());
+      }
 
-      var text =
-          I18N.getText(
-              player.getLoaded() ? "connections.playerIsInZone" : "connections.playerIsLoadingZone",
-              player.toString(),
-              zone == null ? null : zone.getDisplayName());
       sb.append("\n");
       sb.append(text);
     }

--- a/src/main/java/net/rptools/maptool/client/ui/connections/PlayerListCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connections/PlayerListCellRenderer.java
@@ -26,16 +26,24 @@ public class PlayerListCellRenderer extends DefaultListCellRenderer {
   public Component getListCellRendererComponent(
       JList<?> list, Object value, int index, boolean isSelected, boolean hasFocus) {
     if (value instanceof Player player) {
-      var zone =
-          player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
-
-      String text =
-          I18N.getText(
-              player.getLoaded() ? "connections.playerIsInZone" : "connections.playerIsLoadingZone",
-              player.toString(),
-              zone == null ? null : zone.getDisplayName());
+      String text;
+      if (player.isGM()) {
+        // Don't display zone information.
+        text = player.toString();
+      } else {
+        var zone =
+            player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
+        text =
+            I18N.getText(
+                player.getLoaded()
+                    ? "connections.playerIsInZone"
+                    : "connections.playerIsLoadingZone",
+                player.toString(),
+                zone == null ? null : zone.getDisplayName());
+      }
       return super.getListCellRendererComponent(list, text, index, isSelected, hasFocus);
     }
+
     return super.getListCellRendererComponent(list, value, index, isSelected, hasFocus);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/connections/PlayerListCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connections/PlayerListCellRenderer.java
@@ -26,11 +26,11 @@ public class PlayerListCellRenderer extends DefaultListCellRenderer {
   public Component getListCellRendererComponent(
       JList<?> list, Object value, int index, boolean isSelected, boolean hasFocus) {
     if (value instanceof Player player) {
+      // GMs can see everyone's zone, players can only see each other's.
+      var showZone = MapTool.getPlayer().isGM() || !player.isGM();
+
       String text;
-      if (player.isGM()) {
-        // Don't display zone information.
-        text = player.toString();
-      } else {
+      if (showZone) {
         var zone =
             player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
         text =
@@ -40,6 +40,8 @@ public class PlayerListCellRenderer extends DefaultListCellRenderer {
                     : "connections.playerIsLoadingZone",
                 player.toString(),
                 zone == null ? null : zone.getDisplayName());
+      } else {
+        text = player.toString();
       }
       return super.getListCellRendererComponent(list, text, index, isSelected, hasFocus);
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4595

### Description of the Change

For player clients, this hides the name of the GM's zone in the Connections window and status bar. Players can still see each other's zones, and GMs can still see everyone's zone.

### Possible Drawbacks

None

### Documentation Notes

In the Connections window, players cannot see the map any GM is on. Same for the status bar indicator.

### Release Notes

- Fixed a bug where names of hidden maps are shown to players in the Connections window when a GM is on the map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4982)
<!-- Reviewable:end -->
