### PR TITLE
Do not show local player in Connections window or status panel

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolClient.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolClient.java
@@ -211,7 +211,9 @@ public class MapToolClient {
   public void addPlayer(Player player) {
     if (!playerList.contains(player)) {
       playerList.add(player);
-      new MapToolEventBus().getMainEventBus().post(new PlayerConnected(player));
+      new MapToolEventBus()
+          .getMainEventBus()
+          .post(new PlayerConnected(player, this.player.equals(player)));
       playerDatabase.playerSignedIn(player);
 
       playerList.sort((arg0, arg1) -> arg0.getName().compareToIgnoreCase(arg1.getName()));

--- a/src/main/java/net/rptools/maptool/client/events/PlayerConnected.java
+++ b/src/main/java/net/rptools/maptool/client/events/PlayerConnected.java
@@ -16,4 +16,4 @@ package net.rptools.maptool.client.events;
 
 import net.rptools.maptool.model.player.Player;
 
-public record PlayerConnected(Player player) {}
+public record PlayerConnected(Player player, boolean isLocal) {}

--- a/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
@@ -41,30 +41,21 @@ public class PlayersLoadingStatusBar extends JLabel {
     loadingIcon = RessourceManager.getSmallIcon(Icons.STATUSBAR_PLAYERS_LOADING);
   }
 
+  private final ArrayList<Player> players = new ArrayList<>();
+
   public PlayersLoadingStatusBar() {
     refreshCount();
     new MapToolEventBus().getMainEventBus().register(this);
   }
 
   private void refreshCount() {
-    var localPlayer = MapTool.getPlayer();
-    var players = new ArrayList<>(MapTool.getPlayerList());
-    players.remove(localPlayer);
-
     var total = players.size();
     var loaded = players.stream().filter(x -> x.getLoaded()).count();
 
     var sb =
         new StringBuilder(I18N.getText("ConnectionStatusPanel.playersLoadedZone", loaded, total));
 
-    var self = MapTool.getPlayer();
-
     for (Player player : players) {
-      // The Player in the list is a seperate entity to the one from MapTool.getPlayer()
-      // So it doesn't have the correct status data.
-      if (player.getName().equals(self.getName())) {
-        player = self;
-      }
       var zone =
           player.getZoneId() == null ? null : MapTool.getCampaign().getZone(player.getZoneId());
 
@@ -108,6 +99,11 @@ public class PlayersLoadingStatusBar extends JLabel {
 
   @Subscribe
   private void onPlayerConnected(PlayerConnected event) {
+    if (event.isLocal()) {
+      return;
+    }
+    players.add(event.player());
+
     refreshCount();
   }
 
@@ -118,11 +114,13 @@ public class PlayersLoadingStatusBar extends JLabel {
 
   @Subscribe
   private void onPlayerDisconnected(PlayerDisconnected event) {
+    players.remove(event.player());
     refreshCount();
   }
 
   @Subscribe
   private void onServerDisconnected(ServerDisconnected event) {
+    players.clear();
     refreshCount();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/PlayersLoadingStatusBar.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.client.swing;
 
 import com.google.common.eventbus.Subscribe;
 import java.awt.Dimension;
+import java.util.ArrayList;
 import javax.swing.Icon;
 import javax.swing.JLabel;
 import net.rptools.maptool.client.MapTool;
@@ -46,7 +47,10 @@ public class PlayersLoadingStatusBar extends JLabel {
   }
 
   private void refreshCount() {
-    var players = MapTool.getPlayerList();
+    var localPlayer = MapTool.getPlayer();
+    var players = new ArrayList<>(MapTool.getPlayerList());
+    players.remove(localPlayer);
+
     var total = players.size();
     var loaded = players.stream().filter(x -> x.getLoaded()).count();
 

--- a/src/main/java/net/rptools/maptool/client/ui/connections/ClientConnectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connections/ClientConnectionPanel.java
@@ -111,6 +111,10 @@ public class ClientConnectionPanel extends JPanel {
 
   @Subscribe
   private void onPlayerConnected(PlayerConnected event) {
+    if (event.isLocal()) {
+      return;
+    }
+
     listModel.addElement(event.player());
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4820

### Description of the Change

The local player is filtered out before adding it to the Connections window or the status bar.

### Possible Drawbacks

One less place to see yourself.

### Documentation Notes

The local player is not shown in the Connection window.

### Release Notes

- No longer show the local player in the Connections window

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4983)
<!-- Reviewable:end -->
