### PR TITLE
Clean up AppPreferences

### DIFF
--- a/src/main/java/net/rptools/lib/image/ImageUtil.java
+++ b/src/main/java/net/rptools/lib/image/ImageUtil.java
@@ -155,7 +155,7 @@ public class ImageUtil {
     Graphics2D g = null;
     try {
       g = compImg.createGraphics();
-      AppPreferences.getRenderQuality().setRenderingHints(g);
+      AppPreferences.renderQuality.get().setRenderingHints(g);
       g.drawImage(img, 0, 0, width, height, null);
     } finally {
       if (g != null) {
@@ -442,7 +442,7 @@ public class ImageUtil {
    */
   public static BufferedImage scaleBufferedImage(BufferedImage image, int width, int height) {
     ResampleOp resampleOp =
-        new ResampleOp(width, height, AppPreferences.getRenderQuality().getResampleOpFilter());
+        new ResampleOp(width, height, AppPreferences.renderQuality.get().getResampleOpFilter());
     return resampleOp.filter(image, null);
   }
 }

--- a/src/main/java/net/rptools/lib/image/ThumbnailManager.java
+++ b/src/main/java/net/rptools/lib/image/ThumbnailManager.java
@@ -79,7 +79,7 @@ public class ThumbnailManager {
         new BufferedImage(imgSize.width, imgSize.height, ImageUtil.pickBestTransparency(image));
 
     Graphics2D g = thumbnailImage.createGraphics();
-    AppPreferences.getRenderQuality().setShrinkRenderingHints(g);
+    AppPreferences.renderQuality.get().setShrinkRenderingHints(g);
     g.drawImage(image, 0, 0, imgSize.width, imgSize.height, null);
     g.dispose();
 

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2600,7 +2600,7 @@ public class AppActions {
         ImageManager.flush(); // Clear out the old campaign's images
 
         AppState.setCampaignFile(campaignFile);
-        AppPreferences.setLoadDir(campaignFile.getParentFile());
+        AppPreferences.loadDirectory.set(campaignFile.getParentFile());
         AppMenuBar.getMruManager().addMRUCampaign(campaignFile);
         campaign.campaign.setName(AppState.getCampaignName()); // Update campaign name
 
@@ -2792,7 +2792,7 @@ public class AppActions {
     }
     doSaveCampaign(campaignFile, onSuccess);
     AppState.setCampaignFile(campaignFile);
-    AppPreferences.setSaveDir(campaignFile.getParentFile());
+    AppPreferences.saveDirectory.set(campaignFile.getParentFile());
     AppMenuBar.getMruManager().addMRUCampaign(AppState.getCampaignFile());
     if (MapTool.isHostingServer() || MapTool.isPersonalServer()) {
       MapTool.serverCommand().setCampaignName(AppState.getCampaignName());
@@ -2846,7 +2846,7 @@ public class AppActions {
                   }
                 }
                 PersistenceUtil.saveMap(zr.getZone(), mapFile);
-                AppPreferences.setSaveMapDir(mapFile.getParentFile());
+                AppPreferences.mapSaveDirectory.set(mapFile.getParentFile());
                 MapTool.showInformation("msg.info.mapSaved");
               } catch (IOException ioe) {
                 MapTool.showError("msg.error.failedSaveMap", ioe);
@@ -2973,7 +2973,7 @@ public class AppActions {
 
       try {
         PersistedMap map = get();
-        AppPreferences.setLoadDir(mapFile.getParentFile());
+        AppPreferences.loadDirectory.set(mapFile.getParentFile());
         if ((map.zone.getExposedArea() != null && !map.zone.getExposedArea().isEmpty())
             || (map.zone.getExposedAreaMetaData() != null
                 && !map.zone.getExposedAreaMetaData().isEmpty())) {

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1195,7 +1195,7 @@ public class AppActions {
             MapTool.showError("msg.error.mustSelectRootGroup");
             return;
           }
-          AppPreferences.removeAssetRoot(dir.getPath());
+          AppStatePersisted.removeAssetRoot(dir.getPath());
           assetPanel.removeAssetRoot(dir);
         }
       };

--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -26,12 +26,10 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.prefs.Preferences;
 import javax.annotation.Nullable;
-import net.rptools.maptool.client.ui.theme.RessourceManager;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.Label;
-import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,695 +51,375 @@ public class AppPreferences {
   private static final Preferences prefs =
       Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs");
 
-  /** Holds the render quality preference setting for the application. */
-  private static RenderQuality renderQuality;
-
-  /**
-   * Defines the key constant for retrieving asset roots.
-   *
-   * <p>This constant is used to define the key for accessing asset roots in a configuration file or
-   * a data source. Asset roots represent the directories or paths where application assets are
-   * stored.
-   *
-   * <p>The asset roots can be used to locate and load files, images, or other resources required by
-   * the application at runtime. By convention, the asset root directories are organized in a
-   * structured manner to facilitate easy retrieval of assets.
-   */
-  private static final String KEY_ASSET_ROOTS = "assetRoots";
-
-  /**
-   * The constant representing the key for the save directory.
-   *
-   * <p>This key is used to access and store the value of the save directory. The value associated
-   * with this key should be a string representing the directory path.
-   */
-  private static final String KEY_SAVE_DIR = "saveDir";
-
-  /**
-   * The constant representing the key for saving token directory. This constant is used to retrieve
-   * the directory path where token information will be exported.
-   */
-  private static final String KEY_SAVE_TOKEN_DIR = "saveTokenDir";
-
-  /**
-   * The variable to store the key for saving the map directory.
-   *
-   * <p>This variable is used to configure the directory where the map will be export.
-   */
-  private static final String KEY_SAVE_MAP_DIR = "saveMapDir";
-
-  /**
-   * The key for the load directory.
-   *
-   * <p>This constant represents the key used to specify the last directory used for loading files
-   * so that subsequent dialogs will be opened with the same path.
-   *
-   * <p>The value should be a String representing the directory path.
-   */
-  private static final String KEY_LOAD_DIR = "loadDir";
-
-  /**
-   * The configuration key for specifying the directory path where the last add-on was loaded from,
-   * so that subsequent dialogs will be opened with the same path.
-   *
-   * <p>The value should be a String representing the directory path.
-   */
-  private static final String KEY_ADD_ON_LOAD_DIR = "addOnLoadDir";
-
-  /** Represents the key used to load the most recent campaign on launch. Defaults to false */
-  private static final String KEY_LOAD_MRU_CAMPAIGN_AT_START = "loadMRUCampaignAtStart";
-
-  private static final boolean DEFAULT_LOAD_MRU_CAMPAIGN_AT_START = false;
-
-  /**
-   * Represents the key used to determine if the user should be prompted to save the campaign on
-   * quit.
-   */
-  private static final String KEY_SAVE_REMINDER = "autoSaveReminder";
-
-  /**
-   * The default value for the {@code KEY_SAVE_REMINDER} key.
-   *
-   * @see #KEY_SAVE_REMINDER
-   */
-  private static final boolean DEFAULT_SAVE_REMINDER = true;
-
-  /**
-   * Represents the key for the method used to determine which name of the token (Player/GM) the
-   * number is appended to.
-   */
-  private static final String KEY_TOKEN_NUMBER_DISPLAY = "tokenNumberDisplayg";
-
-  /**
-   * The default value for the {@code KEY_TOKEN_NUMBER_DISPLAY} preference option,.
-   *
-   * @see #KEY_TOKEN_NUMBER_DISPLAY
-   */
-  private static final String DEFAULT_TOKEN_NUMBER_DISPLAY = Token.NUM_ON_NAME;
-
-  /** Represents the key used to retrieve the number of minutes between auto saves. */
-  private static final String KEY_AUTO_SAVE_INCREMENT = "autoSaveIncrement";
-
-  /**
-   * The default value for the {@code KEY_AUTO_SAVE_INCREMENT} preference option.
-   *
-   * @see #KEY_AUTO_SAVE_INCREMENT
-   */
-  private static final int DEFAULT_AUTO_SAVE_INCREMENT = 5; // Minutes
-
-  private static final String KEY_CHAT_AUTOSAVE_TIME = "chatAutosaveTime";
-  private static final int DEFAULT_CHAT_AUTOSAVE_TIME = 0; // Minutes; zero=disabled
-
-  private static final String KEY_CHAT_FILENAME_FORMAT = "chatFilenameFormat";
-  private static final String DEFAULT_CHAT_FILENAME_FORMAT =
-      "chatlog-%1$tF-%1$tR.html"; // http://download.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html
+  public static final Preference<Boolean> fillSelectionBox =
+      BooleanType.create("fillSelectionBox", true);
 
-  private static final String KEY_DUPLICATE_TOKEN_NUMBER = "duplicateTokenNumber";
-  private static final String DEFAULT_DUPLICATE_TOKEN_NUMBER = Token.NUM_INCREMENT;
+  public static final Preference<Color> chatColor =
+      ColorType.create("chatColor", Color.black, false);
 
-  private static final String KEY_NEW_TOKEN_NAMING = "newTokenNaming";
-  private static final String DEFAULT_NEW_TOKEN_NAMING = Token.NAME_USE_FILENAME;
+  public static final Preference<Boolean> saveReminder =
+      BooleanType.create("autoSaveReminder", true);
 
-  private static final String KEY_USE_HALO_COLOR_ON_VISION_OVERLAY = "useHaloColorForVisionOverlay";
-  private static final boolean DEFAULT_USE_HALO_COLOR_ON_VISION_OVERLAY = false;
+  public static final Preference<Integer> autoSaveIncrement =
+      IntegerType.create("autoSaveIncrement", 5);
 
-  private static final String KEY_HALO_OVERLAY_OPACITY = "haloOverlayOpacity";
-  private static final int DEFAULT_HALO_OVERLAY_OPACITY = 60;
+  public static final Preference<Integer> chatAutoSaveTimeInMinutes =
+      IntegerType.create("chatAutosaveTime", 0);
 
-  private static final String KEY_AURA_OVERLAY_OPACITY = "auraOverlayOpacity";
-  private static final int DEFAULT_AURA_OVERLAY_OPACITY = 60;
+  public static final Preference<String> chatFilenameFormat =
+      StringType.create("chatFilenameFormat", "chatlog-%1$tF-%1$tR.html");
 
-  private static final String KEY_LIGHT_OVERLAY_OPACITY = "lightOverlayOpacity";
-  private static final int DEFAULT_LIGHT_OVERLAY_OPACITY = 60;
+  public static final Preference<String> tokenNumberDisplay =
+      StringType.create("tokenNumberDisplayg", "Name");
 
-  private static final String KEY_LUMENS_OVERLAY_OPACITY = "lumensOverlayOpacity";
-  private static final int DEFAULT_LUMENS_OVERLAY_OPACITY = 120;
+  public static final Preference<String> duplicateTokenNumber =
+      StringType.create("duplicateTokenNumber", "Increment");
 
-  private static final String KEY_LUMENS_OVERLAY_BORDER_THICKNESS = "lumensOverlayBorderThickness";
-  private static final int DEFAULT_LUMENS_OVERLAY_BORDER_THICKNESS = 5;
+  public static final Preference<String> newTokenNaming =
+      StringType.create("newTokenNaming", "Use Filename");
 
-  private static final String KEY_LUMENS_OVERLAY_SHOW_BY_DEFAULT = "lumensOverlayShowByDefault";
-  private static final boolean DEFAULT_LUMENS_OVERLAY_SHOW_BY_DEFAULT = false;
+  public static final Preference<Boolean> useHaloColorOnVisionOverlay =
+      BooleanType.create("useHaloColorForVisionOverlay", false);
 
-  private static final String KEY_LIGHTS_SHOW_BY_DEFAULT = "lightsShowByDefault";
-  private static final boolean DEFAULT_LIGHTS_SHOW_BY_DEFAULT = true;
+  public static final Preference<Boolean> mapVisibilityWarning =
+      BooleanType.create("mapVisibilityWarning", false);
 
-  private static final String KEY_FOG_OVERLAY_OPACITY = "fogOverlayOpacity";
-  private static final int DEFAULT_FOG_OVERLAY_OPACITY = 100;
+  public static final Preference<Boolean> autoRevealVisionOnGMMovement =
+      BooleanType.create("autoRevealVisionOnGMMove", false);
 
-  private static final String KEY_HALO_LINE_WIDTH = "haloLineWidth";
-  private static final int DEFAULT_HALO_LINE_WIDTH = 2;
+  public static final Preference<Integer> haloOverlayOpacity =
+      ByteType.create("haloOverlayOpacity", 60);
 
-  private static final String KEY_AUTO_REVEAL_VISION_ON_GM_MOVEMENT = "autoRevealVisionOnGMMove";
-  private static final boolean DEFAULT_AUTO_REVEAL_VISION_ON_GM_MOVEMENT = false;
+  public static final Preference<Integer> auraOverlayOpacity =
+      ByteType.create("auraOverlayOpacity", 60);
 
-  private static final String KEY_USE_SOFT_FOG_EDGES = "useSoftFog";
-  private static final boolean DEFAULT_USE_SOFT_FOG_EDGES = true;
+  public static final Preference<Integer> lightOverlayOpacity =
+      ByteType.create("lightOverlayOpacity", 60);
 
-  private static final String KEY_MAP_VISIBILITY_WARNING = "mapVisibilityWarning";
+  public static final Preference<Integer> lumensOverlayOpacity =
+      ByteType.create("lumensOverlayOpacity", 120);
 
-  private static final String KEY_NEW_MAPS_HAVE_FOW = "newMapsHaveFow";
-  private static final boolean DEFAULT_NEW_MAPS_HAVE_FOW = false;
+  public static final Preference<Integer> fogOverlayOpacity =
+      ByteType.create("fogOverlayOpacity", 100);
 
-  private static final String KEY_NEW_TOKENS_VISIBLE = "newTokensVisible";
-  private static final boolean DEFAULT_NEW_TOKENS_VISIBLE = true;
+  public static final Preference<Integer> lumensOverlayBorderThickness =
+      IntegerType.create("lumensOverlayBorderThickness", 5);
 
-  private static final String KEY_NEW_MAPS_VISIBLE = "newMapsVisible";
-  private static final boolean DEFAULT_NEW_MAPS_VISIBLE = true;
+  public static final Preference<Boolean> lumensOverlayShowByDefault =
+      BooleanType.create("lumensOverlayShowByDefault", false);
 
-  private static final String KEY_NEW_OBJECTS_VISIBLE = "newObjectsVisible";
-  private static final boolean DEFAULT_NEW_OBJECTS_VISIBLE = true;
+  public static final Preference<Boolean> lightsShowByDefault =
+      BooleanType.create("lightsShowByDefault", true);
 
-  private static final String KEY_NEW_BACKGROUNDS_VISIBLE = "newBackgroundsVisible";
-  private static final boolean DEFAULT_NEW_BACKGROUNDS_VISIBLE = true;
+  public static final Preference<Integer> haloLineWidth = IntegerType.create("haloLineWidth", 2);
 
-  private static final String KEY_TOKENS_START_FREESIZE = "newTokensStartFreesize";
-  private static final boolean DEFAULT_TOKENS_START_FREESIZE = false;
+  public static final Preference<Integer> typingNotificationDurationInSeconds =
+      IntegerType.create("typingNotificationDuration", 5);
 
-  private static final String KEY_TOKENS_WARN_WHEN_DELETED = "tokensWarnWhenDeleted";
-  private static final boolean DEFAULT_TOKENS_WARN_WHEN_DELETED = true;
+  public static final Preference<Boolean> chatNotificationBackground =
+      BooleanType.create("chatNotificationShowBackground", true);
 
-  private static final String KEY_DRAW_WARN_WHEN_DELETED = "drawWarnWhenDeleted";
-  private static final boolean DEFAULT_DRAW_WARN_WHEN_DELETED = true;
+  public static final Preference<Boolean> useToolTipForInlineRoll =
+      BooleanType.create("toolTipInlineRolls", false);
 
-  private static final String KEY_TOKENS_START_SNAP_TO_GRID = "newTokensStartSnapToGrid";
-  private static final boolean DEFAULT_TOKENS_START_SNAP_TO_GRID = true;
+  public static final Preference<Boolean> suppressToolTipsForMacroLinks =
+      BooleanType.create("suppressToolTipsMacroLinks", false);
 
-  private static final String KEY_TOKENS_SNAP_WHILE_DRAGGING = "tokensSnapWhileDragging";
-  private static final boolean DEFAULT_KEY_TOKENS_SNAP_WHILE_DRAGGING = true;
+  public static final Preference<Color> chatNotificationColor =
+      ColorType.create("chatNotificationColor", Color.white, false);
 
-  private static final String KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING =
-      "hideMousePointerWhileDragging";
-  private static final boolean DEFAULT_KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING = true;
+  public static final Preference<Color> trustedPrefixBackground =
+      ColorType.create("trustedPrefixBG", new Color(0xD8, 0xE9, 0xF6), false);
 
-  private static final String KEY_HIDE_TOKEN_STACK_INDICATOR = "hideTokenStackIndicator";
-  private static final boolean DEFAULT_KEY_HIDE_TOKEN_STACK_INDICATOR = false;
+  public static final Preference<Color> trustedPrefixForeground =
+      ColorType.create("trustedPrefixFG", Color.BLACK, false);
 
-  private static final String KEY_OBJECTS_START_SNAP_TO_GRID = "newStampsStartSnapToGrid";
-  private static final boolean DEFAULT_OBJECTS_START_SNAP_TO_GRID = false;
+  public static final Preference<Integer> toolTipInitialDelay =
+      IntegerType.create("toolTipInitialDelay", 250);
 
-  private static final String KEY_OBJECTS_START_FREESIZE = "newStampsStartFreesize";
-  private static final boolean DEFAULT_OBJECTS_START_FREESIZE = true;
+  public static final Preference<Integer> toolTipDismissDelay =
+      IntegerType.create("toolTipDismissDelay", 30000);
 
-  private static final String KEY_BACKGROUNDS_START_SNAP_TO_GRID = "newBackgroundsStartSnapToGrid";
-  private static final boolean DEFAULT_BACKGROUNDS_START_SNAP_TO_GRID = false;
+  public static final Preference<Boolean> allowPlayerMacroEditsDefault =
+      BooleanType.create("allowPlayerMacroEditsDefault", true);
 
-  private static final String KEY_BACKGROUNDS_START_FREESIZE = "newBackgroundsStartFreesize";
-  private static final boolean DEFAULT_BACKGROUNDS_START_FREESIZE = true;
+  public static final Preference<Integer> portraitSize = IntegerType.create("portraitSize", 175);
 
-  private static final String KEY_SOUNDS_ONLY_WHEN_NOT_FOCUSED =
-      "playSystemSoundsOnlyWhenNotFocused";
-  private static final boolean DEFAULT_SOUNDS_ONLY_WHEN_NOT_FOCUSED = false;
+  public static final Preference<Integer> thumbnailSize = IntegerType.create("thumbnailSize", 500);
 
-  private static final String KEY_SYRINSCAPE_ACTIVE = "syrinscapeActive";
-  private static final boolean DEFAULT_SYRINSCAPE_ACTIVE = false;
+  public static final Preference<Boolean> showSmilies = BooleanType.create("insertSmilies", true);
 
-  private static final String KEY_SHOW_AVATAR_IN_CHAT = "showAvatarInChat";
-  private static final boolean DEFAULT_SHOW_AVATAR_IN_CHAT = true;
+  public static final Preference<Boolean> showDialogOnNewToken =
+      BooleanType.create("showDialogOnNewToken", true);
 
-  private static final String KEY_SHOW_DIALOG_ON_NEW_TOKEN = "showDialogOnNewToken";
-  private static final boolean DEFAULT_SHOW_DIALOG_ON_NEW_TOKEN = true;
+  public static final Preference<Boolean> showAvatarInChat =
+      BooleanType.create("showAvatarInChat", true);
 
-  private static final String KEY_INSERT_SMILIES = "insertSmilies";
-  private static final boolean DEFAULT_SHOW_SMILIES = true;
+  public static final Preference<Boolean> playSystemSounds =
+      BooleanType.create("playSystemSounds", true);
 
-  private static final String KEY_MOVEMENT_METRIC = "movementMetric";
-  private static final WalkerMetric DEFAULT_MOVEMENT_METRIC = WalkerMetric.ONE_TWO_ONE;
+  public static final Preference<Boolean> playSystemSoundsOnlyWhenNotFocused =
+      BooleanType.create("playSystemSoundsOnlyWhenNotFocused", false);
 
-  private static final String KEY_SHOW_STAT_SHEET = "showStatSheet";
-  private static final boolean DEFAULT_SHOW_STAT_SHEET = true;
+  public static final Preference<Boolean> playStreams = BooleanType.create("playStreams", true);
 
-  private static final String KEY_SHOW_PORTRAIT = "showPortrait";
-  private static final boolean DEFAULT_SHOW_PORTRAIT = true;
+  public static final Preference<Boolean> syrinscapeActive =
+      BooleanType.create("syrinscapeActive", false);
 
-  private static final String KEY_SHOW_STAT_SHEET_MODIFIER = "showStatSheetModifier";
-  private static final boolean DEFAULT_SHOW_STAT_SHEET_MODIFIER = false;
+  public static final Preference<Integer> fontSize = IntegerType.create("fontSize", 12);
 
-  private static final String KEY_FILL_SELECTION_BOX = "fillSelectionBox";
-  private static final boolean DEFAULT_FILL_SELECTION_BOX = true;
+  public static final Preference<Color> defaultGridColor =
+      ColorType.create("defaultGridColor", Color.black, false);
 
-  private static final String KEY_SHOW_INIT_GAIN_MESSAGE = "showInitGainMessage";
-  private static final boolean DEFAULT_SHOW_INIT_GAIN_MESSAGE = true;
+  public static final Preference<Integer> defaultGridSize =
+      IntegerType.create("defaultGridSize", 100);
 
-  private static final String KEY_FORCE_FACING_ARROW = "forceFacingArrow";
-  private static final boolean DEFAULT_FORCE_FACING_ARROW = false;
+  public static final Preference<Double> defaultUnitsPerCell =
+      DoubleType.create("unitsPerCell", 5.);
 
-  private static final String KEY_USE_ASTAR_PATHFINDING = "useAstarPathfinding";
-  private static final boolean DEFAULT_USE_ASTAR_PATHFINDING = true;
+  public static final Preference<Boolean> faceVertex = BooleanType.create("faceVertex", false);
 
-  private static final String KEY_VBL_BLOCKS_MOVE = "vblBlocksMove";
-  private static final boolean DEFAULT_VBL_BLOCKS_MOVE = true;
+  public static final Preference<Boolean> faceEdge = BooleanType.create("faceEdge", true);
 
-  private static final String MACRO_EDITOR_THEME = "macroEditorTheme";
-  private static final String DEFAULT_MACRO_EDITOR_THEME = "Default";
+  public static final Preference<Integer> defaultVisionDistance =
+      IntegerType.create("defaultVisionDistance", 1000);
 
-  private static final String ICON_THEME = "iconTheme";
-  private static final String DEFAULT_ICON_THEME = RessourceManager.ROD_TAKEHARA;
+  public static final Preference<Zone.VisionType> defaultVisionType =
+      EnumType.create(Zone.VisionType.class, "defaultVisionType", Zone.VisionType.OFF);
 
-  private static final String KEY_WEB_END_POINT_PORT = "webEndPointPort";
-  private static final int DEFAULT_WEB_END_POINT = 654555;
+  public static final Preference<MapSortType> mapSortType =
+      EnumType.create(MapSortType.class, "sortByGMName", MapSortType.GMNAME);
 
-  public static void setFillSelectionBox(boolean fill) {
-    prefs.putBoolean(KEY_FILL_SELECTION_BOX, fill);
-  }
+  public static final Preference<Boolean> useSoftFogEdges = BooleanType.create("useSoftFog", true);
 
-  public static boolean getFillSelectionBox() {
-    return prefs.getBoolean(KEY_FILL_SELECTION_BOX, DEFAULT_FILL_SELECTION_BOX);
-  }
+  public static final Preference<Boolean> newMapsHaveFow =
+      BooleanType.create("newMapsHaveFow", false);
 
-  public static Color getChatColor() {
-    return new Color(prefs.getInt(KEY_CHAT_COLOR, DEFAULT_CHAT_COLOR.getRGB()));
-  }
+  public static final Preference<Boolean> newTokensVisible =
+      BooleanType.create("newTokensVisible", true);
 
-  public static void setSaveReminder(boolean reminder) {
-    prefs.putBoolean(KEY_SAVE_REMINDER, reminder);
-  }
+  public static final Preference<Boolean> newMapsVisible =
+      BooleanType.create("newMapsVisible", true);
 
-  public static boolean getSaveReminder() {
-    return prefs.getBoolean(KEY_SAVE_REMINDER, DEFAULT_SAVE_REMINDER);
-  }
+  public static final Preference<Boolean> newObjectsVisible =
+      BooleanType.create("newObjectsVisible", true);
 
-  // public static void setEnabledMapExportImport(boolean reminder) {
-  // prefs.putBoolean(KEY_ENABLE_MAP_EXPORT_IMPORT, reminder);
-  // AppActions.updateActions();
-  // }
+  public static final Preference<Boolean> newBackgroundsVisible =
+      BooleanType.create("newBackgroundsVisible", true);
 
-  // public static boolean isEnabledMapExportImport() {
-  // return prefs.getBoolean(KEY_ENABLE_MAP_EXPORT_IMPORT, DEFAULT_ENABLE_MAP_EXPORT_IMPORT);
-  // }
+  public static final Preference<File> saveDirectory =
+      FileType.create("saveDir", () -> new File(File.separator));
 
-  public static void setAutoSaveIncrement(int increment) {
-    prefs.putInt(KEY_AUTO_SAVE_INCREMENT, increment);
-  }
+  public static final Preference<File> tokenSaveDirectory =
+      FileType.create("saveTokenDir", saveDirectory::get);
 
-  public static int getAutoSaveIncrement() {
-    return prefs.getInt(KEY_AUTO_SAVE_INCREMENT, DEFAULT_AUTO_SAVE_INCREMENT);
-  }
+  public static final Preference<File> mapSaveDirectory =
+      FileType.create("saveMapDir", saveDirectory::get);
 
-  public static void setChatAutosaveTime(int minutes) {
-    if (minutes >= 0) {
-      prefs.putInt(KEY_CHAT_AUTOSAVE_TIME, minutes);
-      ChatAutoSave.changeTimeout(minutes);
+  public static final Preference<File> addOnLoadDirectory =
+      FileType.create("addOnLoadDir", saveDirectory::get);
+
+  public static final Preference<File> loadDirectory =
+      FileType.create("loadDir", () -> new File(File.separator));
+
+  public static final Preference<RenderQuality> renderQuality =
+      EnumType.create(RenderQuality.class, "renderScaleQuality", RenderQuality.LOW_SCALING)
+          .cacheIt();
+
+  /** The background color to use for NPC map labels. */
+  public static final Preference<Color> npcMapLabelBackground =
+      ColorType.create("npcMapLabelBG", Color.LIGHT_GRAY, true);
+
+  /** The foreground color to use for NPC map labels. */
+  public static final Preference<Color> npcMapLabelForeground =
+      ColorType.create("npcMapLabelFG", Color.BLACK, true);
+
+  /** The border color to use for NPC map labels. */
+  public static final Preference<Color> npcMapLabelBorder =
+      ColorType.create("mapLabelBorderColor", npcMapLabelForeground.getDefault(), true);
+
+  /** The background color to use for PC map labels. */
+  public static final Preference<Color> pcMapLabelBackground =
+      ColorType.create("pcMapLabelBG", Color.WHITE, true);
+
+  /** The foreground color to use for PC map labels. */
+  public static final Preference<Color> pcMapLabelForeground =
+      ColorType.create("pcMapLabelFG", Color.BLUE, true);
+
+  /** The border color to use for PC map labels. */
+  public static final Preference<Color> pcMapLabelBorder =
+      ColorType.create("pcMapLabelBorderColor", pcMapLabelForeground.getDefault(), true);
+
+  /** The background color to use for Non-Visible Token map labels. */
+  public static final Preference<Color> nonVisibleTokenMapLabelBackground =
+      ColorType.create("nonVisMapLabelBG", Color.BLACK, true);
+
+  /** The foreground color to use for Non-Visible Token map labels. */
+  public static final Preference<Color> nonVisibleTokenMapLabelForeground =
+      ColorType.create("nonVisMapLabelFG", Color.WHITE, true);
+
+  /** The border color to use for Non-Visible Token map labels. */
+  public static final Preference<Color> nonVisibleTokenMapLabelBorder =
+      ColorType.create(
+          "nonVisMapLabelBorderColor", nonVisibleTokenMapLabelForeground.getDefault(), true);
+
+  /** The font size to use for token map labels. */
+  public static final Preference<Integer> mapLabelFontSize =
+      IntegerType.create("mapLabelFontSize", AppStyle.labelFont.getSize());
+
+  /** The width of the border for token map labels, in pixels. */
+  public static final Preference<Integer> mapLabelBorderWidth =
+      IntegerType.create("mapLabelBorderWidth", Label.DEFAULT_LABEL_BORDER_WIDTH);
+
+  /** The size of the border arc for token map labels. */
+  public static final Preference<Integer> mapLabelBorderArc =
+      IntegerType.create("mapLabelBorderArc", Label.DEFAULT_LABEL_BORDER_ARC);
+
+  /** {@code true} if borders should be shown around map labels, {@code false} otherwise. */
+  public static final Preference<Boolean> mapLabelShowBorder =
+      BooleanType.create("mapLabelShowBorder", true);
+
+  // TODO Why is the default not a valid port?
+  public static final Preference<Integer> webEndpointPort =
+      IntegerType.create("webEndPointPort", 654555);
+
+  public static final Preference<Boolean> tokensWarnWhenDeleted =
+      BooleanType.create("tokensWarnWhenDeleted", true);
+
+  public static final Preference<Boolean> drawingsWarnWhenDeleted =
+      BooleanType.create("drawWarnWhenDeleted", true);
+
+  public static final Preference<Boolean> tokensSnapWhileDragging =
+      BooleanType.create("tokensSnapWhileDragging", true);
+
+  public static final Preference<Boolean> hideMousePointerWhileDragging =
+      BooleanType.create("hideMousePointerWhileDragging", true);
+
+  public static final Preference<Boolean> hideTokenStackIndicator =
+      BooleanType.create("hideTokenStackIndicator", false);
+
+  public static final Preference<Boolean> tokensStartSnapToGrid =
+      BooleanType.create("newTokensStartSnapToGrid", true);
+
+  public static final Preference<Boolean> objectsStartSnapToGrid =
+      BooleanType.create("newStampsStartSnapToGrid", false);
+
+  public static final Preference<Boolean> backgroundsStartSnapToGrid =
+      BooleanType.create("newBackgroundsStartSnapToGrid", false);
+
+  public static final Preference<Boolean> tokensStartFreesize =
+      BooleanType.create("newTokensStartFreesize", false);
+
+  public static final Preference<Boolean> objectsStartFreesize =
+      BooleanType.create("newStampsStartFreesize", true);
+
+  public static final Preference<Boolean> backgroundsStartFreesize =
+      BooleanType.create("newBackgroundsStartFreesize", true);
+
+  public static final Preference<String> defaultGridType =
+      StringType.create("defaultGridType", GridFactory.SQUARE);
+
+  public static final Preference<Boolean> showStatSheet = BooleanType.create("showStatSheet", true);
+
+  public static final Preference<Boolean> showStatSheetRequiresModifierKey =
+      BooleanType.create("showStatSheetModifier", false);
+
+  public static final Preference<Boolean> showPortrait = BooleanType.create("showPortrait", true);
+
+  public static final Preference<Boolean> forceFacingArrow =
+      BooleanType.create("forceFacingArrow", false);
+
+  public static final Preference<Boolean> fitGmView = BooleanType.create("fitGMView", true);
+
+  public static final Preference<String> defaultUserName =
+      StringType.create(
+          "defaultUsername", I18N.getString("Preferences.client.default.username.value"));
+
+  public static final Preference<WalkerMetric> movementMetric =
+      EnumType.create(WalkerMetric.class, "movementMetric", WalkerMetric.ONE_TWO_ONE);
+
+  public static final Preference<Integer> frameRateCap =
+      IntegerType.create("frameRateCap", 60).validateIt(cap -> cap > 0);
+
+  public static final Preference<Integer> upnpDiscoveryTimeout =
+      IntegerType.create("upnpDiscoveryTimeout", 5000);
+
+  public static final Preference<String> fileSyncPath = StringType.create("fileSyncPath", "");
+
+  public static final Preference<Boolean> skipAutoUpdate =
+      BooleanType.create("skipAutoUpdate", false);
+
+  public static final Preference<String> skipAutoUpdateRelease =
+      StringType.create("skipAutoUpdateRelease", "");
+
+  public static final Preference<Boolean> allowExternalMacroAccess =
+      BooleanType.create("allowExternalMacroAccess", false);
+
+  public static final Preference<Boolean> loadMruCampaignAtStart =
+      BooleanType.create("loadMRUCampaignAtStart", false);
+
+  public static final Preference<Boolean> initiativePanelShowsTokenImage =
+      BooleanType.create("initShowTokens", true);
+
+  public static final Preference<Boolean> initiativePanelShowsTokenState =
+      BooleanType.create("initShowTokenStates", true);
+
+  public static final Preference<Boolean> initiativePanelShowsInitiative =
+      BooleanType.create("initShowInitiative", true);
+
+  public static final Preference<Boolean> initiativePanelShowsInitiativeOnLine2 =
+      BooleanType.create("initShow2ndLine", false);
+
+  public static final Preference<Boolean> initiativePanelHidesNpcs =
+      BooleanType.create("initHideNpcs", false);
+
+  public static final Preference<Boolean> initiativePanelAllowsOwnerPermissions =
+      BooleanType.create("initOwnerPermissions", false);
+
+  public static final Preference<Boolean> initiativeMovementLocked =
+      BooleanType.create("initLockMovement", false);
+
+  public static final Preference<Boolean> showInitiativeGainedMessage =
+      BooleanType.create("showInitGainMessage", true);
+
+  public static final Preference<Boolean> pathfindingEnabled =
+      BooleanType.create("useAstarPathfinding", true);
+
+  public static final Preference<Boolean> pathfindingBlockedByVbl =
+      BooleanType.create("vblBlocksMove", true);
+
+  public static final Preference<String> defaultMacroEditorTheme =
+      StringType.create("macroEditorTheme", "Default");
+
+  public static final Preference<String> iconTheme = StringType.create("iconTheme", "Rod Takehara");
+
+  static {
+    // Used to be stored as separate components but now is one color. Add if not already there.
+    if (prefs.get("trustedPrefixFG", null) == null) {
+      var defaultValue = trustedPrefixForeground.getDefault();
+      trustedPrefixForeground.set(
+          new Color(
+              prefs.getInt("trustedPrefixFGRed", defaultValue.getRed()),
+              prefs.getInt("trustedPrefixFGGreen", defaultValue.getGreen()),
+              prefs.getInt("trustedPrefixFBlue", defaultValue.getBlue())));
+    }
+    if (prefs.get("trustedPrefixBG", null) == null) {
+      var defaultValue = trustedPrefixBackground.getDefault();
+      trustedPrefixBackground.set(
+          new Color(
+              prefs.getInt("trustedPrefixBGRed", defaultValue.getRed()),
+              prefs.getInt("trustedPrefixBGGreen", defaultValue.getGreen()),
+              prefs.getInt("trustedPrefixBBlue", defaultValue.getBlue())));
+    }
+    if (prefs.get("chatNotificationColor", null) == null) {
+      var defaultValue = chatNotificationColor.getDefault();
+      chatNotificationColor.set(
+          new Color(
+              prefs.getInt("chatNotificationColorRed", defaultValue.getRed()),
+              prefs.getInt("chatNotificationColorGreen", defaultValue.getGreen()),
+              prefs.getInt("chatNotificationColorBlue", defaultValue.getBlue())));
     }
   }
-
-  public static int getChatAutosaveTime() {
-    return prefs.getInt(KEY_CHAT_AUTOSAVE_TIME, DEFAULT_CHAT_AUTOSAVE_TIME);
-  }
-
-  public static void setChatFilenameFormat(String pattern) {
-    prefs.put(KEY_CHAT_FILENAME_FORMAT, pattern);
-  }
-
-  public static String getChatFilenameFormat() {
-    return prefs.get(KEY_CHAT_FILENAME_FORMAT, DEFAULT_CHAT_FILENAME_FORMAT);
-  }
-
-  public static void clearChatFilenameFormat() {
-    prefs.remove(KEY_CHAT_FILENAME_FORMAT);
-  }
-
-  public static void setTokenNumberDisplay(String display) {
-    prefs.put(KEY_TOKEN_NUMBER_DISPLAY, display);
-  }
-
-  public static String getTokenNumberDisplay() {
-    return prefs.get(KEY_TOKEN_NUMBER_DISPLAY, DEFAULT_TOKEN_NUMBER_DISPLAY);
-  }
-
-  public static void setDuplicateTokenNumber(String numbering) {
-    prefs.put(KEY_DUPLICATE_TOKEN_NUMBER, numbering);
-  }
-
-  public static String getDuplicateTokenNumber() {
-    return prefs.get(KEY_DUPLICATE_TOKEN_NUMBER, DEFAULT_DUPLICATE_TOKEN_NUMBER);
-  }
-
-  public static void setNewTokenNaming(String naming) {
-    prefs.put(KEY_NEW_TOKEN_NAMING, naming);
-  }
-
-  public static String getNewTokenNaming() {
-    return prefs.get(KEY_NEW_TOKEN_NAMING, DEFAULT_NEW_TOKEN_NAMING);
-  }
-
-  public static void setUseHaloColorOnVisionOverlay(boolean flag) {
-    prefs.putBoolean(KEY_USE_HALO_COLOR_ON_VISION_OVERLAY, flag);
-  }
-
-  public static boolean getUseHaloColorOnVisionOverlay() {
-    return prefs.getBoolean(
-        KEY_USE_HALO_COLOR_ON_VISION_OVERLAY, DEFAULT_USE_HALO_COLOR_ON_VISION_OVERLAY);
-  }
-
-  public static void setMapVisibilityWarning(boolean flag) {
-    prefs.putBoolean(KEY_MAP_VISIBILITY_WARNING, flag);
-  }
-
-  public static boolean getMapVisibilityWarning() {
-    return prefs.getBoolean(KEY_MAP_VISIBILITY_WARNING, false);
-  }
-
-  public static void setAutoRevealVisionOnGMMovement(boolean flag) {
-    prefs.putBoolean(KEY_AUTO_REVEAL_VISION_ON_GM_MOVEMENT, flag);
-  }
-
-  public static boolean getAutoRevealVisionOnGMMovement() {
-    return prefs.getBoolean(
-        KEY_AUTO_REVEAL_VISION_ON_GM_MOVEMENT, DEFAULT_AUTO_REVEAL_VISION_ON_GM_MOVEMENT);
-  }
-
-  private static int range0to255(int value) {
-    return value < 1 ? 0 : Math.min(value, 255);
-  }
-
-  public static void setHaloOverlayOpacity(int size) {
-    prefs.putInt(KEY_HALO_OVERLAY_OPACITY, range0to255(size));
-  }
-
-  public static int getHaloOverlayOpacity() {
-    int value = prefs.getInt(KEY_HALO_OVERLAY_OPACITY, DEFAULT_HALO_OVERLAY_OPACITY);
-    return range0to255(value);
-  }
-
-  public static void setAuraOverlayOpacity(int size) {
-    prefs.putInt(KEY_AURA_OVERLAY_OPACITY, range0to255(size));
-  }
-
-  public static int getAuraOverlayOpacity() {
-    int value = prefs.getInt(KEY_AURA_OVERLAY_OPACITY, DEFAULT_AURA_OVERLAY_OPACITY);
-    return range0to255(value);
-  }
-
-  public static void setLightOverlayOpacity(int size) {
-    prefs.putInt(KEY_LIGHT_OVERLAY_OPACITY, range0to255(size));
-  }
-
-  public static int getLightOverlayOpacity() {
-    int value = prefs.getInt(KEY_LIGHT_OVERLAY_OPACITY, DEFAULT_LIGHT_OVERLAY_OPACITY);
-    return range0to255(value);
-  }
-
-  public static void setLumensOverlayOpacity(int size) {
-    prefs.putInt(KEY_LUMENS_OVERLAY_OPACITY, range0to255(size));
-  }
-
-  public static int getLumensOverlayOpacity() {
-    int value = prefs.getInt(KEY_LUMENS_OVERLAY_OPACITY, DEFAULT_LUMENS_OVERLAY_OPACITY);
-    return range0to255(value);
-  }
-
-  public static void setLumensOverlayBorderThickness(int thickness) {
-    prefs.putInt(KEY_LUMENS_OVERLAY_BORDER_THICKNESS, thickness);
-  }
-
-  public static int getLumensOverlayBorderThickness() {
-    return prefs.getInt(
-        KEY_LUMENS_OVERLAY_BORDER_THICKNESS, DEFAULT_LUMENS_OVERLAY_BORDER_THICKNESS);
-  }
-
-  public static void setLumensOverlayShowByDefault(boolean show) {
-    prefs.putBoolean(KEY_LUMENS_OVERLAY_SHOW_BY_DEFAULT, show);
-  }
-
-  public static boolean getLumensOverlayShowByDefault() {
-    return prefs.getBoolean(
-        KEY_LUMENS_OVERLAY_SHOW_BY_DEFAULT, DEFAULT_LUMENS_OVERLAY_SHOW_BY_DEFAULT);
-  }
-
-  public static void setLightsShowByDefault(boolean show) {
-    prefs.putBoolean(KEY_LIGHTS_SHOW_BY_DEFAULT, show);
-  }
-
-  public static boolean getLightsShowByDefault() {
-    return prefs.getBoolean(KEY_LIGHTS_SHOW_BY_DEFAULT, DEFAULT_LIGHTS_SHOW_BY_DEFAULT);
-  }
-
-  public static void setFogOverlayOpacity(int size) {
-    prefs.putInt(KEY_FOG_OVERLAY_OPACITY, range0to255(size));
-
-    // FIXME Force ModelChange event to flush fog from zone :(
-    Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
-    zone.setHasFog(zone.hasFog());
-  }
-
-  public static int getFogOverlayOpacity() {
-    int value = prefs.getInt(KEY_FOG_OVERLAY_OPACITY, DEFAULT_FOG_OVERLAY_OPACITY);
-    return range0to255(value);
-  }
-
-  private static final String KEY_DEFAULT_GRID_TYPE = "defaultGridType";
-  private static final String DEFAULT_DEFAULT_GRID_TYPE = GridFactory.SQUARE;
-
-  private static final String KEY_FACE_VERTEX = "faceVertex";
-  private static final boolean DEFAULT_FACE_VERTEX = false;
-
-  private static final String KEY_FACE_EDGE = "faceEdge";
-  private static final boolean DEFAULT_FACE_EDGE = true;
-
-  private static final String KEY_DEFAULT_GRID_SIZE = "defaultGridSize";
-  private static final int DEFAULT_DEFAULT_GRID_SIZE = 100;
-
-  private static final String KEY_DEFAULT_GRID_COLOR = "defaultGridColor";
-  private static final int DEFAULT_DEFAULT_GRID_COLOR = Color.black.getRGB();
-
-  private static final String KEY_DEFAULT_UNITS_PER_CELL = "unitsPerCell";
-  private static final int DEFAULT_DEFAULT_UNITS_PER_CELL = 5;
-
-  private static final String KEY_DEFAULT_VISION_DISTANCE = "defaultVisionDistance";
-  private static final int DEFAULT_DEFAULT_VISION_DISTANCE = 1000;
-
-  private static final String KEY_DEFAULT_VISION_TYPE = "defaultVisionType";
-  private static final Zone.VisionType DEFAULT_VISION_TYPE = Zone.VisionType.OFF;
-
-  private static final String KEY_MAP_SORT_TYPE = "sortByGMName";
-  private static final MapSortType DEFAULT_MAP_SORT_TYPE = MapSortType.GMNAME;
-
-  private static final String KEY_FONT_SIZE = "fontSize";
-  private static final int DEFAULT_FONT_SIZE = 12;
-
-  private static final String KEY_CHAT_COLOR = "chatColor";
-  private static final Color DEFAULT_CHAT_COLOR = Color.black;
-
-  private static final String KEY_PLAY_SYSTEM_SOUNDS = "playSystemSounds";
-  private static final boolean DEFAULT_PLAY_SYSTEM_SOUNDS = true;
-
-  private static final String KEY_PLAY_STREAMS = "playStreams";
-  private static final boolean DEFAULT_PLAY_STREAMS = true;
-
-  /**
-   * The key for retrieving the background color of NPC map labels. The value of this key is used to
-   * store and retrieve background color information for NPC map The background color is used to
-   * style the text of the map labels for Non-Player Characters (NPCs). labels. The value associated
-   * with this key should be a valid color value.
-   */
-  private static final String KEY_NPC_MAP_LABEL_BG_COLOR = "npcMapLabelBG";
-
-  /**
-   * Constant variable for the foreground color of NPC map labels. The value represents the key used
-   * to retrieve the color from a map or configuration file. The foreground color is used to style
-   * the text of the map labels for Non-Player Characters (NPCs). This constant is intended to be
-   * used within the context of a software application or system.
-   */
-  private static final String KEY_NPC_MAP_LABEL_FG_COLOR = "npcMapLabelFG";
-
-  /**
-   * Constant variable for the border color of NPC map labels. The value represents the key used to
-   * retrieve the color from a map or configuration file. The foreground color is used to style the
-   * text of the map labels for Non-Player Characters (NPCs). This constant is intended to be used
-   * within the context of a software application or system.
-   */
-  private static final String KEY_NPC_MAP_LABEL_BORDER_COLOR = "mapLabelBorderColor";
-
-  /**
-   * The key for retrieving the background color of PC map labels. The value of this key is used to
-   * store and retrieve background color information for NPC map The background color is used to
-   * style the text of the map labels for Player Characters (PCs) labels. The value associated with
-   * this key should be a valid color value.
-   */
-  private static final String KEY_PC_MAP_LABEL_BG_COLOR = "pcMapLabelBG";
-
-  /**
-   * Constant variable for the foreground color of NPC map labels. The value represents the key used
-   * to retrieve the color from a map or configuration file. The border color is used to style the
-   * text of the map labels for Non Player Characters (NPCs).
-   */
-  private static final String KEY_PC_MAP_LABEL_FG_COLOR = "pcMapLabelFG";
-
-  /**
-   * Constant variable for the foreground color of PC map labels. The value represents the key used
-   * to retrieve the color from a map or configuration file. The border color is used to style the
-   * text of the map labels for Player Characters (PCs).
-   */
-  private static final String KEY_PC_MAP_LABEL_BORDER_COLOR = "pcMapLabelBorderColor";
-
-  /**
-   * This variable represents the key used to store the background color of non-visible token map
-   * labels. The background color is used to style the text of the map labels for tokens that are
-   * not visible to the player. The value associated with this key should be a valid color value.
-   */
-  private static final String KEY_NONVIS_MAP_LABEL_BG_COLOR = "nonVisMapLabelBG";
-
-  /**
-   * This variable represents the key used to store the foreground color of non-visible token map
-   * labels. The foreground color is used to style the text of the map labels for tokens that are
-   * not visible to the player. The value associated with this key should be a valid color value.
-   */
-  private static final String KEY_NONVIS_MAP_LABEL_FG_COLOR = "nonVisMapLabelFG";
-
-  /**
-   * This variable represents the key used to store the border color of non-visible token map
-   * labels. The foreground color is used to style the text of the map labels for tokens that are
-   * not visible to the player. The value associated with this key should be a valid color value.
-   */
-  private static final String KEY_NONVIS_MAP_LABEL_BORDER_COLOR = "nonVisMapLabelBorderColor";
-
-  /**
-   * The KEY_MAP_LABEL_FONT_SIZE constant is used to define the name of the key that represents the
-   * font size of map labels.
-   */
-  private static final String KEY_MAP_LABEL_FONT_SIZE = "mapLabelFontSize";
-
-  /** The configuration key for specifying the width of the border around map labels for tokens. */
-  private static final String KEY_MAP_LABEL_BORDER_WIDTH = "mapLabelBorderWidth";
-
-  /** The configuration key for specifying the arc of the border around map labels for tokens. */
-  private static final String KEY_MAP_LABEL_BORDER_ARC = "mapLabelBorderArc";
-
-  /** The configuration key for specifying the width of the border around map labels for tokens. */
-  private static final String KEY_MAP_LABEL_SHOW_BORDER = "mapLabelShowBorder";
-
-  /** The default background color for the NPC map label. */
-  private static final Color DEFAULT_NPC_MAP_LABEL_BG_COLOR = Color.LIGHT_GRAY;
-
-  /** The default foreground color for NPC map labels. */
-  private static final Color DEFAULT_NPC_MAP_LABEL_FG_COLOR = Color.BLACK;
-
-  /** The default border color for NPC map labels. */
-  private static final Color DEFAULT_NPC_MAP_LABEL_BORDER_COLOR = DEFAULT_NPC_MAP_LABEL_FG_COLOR;
-
-  /** The default background color for the PC map label. */
-  private static final Color DEFAULT_PC_MAP_LABEL_BG_COLOR = Color.WHITE;
-
-  /** The default foreground color for the map labels in the PC map. */
-  private static final Color DEFAULT_PC_MAP_LABEL_FG_COLOR = Color.BLUE;
-
-  /** The default border color for the PC map labels. */
-  private static final Color DEFAULT_PC_MAP_LABEL_BORDER_COLOR = DEFAULT_PC_MAP_LABEL_FG_COLOR;
-
-  /** The default background color for non-visible map labels. */
-  private static final Color DEFAULT_NONVIS_MAP_LABEL_BG_COLOR = Color.BLACK;
-
-  /** The default foreground color for non-visible map labels. */
-  private static final Color DEFAULT_NONVIS_MAP_LABEL_FG_COLOR = Color.WHITE;
-
-  /** The default border color for non-visible map labels. */
-  private static final Color DEFAULT_NONVIS_MAP_LABEL_BORDER_COLOR =
-      DEFAULT_NONVIS_MAP_LABEL_FG_COLOR;
-
-  /** The default font size for map labels. */
-  private static final int DEFAULT_MAP_LABEL_FONT_SIZE = AppStyle.labelFont.getSize();
-
-  /** The default border width for token map labels. */
-  private static final int DEFAULT_MAP_LABEL_BORDER_WIDTH = Label.DEFAULT_LABEL_BORDER_WIDTH;
-
-  /** The default border arc for token map labels. */
-  private static final int DEFAULT_MAP_LABEL_BORDER_ARC = Label.DEFAULT_LABEL_BORDER_ARC;
-
-  /** The default border arc for token map labels. */
-  private static final boolean DEFAULT_MAP_LABEL_SHOW_BORDER = true;
-
-  public static void setHaloLineWidth(int size) {
-    prefs.putInt(KEY_HALO_LINE_WIDTH, size);
-  }
-
-  public static int getHaloLineWidth() {
-    return prefs.getInt(KEY_HALO_LINE_WIDTH, DEFAULT_HALO_LINE_WIDTH);
-  }
-
-  private static final String KEY_PORTRAIT_SIZE = "portraitSize";
-  private static final int DEFAULT_PORTRAIT_SIZE = 175;
-
-  private static final String KEY_THUMBNAIL_SIZE = "thumbnailSize";
-  private static final int DEFAULT_THUMBNAIL_SIZE = 500;
-
-  private static final String KEY_ALLOW_PLAYER_MACRO_EDITS_DEFAULT = "allowPlayerMacroEditsDefault";
-  private static final boolean DEFAULT_ALLOW_PLAYER_MACRO_EDITS_DEFAULT = true;
-
-  private static final String KEY_TOOLTIP_INITIAL_DELAY = "toolTipInitialDelay";
-  private static final int DEFAULT_TOOLTIP_INITIAL_DELAY = 250;
-
-  private static final String KEY_TOOLTIP_DISMISS_DELAY = "toolTipDismissDelay";
-  private static final int DEFAULT_TOOLTIP_DISMISS_DELAY = 30000;
-
-  private static final String KEY_TOOLTIP_FOR_INLINE_ROLLS = "toolTipInlineRolls";
-  private static final boolean DEFAULT_TOOLTIP_FOR_INLINE_ROLLS = false;
-
-  private static final String KEY_SUPPRESS_TOOLTIPS_FOR_MACROLINKS = "suppressToolTipsMacroLinks";
-  private static final boolean DEFAULT_SUPPRESS_TOOLTIPS_FOR_MACROLINKS = false;
-
-  // chat notification colors
-  private static final String KEY_CHAT_NOTIFICATION_COLOR_RED = "chatNotificationColorRed";
-  private static final int DEFAULT_CHAT_NOTIFICATION_COLOR_RED = 0xFF;
-
-  private static final String KEY_CHAT_NOTIFICATION_COLOR_GREEN = "chatNotificationColorGreen";
-  private static final int DEFAULT_CHAT_NOTIFICATION_COLOR_GREEN = 0xFF;
-
-  private static final String KEY_CHAT_NOTIFICATION_COLOR_BLUE = "chatNotificationColorBlue";
-  private static final int DEFAULT_CHAT_NOTIFICATION_COLOR_BLUE = 0xFF;
-
-  // end chat notification colors
-
-  private static final String KEY_CHAT_NOTIFICATION_SHOW_BACKGROUND =
-      "chatNotificationShowBackground";
-  private static final boolean DEFAULT_CHAT_NOTIFICATION_SHOW_BACKGROUND = true;
-
-  private static final String KEY_TRUSTED_PREFIX_BG_RED = "trustedPrefixBGRed";
-  private static final int DEFAULT_TRUSTED_PREFIX_BG_RED = 0xD8;
-
-  private static final String KEY_TRUSTED_PREFIX_BG_GREEN = "trustedPrefixBGGreen";
-  private static final int DEFAULT_TRUSTED_PREFIX_BG_GREEN = 0xE9;
-
-  private static final String KEY_TRUSTED_PREFIX_BG_BLUE = "trustedPrefixBBlue";
-  private static final int DEFAULT_TRUSTED_PREFIX_BG_BLUE = 0xF6;
-
-  private static final String KEY_TRUSTED_PREFIX_FG_RED = "trustedPrefixFGRed";
-  private static final int DEFAULT_TRUSTED_PREFIX_FG_RED = 0x00;
-
-  private static final String KEY_TRUSTED_PREFIX_FG_GREEN = "trustedPrefixFGGreen";
-  private static final int DEFAULT_TRUSTED_PREFIX_FG_GREEN = 0x00;
-
-  private static final String KEY_TRUSTED_PREFIX_FG_BLUE = "trustedPrefixFBlue";
-  private static final int DEFAULT_TRUSTED_PREFIX_FG_BLUE = 0x00;
-
-  private static final String KEY_FIT_GM_VIEW = "fitGMView";
-  private static final boolean DEFAULT_FIT_GM_VIEW = true;
-
-  private static final String KEY_DEFAULT_USERNAME = "defaultUsername";
-  private static final String DEFAULT_USERNAME =
-      I18N.getString("Preferences.client.default.username.value");
-
-  private static final String KEY_TYPING_NOTIFICATION_DURATION = "typingNotificationDuration";
-  private static final int DEFAULT_TYPING_NOTIFICATION_DURATION = 5000;
-
-  private static final String KEY_FRAME_RATE_CAP = "frameRateCap";
-  private static final int DEFAULT_FRAME_RATE_CAP = 60;
-
-  private static final String KEY_UPNP_DISCOVERY_TIMEOUT = "upnpDiscoveryTimeout";
-  private static final int DEFAULT_UPNP_DISCOVERY_TIMEOUT = 5000;
-
-  private static final String KEY_FILE_SYNC_PATH = "fileSyncPath";
-  private static final String DEFAULT_FILE_SYNC_PATH = "";
-
-  private static final String KEY_SKIP_AUTO_UPDATE = "skipAutoUpdate";
-  private static final boolean DEFAULT_SKIP_AUTO_UPDATE = false;
-  private static final String KEY_SKIP_AUTO_UPDATE_RELEASE = "skipAutoUpdateRelease";
-  private static final String DEFAULT_SKIP_AUTO_UPDATE_RELEASE = "";
-
-  private static final String KEY_ALLOW_EXTERNAL_MACRO_ACCESS = "allowExternalMacroAccess";
-  private static final boolean DEFAULT_ALLOW_EXTERNAL_MACRO_ACCESS = false;
-
-  private static final String KEY_RENDER_QUALITY = "renderScaleQuality";
 
   public enum RenderQuality {
     LOW_SCALING,
@@ -800,732 +478,6 @@ public class AppPreferences {
     }
   }
 
-  public static void setRenderQuality(RenderQuality quality) {
-    prefs.put(KEY_RENDER_QUALITY, quality.name());
-    renderQuality = quality;
-  }
-
-  public static RenderQuality getRenderQuality() {
-    if (renderQuality == null) {
-      try {
-        renderQuality =
-            RenderQuality.valueOf(prefs.get(KEY_RENDER_QUALITY, RenderQuality.LOW_SCALING.name()));
-      } catch (Exception e) {
-        renderQuality = RenderQuality.LOW_SCALING;
-      }
-    }
-    return renderQuality;
-  }
-
-  public static void setTypingNotificationDuration(int ms) {
-    prefs.putInt(KEY_TYPING_NOTIFICATION_DURATION, ms);
-    MapTool.getFrame().setChatNotifyDuration(ms);
-  }
-
-  public static Integer getTypingNotificationDuration() {
-    Integer value =
-        prefs.getInt(KEY_TYPING_NOTIFICATION_DURATION, DEFAULT_TYPING_NOTIFICATION_DURATION);
-    return value;
-  }
-
-  public static void setUseToolTipForInlineRoll(boolean tooltip) {
-    prefs.putBoolean(KEY_TOOLTIP_FOR_INLINE_ROLLS, tooltip);
-  }
-
-  public static boolean getUseToolTipForInlineRoll() {
-    return prefs.getBoolean(KEY_TOOLTIP_FOR_INLINE_ROLLS, DEFAULT_TOOLTIP_FOR_INLINE_ROLLS);
-  }
-
-  public static void setSuppressToolTipsForMacroLinks(boolean tooltip) {
-    prefs.putBoolean(KEY_SUPPRESS_TOOLTIPS_FOR_MACROLINKS, tooltip);
-  }
-
-  public static boolean getSuppressToolTipsForMacroLinks() {
-    return prefs.getBoolean(
-        KEY_SUPPRESS_TOOLTIPS_FOR_MACROLINKS, DEFAULT_SUPPRESS_TOOLTIPS_FOR_MACROLINKS);
-  }
-
-  public static void setChatNotificationColor(Color color) {
-    prefs.putInt(KEY_CHAT_NOTIFICATION_COLOR_RED, color.getRed());
-    prefs.putInt(KEY_CHAT_NOTIFICATION_COLOR_GREEN, color.getGreen());
-    prefs.putInt(KEY_CHAT_NOTIFICATION_COLOR_BLUE, color.getBlue());
-  }
-
-  public static Color getChatNotificationColor() {
-    return new Color(
-        prefs.getInt(KEY_CHAT_NOTIFICATION_COLOR_RED, DEFAULT_CHAT_NOTIFICATION_COLOR_RED),
-        prefs.getInt(KEY_CHAT_NOTIFICATION_COLOR_GREEN, DEFAULT_CHAT_NOTIFICATION_COLOR_GREEN),
-        prefs.getInt(KEY_CHAT_NOTIFICATION_COLOR_BLUE, DEFAULT_CHAT_NOTIFICATION_COLOR_BLUE));
-  }
-
-  public static void setTrustedPrefixBG(Color color) {
-    prefs.putInt(KEY_TRUSTED_PREFIX_BG_RED, color.getRed());
-    prefs.putInt(KEY_TRUSTED_PREFIX_BG_GREEN, color.getGreen());
-    prefs.putInt(KEY_TRUSTED_PREFIX_BG_BLUE, color.getBlue());
-  }
-
-  public static Color getTrustedPrefixBG() {
-    return new Color(
-        prefs.getInt(KEY_TRUSTED_PREFIX_BG_RED, DEFAULT_TRUSTED_PREFIX_BG_RED),
-        prefs.getInt(KEY_TRUSTED_PREFIX_BG_GREEN, DEFAULT_TRUSTED_PREFIX_BG_GREEN),
-        prefs.getInt(KEY_TRUSTED_PREFIX_BG_BLUE, DEFAULT_TRUSTED_PREFIX_BG_BLUE));
-  }
-
-  public static void setTrustedPrefixFG(Color color) {
-    prefs.putInt(KEY_TRUSTED_PREFIX_FG_RED, color.getRed());
-    prefs.putInt(KEY_TRUSTED_PREFIX_FG_GREEN, color.getGreen());
-    prefs.putInt(KEY_TRUSTED_PREFIX_FG_BLUE, color.getBlue());
-  }
-
-  public static Color getTrustedPrefixFG() {
-    return new Color(
-        prefs.getInt(KEY_TRUSTED_PREFIX_FG_RED, DEFAULT_TRUSTED_PREFIX_FG_RED),
-        prefs.getInt(KEY_TRUSTED_PREFIX_FG_GREEN, DEFAULT_TRUSTED_PREFIX_FG_GREEN),
-        prefs.getInt(KEY_TRUSTED_PREFIX_FG_BLUE, DEFAULT_TRUSTED_PREFIX_FG_BLUE));
-  }
-
-  public static void setToolTipInitialDelay(int ms) {
-    prefs.putInt(KEY_TOOLTIP_INITIAL_DELAY, ms);
-  }
-
-  public static int getToolTipInitialDelay() {
-    return prefs.getInt(KEY_TOOLTIP_INITIAL_DELAY, DEFAULT_TOOLTIP_INITIAL_DELAY);
-  }
-
-  public static void setToolTipDismissDelay(int ms) {
-    prefs.putInt(KEY_TOOLTIP_DISMISS_DELAY, ms);
-  }
-
-  public static int getToolTipDismissDelay() {
-    return prefs.getInt(KEY_TOOLTIP_DISMISS_DELAY, DEFAULT_TOOLTIP_DISMISS_DELAY);
-  }
-
-  public static void setAllowPlayerMacroEditsDefault(boolean show) {
-    prefs.putBoolean(KEY_ALLOW_PLAYER_MACRO_EDITS_DEFAULT, show);
-  }
-
-  public static boolean getAllowPlayerMacroEditsDefault() {
-    return prefs.getBoolean(
-        KEY_ALLOW_PLAYER_MACRO_EDITS_DEFAULT, DEFAULT_ALLOW_PLAYER_MACRO_EDITS_DEFAULT);
-  }
-
-  public static void setPortraitSize(int size) {
-    prefs.putInt(KEY_PORTRAIT_SIZE, size);
-  }
-
-  public static int getPortraitSize() {
-    return prefs.getInt(KEY_PORTRAIT_SIZE, DEFAULT_PORTRAIT_SIZE);
-  }
-
-  public static void setThumbnailSize(int size) {
-    prefs.putInt(KEY_THUMBNAIL_SIZE, size);
-  }
-
-  public static int getThumbnailSize() {
-    return prefs.getInt(KEY_THUMBNAIL_SIZE, DEFAULT_THUMBNAIL_SIZE);
-  }
-
-  public static void setShowSmilies(boolean show) {
-    prefs.putBoolean(KEY_INSERT_SMILIES, show);
-  }
-
-  public static boolean getShowSmilies() {
-    return prefs.getBoolean(KEY_INSERT_SMILIES, DEFAULT_SHOW_SMILIES);
-  }
-
-  public static void setShowDialogOnNewToken(boolean show) {
-    prefs.putBoolean(KEY_SHOW_DIALOG_ON_NEW_TOKEN, show);
-  }
-
-  public static boolean getShowDialogOnNewToken() {
-    return prefs.getBoolean(KEY_SHOW_DIALOG_ON_NEW_TOKEN, DEFAULT_SHOW_DIALOG_ON_NEW_TOKEN);
-  }
-
-  public static void setShowAvatarInChat(boolean show) {
-    prefs.putBoolean(KEY_SHOW_AVATAR_IN_CHAT, show);
-  }
-
-  public static boolean getShowAvatarInChat() {
-    return prefs.getBoolean(KEY_SHOW_AVATAR_IN_CHAT, DEFAULT_SHOW_AVATAR_IN_CHAT);
-  }
-
-  public static void setPlaySystemSounds(boolean play) {
-    prefs.putBoolean(KEY_PLAY_SYSTEM_SOUNDS, play);
-  }
-
-  public static void setPlayStreams(boolean play) {
-    prefs.putBoolean(KEY_PLAY_STREAMS, play);
-  }
-
-  public static boolean getPlaySystemSounds() {
-    return prefs.getBoolean(KEY_PLAY_SYSTEM_SOUNDS, DEFAULT_PLAY_SYSTEM_SOUNDS);
-  }
-
-  public static boolean getPlayStreams() {
-    return prefs.getBoolean(KEY_PLAY_STREAMS, DEFAULT_PLAY_STREAMS);
-  }
-
-  public static void setPlaySystemSoundsOnlyWhenNotFocused(boolean play) {
-    prefs.putBoolean(KEY_SOUNDS_ONLY_WHEN_NOT_FOCUSED, play);
-  }
-
-  public static boolean getPlaySystemSoundsOnlyWhenNotFocused() {
-    return prefs.getBoolean(KEY_SOUNDS_ONLY_WHEN_NOT_FOCUSED, DEFAULT_SOUNDS_ONLY_WHEN_NOT_FOCUSED);
-  }
-
-  public static void setSyrinscapeActive(boolean active) {
-    prefs.putBoolean(KEY_SYRINSCAPE_ACTIVE, active);
-  }
-
-  public static boolean getSyrinscapeActive() {
-    return prefs.getBoolean(KEY_SYRINSCAPE_ACTIVE, DEFAULT_SYRINSCAPE_ACTIVE);
-  }
-
-  public static void setChatColor(Color color) {
-    prefs.putInt(KEY_CHAT_COLOR, color.getRGB());
-  }
-
-  public static void setFontSize(int size) {
-    prefs.putInt(KEY_FONT_SIZE, size);
-  }
-
-  public static int getFontSize() {
-    return prefs.getInt(KEY_FONT_SIZE, DEFAULT_FONT_SIZE);
-  }
-
-  public static void setDefaultGridColor(Color color) {
-    prefs.putInt(KEY_DEFAULT_GRID_COLOR, color.getRGB());
-  }
-
-  public static Color getDefaultGridColor() {
-    return new Color(prefs.getInt(KEY_DEFAULT_GRID_COLOR, DEFAULT_DEFAULT_GRID_COLOR));
-  }
-
-  public static boolean getFaceVertex() {
-    return prefs.getBoolean(KEY_FACE_VERTEX, DEFAULT_FACE_VERTEX);
-  }
-
-  public static void setFaceVertex(boolean yesNo) {
-    prefs.putBoolean(KEY_FACE_VERTEX, yesNo);
-  }
-
-  public static boolean getFaceEdge() {
-    return prefs.getBoolean(KEY_FACE_EDGE, DEFAULT_FACE_EDGE);
-  }
-
-  public static void setFaceEdge(boolean yesNo) {
-    prefs.putBoolean(KEY_FACE_EDGE, yesNo);
-  }
-
-  public static void clearAssetRoots() {
-    prefs.put(KEY_ASSET_ROOTS, "");
-  }
-
-  public static void setSaveDir(File file) {
-    prefs.put(KEY_SAVE_DIR, file.toString());
-  }
-
-  public static void setDefaultGridSize(int size) {
-    prefs.putInt(KEY_DEFAULT_GRID_SIZE, size);
-  }
-
-  public static int getDefaultGridSize() {
-    return prefs.getInt(KEY_DEFAULT_GRID_SIZE, DEFAULT_DEFAULT_GRID_SIZE);
-  }
-
-  public static void setDefaultUnitsPerCell(double size) {
-    prefs.putDouble(KEY_DEFAULT_UNITS_PER_CELL, size);
-  }
-
-  public static double getDefaultUnitsPerCell() {
-    return prefs.getDouble(KEY_DEFAULT_UNITS_PER_CELL, DEFAULT_DEFAULT_UNITS_PER_CELL);
-  }
-
-  public static void setDefaultVisionDistance(int dist) {
-    prefs.putInt(KEY_DEFAULT_VISION_DISTANCE, dist);
-  }
-
-  public static int getDefaultVisionDistance() {
-    return prefs.getInt(KEY_DEFAULT_VISION_DISTANCE, DEFAULT_DEFAULT_VISION_DISTANCE);
-  }
-
-  public static void setDefaultVisionType(Zone.VisionType visionType) {
-    prefs.put(KEY_DEFAULT_VISION_TYPE, visionType.name());
-  }
-
-  public static void setMapSortType(MapSortType mapSortType) {
-    prefs.put(KEY_MAP_SORT_TYPE, mapSortType.name());
-  }
-
-  public static Zone.VisionType getDefaultVisionType() {
-    try {
-      return Zone.VisionType.valueOf(
-          prefs.get(KEY_DEFAULT_VISION_TYPE, DEFAULT_VISION_TYPE.name()));
-    } catch (Exception e) {
-      return DEFAULT_VISION_TYPE;
-    }
-  }
-
-  public static MapSortType getMapSortType() {
-    try {
-      return MapSortType.valueOf(prefs.get(KEY_MAP_SORT_TYPE, DEFAULT_MAP_SORT_TYPE.name()));
-    } catch (Exception e) {
-      return DEFAULT_MAP_SORT_TYPE;
-    }
-  }
-
-  public static void setUseSoftFogEdges(boolean flag) {
-    prefs.putBoolean(KEY_USE_SOFT_FOG_EDGES, flag);
-  }
-
-  public static boolean getUseSoftFogEdges() {
-    return prefs.getBoolean(KEY_USE_SOFT_FOG_EDGES, DEFAULT_USE_SOFT_FOG_EDGES);
-  }
-
-  public static void setNewMapsHaveFOW(boolean flag) {
-    prefs.putBoolean(KEY_NEW_MAPS_HAVE_FOW, flag);
-  }
-
-  public static boolean getNewMapsHaveFOW() {
-    return prefs.getBoolean(KEY_NEW_MAPS_HAVE_FOW, DEFAULT_NEW_MAPS_HAVE_FOW);
-  }
-
-  public static void setNewTokensVisible(boolean flag) {
-    prefs.putBoolean(KEY_NEW_TOKENS_VISIBLE, flag);
-  }
-
-  public static boolean getNewTokensVisible() {
-    return prefs.getBoolean(KEY_NEW_TOKENS_VISIBLE, DEFAULT_NEW_TOKENS_VISIBLE);
-  }
-
-  public static void setNewMapsVisible(boolean flag) {
-    prefs.putBoolean(KEY_NEW_MAPS_VISIBLE, flag);
-  }
-
-  public static boolean getNewMapsVisible() {
-    return prefs.getBoolean(KEY_NEW_MAPS_VISIBLE, DEFAULT_NEW_MAPS_VISIBLE);
-  }
-
-  public static void setNewObjectsVisible(boolean flag) {
-    prefs.putBoolean(KEY_NEW_OBJECTS_VISIBLE, flag);
-  }
-
-  public static boolean getNewObjectsVisible() {
-    return prefs.getBoolean(KEY_NEW_OBJECTS_VISIBLE, DEFAULT_NEW_OBJECTS_VISIBLE);
-  }
-
-  public static void setNewBackgroundsVisible(boolean flag) {
-    prefs.putBoolean(KEY_NEW_BACKGROUNDS_VISIBLE, flag);
-  }
-
-  public static boolean getNewBackgroundsVisible() {
-    return prefs.getBoolean(KEY_NEW_BACKGROUNDS_VISIBLE, DEFAULT_NEW_BACKGROUNDS_VISIBLE);
-  }
-
-  public static void setTokensWarnWhenDeleted(boolean flag) {
-    prefs.putBoolean(KEY_TOKENS_WARN_WHEN_DELETED, flag);
-  }
-
-  public static boolean getTokensWarnWhenDeleted() {
-    return prefs.getBoolean(KEY_TOKENS_WARN_WHEN_DELETED, DEFAULT_TOKENS_WARN_WHEN_DELETED);
-  }
-
-  public static void setDrawWarnWhenDeleted(boolean flag) {
-    prefs.putBoolean(KEY_DRAW_WARN_WHEN_DELETED, flag);
-  }
-
-  public static boolean getDrawWarnWhenDeleted() {
-    return prefs.getBoolean(KEY_DRAW_WARN_WHEN_DELETED, DEFAULT_DRAW_WARN_WHEN_DELETED);
-  }
-
-  public static void setTokensStartSnapToGrid(boolean flag) {
-    prefs.putBoolean(KEY_TOKENS_START_SNAP_TO_GRID, flag);
-  }
-
-  public static boolean getTokensStartSnapToGrid() {
-    return prefs.getBoolean(KEY_TOKENS_START_SNAP_TO_GRID, DEFAULT_TOKENS_START_SNAP_TO_GRID);
-  }
-
-  public static void setTokensSnapWhileDragging(boolean flag) {
-    prefs.putBoolean(KEY_TOKENS_SNAP_WHILE_DRAGGING, flag);
-  }
-
-  public static boolean getTokensSnapWhileDragging() {
-    return prefs.getBoolean(KEY_TOKENS_SNAP_WHILE_DRAGGING, DEFAULT_KEY_TOKENS_SNAP_WHILE_DRAGGING);
-  }
-
-  public static void setHideMousePointerWhileDragging(boolean flag) {
-    prefs.putBoolean(KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING, flag);
-  }
-
-  public static boolean getHideMousePointerWhileDragging() {
-    return prefs.getBoolean(
-        KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING, DEFAULT_KEY_HIDE_MOUSE_POINTER_WHILE_DRAGGING);
-  }
-
-  public static void setHideTokenStackIndicator(boolean flag) {
-    prefs.putBoolean(KEY_HIDE_TOKEN_STACK_INDICATOR, flag);
-  }
-
-  public static boolean getHideTokenStackIndicator() {
-    return prefs.getBoolean(KEY_HIDE_TOKEN_STACK_INDICATOR, DEFAULT_KEY_HIDE_TOKEN_STACK_INDICATOR);
-  }
-
-  public static void setObjectsStartSnapToGrid(boolean flag) {
-    prefs.putBoolean(KEY_OBJECTS_START_SNAP_TO_GRID, flag);
-  }
-
-  public static boolean getObjectsStartSnapToGrid() {
-    return prefs.getBoolean(KEY_OBJECTS_START_SNAP_TO_GRID, DEFAULT_OBJECTS_START_SNAP_TO_GRID);
-  }
-
-  public static void setTokensStartFreesize(boolean flag) {
-    prefs.putBoolean(KEY_TOKENS_START_FREESIZE, flag);
-  }
-
-  public static boolean getTokensStartFreesize() {
-    return prefs.getBoolean(KEY_TOKENS_START_FREESIZE, DEFAULT_TOKENS_START_FREESIZE);
-  }
-
-  public static void setObjectsStartFreesize(boolean flag) {
-    prefs.putBoolean(KEY_OBJECTS_START_FREESIZE, flag);
-  }
-
-  public static boolean getObjectsStartFreesize() {
-    return prefs.getBoolean(KEY_OBJECTS_START_FREESIZE, DEFAULT_OBJECTS_START_FREESIZE);
-  }
-
-  public static void setBackgroundsStartSnapToGrid(boolean flag) {
-    prefs.putBoolean(KEY_BACKGROUNDS_START_SNAP_TO_GRID, flag);
-  }
-
-  public static boolean getBackgroundsStartSnapToGrid() {
-    return prefs.getBoolean(
-        KEY_BACKGROUNDS_START_SNAP_TO_GRID, DEFAULT_BACKGROUNDS_START_SNAP_TO_GRID);
-  }
-
-  public static void setBackgroundsStartFreesize(boolean flag) {
-    prefs.putBoolean(KEY_BACKGROUNDS_START_FREESIZE, flag);
-  }
-
-  public static boolean getBackgroundsStartFreesize() {
-    return prefs.getBoolean(KEY_BACKGROUNDS_START_FREESIZE, DEFAULT_BACKGROUNDS_START_FREESIZE);
-  }
-
-  public static String getDefaultGridType() {
-    return prefs.get(KEY_DEFAULT_GRID_TYPE, DEFAULT_DEFAULT_GRID_TYPE);
-  }
-
-  public static void setDefaultGridType(String type) {
-    prefs.put(KEY_DEFAULT_GRID_TYPE, type);
-  }
-
-  public static boolean getShowStatSheet() {
-    return prefs.getBoolean(KEY_SHOW_STAT_SHEET, DEFAULT_SHOW_STAT_SHEET);
-  }
-
-  public static void setShowStatSheet(boolean show) {
-    prefs.putBoolean(KEY_SHOW_STAT_SHEET, show);
-  }
-
-  public static boolean getShowPortrait() {
-    return prefs.getBoolean(KEY_SHOW_PORTRAIT, DEFAULT_SHOW_PORTRAIT);
-  }
-
-  public static void setShowPortrait(boolean show) {
-    prefs.putBoolean(KEY_SHOW_PORTRAIT, show);
-  }
-
-  public static boolean getShowStatSheetModifier() {
-    return prefs.getBoolean(KEY_SHOW_STAT_SHEET_MODIFIER, DEFAULT_SHOW_STAT_SHEET_MODIFIER);
-  }
-
-  public static void setShowStatSheetModifier(boolean show) {
-    prefs.putBoolean(KEY_SHOW_STAT_SHEET_MODIFIER, show);
-  }
-
-  public static boolean getForceFacingArrow() {
-    return prefs.getBoolean(KEY_FORCE_FACING_ARROW, DEFAULT_FORCE_FACING_ARROW);
-  }
-
-  public static void setForceFacingArrow(boolean show) {
-    prefs.putBoolean(KEY_FORCE_FACING_ARROW, show);
-  }
-
-  public static boolean getFitGMView() {
-    return prefs.getBoolean(KEY_FIT_GM_VIEW, DEFAULT_FIT_GM_VIEW);
-  }
-
-  public static void setFitGMView(boolean fit) {
-    prefs.putBoolean(KEY_FIT_GM_VIEW, fit);
-  }
-
-  public static String getDefaultUserName() {
-    return prefs.get(KEY_DEFAULT_USERNAME, DEFAULT_USERNAME);
-  }
-
-  public static void setDefaultUserName(String uname) {
-    prefs.put(KEY_DEFAULT_USERNAME, uname);
-  }
-
-  public static void setMovementMetric(WalkerMetric metric) {
-    prefs.put(KEY_MOVEMENT_METRIC, metric.name());
-  }
-
-  public static void setFrameRateCap(int cap) {
-    if (cap <= 0) {
-      // The provided value is invalid. Change to default instead.
-      cap = DEFAULT_FRAME_RATE_CAP;
-    }
-    prefs.putInt(KEY_FRAME_RATE_CAP, cap);
-  }
-
-  public static int getFrameRateCap() {
-    int result = prefs.getInt(KEY_FRAME_RATE_CAP, DEFAULT_FRAME_RATE_CAP);
-    if (result <= 0) {
-      // An invalid value is stored. Fix that.
-      result = DEFAULT_FRAME_RATE_CAP;
-      setFrameRateCap(result);
-    }
-    return result;
-  }
-
-  public static void setUpnpDiscoveryTimeout(int timeout) {
-    prefs.putInt(KEY_UPNP_DISCOVERY_TIMEOUT, timeout);
-  }
-
-  public static int getUpnpDiscoveryTimeout() {
-    return prefs.getInt(KEY_UPNP_DISCOVERY_TIMEOUT, DEFAULT_UPNP_DISCOVERY_TIMEOUT);
-  }
-
-  public static String getFileSyncPath() {
-    return prefs.get(KEY_FILE_SYNC_PATH, DEFAULT_FILE_SYNC_PATH);
-  }
-
-  public static void setFileSyncPath(String path) {
-    prefs.put(KEY_FILE_SYNC_PATH, path);
-  }
-
-  public static boolean getSkipAutoUpdate() {
-    return prefs.getBoolean(KEY_SKIP_AUTO_UPDATE, DEFAULT_SKIP_AUTO_UPDATE);
-  }
-
-  public static void setSkipAutoUpdate(boolean value) {
-    prefs.putBoolean(KEY_SKIP_AUTO_UPDATE, value);
-  }
-
-  public static String getSkipAutoUpdateRelease() {
-    return prefs.get(KEY_SKIP_AUTO_UPDATE_RELEASE, DEFAULT_SKIP_AUTO_UPDATE_RELEASE);
-  }
-
-  public static void setSkipAutoUpdateRelease(String releaseId) {
-    prefs.put(KEY_SKIP_AUTO_UPDATE_RELEASE, releaseId);
-  }
-
-  public static boolean getAllowExternalMacroAccess() {
-    return prefs.getBoolean(KEY_ALLOW_EXTERNAL_MACRO_ACCESS, DEFAULT_ALLOW_EXTERNAL_MACRO_ACCESS);
-  }
-
-  public static void setAllowExternalMacroAccess(boolean value) {
-    prefs.putBoolean(KEY_ALLOW_EXTERNAL_MACRO_ACCESS, value);
-  }
-
-  public static boolean getLoadMRUCampaignAtStart() {
-    return prefs.getBoolean(KEY_LOAD_MRU_CAMPAIGN_AT_START, DEFAULT_LOAD_MRU_CAMPAIGN_AT_START);
-  }
-
-  public static void setLoadMRUCampaignAtStart(boolean value) {
-    prefs.putBoolean(KEY_LOAD_MRU_CAMPAIGN_AT_START, value);
-  }
-
-  public static WalkerMetric getMovementMetric() {
-    WalkerMetric metric;
-    try {
-      metric = WalkerMetric.valueOf(prefs.get(KEY_MOVEMENT_METRIC, DEFAULT_MOVEMENT_METRIC.name()));
-    } catch (Exception exc) {
-      metric = DEFAULT_MOVEMENT_METRIC;
-    }
-    return metric;
-  }
-
-  public static File getSaveDir() {
-    String filePath = prefs.get(KEY_SAVE_DIR, null);
-    return filePath != null ? new File(filePath) : new File(File.separator);
-  }
-
-  public static File getSaveTokenDir() {
-    String filePath = prefs.get(KEY_SAVE_TOKEN_DIR, null);
-    return filePath != null ? new File(filePath) : getSaveDir();
-  }
-
-  public static void setTokenSaveDir(File file) {
-    prefs.put(KEY_SAVE_TOKEN_DIR, file.toString());
-  }
-
-  public static File getSaveMapDir() {
-    String filePath = prefs.get(KEY_SAVE_MAP_DIR, null);
-    return filePath != null ? new File(filePath) : getSaveDir();
-  }
-
-  public static void setSaveMapDir(File file) {
-    prefs.put(KEY_SAVE_MAP_DIR, file.toString());
-  }
-
-  public static void setLoadDir(File file) {
-    prefs.put(KEY_LOAD_DIR, file.toString());
-  }
-
-  public static File getLoadDir() {
-    String filePath = prefs.get(KEY_LOAD_DIR, null);
-    return filePath != null ? new File(filePath) : new File(File.separator);
-  }
-
-  public static File getAddOnLoadDir() {
-    String filePath = prefs.get(KEY_ADD_ON_LOAD_DIR, null);
-    return filePath != null ? new File(filePath) : getSaveDir();
-  }
-
-  public static void setAddOnLoadDir(File file) {
-    prefs.put(KEY_ADD_ON_LOAD_DIR, file.toString());
-  }
-
-  private static final String INIT_SHOW_TOKENS = "initShowTokens";
-  private static final boolean DEFAULT_INIT_SHOW_TOKENS = true;
-
-  private static final String INIT_SHOW_TOKEN_STATES = "initShowTokenStates";
-  private static final boolean DEFAULT_INIT_SHOW_TOKEN_STATES = true;
-
-  private static final String INIT_SHOW_INITIATIVE = "initShowInitiative";
-  private static final boolean DEFAULT_INIT_SHOW_INITIATIVE = true;
-
-  private static final String INIT_SHOW_2ND_LINE = "initShow2ndLine";
-  private static final boolean DEFAULT_INIT_SHOW_2ND_LINE = false;
-
-  private static final String INIT_HIDE_NPCS = "initHideNpcs";
-  private static final boolean DEFAULT_INIT_HIDE_NPCS = false;
-
-  private static final String INIT_OWNER_PERMISSIONS = "initOwnerPermissions";
-  private static final boolean DEFAULT_INIT_OWNER_PERMISSIONS = false;
-
-  private static final String INIT_LOCK_MOVEMENT = "initLockMovement";
-  private static final boolean DEFAULT_INIT_LOCK_MOVEMENT = false;
-
-  public static boolean getInitShowTokens() {
-    return prefs.getBoolean(INIT_SHOW_TOKENS, DEFAULT_INIT_SHOW_TOKENS);
-  }
-
-  public static void setInitShowTokens(boolean showTokens) {
-    prefs.putBoolean(INIT_SHOW_TOKENS, showTokens);
-  }
-
-  public static boolean getInitShowTokenStates() {
-    return prefs.getBoolean(INIT_SHOW_TOKEN_STATES, DEFAULT_INIT_SHOW_TOKEN_STATES);
-  }
-
-  public static void setInitShowTokenStates(boolean showTokenStates) {
-    prefs.putBoolean(INIT_SHOW_TOKEN_STATES, showTokenStates);
-  }
-
-  public static boolean getInitShowInitiative() {
-    return prefs.getBoolean(INIT_SHOW_INITIATIVE, DEFAULT_INIT_SHOW_INITIATIVE);
-  }
-
-  public static void setInitShowInitiative(boolean showInitiative) {
-    prefs.putBoolean(INIT_SHOW_INITIATIVE, showInitiative);
-  }
-
-  public static boolean getInitShow2ndLine() {
-    return prefs.getBoolean(INIT_SHOW_2ND_LINE, DEFAULT_INIT_SHOW_2ND_LINE);
-  }
-
-  public static void setInitShow2ndLine(boolean secondLine) {
-    prefs.putBoolean(INIT_SHOW_2ND_LINE, secondLine);
-  }
-
-  public static boolean getInitHideNpcs() {
-    return prefs.getBoolean(INIT_HIDE_NPCS, DEFAULT_INIT_HIDE_NPCS);
-  }
-
-  public static void setInitHideNpcs(boolean hideNpcs) {
-    prefs.putBoolean(INIT_HIDE_NPCS, hideNpcs);
-  }
-
-  public static boolean getInitOwnerPermissions() {
-    return prefs.getBoolean(INIT_OWNER_PERMISSIONS, DEFAULT_INIT_OWNER_PERMISSIONS);
-  }
-
-  public static void setInitOwnerPermissions(boolean ownerPermissions) {
-    prefs.putBoolean(INIT_OWNER_PERMISSIONS, ownerPermissions);
-  }
-
-  public static boolean getInitLockMovement() {
-    return prefs.getBoolean(INIT_LOCK_MOVEMENT, DEFAULT_INIT_LOCK_MOVEMENT);
-  }
-
-  public static void setInitLockMovement(boolean lockMovement) {
-    prefs.putBoolean(INIT_LOCK_MOVEMENT, lockMovement);
-  }
-
-  public static boolean getChatNotificationShowBackground() {
-    // System.out.println("Getting Value:" + prefs.getBoolean(KEY_CHAT_NOTIFICATION_SHOW_BACKGROUND,
-    // DEFAULT_CHAT_NOTIFICATION_SHOW_BACKGROUND));
-    return prefs.getBoolean(
-        KEY_CHAT_NOTIFICATION_SHOW_BACKGROUND, DEFAULT_CHAT_NOTIFICATION_SHOW_BACKGROUND);
-  }
-
-  public static void setChatNotificationShowBackground(boolean flag) {
-    prefs.putBoolean(KEY_CHAT_NOTIFICATION_SHOW_BACKGROUND, flag);
-  }
-
-  public static boolean isShowInitGainMessage() {
-    // KEY_SHOW_INIT_GAIN_MESSAGE
-    return prefs.getBoolean(KEY_SHOW_INIT_GAIN_MESSAGE, DEFAULT_SHOW_INIT_GAIN_MESSAGE);
-  }
-
-  public static void setShowInitGainMessage(boolean flag) {
-    prefs.putBoolean(KEY_SHOW_INIT_GAIN_MESSAGE, flag);
-  }
-
-  public static boolean isUsingAstarPathfinding() {
-    return prefs.getBoolean(KEY_USE_ASTAR_PATHFINDING, DEFAULT_USE_ASTAR_PATHFINDING);
-  }
-
-  public static void setUseAstarPathfinding(boolean show) {
-    prefs.putBoolean(KEY_USE_ASTAR_PATHFINDING, show);
-  }
-
-  public static boolean getVblBlocksMove() {
-    return prefs.getBoolean(KEY_VBL_BLOCKS_MOVE, DEFAULT_VBL_BLOCKS_MOVE);
-  }
-
-  public static void setVblBlocksMove(boolean use) {
-    prefs.putBoolean(KEY_VBL_BLOCKS_MOVE, use);
-  }
-
-  public static String getDefaultMacroEditorTheme() {
-    return prefs.get(MACRO_EDITOR_THEME, DEFAULT_MACRO_EDITOR_THEME);
-  }
-
-  public static void setDefaultMacroEditorTheme(String type) {
-    prefs.put(MACRO_EDITOR_THEME, type);
-  }
-
-  public static String getIconTheme() {
-    return prefs.get(ICON_THEME, DEFAULT_ICON_THEME);
-  }
-
-  public static void setIconTheme(String theme) {
-    prefs.put(ICON_THEME, theme);
-  }
-
-  public static void setWebEndPointPort(int value) {
-    prefs.putInt(KEY_WEB_END_POINT_PORT, value);
-  }
-
-  public static int getWebEndPointPort() {
-    return prefs.getInt(KEY_WEB_END_POINT_PORT, DEFAULT_WEB_END_POINT);
-  }
-
   // Based off vision type enum in Zone.java, this could easily get tossed somewhere else if
   // preferred.
   public enum MapSortType {
@@ -1542,256 +494,6 @@ public class AppPreferences {
     public String toString() {
       return displayName;
     }
-  }
-
-  /**
-   * Returns the background color to use for NPC Map Labels.
-   *
-   * @return the background color to use for NPC Map Labels.
-   */
-  public static Color getNPCMapLabelBG() {
-    return new Color(
-        prefs.getInt(KEY_NPC_MAP_LABEL_BG_COLOR, DEFAULT_NPC_MAP_LABEL_BG_COLOR.getRGB()), true);
-  }
-
-  /**
-   * Sets the background color to use for NPC Map Labels.
-   *
-   * @param color the background color to use for NPC Map Labels.
-   */
-  public static void setNPCMapLabelBG(Color color) {
-    prefs.putInt(KEY_NPC_MAP_LABEL_BG_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the border color to use for PC Map Labels.
-   *
-   * @return the border color to use for PC Map Labels.
-   */
-  public static Color getPCMapLabelBorder() {
-    return new Color(
-        prefs.getInt(KEY_PC_MAP_LABEL_BORDER_COLOR, DEFAULT_PC_MAP_LABEL_BORDER_COLOR.getRGB()),
-        true);
-  }
-
-  /**
-   * Sets the border color to use for PC Map Labels.
-   *
-   * @param color the border color to use for PC Map Labels.
-   */
-  public static void setPCMapLabelBorder(Color color) {
-    prefs.putInt(KEY_PC_MAP_LABEL_BORDER_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the foreground color to use for NPC Map Labels.
-   *
-   * @return the foreground color to use for NPC Map Labels.
-   */
-  public static Color getNPCMapLabelFG() {
-    return new Color(
-        prefs.getInt(KEY_NPC_MAP_LABEL_FG_COLOR, DEFAULT_NPC_MAP_LABEL_FG_COLOR.getRGB()), true);
-  }
-
-  /**
-   * Sets the foreground color to use for NPC Map Labels.
-   *
-   * @param color the foreground color to use for NPC Map Labels.
-   */
-  public static void setNPCMapLabelFG(Color color) {
-    prefs.putInt(KEY_NPC_MAP_LABEL_FG_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the border color to use for NPC Map Labels.
-   *
-   * @return the border color to use for NPC Map Labels.
-   */
-  public static Color getNPCMapLabelBorder() {
-    return new Color(
-        prefs.getInt(KEY_NPC_MAP_LABEL_BORDER_COLOR, DEFAULT_NPC_MAP_LABEL_BORDER_COLOR.getRGB()),
-        true);
-  }
-
-  /**
-   * Sets the border color to use for NPC Map Labels.
-   *
-   * @param color the border color to use for NPC Map Labels.
-   */
-  public static void setNPCMapLabelBorder(Color color) {
-    prefs.putInt(KEY_NPC_MAP_LABEL_BORDER_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the background color to use for PC Map Labels.
-   *
-   * @return the background color to use for PC Map Labels.
-   */
-  public static Color getPCMapLabelBG() {
-    return new Color(
-        prefs.getInt(KEY_PC_MAP_LABEL_BG_COLOR, DEFAULT_PC_MAP_LABEL_BG_COLOR.getRGB()), true);
-  }
-
-  /**
-   * Sets the background color to use for PC Map Labels.
-   *
-   * @param color the background color to use for PC Map Labels.
-   */
-  public static void setPCMapLabelBG(Color color) {
-    prefs.putInt(KEY_PC_MAP_LABEL_BG_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the foreground color to use for PC Map Labels.
-   *
-   * @return the foreground color to use for PC Map Labels.
-   */
-  public static Color getPCMapLabelFG() {
-    return new Color(
-        prefs.getInt(KEY_PC_MAP_LABEL_FG_COLOR, DEFAULT_PC_MAP_LABEL_FG_COLOR.getRGB()), true);
-  }
-
-  /**
-   * Sets the foreground color to use for PC Map Labels.
-   *
-   * @param color the foreground color to use for PC Map Labels.
-   */
-  public static void setPCMapLabelFG(Color color) {
-    prefs.putInt(KEY_PC_MAP_LABEL_FG_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the background color to use for Non-Visible Token Map Labels.
-   *
-   * @return the background color to use for Non-Visible Token Map Labels.
-   */
-  public static Color getNonVisMapLabelBG() {
-    return new Color(
-        prefs.getInt(KEY_NONVIS_MAP_LABEL_BG_COLOR, DEFAULT_NONVIS_MAP_LABEL_BG_COLOR.getRGB()),
-        true);
-  }
-
-  /**
-   * Sets the background color to use for Non-Visible Token Map Labels.
-   *
-   * @param color the background color to use for Non-Visible Token Map Labels.
-   */
-  public static void setNonVisMapLabelBG(Color color) {
-    prefs.putInt(KEY_NONVIS_MAP_LABEL_BG_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the foreground color to use for Non-Visible Token Map Labels.
-   *
-   * @return the foreground color to use for Non-Visible Token Map Labels.
-   */
-  public static Color getNonVisMapLabelFG() {
-    return new Color(
-        prefs.getInt(KEY_NONVIS_MAP_LABEL_FG_COLOR, DEFAULT_NONVIS_MAP_LABEL_FG_COLOR.getRGB()),
-        true);
-  }
-
-  /**
-   * Sets the foreground color to use for Non-Visible Token Map Labels.
-   *
-   * @param color the foreground color to use for Non-Visible Token Map Labels.
-   */
-  public static void setNonVisMapLabelFG(Color color) {
-    prefs.putInt(KEY_NONVIS_MAP_LABEL_FG_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the border color to use for Non-Visible Token Map Labels.
-   *
-   * @return the border color to use for Non-Visible Token Map Labels.
-   */
-  public static Color getNonVisMapLabelBorder() {
-    return new Color(
-        prefs.getInt(
-            KEY_NONVIS_MAP_LABEL_BORDER_COLOR, DEFAULT_NONVIS_MAP_LABEL_BORDER_COLOR.getRGB()),
-        true);
-  }
-
-  /**
-   * Sets the border color to use for Non-Visible Token Map Labels.
-   *
-   * @param color the border color to use for Non-Visible Token Map Labels.
-   */
-  public static void setNonVisMapLabelBorder(Color color) {
-    prefs.putInt(KEY_NONVIS_MAP_LABEL_BORDER_COLOR, color.getRGB());
-  }
-
-  /**
-   * Returns the font size to use for Map Token Labels.
-   *
-   * @return the font size to use for Map Token Labels.
-   */
-  public static int getMapLabelFontSize() {
-    return prefs.getInt(KEY_MAP_LABEL_FONT_SIZE, DEFAULT_MAP_LABEL_FONT_SIZE);
-  }
-
-  /**
-   * Sets the font size to use for Map Token Labels.
-   *
-   * @param size the font size to use for Map Token Labels.
-   */
-  public static void setMapLabelFontSize(int size) {
-    prefs.putInt(KEY_MAP_LABEL_FONT_SIZE, size);
-  }
-
-  /**
-   * Gets the width of the border for token map labels.
-   *
-   * @return The width of the border for map labels.
-   */
-  public static int getMapLabelBorderWidth() {
-    return prefs.getInt(KEY_MAP_LABEL_BORDER_WIDTH, DEFAULT_MAP_LABEL_BORDER_WIDTH);
-  }
-
-  /**
-   * Sets the width of the border for token map labels.
-   *
-   * @param width the width of the border in pixels
-   */
-  public static void setMapLabelBorderWidth(int width) {
-    prefs.putInt(KEY_MAP_LABEL_BORDER_WIDTH, width);
-  }
-
-  /**
-   * Returns the value of the preference for the map label border arc.
-   *
-   * @return the value of the preference for the map label border arc
-   */
-  public static int getMapLabelBorderArc() {
-    return prefs.getInt(KEY_MAP_LABEL_BORDER_ARC, DEFAULT_MAP_LABEL_BORDER_ARC);
-  }
-
-  /**
-   * Sets the value of the preference for the map label border arc.
-   *
-   * @param arc the value of the preference for the map label border arc
-   */
-  public static void setMapLabelBorderArc(int arc) {
-    prefs.putInt(KEY_MAP_LABEL_BORDER_ARC, arc);
-  }
-
-  /**
-   * Returns the value of the preference "show map label border". The preference determines whether
-   * the border should be shown around the map label or not.
-   *
-   * @return {@code true} if the map label border should be shown, {@code false} otherwise.
-   */
-  public static boolean getShowMapLabelBorder() {
-    return prefs.getBoolean(KEY_MAP_LABEL_SHOW_BORDER, DEFAULT_MAP_LABEL_SHOW_BORDER);
-  }
-
-  /**
-   * Sets the preference for showing or hiding the border of map labels.
-   *
-   * @param show {@code true} to show the border, {@code false} to hide the border
-   */
-  public static void setShowMapLabelBorder(boolean show) {
-    prefs.putBoolean(KEY_MAP_LABEL_SHOW_BORDER, show);
   }
 
   private interface Type<T> {

--- a/src/main/java/net/rptools/maptool/client/AppSetup.java
+++ b/src/main/java/net/rptools/maptool/client/AppSetup.java
@@ -157,7 +157,7 @@ public class AppSetup {
 
   public static void installLibrary(final String libraryName, final File root) {
     // Add as a resource root
-    AppPreferences.addAssetRoot(root);
+    AppStatePersisted.addAssetRoot(root);
     if (MapTool.getFrame() != null) {
       MapTool.getFrame().addAssetRoot(root);
 

--- a/src/main/java/net/rptools/maptool/client/AppState.java
+++ b/src/main/java/net/rptools/maptool/client/AppState.java
@@ -50,8 +50,8 @@ public class AppState {
   private static PropertyChangeSupport changeSupport = new PropertyChangeSupport(AppState.class);
 
   static {
-    showLumensOverlay = AppPreferences.getLumensOverlayShowByDefault();
-    showLights = AppPreferences.getLightsShowByDefault();
+    showLumensOverlay = AppPreferences.lumensOverlayShowByDefault.get();
+    showLights = AppPreferences.lightsShowByDefault.get();
   }
 
   public static void addPropertyChangeListener(PropertyChangeListener listener) {

--- a/src/main/java/net/rptools/maptool/client/AppStatePersisted.java
+++ b/src/main/java/net/rptools/maptool/client/AppStatePersisted.java
@@ -1,0 +1,224 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.prefs.Preferences;
+import net.rptools.maptool.model.Zone;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Keeps track of application state between runs.
+ *
+ * <p>This started as an offshoot of {@link net.rptools.maptool.client.AppPreferences}, hence why
+ * the same node is used. But these keys do not represent preferences of the user, rather they are
+ * application state such as MRU lists the need to be remembered between runs. This also makes it
+ * different from {@link net.rptools.maptool.client.AppState} which is application state that is not
+ * preserved between runs.
+ */
+public class AppStatePersisted {
+  private static final Logger log = LogManager.getLogger(AppStatePersisted.class);
+  private static final Preferences prefs =
+      Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs");
+
+  /**
+   * Defines the key constant for retrieving asset roots.
+   *
+   * <p>This constant is used to define the key for accessing asset roots in a configuration file or
+   * a data source. Asset roots represent the directories or paths where application assets are
+   * stored.
+   *
+   * <p>The asset roots can be used to locate and load files, images, or other resources required by
+   * the application at runtime. By convention, the asset root directories are organized in a
+   * structured manner to facilitate easy retrieval of assets.
+   */
+  private static final String KEY_ASSET_ROOTS = "assetRoots";
+
+  /** Represents the key used to access the most recently used campaigns for the menu option. */
+  private static final String KEY_MRU_CAMPAIGNS = "mruCampaigns";
+
+  // When hill VBL was introduced, older versions of MapTool were unable to read the new topology
+  // modes. So we use a different preference key than in the past so older versions would not
+  // unexpectedly break.
+  private static final String KEY_TOPOLOGY_TYPES = "topologyTypes";
+  private static final String KEY_OLD_TOPOLOGY_DRAWING_MODE = "topologyDrawingMode";
+  private static final String DEFAULT_TOPOLOGY_TYPE = "VBL";
+
+  /** Represents the key used to save the paint textures to the preferences. */
+  private static final String KEY_SAVED_PAINT_TEXTURES = "savedTextures";
+
+  public static void clearAssetRoots() {
+    prefs.put(KEY_ASSET_ROOTS, "");
+  }
+
+  public static void addAssetRoot(File root) {
+    String list = prefs.get(KEY_ASSET_ROOTS, "");
+    if (!list.isEmpty()) {
+      // Add the new one and then remove all duplicates.
+      list += ";" + root.getPath();
+      String[] roots = list.split(";");
+      var result = new StringBuilder(list.length() + root.getPath().length() + 10);
+      var rootList = new HashSet<String>(roots.length);
+
+      // This loop ensures that each path only appears once. If there are currently
+      // duplicates in the list, only the first one is kept.
+      for (String r : roots) {
+        if (!rootList.contains(r)) {
+          result.append(';').append(r);
+          rootList.add(r);
+        }
+      }
+      list = result.substring(1);
+    } else {
+      list += root.getPath();
+    }
+    prefs.put(KEY_ASSET_ROOTS, list);
+  }
+
+  public static Set<File> getAssetRoots() {
+    String list = prefs.get(KEY_ASSET_ROOTS, "");
+    String[] roots = list.split(";"); // FJE Probably should be File.path_separator ...
+
+    var rootList = new HashSet<File>();
+    for (String root : roots) {
+      File file = new File(root);
+
+      // LATER: Should this actually remove it from the pref list ?
+      if (!file.exists()) {
+        continue;
+      }
+      rootList.add(file);
+    }
+    return rootList;
+  }
+
+  public static void removeAssetRoot(File root) {
+    String list = prefs.get(KEY_ASSET_ROOTS, "");
+    if (!list.isEmpty()) {
+      // Add the new one and then remove all duplicates.
+      String[] roots = list.split(";");
+      var result = new StringBuilder(list.length());
+      var rootList = new HashSet<String>(roots.length);
+      String rootPath = root.getPath();
+
+      // This loop ensures that each path only appears once. If there are
+      // duplicates in the list, only the first one is kept.
+      for (String r : roots) {
+        if (!r.equals(rootPath) && !rootList.contains(r)) {
+          result.append(';').append(r);
+          rootList.add(r);
+        }
+      }
+      list = result.substring(result.isEmpty() ? 0 : 1);
+      prefs.put(KEY_ASSET_ROOTS, list);
+    }
+  }
+
+  public static void setMruCampaigns(List<File> mruCampaigns) {
+    StringBuilder combined = new StringBuilder();
+    for (File file : mruCampaigns) {
+      String path;
+      try {
+        path = file.getCanonicalPath();
+      } catch (IOException e) {
+        // Probably pretty rare, but we want to know about it
+        log.info("unexpected during file.getCanonicalPath()", e); // $NON-NLS-1$
+        path = file.getPath();
+      }
+      // It's important that '%3A' is done last. Note that the pathSeparator may not be a colon on
+      // the current platform, but it doesn't matter since it will be reconverted when read back in
+      // again.
+      // THink of the '%3A' as a symbol of the separator, not an encoding of the character.
+      combined.append(path.replaceAll("%", "%25").replaceAll(File.pathSeparator, "%3A"));
+      combined.append(File.pathSeparator);
+    }
+    prefs.put(KEY_MRU_CAMPAIGNS, combined.toString());
+  }
+
+  public static List<File> getMruCampaigns() {
+    var mruCampaigns = new ArrayList<File>();
+    String combined = prefs.get(KEY_MRU_CAMPAIGNS, null);
+    if (combined != null) {
+      // It's important that '%3A' is done first
+      combined = combined.replaceAll("%3A", File.pathSeparator).replaceAll("%25", "%");
+      String[] all = combined.split(File.pathSeparator);
+      for (String s : all) {
+        mruCampaigns.add(new File(s));
+      }
+    }
+    return mruCampaigns;
+  }
+
+  public static Zone.TopologyTypeSet getTopologyTypes() {
+    try {
+      String typeNames = prefs.get(KEY_TOPOLOGY_TYPES, "");
+      if ("".equals(typeNames)) {
+        // Fallback to the key used prior to the introduction of various VBL types.
+        String oldDrawingMode = prefs.get(KEY_OLD_TOPOLOGY_DRAWING_MODE, DEFAULT_TOPOLOGY_TYPE);
+        return switch (oldDrawingMode) {
+          case "VBL" -> new Zone.TopologyTypeSet(Zone.TopologyType.WALL_VBL);
+          case "MBL" -> new Zone.TopologyTypeSet(Zone.TopologyType.MBL);
+          case "COMBINED" -> new Zone.TopologyTypeSet(
+              Zone.TopologyType.WALL_VBL, Zone.TopologyType.MBL);
+          default -> new Zone.TopologyTypeSet(Zone.TopologyType.WALL_VBL);
+        };
+      } else {
+        return Zone.TopologyTypeSet.valueOf(typeNames);
+      }
+    } catch (Exception exc) {
+      return new Zone.TopologyTypeSet(Zone.TopologyType.WALL_VBL);
+    }
+  }
+
+  /**
+   * Sets the selected topology modes.
+   *
+   * @param types the topology types. A value of null resets to default.
+   */
+  public static void setTopologyTypes(Zone.TopologyTypeSet types) {
+    if (types == null) {
+      prefs.remove(KEY_TOPOLOGY_TYPES);
+    } else {
+      prefs.put(KEY_TOPOLOGY_TYPES, types.toString());
+    }
+  }
+
+  public static void setSavedPaintTextures(List<File> savedTextures) {
+    StringBuilder combined = new StringBuilder();
+    for (File savedTexture : savedTextures) {
+      combined.append(savedTexture.getPath());
+      combined.append(File.pathSeparator);
+    }
+    prefs.put(KEY_SAVED_PAINT_TEXTURES, combined.toString());
+  }
+
+  public static List<File> getSavedPaintTextures() {
+    var savedTextures = new ArrayList<File>();
+    String combined = prefs.get(KEY_SAVED_PAINT_TEXTURES, null);
+    if (combined != null) {
+      String[] all = combined.split(File.pathSeparator);
+      for (String s : all) {
+        savedTextures.add(new File(s));
+      }
+    }
+    return savedTextures;
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -47,7 +47,9 @@ public class AppUpdate {
    */
   public static boolean gitHubReleases() {
     // AppPreferences.setSkipAutoUpdate(false); // For testing only
-    if (AppPreferences.getSkipAutoUpdate()) return false;
+    if (AppPreferences.skipAutoUpdate.get()) {
+      return false;
+    }
 
     // Default for Linux?
     String DOWNLOAD_EXTENSION = ".deb";
@@ -75,7 +77,7 @@ public class AppUpdate {
       return false;
     }
 
-    if (!AppPreferences.getSkipAutoUpdateRelease().equals(latestReleaseId)
+    if (!AppPreferences.skipAutoUpdateRelease.get().equals(latestReleaseId)
         && ModelVersionManager.isBefore(runningVersion, latestReleaseVersion)) {
       JsonArray releaseAssets = latestRelease.get("assets").getAsJsonArray();
 
@@ -240,9 +242,11 @@ public class AppUpdate {
             options[1]);
     boolean dontAsk = dontAskCheckbox.isSelected();
 
-    if (dontAsk) AppPreferences.setSkipAutoUpdate(true);
+    if (dontAsk) {
+      AppPreferences.skipAutoUpdate.set(true);
+    }
 
-    if (result == JOptionPane.CANCEL_OPTION) AppPreferences.setSkipAutoUpdateRelease(releaseId);
+    if (result == JOptionPane.CANCEL_OPTION) AppPreferences.skipAutoUpdateRelease.set(releaseId);
 
     return (result == JOptionPane.YES_OPTION);
   }

--- a/src/main/java/net/rptools/maptool/client/AutoSaveManager.java
+++ b/src/main/java/net/rptools/maptool/client/AutoSaveManager.java
@@ -65,7 +65,7 @@ public class AutoSaveManager {
   private boolean executeAndContinue() {
 
     int interval =
-        AppPreferences.getAutoSaveIncrement()
+        AppPreferences.autoSaveIncrement.get()
             * 1000
             * (DeveloperOptions.Toggle.AutoSaveMeasuredInSeconds.isEnabled() ? 1 : 60);
 

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -917,7 +917,7 @@ public class ClientMessageHandler implements MessageHandler {
           if (renderer == null) {
             return;
           }
-          if (AppPreferences.getFitGMView()) {
+          if (AppPreferences.fitGmView.get()) {
             renderer.enforceView(x, y, scale, gmWidth, gmHeight);
           } else {
             renderer.setScale(scale);

--- a/src/main/java/net/rptools/maptool/client/MRUCampaignManager.java
+++ b/src/main/java/net/rptools/maptool/client/MRUCampaignManager.java
@@ -105,11 +105,11 @@ public class MRUCampaignManager {
   }
 
   private void saveMruCampaignList() {
-    AppPreferences.setMruCampaigns(mruCampaigns);
+    AppStatePersisted.setMruCampaigns(mruCampaigns);
   }
 
   private void loadMruCampaignList() {
-    mruCampaigns = AppPreferences.getMruCampaigns();
+    mruCampaigns = AppStatePersisted.getMruCampaigns();
     addMRUsToMenu();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -145,7 +145,7 @@ public class MapTool {
   // Set it to 500 (from 100) for now to support larger asset window previews
   // TODO: Add preferences option as well as add auto-purge after x days preferences
   private static final Dimension THUMBNAIL_SIZE =
-      new Dimension(AppPreferences.getThumbnailSize(), AppPreferences.getThumbnailSize());
+      new Dimension(AppPreferences.thumbnailSize.get(), AppPreferences.thumbnailSize.get());
 
   private static ThumbnailManager thumbnailManager;
   private static String version = "DEVELOPMENT";
@@ -168,6 +168,7 @@ public class MapTool {
   private static TaskBarFlasher taskbarFlasher;
   private static MapToolLineParser parser = new MapToolLineParser();
   private static String lastWhisperer;
+  private static ChatAutoSave chatAutoSave;
 
   // Jamz: To support new command line parameters for multi-monitor support & enhanced PrintStream
   private static boolean debug = false;
@@ -394,7 +395,7 @@ public class MapTool {
    * @return true if the token should be deleted.
    */
   public static boolean confirmTokenDelete() {
-    if (!AppPreferences.getTokensWarnWhenDeleted()) {
+    if (!AppPreferences.tokensWarnWhenDeleted.get()) {
       return true;
     }
 
@@ -404,7 +405,7 @@ public class MapTool {
     // "Yes, don't show again" Button
     if (val == 2) {
       showInformation("msg.confirm.deleteToken.removed");
-      AppPreferences.setTokensWarnWhenDeleted(false);
+      AppPreferences.tokensWarnWhenDeleted.set(false);
     }
     // Any version of 'Yes' returns true, false otherwise
     return val == JOptionPane.YES_OPTION || val == 2;
@@ -418,7 +419,7 @@ public class MapTool {
    * @return <code>true</code> if the user clicks either Yes button, <code>falsee</code> otherwise.
    */
   public static boolean confirmDrawDelete() {
-    if (!AppPreferences.getDrawWarnWhenDeleted()) {
+    if (!AppPreferences.drawingsWarnWhenDeleted.get()) {
       return true;
     }
 
@@ -428,7 +429,7 @@ public class MapTool {
     // "Yes, don't show again" Button
     if (val == JOptionPane.CANCEL_OPTION) {
       showInformation("msg.confirm.deleteDraw.removed");
-      AppPreferences.setDrawWarnWhenDeleted(false);
+      AppPreferences.drawingsWarnWhenDeleted.set(false);
     }
     // Any version of 'Yes' returns true, otherwise false
     return val == JOptionPane.YES_OPTION || val == JOptionPane.CANCEL_OPTION;
@@ -530,8 +531,8 @@ public class MapTool {
    * @param eventId the eventId of the sound.
    */
   public static void playSound(String eventId) {
-    if (AppPreferences.getPlaySystemSounds()) {
-      if (AppPreferences.getPlaySystemSoundsOnlyWhenNotFocused() && isInFocus()) {
+    if (AppPreferences.playSystemSounds.get()) {
+      if (AppPreferences.playSystemSoundsOnlyWhenNotFocused.get() && isInFocus()) {
         return;
       }
       SoundManager.playSoundEvent(eventId);
@@ -686,9 +687,12 @@ public class MapTool {
     }
     AppActions.updateActions();
 
-    ToolTipManager.sharedInstance().setInitialDelay(AppPreferences.getToolTipInitialDelay());
-    ToolTipManager.sharedInstance().setDismissDelay(AppPreferences.getToolTipDismissDelay());
-    ChatAutoSave.changeTimeout(AppPreferences.getChatAutosaveTime());
+    ToolTipManager.sharedInstance().setInitialDelay(AppPreferences.toolTipInitialDelay.get());
+    ToolTipManager.sharedInstance().setDismissDelay(AppPreferences.toolTipDismissDelay.get());
+
+    chatAutoSave = new ChatAutoSave();
+    chatAutoSave.setTimeout(AppPreferences.chatAutoSaveTimeInMinutes.get());
+    AppPreferences.chatAutoSaveTimeInMinutes.onChange(chatAutoSave::setTimeout);
 
     // TODO: make this more formal when we switch to mina
     new ServerHeartBeatThread().start();
@@ -1276,7 +1280,7 @@ public class MapTool {
         }
       }
       // alternately load MRU campaign if preference set
-      else if (AppPreferences.getLoadMRUCampaignAtStart()) {
+      else if (AppPreferences.loadMruCampaignAtStart.get()) {
         try {
           campaignFile = AppStatePersisted.getMruCampaigns().getFirst();
           if (campaignFile.exists()) {
@@ -1354,7 +1358,7 @@ public class MapTool {
 
   public static boolean useToolTipsForUnformatedRolls() {
     if (isPersonalServer() || getServerPolicy() == null) {
-      return AppPreferences.getUseToolTipForInlineRoll();
+      return AppPreferences.useToolTipForInlineRoll.get();
     } else {
       return getServerPolicy().getUseToolTipsForDefaultRollFormat();
     }
@@ -1653,7 +1657,7 @@ public class MapTool {
     factory.registerProtocol("lib", new LibraryURLStreamHandler());
 
     // Syrinscape Protocols
-    if (AppPreferences.getSyrinscapeActive()) {
+    if (AppPreferences.syrinscapeActive.get()) {
       factory.registerProtocol("syrinscape-fantasy", new SyrinscapeURLStreamHandler());
       factory.registerProtocol("syrinscape-sci-fi", new SyrinscapeURLStreamHandler());
       factory.registerProtocol("syrinscape-boardgame", new SyrinscapeURLStreamHandler());

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -674,7 +674,7 @@ public class MapTool {
       Campaign cmpgn = CampaignFactory.createBasicCampaign();
       // Set the Topology drawing mode to the last mode used for convenience
       // Should only be one zone, but let's cover our bases.
-      cmpgn.getZones().forEach(zone -> zone.setTopologyTypes(AppPreferences.getTopologyTypes()));
+      cmpgn.getZones().forEach(zone -> zone.setTopologyTypes(AppStatePersisted.getTopologyTypes()));
 
       // Stop the pre-init client/server.
       disconnect();
@@ -1278,7 +1278,7 @@ public class MapTool {
       // alternately load MRU campaign if preference set
       else if (AppPreferences.getLoadMRUCampaignAtStart()) {
         try {
-          campaignFile = AppPreferences.getMruCampaigns().getFirst();
+          campaignFile = AppStatePersisted.getMruCampaigns().getFirst();
           if (campaignFile.exists()) {
             AppActions.loadCampaign(campaignFile);
           }

--- a/src/main/java/net/rptools/maptool/client/MapToolUtil.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolUtil.java
@@ -137,7 +137,7 @@ public class MapToolUtil {
     String newName;
     Integer newNum = null;
 
-    if (isToken && AppPreferences.getNewTokenNaming().equals(Token.NAME_USE_CREATURE)) {
+    if (isToken && AppPreferences.newTokenNaming.get().equals(Token.NAME_USE_CREATURE)) {
       newName = I18N.getString("Token.name.creature");
     } else if (!force) {
       return baseName;
@@ -162,9 +162,12 @@ public class MapToolUtil {
         newName = baseName;
       }
     }
-    boolean random = (isToken && AppPreferences.getDuplicateTokenNumber().equals(Token.NUM_RANDOM));
-    boolean addNumToGM = !AppPreferences.getTokenNumberDisplay().equals(Token.NUM_ON_NAME);
-    boolean addNumToName = !AppPreferences.getTokenNumberDisplay().equals(Token.NUM_ON_GM);
+    boolean random =
+        (isToken && AppPreferences.duplicateTokenNumber.get().equals(Token.NUM_RANDOM));
+
+    var tokenNumberDisplay = AppPreferences.tokenNumberDisplay.get();
+    boolean addNumToGM = !tokenNumberDisplay.equals(Token.NUM_ON_NAME);
+    boolean addNumToName = !tokenNumberDisplay.equals(Token.NUM_ON_GM);
 
     /*
      * If the token already has a number suffix, if the preferences indicate that token numbering should be random and this token is on the Token layer, or if the token already exists somewhere on

--- a/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ExportDataFunctions.java
@@ -57,7 +57,7 @@ public class ExportDataFunctions extends AbstractFunction {
     if (!MapTool.getParser().isMacroTrusted())
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
 
-    if (!AppPreferences.getAllowExternalMacroAccess())
+    if (!AppPreferences.allowExternalMacroAccess.get())
       throw new ParserException(I18N.getText("macro.function.general.accessDenied", functionName));
 
     // New function to save data to an external file.

--- a/src/main/java/net/rptools/maptool/client/functions/IsTrustedFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/IsTrustedFunction.java
@@ -44,7 +44,7 @@ public class IsTrustedFunction extends AbstractFunction {
     if (functionName.equalsIgnoreCase("isTrusted")) {
       return MapTool.getParser().isMacroTrusted() ? BigDecimal.ONE : BigDecimal.ZERO;
     } else if (functionName.equalsIgnoreCase("isExternalMacroAccessAllowed")) {
-      return AppPreferences.getAllowExternalMacroAccess() ? BigDecimal.ONE : BigDecimal.ZERO;
+      return AppPreferences.allowExternalMacroAccess.get() ? BigDecimal.ONE : BigDecimal.ZERO;
     } else if ("isGM".equalsIgnoreCase(functionName)) {
       if (parameters.isEmpty())
         return MapTool.getPlayer().isGM() ? BigDecimal.ONE : BigDecimal.ZERO;

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -229,25 +229,25 @@ public class MapFunctions extends AbstractFunction {
         final var gridType =
             gridConfig.has("type")
                 ? gridConfig.getAsJsonPrimitive("type").getAsString()
-                : AppPreferences.getDefaultGridType();
+                : AppPreferences.defaultGridType.get();
         final var grid = GridFactory.createGrid(gridType);
 
         final var gridColor =
             gridConfig.has("color")
                 ? MapToolUtil.getColor(gridConfig.getAsJsonPrimitive("color").getAsString())
-                : AppPreferences.getDefaultGridColor();
+                : AppPreferences.defaultGridColor.get();
         newMap.setGridColor(gridColor.getRGB());
 
         final var gridUnitsPerCell =
             gridConfig.has("units per cell")
                 ? gridConfig.getAsJsonPrimitive("units per cell").getAsDouble()
-                : AppPreferences.getDefaultUnitsPerCell();
+                : AppPreferences.defaultUnitsPerCell.get();
         newMap.setUnitsPerCell(gridUnitsPerCell);
 
         final var gridSize =
             gridConfig.has("size")
                 ? gridConfig.getAsJsonPrimitive("size").getAsInt()
-                : AppPreferences.getDefaultGridSize();
+                : AppPreferences.defaultGridSize.get();
         grid.setSize(gridSize);
 
         final var gridOffsetX =

--- a/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/RESTfulFunctions.java
@@ -79,7 +79,7 @@ public class RESTfulFunctions extends AbstractFunction {
       throw new ParserException(I18N.getText("macro.function.general.noPerm", functionName));
     }
 
-    if (!AppPreferences.getAllowExternalMacroAccess()) {
+    if (!AppPreferences.allowExternalMacroAccess.get()) {
       throw new ParserException(I18N.getText("macro.function.general.accessDenied", functionName));
     }
 
@@ -282,7 +282,7 @@ public class RESTfulFunctions extends AbstractFunction {
    * @throws ParserException
    */
   private BigDecimal launchSyrinscape(String baseURL) throws ParserException {
-    if (!AppPreferences.getSyrinscapeActive()) {
+    if (!AppPreferences.syrinscapeActive.get()) {
       return BigDecimal.ZERO;
     }
 

--- a/src/main/java/net/rptools/maptool/client/functions/SoundFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/SoundFunctions.java
@@ -68,7 +68,7 @@ public class SoundFunctions extends AbstractFunction {
     int psize = args.size();
     if (functionName.equalsIgnoreCase("playStream")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 5);
-      if (!AppPreferences.getPlayStreams()) return -1; // do nothing if disabled in preferences
+      if (!AppPreferences.playStreams.get()) return -1; // do nothing if disabled in preferences
       String strUri = convertToURI(args.get(0), true);
 
       Integer cycleCount = getCycleCount(functionName, args, 1);
@@ -81,7 +81,7 @@ public class SoundFunctions extends AbstractFunction {
           : BigDecimal.ZERO;
     } else if (functionName.equalsIgnoreCase("playClip")) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 3);
-      if (!AppPreferences.getPlayStreams()) return -1; // do nothing if disabled in preferences
+      if (!AppPreferences.playStreams.get()) return -1; // do nothing if disabled in preferences
       String strUri = convertToURI(args.get(0), true);
 
       Integer cycleCount = getCycleCount(functionName, args, 1);

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -307,7 +307,7 @@ public class TokenLocationFunctions extends AbstractFunction {
         if (wmetric == null && grid.useMetric())
           wmetric =
               MapTool.isPersonalServer()
-                  ? AppPreferences.getMovementMetric()
+                  ? AppPreferences.movementMetric.get()
                   : MapTool.getServerPolicy().getMovementMetric();
         // explicitly find difference without walkers
         double curDist;

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -479,7 +479,7 @@ public class TokenMoveFunctions extends AbstractFunction {
 
     WalkerMetric metric =
         MapTool.isPersonalServer()
-            ? AppPreferences.getMovementMetric()
+            ? AppPreferences.movementMetric.get()
             : MapTool.getServerPolicy().getMovementMetric();
 
     ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -217,17 +217,19 @@ public class getInfoFunction extends AbstractFunction {
   private JsonObject getClientInfo() {
     JsonObject cinfo = new JsonObject();
 
-    cinfo.addProperty("face edge", FunctionUtil.getDecimalForBoolean(AppPreferences.getFaceEdge()));
     cinfo.addProperty(
-        "face vertex", FunctionUtil.getDecimalForBoolean(AppPreferences.getFaceVertex()));
-    cinfo.addProperty("portrait size", AppPreferences.getPortraitSize());
-    cinfo.addProperty("show portrait", AppPreferences.getShowPortrait());
-    cinfo.addProperty("show stat sheet", AppPreferences.getShowStatSheet());
-    cinfo.addProperty("file sync directory", AppPreferences.getFileSyncPath());
-    cinfo.addProperty("show avatar in chat", AppPreferences.getShowAvatarInChat());
+        "face edge", FunctionUtil.getDecimalForBoolean(AppPreferences.faceEdge.get()));
     cinfo.addProperty(
-        "suppress tooltips for macroLinks", AppPreferences.getSuppressToolTipsForMacroLinks());
-    cinfo.addProperty("use tooltips for inline rolls", AppPreferences.getUseToolTipForInlineRoll());
+        "face vertex", FunctionUtil.getDecimalForBoolean(AppPreferences.faceVertex.get()));
+    cinfo.addProperty("portrait size", AppPreferences.portraitSize.get());
+    cinfo.addProperty("show portrait", AppPreferences.showPortrait.get());
+    cinfo.addProperty("show stat sheet", AppPreferences.showStatSheet.get());
+    cinfo.addProperty("file sync directory", AppPreferences.fileSyncPath.get());
+    cinfo.addProperty("show avatar in chat", AppPreferences.showAvatarInChat.get());
+    cinfo.addProperty(
+        "suppress tooltips for macroLinks", AppPreferences.suppressToolTipsForMacroLinks.get());
+    cinfo.addProperty(
+        "use tooltips for inline rolls", AppPreferences.useToolTipForInlineRoll.get());
     cinfo.addProperty("version", MapTool.getVersion());
     cinfo.addProperty(
         "isFullScreen", FunctionUtil.getDecimalForBoolean(MapTool.getFrame().isFullScreen()));

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIClientInfo.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIClientInfo.java
@@ -31,22 +31,22 @@ public class JSAPIClientInfo implements MapToolJSAPIInterface {
 
   @HostAccess.Export
   public boolean faceEdge() {
-    return AppPreferences.getFaceEdge();
+    return AppPreferences.faceEdge.get();
   }
 
   @HostAccess.Export
   public boolean faceVertex() {
-    return AppPreferences.getFaceVertex();
+    return AppPreferences.faceVertex.get();
   }
 
   @HostAccess.Export
   public int portraitSize() {
-    return AppPreferences.getPortraitSize();
+    return AppPreferences.portraitSize.get();
   }
 
   @HostAccess.Export
   public boolean showStatSheet() {
-    return AppPreferences.getShowStatSheet();
+    return AppPreferences.showStatSheet.get();
   }
 
   @HostAccess.Export

--- a/src/main/java/net/rptools/maptool/client/swing/ImagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/ImagePanel.java
@@ -260,9 +260,9 @@ public class ImagePanel extends JComponent
                 Dimension dim = constrainSize(image, gridSize);
                 var savedRenderingHints = g.getRenderingHints();
                 if (dim.width < image.getWidth(null) || dim.height < image.getHeight(null)) {
-                  AppPreferences.getRenderQuality().setShrinkRenderingHints(g);
+                  AppPreferences.renderQuality.get().setShrinkRenderingHints(g);
                 } else if (dim.width > image.getWidth(null) || dim.height > image.getHeight(null)) {
-                  AppPreferences.getRenderQuality().setRenderingHints(g);
+                  AppPreferences.renderQuality.get().setRenderingHints(g);
                 }
                 g.drawImage(
                     image,

--- a/src/main/java/net/rptools/maptool/client/swing/TooltipView.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TooltipView.java
@@ -53,7 +53,7 @@ public class TooltipView extends InlineView {
 
       if (href.startsWith("macro:")) {
         boolean isInsideChat = mlToolTips;
-        boolean allowToolTipToShow = !AppPreferences.getSuppressToolTipsForMacroLinks();
+        boolean allowToolTipToShow = !AppPreferences.suppressToolTipsForMacroLinks.get();
         if (isInsideChat && allowToolTipToShow) {
           return MacroLinkFunction.getInstance().macroLinkToolTip(href);
         }

--- a/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
@@ -21,7 +21,7 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
@@ -49,7 +49,7 @@ public class TopologyModeSelectionPanel extends JToolBar {
 
     modeButtons = new EnumMap<>(Zone.TopologyType.class);
 
-    var initiallySelectedTypes = AppPreferences.getTopologyTypes();
+    var initiallySelectedTypes = AppStatePersisted.getTopologyTypes();
     createAndAddModeButton(
         Zone.TopologyType.WALL_VBL,
         Icons.TOOLBAR_TOPOLOGY_TYPE_VBL_ON,
@@ -120,9 +120,9 @@ public class TopologyModeSelectionPanel extends JToolBar {
   }
 
   public void setMode(Zone.TopologyTypeSet topologyTypes) {
-    AppPreferences.setTopologyTypes(topologyTypes);
+    AppStatePersisted.setTopologyTypes(topologyTypes);
     if (topologyTypes == null) {
-      topologyTypes = AppPreferences.getTopologyTypes();
+      topologyTypes = AppStatePersisted.getTopologyTypes();
     }
 
     for (final var entry : modeButtons.entrySet()) {

--- a/src/main/java/net/rptools/maptool/client/swing/label/FlatImageLabelFactory.java
+++ b/src/main/java/net/rptools/maptool/client/swing/label/FlatImageLabelFactory.java
@@ -39,20 +39,20 @@ public class FlatImageLabelFactory {
 
   /** Creates a new instance of the FlatImageLabelFactory class. */
   public FlatImageLabelFactory() {
-    var npcBackground = AppPreferences.getNPCMapLabelBG();
-    var npcForeground = AppPreferences.getNPCMapLabelFG();
-    var npcBorder = AppPreferences.getNPCMapLabelBorder();
-    var pcBackground = AppPreferences.getPCMapLabelBG();
-    var pcForeground = AppPreferences.getPCMapLabelFG();
-    var pcBorder = AppPreferences.getPCMapLabelBorder();
-    var nonVisBackground = AppPreferences.getNonVisMapLabelBG();
-    var nonVisForeground = AppPreferences.getNonVisMapLabelFG();
-    var nonVisBorder = AppPreferences.getNonVisMapLabelBorder();
-    int fontSize = AppPreferences.getMapLabelFontSize();
+    var npcBackground = AppPreferences.npcMapLabelBackground.get();
+    var npcForeground = AppPreferences.npcMapLabelForeground.get();
+    var npcBorder = AppPreferences.npcMapLabelBorder.get();
+    var pcBackground = AppPreferences.pcMapLabelBackground.get();
+    var pcForeground = AppPreferences.pcMapLabelForeground.get();
+    var pcBorder = AppPreferences.pcMapLabelBorder.get();
+    var nonVisBackground = AppPreferences.nonVisibleTokenMapLabelBackground.get();
+    var nonVisForeground = AppPreferences.nonVisibleTokenMapLabelForeground.get();
+    var nonVisBorder = AppPreferences.nonVisibleTokenMapLabelBorder.get();
+    int fontSize = AppPreferences.mapLabelFontSize.get();
     var font = AppStyle.labelFont.deriveFont(AppStyle.labelFont.getStyle(), fontSize);
-    boolean showBorder = AppPreferences.getShowMapLabelBorder();
-    int borderWidth = showBorder ? AppPreferences.getMapLabelBorderWidth() : 0;
-    int borderArc = AppPreferences.getMapLabelBorderArc();
+    boolean showBorder = AppPreferences.mapLabelShowBorder.get();
+    int borderWidth = showBorder ? AppPreferences.mapLabelBorderWidth.get() : 0;
+    int borderArc = AppPreferences.mapLabelBorderArc.get();
 
     npcImageLabel =
         new FlatImageLabel(

--- a/src/main/java/net/rptools/maptool/client/tool/AI_Tool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/AI_Tool.java
@@ -24,12 +24,12 @@ public class AI_Tool extends DefaultTool {
   public AI_Tool() {
     // Server policy is not available yet but that's ok, we have it saved as a preference which
     // is OK at this stage of initialization.
-    setSelected(AppPreferences.isUsingAstarPathfinding());
+    setSelected(AppPreferences.pathfindingEnabled.get());
   }
 
   @Override
   public void actionPerformed(ActionEvent e) {
-    AppPreferences.setUseAstarPathfinding(isSelected());
+    AppPreferences.pathfindingEnabled.set(isSelected());
 
     var client = MapTool.getClient();
     var policy = client.getServerPolicy();

--- a/src/main/java/net/rptools/maptool/client/tool/AI_UseVblTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/AI_UseVblTool.java
@@ -24,12 +24,12 @@ public class AI_UseVblTool extends DefaultTool {
   public AI_UseVblTool() {
     // Server policy is not available yet but that's ok, we have it saved as a preference which
     // is OK at this stage of initialization.
-    setSelected(AppPreferences.getVblBlocksMove());
+    setSelected(AppPreferences.pathfindingBlockedByVbl.get());
   }
 
   @Override
   public void actionPerformed(ActionEvent e) {
-    AppPreferences.setVblBlocksMove(isSelected());
+    AppPreferences.pathfindingBlockedByVbl.set(isSelected());
 
     var client = MapTool.getClient();
     var policy = client.getServerPolicy();
@@ -57,7 +57,7 @@ public class AI_UseVblTool extends DefaultTool {
 
   @Override
   public boolean isAvailable() {
-    return MapTool.getPlayer().isGM() && AppPreferences.isUsingAstarPathfinding();
+    return MapTool.getPlayer().isGM() && AppPreferences.pathfindingEnabled.get();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -332,8 +332,8 @@ public abstract class DefaultTool extends Tool
                   .getGrid()
                   .nextFacing(
                       facing,
-                      AppPreferences.getFaceEdge(),
-                      AppPreferences.getFaceVertex(),
+                      AppPreferences.faceEdge.get(),
+                      AppPreferences.faceVertex.get(),
                       e.getWheelRotation() <= 0);
         }
 

--- a/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
@@ -104,7 +104,8 @@ public class FacingTool extends DefaultTool {
           renderer
               .getZone()
               .getGrid()
-              .nearestFacing(degrees, AppPreferences.getFaceEdge(), AppPreferences.getFaceVertex());
+              .nearestFacing(
+                  degrees, AppPreferences.faceEdge.get(), AppPreferences.faceVertex.get());
     }
     Area visibleArea = null;
     Set<GUID> remoteSelected = new HashSet<GUID>();
@@ -116,7 +117,7 @@ public class FacingTool extends DefaultTool {
     boolean noOwnerReveal; // if true, reveal FoW if token has no owners.
     if (MapTool.isPersonalServer()) {
       ownerReveal =
-          hasOwnerReveal = noOwnerReveal = AppPreferences.getAutoRevealVisionOnGMMovement();
+          hasOwnerReveal = noOwnerReveal = AppPreferences.autoRevealVisionOnGMMovement.get();
     } else {
       ownerReveal = MapTool.getServerPolicy().isAutoRevealOnMovement();
       hasOwnerReveal = isGM && MapTool.getServerPolicy().isAutoRevealOnMovement();

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -771,7 +771,7 @@ public class PointerTool extends DefaultTool {
             selectedTokenSet,
             new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer),
             false);
-        if (AppPreferences.getHideMousePointerWhileDragging()) {
+        if (AppPreferences.hideMousePointerWhileDragging.get()) {
           SwingUtil.hidePointer(renderer);
         }
       }
@@ -1102,8 +1102,8 @@ public class PointerTool extends DefaultTool {
                 .getGrid()
                 .nextFacing(
                     facing,
-                    AppPreferences.getFaceEdge(),
-                    AppPreferences.getFaceVertex(),
+                    AppPreferences.faceEdge.get(),
+                    AppPreferences.faceVertex.get(),
                     direction < 0);
       }
       MapTool.serverCommand().updateTokenProperty(token, Token.Update.setFacing, facing);
@@ -1371,7 +1371,7 @@ public class PointerTool extends DefaultTool {
       Stroke stroke = g.getStroke();
       g.setStroke(new BasicStroke(2));
 
-      if (AppPreferences.getFillSelectionBox()) {
+      if (AppPreferences.fillSelectionBox.get()) {
         g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, .25f));
         g.setPaint(AppStyle.selectionBoxFill);
         g.fillRoundRect(
@@ -1403,8 +1403,9 @@ public class PointerTool extends DefaultTool {
         && tokenDragOp == null
         && AppUtil.tokenIsVisible(
             renderer.getZone(), tokenUnderMouse, new PlayerView(MapTool.getPlayer().getRole()))) {
-      if (AppPreferences.getPortraitSize() > 0
-          && (SwingUtil.isShiftDown(keysDown) == AppPreferences.getShowStatSheetModifier())
+      if (AppPreferences.portraitSize.get() > 0
+          && (SwingUtil.isShiftDown(keysDown)
+              == AppPreferences.showStatSheetRequiresModifierKey.get())
           && new StatSheetManager().isLegacyStatSheet(tokenUnderMouse.getStatSheet())
           && (tokenOnStatSheet == null
               || !tokenOnStatSheet.equals(tokenUnderMouse)
@@ -1413,7 +1414,7 @@ public class PointerTool extends DefaultTool {
 
         BufferedImage image = null;
         Dimension imgSize = new Dimension(0, 0);
-        if (AppPreferences.getShowPortrait()) {
+        if (AppPreferences.showPortrait.get()) {
           // Portrait
           MD5Key portraitId =
               tokenUnderMouse.getPortraitImage() != null
@@ -1434,7 +1435,7 @@ public class PointerTool extends DefaultTool {
           imgSize = new Dimension(image.getWidth(), image.getHeight());
 
           // Size
-          SwingUtil.constrainTo(imgSize, AppPreferences.getPortraitSize());
+          SwingUtil.constrainTo(imgSize, AppPreferences.portraitSize.get());
         }
 
         Dimension statSize = null;
@@ -1454,7 +1455,7 @@ public class PointerTool extends DefaultTool {
         Map<String, String> propertyMap = new LinkedHashMap<String, String>();
         Map<String, Integer> propertyLineCount = new LinkedHashMap<String, Integer>();
         LinkedList<TextLayout> lineLayouts = new LinkedList<TextLayout>();
-        if (AppPreferences.getShowStatSheet()
+        if (AppPreferences.showStatSheet.get()
             && new StatSheetManager().isLegacyStatSheet(tokenUnderMouse.getStatSheet())) {
           CodeTimer.using(
               "statSheet",
@@ -1640,7 +1641,7 @@ public class PointerTool extends DefaultTool {
           }
 
           // Draw the portrait
-          if (AppPreferences.getShowPortrait()) {
+          if (AppPreferences.showPortrait.get()) {
             Rectangle bounds =
                 new Rectangle(lm, height - imgSize.height - bm, imgSize.width, imgSize.height);
 
@@ -1649,7 +1650,7 @@ public class PointerTool extends DefaultTool {
                     panelTexture,
                     new Rectangle(0, 0, panelTexture.getWidth(), panelTexture.getHeight())));
             statsG.fill(bounds);
-            AppPreferences.getRenderQuality().setShrinkRenderingHints(g);
+            AppPreferences.renderQuality.get().setShrinkRenderingHints(g);
             statsG.drawImage(image, bounds.x, bounds.y, imgSize.width, imgSize.height, this);
             AppStyle.miniMapBorder.paintAround(statsG, bounds);
             AppStyle.shadowBorder.paintWithin(statsG, bounds);
@@ -1657,7 +1658,7 @@ public class PointerTool extends DefaultTool {
             // Label
             GraphicsUtil.drawBoxedString(
                 statsG, tokenUnderMouse.getName(), bounds.width / 2 + lm, height - 15);
-          } else if (AppPreferences.getShowStatSheet() && statSize != null) {
+          } else if (AppPreferences.showStatSheet.get() && statSize != null) {
             // Label
             Rectangle bounds =
                 new Rectangle(
@@ -1865,7 +1866,7 @@ public class PointerTool extends DefaultTool {
       var grid = renderer.getZone().getGrid();
       if (tokenBeingDragged.isSnapToGrid()
           && grid.getCapabilities().isSnapToGridSupported()
-          && AppPreferences.getTokensSnapWhileDragging()) {
+          && AppPreferences.tokensSnapWhileDragging.get()) {
         // Snap to grid point.
         zonePoint = grid.convert(grid.convert(zonePoint));
 
@@ -1967,7 +1968,7 @@ public class PointerTool extends DefaultTool {
 
       if (MapTool.isPersonalServer()) {
         ownerReveal =
-            hasOwnerReveal = noOwnerReveal = AppPreferences.getAutoRevealVisionOnGMMovement();
+            hasOwnerReveal = noOwnerReveal = AppPreferences.autoRevealVisionOnGMMovement.get();
       } else {
         ownerReveal = MapTool.getServerPolicy().isAutoRevealOnMovement();
         hasOwnerReveal = isGM && MapTool.getServerPolicy().isAutoRevealOnMovement();

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -970,7 +970,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         Stroke stroke = g.getStroke();
         g.setStroke(new BasicStroke(2));
 
-        if (AppPreferences.getFillSelectionBox()) {
+        if (AppPreferences.fillSelectionBox.get()) {
           Composite composite = g.getComposite();
           g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, .25f));
           g.setPaint(AppStyle.selectionBoxFill);

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -664,7 +664,7 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
         }
       }
       if (saveDirectory != null) {
-        AppPreferences.setTokenSaveDir(saveDirectory);
+        AppPreferences.tokenSaveDirectory.set(saveDirectory);
       }
     }
   }

--- a/src/main/java/net/rptools/maptool/client/ui/AssetViewerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AssetViewerDialog.java
@@ -167,7 +167,7 @@ public class AssetViewerDialog extends JDialog {
       SwingUtil.constrainTo(imgSize, size.width, size.height);
 
       Object oldHint = g2d.getRenderingHint(RenderingHints.KEY_RENDERING);
-      AppPreferences.getRenderQuality().setShrinkRenderingHints(g2d);
+      AppPreferences.renderQuality.get().setShrinkRenderingHints(g2d);
       g.drawImage(image, 0, 0, imgSize.width, imgSize.height, this);
       g2d.setRenderingHint(RenderingHints.KEY_RENDERING, oldHint);
 

--- a/src/main/java/net/rptools/maptool/client/ui/ChatTypingNotification.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ChatTypingNotification.java
@@ -44,14 +44,14 @@ public class ChatTypingNotification extends JPanel {
   @Override
   protected void paintComponent(Graphics g) {
     // System.out.println("Chat panel is painting itself...");
-    if (AppPreferences.getTypingNotificationDuration() == 0) {
+    if (AppPreferences.typingNotificationDurationInSeconds.get() == 0) {
       return;
     }
     LinkedMap chatTypers = MapTool.getFrame().getChatNotificationTimers().getChatTypers();
     if (chatTypers == null || chatTypers.isEmpty()) {
       return;
     }
-    boolean showBackground = AppPreferences.getChatNotificationShowBackground();
+    boolean showBackground = AppPreferences.chatNotificationBackground.get();
 
     Graphics2D statsG = (Graphics2D) g.create();
 

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -307,7 +307,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     private final LinkedMap<String, Long> chatTypingNotificationTimers;
 
     public synchronized void setChatTyper(final String playerName) {
-      if (AppPreferences.getTypingNotificationDuration() == 0) {
+      if (AppPreferences.typingNotificationDurationInSeconds.get() == 0) {
         turnOffUpdates();
         chatTypingNotificationTimers.clear();
       } else {
@@ -356,8 +356,9 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     setFocusTraversalPolicy(new MapToolFocusTraversalPolicy());
 
     setIconImage(RessourceManager.getImage(Images.MAPTOOL_LOGO_MINI));
-    // Notify duration
-    initializeNotifyDuration();
+    chatNotifyDuration = AppPreferences.typingNotificationDurationInSeconds.get();
+    AppPreferences.typingNotificationDurationInSeconds.onChange(
+        value -> chatNotifyDuration = value);
 
     // Components
     glassPane = new GlassPane();
@@ -462,7 +463,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     new WindowPreferences(AppConstants.APP_NAME, "mainFrame", this);
     chatTyperTimers = new ChatNotificationTimers();
     chatTimer = getChatTimer();
-    setChatTypingLabelColor(AppPreferences.getChatNotificationColor());
+    setChatTypingLabelColor(AppPreferences.chatNotificationColor.get());
   }
 
   public ChatNotificationTimers getChatNotificationTimers() {
@@ -852,7 +853,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getLoadPropsFileChooser() {
     if (loadPropsFileChooser == null) {
       loadPropsFileChooser = new JFileChooser();
-      loadPropsFileChooser.setCurrentDirectory(AppPreferences.getLoadDir());
+      loadPropsFileChooser.setCurrentDirectory(AppPreferences.loadDirectory.get());
       loadPropsFileChooser.addChoosableFileFilter(propertiesFilter);
       loadPropsFileChooser.setDialogTitle(I18N.getText("msg.title.importProperties"));
     }
@@ -863,7 +864,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getLoadFileChooser() {
     if (loadFileChooser == null) {
       loadFileChooser = new JFileChooser();
-      loadFileChooser.setCurrentDirectory(AppPreferences.getLoadDir());
+      loadFileChooser.setCurrentDirectory(AppPreferences.loadDirectory.get());
     }
     return loadFileChooser;
   }
@@ -871,7 +872,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveCmpgnFileChooser() {
     if (saveCmpgnFileChooser == null) {
       saveCmpgnFileChooser = new JFileChooser();
-      saveCmpgnFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
+      saveCmpgnFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
       saveCmpgnFileChooser.addChoosableFileFilter(campaignFilter);
       saveCmpgnFileChooser.setDialogTitle(I18N.getText("msg.title.saveCampaign"));
     }
@@ -882,7 +883,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSavePropsFileChooser() {
     if (savePropsFileChooser == null) {
       savePropsFileChooser = new JFileChooser();
-      savePropsFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
+      savePropsFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
       savePropsFileChooser.addChoosableFileFilter(propertiesFilter);
       savePropsFileChooser.setDialogTitle(I18N.getText("msg.title.exportProperties"));
     }
@@ -893,7 +894,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveTokenFileChooser() {
     if (saveTokenFileChooser == null) {
       saveTokenFileChooser = new JFileChooser();
-      saveTokenFileChooser.setCurrentDirectory(AppPreferences.getSaveTokenDir());
+      saveTokenFileChooser.setCurrentDirectory(AppPreferences.tokenSaveDirectory.get());
     }
     return saveTokenFileChooser;
   }
@@ -901,7 +902,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveMapFileChooser() {
     if (saveMapFileChooser == null) {
       saveMapFileChooser = new JFileChooser();
-      saveMapFileChooser.setCurrentDirectory(AppPreferences.getSaveMapDir());
+      saveMapFileChooser.setCurrentDirectory(AppPreferences.mapSaveDirectory.get());
     }
     return saveMapFileChooser;
   }
@@ -909,7 +910,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveFileChooser() {
     if (saveFileChooser == null) {
       saveFileChooser = new JFileChooser();
-      saveFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
+      saveFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
     }
     return saveFileChooser;
   }
@@ -1078,14 +1079,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     if (color != null) {
       chatTypingLabelColor = color;
     }
-  }
-
-  public void setChatNotifyDuration(int duration) {
-    chatNotifyDuration = duration;
-  }
-
-  private void initializeNotifyDuration() {
-    chatNotifyDuration = AppPreferences.getTypingNotificationDuration();
   }
 
   public JLabel getChatActionLabel() {
@@ -1930,7 +1923,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   }
 
   public void closingMaintenance() {
-    if (AppPreferences.getSaveReminder() && MapTool.isCampaignDirty()) {
+    if (AppPreferences.saveReminder.get() && MapTool.isCampaignDirty()) {
       if (MapTool.getPlayer().isGM()) {
         int result =
             MapTool.confirmImpl(
@@ -2134,7 +2127,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveMacroFileChooser() {
     if (saveMacroFileChooser == null) {
       saveMacroFileChooser = new JFileChooser();
-      saveMacroFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
+      saveMacroFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
       saveMacroFileChooser.addChoosableFileFilter(macroFilter);
       saveMacroFileChooser.setDialogTitle(I18N.getText("msg.title.exportMacro"));
     }
@@ -2145,7 +2138,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveMacroSetFileChooser() {
     if (saveMacroSetFileChooser == null) {
       saveMacroSetFileChooser = new JFileChooser();
-      saveMacroSetFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
+      saveMacroSetFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
       saveMacroSetFileChooser.addChoosableFileFilter(macroSetFilter);
       saveMacroSetFileChooser.setDialogTitle(I18N.getText("msg.title.exportMacroSet"));
     }
@@ -2159,7 +2152,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getLoadMacroFileChooser() {
     if (loadMacroFileChooser == null) {
       loadMacroFileChooser = new JFileChooser();
-      loadMacroFileChooser.setCurrentDirectory(AppPreferences.getLoadDir());
+      loadMacroFileChooser.setCurrentDirectory(AppPreferences.loadDirectory.get());
       loadMacroFileChooser.addChoosableFileFilter(macroFilter);
       loadMacroFileChooser.setDialogTitle(I18N.getText("msg.title.importMacro"));
     }
@@ -2170,7 +2163,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getLoadMacroSetFileChooser() {
     if (loadMacroSetFileChooser == null) {
       loadMacroSetFileChooser = new JFileChooser();
-      loadMacroSetFileChooser.setCurrentDirectory(AppPreferences.getLoadDir());
+      loadMacroSetFileChooser.setCurrentDirectory(AppPreferences.loadDirectory.get());
       loadMacroSetFileChooser.addChoosableFileFilter(macroSetFilter);
       loadMacroSetFileChooser.setDialogTitle(I18N.getText("msg.title.importMacroSet"));
     }
@@ -2186,7 +2179,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getSaveTableFileChooser() {
     if (saveTableFileChooser == null) {
       saveTableFileChooser = new JFileChooser();
-      saveTableFileChooser.setCurrentDirectory(AppPreferences.getSaveDir());
+      saveTableFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
       saveTableFileChooser.addChoosableFileFilter(tableFilter);
       saveTableFileChooser.setDialogTitle(I18N.getText("Label.table.export"));
     }
@@ -2200,7 +2193,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   public JFileChooser getLoadTableFileChooser() {
     if (loadTableFileChooser == null) {
       loadTableFileChooser = new JFileChooser();
-      loadTableFileChooser.setCurrentDirectory(AppPreferences.getLoadDir());
+      loadTableFileChooser.setCurrentDirectory(AppPreferences.loadDirectory.get());
       loadTableFileChooser.addChoosableFileFilter(tableFilter);
       loadTableFileChooser.setDialogTitle(I18N.getText("Label.table.import"));
     }

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1131,7 +1131,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   }
 
   private void restorePreferences() {
-    Set<File> assetRootList = AppPreferences.getAssetRoots();
+    Set<File> assetRootList = AppStatePersisted.getAssetRoots();
     for (File file : assetRootList) {
       addAssetRoot(file);
     }

--- a/src/main/java/net/rptools/maptool/client/ui/PreviewPanelFileChooser.java
+++ b/src/main/java/net/rptools/maptool/client/ui/PreviewPanelFileChooser.java
@@ -41,7 +41,7 @@ public class PreviewPanelFileChooser extends JFileChooser {
       new ThumbnailManager(AppUtil.getAppHome("previewPanelThumbs"), new Dimension(150, 150));
 
   public PreviewPanelFileChooser() {
-    this.setCurrentDirectory(AppPreferences.getLoadDir());
+    this.setCurrentDirectory(AppPreferences.loadDirectory.get());
     this.setAccessory(getPreviewWrapperPanel());
     this.addPropertyChangeListener(
         PreviewPanelFileChooser.SELECTED_FILE_CHANGED_PROPERTY, new FileSystemSelectionHandler());

--- a/src/main/java/net/rptools/maptool/client/ui/ZoneSelectionPopup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ZoneSelectionPopup.java
@@ -54,7 +54,7 @@ public class ZoneSelectionPopup extends JScrollPopupMenu {
         rendererList.removeIf(renderer -> !renderer.getZone().isVisible());
       }
 
-      if (AppPreferences.getMapSortType().equals(AppPreferences.MapSortType.GMNAME))
+      if (AppPreferences.mapSortType.get().equals(AppPreferences.MapSortType.GMNAME))
         rendererList.sort(
             (o1, o2) -> {
               String name1 = o1.getZone().getName();

--- a/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
@@ -40,8 +40,8 @@ import javax.swing.ListModel;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingWorker;
 import net.rptools.lib.FileUtil;
-import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppSetup;
+import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.RemoteFileDownloader;
 import net.rptools.maptool.client.WebDownloader;
@@ -196,7 +196,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
           new DownloadListWorker(
               getLibraryList(),
               new WebDownloader(new URL(LIBRARY_LIST_URL)),
-              AppPreferences.getAssetRoots());
+              AppStatePersisted.getAssetRoots());
       worker.execute();
     } catch (MalformedURLException e) {
       MapTool.showMessage(

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
@@ -381,7 +381,7 @@ public class TokenBarController
         } // endif
         ((JScrollPane) formPanel.getComponent("tokenBarImagesScroll"))
             .scrollRectToVisible(imageList.getCellBounds(imageSelected, imageSelected));
-        AppPreferences.setLoadDir(imageFile.getParentFile());
+        AppPreferences.loadDirectory.set(imageFile.getParentFile());
         changedUpdate(null);
       } // endif
 
@@ -399,7 +399,7 @@ public class TokenBarController
         imageModel.set(
             imageSelected,
             TokenStatesController.loadAsssetFile(imageFile.getAbsolutePath(), formPanel));
-        AppPreferences.setLoadDir(imageFile.getParentFile());
+        AppPreferences.loadDirectory.set(imageFile.getParentFile());
       } // endif
 
       // Delete an image in the list

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -345,7 +345,7 @@ public class TokenStatesController
             || !imageFile.exists()
             || !imageFile.canRead()) return;
         formPanel.getTextComponent(IMAGE).setText(imageFile.getPath());
-        AppPreferences.setLoadDir(imageFile.getParentFile());
+        AppPreferences.loadDirectory.set(imageFile.getParentFile());
       } // endif
 
       // Change the enabled data components.

--- a/src/main/java/net/rptools/maptool/client/ui/chat/SmileyChatTranslationRuleGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/chat/SmileyChatTranslationRuleGroup.java
@@ -46,7 +46,7 @@ public class SmileyChatTranslationRuleGroup extends ChatTranslationRuleGroup {
 
   @Override
   public boolean isEnabled() {
-    return AppPreferences.getShowSmilies();
+    return AppPreferences.showSmilies.get();
   }
 
   private void initSmilies() {

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/CommandPanel.java
@@ -295,7 +295,7 @@ public class CommandPanel extends JPanel {
     // Resize on demand
     if (commandTextArea != null) {
       commandTextArea.setFont(
-          commandTextArea.getFont().deriveFont((float) AppPreferences.getFontSize()));
+          commandTextArea.getFont().deriveFont((float) AppPreferences.fontSize.get()));
       doLayout();
     }
 
@@ -606,7 +606,7 @@ public class CommandPanel extends JPanel {
           };
       commandTextArea.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
       commandTextArea.setPreferredSize(new Dimension(50, 40)); // XXX should be resizable
-      commandTextArea.setFont(new Font("sans-serif", 0, AppPreferences.getFontSize()));
+      commandTextArea.setFont(new Font("sans-serif", 0, AppPreferences.fontSize.get()));
       if (!ThemeSupport.shouldUseThemeColorsForChat()) {
         commandTextArea.setBackground(Color.WHITE);
         commandTextArea.setForeground(Color.BLACK);
@@ -837,7 +837,7 @@ public class CommandPanel extends JPanel {
     private static final long serialVersionUID = -9006587537198176935L;
 
     // Set the Color from the saved chat color from AppPreferences
-    private Color color = AppPreferences.getChatColor();
+    private Color color = AppPreferences.chatColor.get();
 
     public TextColorWell() {
       setMinimumSize(new Dimension(15, 15));
@@ -862,7 +862,7 @@ public class CommandPanel extends JPanel {
     public void setColor(Color newColor) {
       color = newColor;
       repaint();
-      AppPreferences.setChatColor(color); // Set the Chat Color in AppPreferences
+      AppPreferences.chatColor.set(color); // Set the Chat Color in AppPreferences
     }
 
     public Color getColor() {
@@ -919,7 +919,7 @@ public class CommandPanel extends JPanel {
       Dimension imgSize = new Dimension(image.getWidth(null), image.getHeight(null));
       SwingUtil.constrainTo(imgSize, size.width - PADDING * 2, size.height - PADDING * 2);
 
-      AppPreferences.getRenderQuality().setShrinkRenderingHints((Graphics2D) g);
+      AppPreferences.renderQuality.get().setShrinkRenderingHints((Graphics2D) g);
       g.drawImage(
           image,
           (size.width - imgSize.width) / 2,

--- a/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/commandpanel/MessagePanel.java
@@ -166,14 +166,14 @@ public class MessagePanel extends JPanel {
             + "; color: "
             + fgColour
             + " ; font-family: sans-serif; font-size: "
-            + AppPreferences.getFontSize()
+            + AppPreferences.fontSize.get()
             + "pt}";
 
     style.addRule(mainCss);
     style.addRule("div {margin-bottom: 5px}");
     style.addRule(".roll {background:#efefef}");
     setTrustedMacroPrefixColors(
-        AppPreferences.getTrustedPrefixFG(), AppPreferences.getTrustedPrefixBG());
+        AppPreferences.trustedPrefixForeground.get(), AppPreferences.trustedPrefixBackground.get());
     var css = MessageUtil.getMessageCss();
     style.addRule(css);
     repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
@@ -161,7 +161,7 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
    */
   @Override
   String getCSSRule() {
-    return String.format(CSS_BODY, AppPreferences.getFontSize())
+    return String.format(CSS_BODY, AppPreferences.fontSize.get())
         + CSS_SPAN
         + CSS_DIV
         + CSS_POINTERMAP;

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPane.java
@@ -91,7 +91,7 @@ public class HTMLPane extends JEditorPane {
    * @return the rule for the body tag
    */
   public String getRuleBody() {
-    return String.format(CSS_RULE_BODY, AppPreferences.getFontSize());
+    return String.format(CSS_RULE_BODY, AppPreferences.fontSize.get());
   }
 
   public void addActionListener(ActionListener listener) {

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -421,7 +421,7 @@ public class HTMLWebViewManager {
   }
 
   String getCSSRule() {
-    return String.format(CSS_BODY, AppPreferences.getFontSize()) + CSS_SPAN + CSS_DIV;
+    return String.format(CSS_BODY, AppPreferences.fontSize.get()) + CSS_SPAN + CSS_DIV;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPrefs.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButtonPrefs.java
@@ -202,7 +202,7 @@ public class MacroButtonPrefs {
               String maxWidth = buttonPref.get(PREF_MAX_WIDTH, "");
               boolean allowPlayerEdits =
                   buttonPref.getBoolean(
-                      PREF_ALLOW_PLAYER_EDITS, AppPreferences.getAllowPlayerMacroEditsDefault());
+                      PREF_ALLOW_PLAYER_EDITS, AppPreferences.allowPlayerMacroEditsDefault.get());
               String toolTip = buttonPref.get(PREF_TOOLTIP, "");
               boolean displayHotKey = buttonPref.getBoolean(PREF_DISPLAY_HOT_KEY, true);
 
@@ -245,7 +245,7 @@ public class MacroButtonPrefs {
         String maxWidth = buttonPref.get(PREF_MAX_WIDTH, "");
         boolean allowPlayerEdits =
             buttonPref.getBoolean(
-                PREF_ALLOW_PLAYER_EDITS, AppPreferences.getAllowPlayerMacroEditsDefault());
+                PREF_ALLOW_PLAYER_EDITS, AppPreferences.allowPlayerMacroEditsDefault.get());
         String hotKey = buttonPref.get(PREF_HOTKEY_KEY, MacroButtonHotKeyManager.HOTKEYS[0]);
         String toolTip = buttonPref.get(PREF_TOOLTIP, "");
         boolean displayHotKey = buttonPref.getBoolean(PREF_DISPLAY_HOT_KEY, true);

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
@@ -493,7 +493,7 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
     // Set the color style via Theme
     try {
       File themeFile =
-          new File(AppConstants.THEMES_DIR, AppPreferences.getDefaultMacroEditorTheme() + ".xml");
+          new File(AppConstants.THEMES_DIR, AppPreferences.defaultMacroEditorTheme.get() + ".xml");
       Theme theme = Theme.load(new FileInputStream(themeFile));
       theme.apply(macroEditorRSyntaxTextArea);
       theme.apply(getToolTipTextField());

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
@@ -328,29 +328,29 @@ public class MapPropertiesDialog extends JDialog {
   }
 
   private void initIsometricRadio() {
-    getIsometricRadio().setSelected(GridFactory.isIsometric(AppPreferences.getDefaultGridType()));
+    getIsometricRadio().setSelected(GridFactory.isIsometric(AppPreferences.defaultGridType.get()));
     getIsometricIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_ISOMETRIC));
   }
 
   private void initHexHoriRadio() {
     getHexHorizontalRadio()
-        .setSelected(GridFactory.isHexHorizontal(AppPreferences.getDefaultGridType()));
+        .setSelected(GridFactory.isHexHorizontal(AppPreferences.defaultGridType.get()));
     getHexHorizontalIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_HEX_HORIZONTAL));
   }
 
   private void initHexVertRadio() {
     getHexVerticalRadio()
-        .setSelected(GridFactory.isHexVertical(AppPreferences.getDefaultGridType()));
+        .setSelected(GridFactory.isHexVertical(AppPreferences.defaultGridType.get()));
     getHexVerticalIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_HEX_VERTICAL));
   }
 
   private void initSquareRadio() {
-    getSquareRadio().setSelected(GridFactory.isSquare(AppPreferences.getDefaultGridType()));
+    getSquareRadio().setSelected(GridFactory.isSquare(AppPreferences.defaultGridType.get()));
     getSquareIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_SQUARE));
   }
 
   private void initNoGridRadio() {
-    getNoGridRadio().setSelected(GridFactory.isNone(AppPreferences.getDefaultGridType()));
+    getNoGridRadio().setSelected(GridFactory.isNone(AppPreferences.defaultGridType.get()));
     getNoGridIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_NONE));
   }
 
@@ -508,7 +508,7 @@ public class MapPropertiesDialog extends JDialog {
   }
 
   private void initPixelsPerCellTextField() {
-    getPixelsPerCellTextField().setText(Integer.toString(AppPreferences.getDefaultGridSize()));
+    getPixelsPerCellTextField().setText(Integer.toString(AppPreferences.defaultGridSize.get()));
   }
 
   public JTextField getDefaultVisionTextField() {
@@ -517,7 +517,7 @@ public class MapPropertiesDialog extends JDialog {
 
   private void initDefaultVisionTextField() {
     this.getDefaultVisionTextField()
-        .setText(Integer.toString(AppPreferences.getDefaultVisionDistance()));
+        .setText(Integer.toString(AppPreferences.defaultVisionDistance.get()));
   }
 
   private void initVisionTypeCombo() {
@@ -525,7 +525,7 @@ public class MapPropertiesDialog extends JDialog {
     for (Zone.VisionType vt : Zone.VisionType.values()) {
       model.addElement(vt);
     }
-    model.setSelectedItem(AppPreferences.getDefaultVisionType());
+    model.setSelectedItem(AppPreferences.defaultVisionType.get());
     getVisionTypeCombo().setModel(model);
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
@@ -185,7 +185,7 @@ public class MapPropertiesDialog extends JDialog {
     // Color picker
     paintChooser = new PaintChooser();
     AssetPanelModel model = new AssetPanelModel();
-    Set<File> assetRootList = AppPreferences.getAssetRoots();
+    Set<File> assetRootList = AppStatePersisted.getAssetRoots();
     for (File file : assetRootList) {
       model.addRootGroup(new AssetDirectory(file, AppConstants.IMAGE_FILE_FILTER));
     }
@@ -669,7 +669,7 @@ public class MapPropertiesDialog extends JDialog {
 
     private JComponent createImageExplorerPanel() {
       AssetPanelModel model = new AssetPanelModel();
-      Set<File> assetRootList = AppPreferences.getAssetRoots();
+      Set<File> assetRootList = AppStatePersisted.getAssetRoots();
       for (File file : assetRootList) {
         model.addRootGroup(new AssetDirectory(file, AppConstants.IMAGE_FILE_FILTER));
       }

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -703,30 +703,30 @@ public class PreferencesDialog extends JDialog {
     startupInfoLabel = panel.getLabel("startupInfoLabel");
 
     pcTokenLabelFG = (ColorWell) panel.getComponent("pcTokenLabelFG");
-    pcTokenLabelFG.setColor(AppPreferences.getPCMapLabelFG());
+    pcTokenLabelFG.setColor(AppPreferences.pcMapLabelForeground.get());
     pcTokenLabelBG = (ColorWell) panel.getComponent("pcTokenLabelBG");
-    pcTokenLabelBG.setColor(AppPreferences.getPCMapLabelBG());
+    pcTokenLabelBG.setColor(AppPreferences.pcMapLabelBackground.get());
     pcTokenLabelBorderColor = (ColorWell) panel.getComponent("pcTokenLabelBorder");
-    pcTokenLabelBorderColor.setColor(AppPreferences.getPCMapLabelBorder());
+    pcTokenLabelBorderColor.setColor(AppPreferences.pcMapLabelBorder.get());
     npcTokenLabelFG = (ColorWell) panel.getComponent("npcTokenLabelFG");
-    npcTokenLabelFG.setColor(AppPreferences.getNPCMapLabelFG());
+    npcTokenLabelFG.setColor(AppPreferences.npcMapLabelForeground.get());
     npcTokenLabelBG = (ColorWell) panel.getComponent("npcTokenLabelBG");
-    npcTokenLabelBG.setColor(AppPreferences.getNPCMapLabelBG());
+    npcTokenLabelBG.setColor(AppPreferences.npcMapLabelBackground.get());
     npcTokenLabelBorderColor = (ColorWell) panel.getComponent("npcTokenLabelBorder");
-    npcTokenLabelBorderColor.setColor(AppPreferences.getNPCMapLabelBorder());
+    npcTokenLabelBorderColor.setColor(AppPreferences.npcMapLabelBorder.get());
     nonVisTokenLabelFG = (ColorWell) panel.getComponent("nonVisTokenLabelFG");
-    nonVisTokenLabelFG.setColor(AppPreferences.getNonVisMapLabelFG());
+    nonVisTokenLabelFG.setColor(AppPreferences.nonVisibleTokenMapLabelForeground.get());
     nonVisTokenLabelBG = (ColorWell) panel.getComponent("nonVisTokenLabelBG");
-    nonVisTokenLabelBG.setColor(AppPreferences.getNonVisMapLabelBG());
+    nonVisTokenLabelBG.setColor(AppPreferences.nonVisibleTokenMapLabelBackground.get());
     nonVisTokenLabelBorderColor = (ColorWell) panel.getComponent("nonVisTokenLabelBorder");
-    nonVisTokenLabelBorderColor.setColor(AppPreferences.getNonVisMapLabelBorder());
+    nonVisTokenLabelBorderColor.setColor(AppPreferences.nonVisibleTokenMapLabelBorder.get());
 
     labelFontSizeSpinner = (JSpinner) panel.getComponent("labelFontSizeSpinner");
-    labelFontSizeSpinner.setValue(AppPreferences.getMapLabelFontSize());
+    labelFontSizeSpinner.setValue(AppPreferences.mapLabelFontSize.get());
     labelBorderWidthSpinner = (JSpinner) panel.getComponent("labelBorderWidthSpinner");
-    labelBorderWidthSpinner.setValue(AppPreferences.getMapLabelBorderWidth());
+    labelBorderWidthSpinner.setValue(AppPreferences.mapLabelBorderWidth.get());
     labelBorderArcSpinner = (JSpinner) panel.getComponent("labelBorderArcSpinner");
-    labelBorderArcSpinner.setValue(AppPreferences.getMapLabelBorderArc());
+    labelBorderArcSpinner.setValue(AppPreferences.mapLabelBorderArc.get());
     showLabelBorderCheckBox = (JCheckBox) panel.getComponent("showLabelBorder");
     showLabelBorderCheckBox.addActionListener(
         e -> {
@@ -736,18 +736,18 @@ public class PreferencesDialog extends JDialog {
             nonVisTokenLabelBorderColor.setVisible(true); // Disabling a color well does not work
             labelBorderWidthSpinner.setEnabled(true);
             labelBorderArcSpinner.setEnabled(true);
-            AppPreferences.setShowMapLabelBorder(true);
+            AppPreferences.mapLabelShowBorder.set(true);
           } else {
             pcTokenLabelBorderColor.setVisible(false); // Disabling a color well does not work
             npcTokenLabelBorderColor.setVisible(false); // Disabling a color well does not work
             nonVisTokenLabelBorderColor.setVisible(false); // Disabling a color well does not  work
             labelBorderWidthSpinner.setEnabled(false);
             labelBorderArcSpinner.setEnabled(false);
-            AppPreferences.setShowMapLabelBorder(false);
+            AppPreferences.mapLabelShowBorder.set(false);
           }
         });
 
-    boolean showBorder = AppPreferences.getShowMapLabelBorder();
+    boolean showBorder = AppPreferences.mapLabelShowBorder.get();
     showLabelBorderCheckBox.setSelected(showBorder);
     if (showBorder) {
       pcTokenLabelBorderColor.setVisible(true);
@@ -821,19 +821,19 @@ public class PreferencesDialog extends JDialog {
     // And keep it updated
     facingFaceEdges.addActionListener(
         e -> {
-          AppPreferences.setFaceEdge(facingFaceEdges.isSelected());
+          AppPreferences.faceEdge.set(facingFaceEdges.isSelected());
         });
     facingFaceVertices.addActionListener(
         e -> {
-          AppPreferences.setFaceVertex(facingFaceVertices.isSelected());
+          AppPreferences.faceVertex.set(facingFaceVertices.isSelected());
         });
 
     toolTipInlineRolls.addActionListener(
-        e -> AppPreferences.setUseToolTipForInlineRoll(toolTipInlineRolls.isSelected()));
+        e -> AppPreferences.useToolTipForInlineRoll.set(toolTipInlineRolls.isSelected()));
 
     suppressToolTipsMacroLinks.addActionListener(
         e ->
-            AppPreferences.setSuppressToolTipsForMacroLinks(
+            AppPreferences.suppressToolTipsForMacroLinks.set(
                 suppressToolTipsMacroLinks.isSelected()));
 
     toolTipInitialDelay
@@ -842,7 +842,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Integer>(toolTipInitialDelay) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setToolTipInitialDelay(value);
+                AppPreferences.toolTipInitialDelay.set(value);
                 ToolTipManager.sharedInstance().setInitialDelay(value);
               }
 
@@ -857,7 +857,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Integer>(toolTipDismissDelay) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setToolTipDismissDelay(value);
+                AppPreferences.toolTipDismissDelay.set(value);
                 ToolTipManager.sharedInstance().setDismissDelay(value);
               }
 
@@ -869,39 +869,43 @@ public class PreferencesDialog extends JDialog {
 
     chatNotificationColor.addActionListener(
         e -> {
-          AppPreferences.setChatNotificationColor(chatNotificationColor.getColor());
-          MapTool.getFrame().setChatTypingLabelColor(AppPreferences.getChatNotificationColor());
+          AppPreferences.chatNotificationColor.set(chatNotificationColor.getColor());
+          MapTool.getFrame().setChatTypingLabelColor(AppPreferences.chatNotificationColor.get());
         });
 
     trustedOutputForeground.addActionListener(
         e -> {
-          AppPreferences.setTrustedPrefixFG(trustedOutputForeground.getColor());
+          AppPreferences.trustedPrefixForeground.set(trustedOutputForeground.getColor());
           MapTool.getFrame()
               .getCommandPanel()
               .setTrustedMacroPrefixColors(
-                  AppPreferences.getTrustedPrefixFG(), AppPreferences.getTrustedPrefixBG());
+                  AppPreferences.trustedPrefixForeground.get(),
+                  AppPreferences.trustedPrefixBackground.get());
         });
     trustedOutputBackground.addActionListener(
         e -> {
-          AppPreferences.setTrustedPrefixBG(trustedOutputBackground.getColor());
+          AppPreferences.trustedPrefixBackground.set(trustedOutputBackground.getColor());
           MapTool.getFrame()
               .getCommandPanel()
               .setTrustedMacroPrefixColors(
-                  AppPreferences.getTrustedPrefixFG(), AppPreferences.getTrustedPrefixBG());
+                  AppPreferences.trustedPrefixForeground.get(),
+                  AppPreferences.trustedPrefixBackground.get());
         });
 
     chatAutosaveTime.addChangeListener(
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setChatAutosaveTime(value);
+            if (value >= 0) {
+              AppPreferences.chatAutoSaveTimeInMinutes.set(value);
+            }
           }
         });
     typingNotificationDuration.addChangeListener(
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setTypingNotificationDuration(value);
+            AppPreferences.typingNotificationDurationInSeconds.set(value);
           }
         });
 
@@ -914,32 +918,32 @@ public class PreferencesDialog extends JDialog {
               if (saveFile.indexOf(".") < 0) {
                 saveFile.append(".html");
               }
-              AppPreferences.setChatFilenameFormat(saveFile.toString());
+              AppPreferences.chatFilenameFormat.set(saveFile.toString());
             }
           }
         });
 
     allowPlayerMacroEditsDefault.addActionListener(
         e ->
-            AppPreferences.setAllowPlayerMacroEditsDefault(
+            AppPreferences.allowPlayerMacroEditsDefault.set(
                 allowPlayerMacroEditsDefault.isSelected()));
 
     showAvatarInChat.addActionListener(
-        e -> AppPreferences.setShowAvatarInChat(showAvatarInChat.isSelected()));
+        e -> AppPreferences.showAvatarInChat.set(showAvatarInChat.isSelected()));
     saveReminderCheckBox.addActionListener(
-        e -> AppPreferences.setSaveReminder(saveReminderCheckBox.isSelected()));
+        e -> AppPreferences.saveReminder.set(saveReminderCheckBox.isSelected()));
     fillSelectionCheckBox.addActionListener(
-        e -> AppPreferences.setFillSelectionBox(fillSelectionCheckBox.isSelected()));
+        e -> AppPreferences.fillSelectionBox.set(fillSelectionCheckBox.isSelected()));
     frameRateCapTextField
         .getDocument()
         .addDocumentListener(
             new DocumentListenerProxy<Integer>(frameRateCapTextField) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setFrameRateCap(value);
+                AppPreferences.frameRateCap.set(value);
 
                 // AppPreferences may have rejected the value, so read it back.
-                final var cap = AppPreferences.getFrameRateCap();
+                final var cap = AppPreferences.frameRateCap.get();
                 for (final var renderer : MapTool.getFrame().getZoneRenderers()) {
                   renderer.setFrameRateCap(cap);
                 }
@@ -956,10 +960,10 @@ public class PreferencesDialog extends JDialog {
             });
 
     renderPerformanceComboBox.setModel(
-        getLocalizedModel(renderPerformanceComboItems, AppPreferences.getRenderQuality().name()));
+        getLocalizedModel(renderPerformanceComboItems, AppPreferences.renderQuality.get().name()));
     renderPerformanceComboBox.addItemListener(
         e -> {
-          AppPreferences.setRenderQuality(
+          AppPreferences.renderQuality.set(
               RenderQuality.valueOf(
                   ((LocalizedComboItem) renderPerformanceComboBox.getSelectedItem()).getValue()));
         });
@@ -970,69 +974,71 @@ public class PreferencesDialog extends JDialog {
           public void focusLost(FocusEvent e) {
             if (!e.isTemporary()) {
               StringBuilder userName = new StringBuilder(defaultUsername.getText());
-              AppPreferences.setDefaultUserName(userName.toString());
+              AppPreferences.defaultUserName.set(userName.toString());
             }
           }
         });
 
     loadMRUcheckbox.addActionListener(
-        e -> AppPreferences.setLoadMRUCampaignAtStart(loadMRUcheckbox.isSelected()));
+        e -> AppPreferences.loadMruCampaignAtStart.set(loadMRUcheckbox.isSelected()));
     allowExternalMacroAccessCheckBox.addActionListener(
         e ->
-            AppPreferences.setAllowExternalMacroAccess(
+            AppPreferences.allowExternalMacroAccess.set(
                 allowExternalMacroAccessCheckBox.isSelected()));
     showDialogOnNewToken.addActionListener(
-        e -> AppPreferences.setShowDialogOnNewToken(showDialogOnNewToken.isSelected()));
+        e -> AppPreferences.showDialogOnNewToken.set(showDialogOnNewToken.isSelected()));
     autoSaveSpinner.addChangeListener(
         ce -> {
           int newInterval = (Integer) autoSaveSpinner.getValue();
-          AppPreferences.setAutoSaveIncrement(newInterval);
+          AppPreferences.autoSaveIncrement.set(newInterval);
         });
     newMapsHaveFOWCheckBox.addActionListener(
-        e -> AppPreferences.setNewMapsHaveFOW(newMapsHaveFOWCheckBox.isSelected()));
+        e -> AppPreferences.newMapsHaveFow.set(newMapsHaveFOWCheckBox.isSelected()));
     tokensPopupWarningWhenDeletedCheckBox.addActionListener(
         e ->
-            AppPreferences.setTokensWarnWhenDeleted(
+            AppPreferences.tokensWarnWhenDeleted.set(
                 tokensPopupWarningWhenDeletedCheckBox.isSelected()));
     tokensStartSnapToGridCheckBox.addActionListener(
-        e -> AppPreferences.setTokensStartSnapToGrid(tokensStartSnapToGridCheckBox.isSelected()));
+        e -> AppPreferences.tokensStartSnapToGrid.set(tokensStartSnapToGridCheckBox.isSelected()));
     tokensSnapWhileDraggingCheckBox.addActionListener(
         e ->
-            AppPreferences.setTokensSnapWhileDragging(
+            AppPreferences.tokensSnapWhileDragging.set(
                 tokensSnapWhileDraggingCheckBox.isSelected()));
     hideMousePointerWhileDraggingCheckBox.addActionListener(
         e ->
-            AppPreferences.setHideMousePointerWhileDragging(
+            AppPreferences.hideMousePointerWhileDragging.set(
                 hideMousePointerWhileDraggingCheckBox.isSelected()));
     hideTokenStackIndicatorCheckBox.addActionListener(
         e ->
-            AppPreferences.setHideTokenStackIndicator(
+            AppPreferences.hideTokenStackIndicator.set(
                 hideTokenStackIndicatorCheckBox.isSelected()));
     newMapsVisibleCheckBox.addActionListener(
-        e -> AppPreferences.setNewMapsVisible(newMapsVisibleCheckBox.isSelected()));
+        e -> AppPreferences.newMapsVisible.set(newMapsVisibleCheckBox.isSelected()));
     newTokensVisibleCheckBox.addActionListener(
-        e -> AppPreferences.setNewTokensVisible(newTokensVisibleCheckBox.isSelected()));
+        e -> AppPreferences.newTokensVisible.set(newTokensVisibleCheckBox.isSelected()));
     stampsStartFreeSizeCheckBox.addActionListener(
-        e -> AppPreferences.setObjectsStartFreesize(stampsStartFreeSizeCheckBox.isSelected()));
+        e -> AppPreferences.objectsStartFreesize.set(stampsStartFreeSizeCheckBox.isSelected()));
     tokensStartFreeSizeCheckBox.addActionListener(
-        e -> AppPreferences.setTokensStartFreesize(tokensStartFreeSizeCheckBox.isSelected()));
+        e -> AppPreferences.tokensStartFreesize.set(tokensStartFreeSizeCheckBox.isSelected()));
     stampsStartSnapToGridCheckBox.addActionListener(
-        e -> AppPreferences.setObjectsStartSnapToGrid(stampsStartSnapToGridCheckBox.isSelected()));
+        e -> AppPreferences.objectsStartSnapToGrid.set(stampsStartSnapToGridCheckBox.isSelected()));
     showStatSheetCheckBox.addActionListener(
-        e -> AppPreferences.setShowStatSheet(showStatSheetCheckBox.isSelected()));
+        e -> AppPreferences.showStatSheet.set(showStatSheetCheckBox.isSelected()));
     showPortraitCheckBox.addActionListener(
-        e -> AppPreferences.setShowPortrait(showPortraitCheckBox.isSelected()));
+        e -> AppPreferences.showPortrait.set(showPortraitCheckBox.isSelected()));
     showStatSheetModifierCheckBox.addActionListener(
-        e -> AppPreferences.setShowStatSheetModifier(showStatSheetModifierCheckBox.isSelected()));
+        e ->
+            AppPreferences.showStatSheetRequiresModifierKey.set(
+                showStatSheetModifierCheckBox.isSelected()));
     forceFacingArrowCheckBox.addActionListener(
-        e -> AppPreferences.setForceFacingArrow(forceFacingArrowCheckBox.isSelected()));
+        e -> AppPreferences.forceFacingArrow.set(forceFacingArrowCheckBox.isSelected()));
     backgroundsStartFreeSizeCheckBox.addActionListener(
         e ->
-            AppPreferences.setBackgroundsStartFreesize(
+            AppPreferences.backgroundsStartFreesize.set(
                 backgroundsStartFreeSizeCheckBox.isSelected()));
     backgroundsStartSnapToGridCheckBox.addActionListener(
         e ->
-            AppPreferences.setBackgroundsStartSnapToGrid(
+            AppPreferences.backgroundsStartSnapToGrid.set(
                 backgroundsStartSnapToGridCheckBox.isSelected()));
     defaultGridSizeTextField
         .getDocument()
@@ -1040,7 +1046,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Integer>(defaultGridSizeTextField) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setDefaultGridSize(value);
+                AppPreferences.defaultGridSize.set(value);
               }
 
               @Override
@@ -1055,7 +1061,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Double>(defaultUnitsPerCellTextField) {
               @Override
               protected void storeNumericValue(Double value) {
-                AppPreferences.setDefaultUnitsPerCell(value);
+                AppPreferences.defaultUnitsPerCell.set(value);
               }
 
               @Override
@@ -1069,7 +1075,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Integer>(defaultVisionDistanceTextField) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setDefaultVisionDistance(value);
+                AppPreferences.defaultVisionDistance.set(value);
               }
 
               @Override
@@ -1083,7 +1089,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Integer>(statsheetPortraitSize) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setPortraitSize(value);
+                AppPreferences.portraitSize.set(value);
               }
 
               @Override
@@ -1092,7 +1098,7 @@ public class PreferencesDialog extends JDialog {
               }
             });
     haloLineWidthSpinner.addChangeListener(
-        ce -> AppPreferences.setHaloLineWidth((Integer) haloLineWidthSpinner.getValue()));
+        ce -> AppPreferences.haloLineWidth.set((Integer) haloLineWidthSpinner.getValue()));
 
     // Overlay opacity options in AppPreferences, with
     // error checking to ensure values are within the acceptable range
@@ -1101,7 +1107,7 @@ public class PreferencesDialog extends JDialog {
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setHaloOverlayOpacity(value);
+            AppPreferences.haloOverlayOpacity.set(value);
             MapTool.getFrame().refresh();
           }
         });
@@ -1109,7 +1115,7 @@ public class PreferencesDialog extends JDialog {
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setAuraOverlayOpacity(value);
+            AppPreferences.auraOverlayOpacity.set(value);
             MapTool.getFrame().refresh();
           }
         });
@@ -1117,7 +1123,7 @@ public class PreferencesDialog extends JDialog {
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setLightOverlayOpacity(value);
+            AppPreferences.lightOverlayOpacity.set(value);
             MapTool.getFrame().refresh();
           }
         });
@@ -1125,7 +1131,7 @@ public class PreferencesDialog extends JDialog {
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setLumensOverlayOpacity(value);
+            AppPreferences.lumensOverlayOpacity.set(value);
             MapTool.getFrame().refresh();
           }
         });
@@ -1133,42 +1139,46 @@ public class PreferencesDialog extends JDialog {
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setLumensOverlayBorderThickness(value);
+            AppPreferences.lumensOverlayBorderThickness.set(value);
             MapTool.getFrame().refresh();
           }
         });
     lumensOverlayShowByDefaultCheckBox.addActionListener(
         e ->
-            AppPreferences.setLumensOverlayShowByDefault(
+            AppPreferences.lumensOverlayShowByDefault.set(
                 lumensOverlayShowByDefaultCheckBox.isSelected()));
     lightsShowByDefaultCheckBox.addActionListener(
-        e -> AppPreferences.setLightsShowByDefault(lightsShowByDefaultCheckBox.isSelected()));
+        e -> AppPreferences.lightsShowByDefault.set(lightsShowByDefaultCheckBox.isSelected()));
     fogOverlayOpacitySpinner.addChangeListener(
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setFogOverlayOpacity(value);
+            AppPreferences.fogOverlayOpacity.set(value);
+
+            // FIXME Force ModelChange event to flush fog from zone :(
+            Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+            zone.setHasFog(zone.hasFog());
             MapTool.getFrame().refresh();
           }
         });
     useHaloColorAsVisionOverlayCheckBox.addActionListener(
         e ->
-            AppPreferences.setUseHaloColorOnVisionOverlay(
+            AppPreferences.useHaloColorOnVisionOverlay.set(
                 useHaloColorAsVisionOverlayCheckBox.isSelected()));
     autoRevealVisionOnGMMoveCheckBox.addActionListener(
         e ->
-            AppPreferences.setAutoRevealVisionOnGMMovement(
+            AppPreferences.autoRevealVisionOnGMMovement.set(
                 autoRevealVisionOnGMMoveCheckBox.isSelected()));
     showSmiliesCheckBox.addActionListener(
-        e -> AppPreferences.setShowSmilies(showSmiliesCheckBox.isSelected()));
+        e -> AppPreferences.showSmilies.set(showSmiliesCheckBox.isSelected()));
     playSystemSoundCheckBox.addActionListener(
-        e -> AppPreferences.setPlaySystemSounds(playSystemSoundCheckBox.isSelected()));
+        e -> AppPreferences.playSystemSounds.set(playSystemSoundCheckBox.isSelected()));
     mapVisibilityWarning.addActionListener(
-        e -> AppPreferences.setMapVisibilityWarning(mapVisibilityWarning.isSelected()));
+        e -> AppPreferences.mapVisibilityWarning.set(mapVisibilityWarning.isSelected()));
 
     playStreamsCheckBox.addActionListener(
         e -> {
-          AppPreferences.setPlayStreams(playStreamsCheckBox.isSelected());
+          AppPreferences.playStreams.set(playStreamsCheckBox.isSelected());
           if (!playStreamsCheckBox.isSelected()) {
             MediaPlayerAdapter.stopStream("*", true, 0);
           }
@@ -1176,11 +1186,11 @@ public class PreferencesDialog extends JDialog {
 
     playSystemSoundOnlyWhenNotFocusedCheckBox.addActionListener(
         e ->
-            AppPreferences.setPlaySystemSoundsOnlyWhenNotFocused(
+            AppPreferences.playSystemSoundsOnlyWhenNotFocused.set(
                 playSystemSoundOnlyWhenNotFocusedCheckBox.isSelected()));
 
     syrinscapeActiveCheckBox.addActionListener(
-        e -> AppPreferences.setSyrinscapeActive(syrinscapeActiveCheckBox.isSelected()));
+        e -> AppPreferences.syrinscapeActive.set(syrinscapeActiveCheckBox.isSelected()));
 
     fontSizeTextField
         .getDocument()
@@ -1188,7 +1198,7 @@ public class PreferencesDialog extends JDialog {
             new DocumentListenerProxy<Integer>(fontSizeTextField) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setFontSize(value);
+                AppPreferences.fontSize.set(value);
               }
 
               @Override
@@ -1199,62 +1209,62 @@ public class PreferencesDialog extends JDialog {
 
     npcTokenLabelBG.addActionListener(
         e -> {
-          AppPreferences.setNPCMapLabelBG(npcTokenLabelBG.getColor());
+          AppPreferences.npcMapLabelBackground.set(npcTokenLabelBG.getColor());
         });
 
     npcTokenLabelFG.addActionListener(
         e -> {
-          AppPreferences.setNPCMapLabelFG(npcTokenLabelFG.getColor());
+          AppPreferences.npcMapLabelForeground.set(npcTokenLabelFG.getColor());
         });
 
     pcTokenLabelBG.addActionListener(
         e -> {
-          AppPreferences.setPCMapLabelBG(pcTokenLabelBG.getColor());
+          AppPreferences.pcMapLabelBackground.set(pcTokenLabelBG.getColor());
         });
 
     pcTokenLabelFG.addActionListener(
         e -> {
-          AppPreferences.setPCMapLabelFG(pcTokenLabelFG.getColor());
+          AppPreferences.pcMapLabelForeground.set(pcTokenLabelFG.getColor());
         });
 
     nonVisTokenLabelBG.addActionListener(
         e -> {
-          AppPreferences.setNonVisMapLabelBG(nonVisTokenLabelBG.getColor());
+          AppPreferences.nonVisibleTokenMapLabelBackground.set(nonVisTokenLabelBG.getColor());
         });
 
     nonVisTokenLabelFG.addActionListener(
         e -> {
-          AppPreferences.setNonVisMapLabelFG(nonVisTokenLabelFG.getColor());
+          AppPreferences.nonVisibleTokenMapLabelForeground.set(nonVisTokenLabelFG.getColor());
         });
 
     labelFontSizeSpinner.addChangeListener(
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setMapLabelFontSize(Math.max(value, 0));
+            AppPreferences.mapLabelFontSize.set(Math.max(value, 0));
           }
         });
 
     pcTokenLabelBorderColor.addActionListener(
         e -> {
-          AppPreferences.setPCMapLabelBorder(pcTokenLabelBorderColor.getColor());
+          AppPreferences.pcMapLabelBorder.set(pcTokenLabelBorderColor.getColor());
         });
 
     npcTokenLabelBorderColor.addActionListener(
         e -> {
-          AppPreferences.setNPCMapLabelBorder(npcTokenLabelBorderColor.getColor());
+          AppPreferences.npcMapLabelBorder.set(npcTokenLabelBorderColor.getColor());
         });
 
     nonVisTokenLabelBorderColor.addActionListener(
         e -> {
-          AppPreferences.setNonVisMapLabelBorder(nonVisTokenLabelBorderColor.getColor());
+          AppPreferences.nonVisibleTokenMapLabelBorder.set(nonVisTokenLabelBorderColor.getColor());
         });
 
     labelBorderWidthSpinner.addChangeListener(
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setMapLabelBorderWidth(Math.max(value, 0));
+            AppPreferences.mapLabelBorderWidth.set(Math.max(value, 0));
           }
         });
 
@@ -1262,25 +1272,28 @@ public class PreferencesDialog extends JDialog {
         new ChangeListenerProxy() {
           @Override
           protected void storeSpinnerValue(int value) {
-            AppPreferences.setMapLabelBorderArc(Math.max(value, 0));
+            AppPreferences.mapLabelBorderArc.set(Math.max(value, 0));
           }
         });
 
-    fitGMView.addActionListener(e -> AppPreferences.setFitGMView(fitGMView.isSelected()));
-    hideNPCs.addActionListener(e -> AppPreferences.setInitHideNpcs(hideNPCs.isSelected()));
+    fitGMView.addActionListener(e -> AppPreferences.fitGmView.set(fitGMView.isSelected()));
+    hideNPCs.addActionListener(
+        e -> AppPreferences.initiativePanelHidesNpcs.set(hideNPCs.isSelected()));
     ownerPermissions.addActionListener(
-        e -> AppPreferences.setInitOwnerPermissions(ownerPermissions.isSelected()));
+        e ->
+            AppPreferences.initiativePanelAllowsOwnerPermissions.set(
+                ownerPermissions.isSelected()));
     lockMovement.addActionListener(
-        e -> AppPreferences.setInitLockMovement(lockMovement.isSelected()));
+        e -> AppPreferences.initiativeMovementLocked.set(lockMovement.isSelected()));
     showInitGainMessage.addActionListener(
-        e -> AppPreferences.setShowInitGainMessage(showInitGainMessage.isSelected()));
+        e -> AppPreferences.showInitiativeGainedMessage.set(showInitGainMessage.isSelected()));
     upnpDiscoveryTimeoutTextField
         .getDocument()
         .addDocumentListener(
             new DocumentListenerProxy<Integer>(upnpDiscoveryTimeoutTextField) {
               @Override
               protected void storeNumericValue(Integer value) {
-                AppPreferences.setUpnpDiscoveryTimeout(value);
+                AppPreferences.upnpDiscoveryTimeout.set(value);
               }
 
               @Override
@@ -1290,7 +1303,7 @@ public class PreferencesDialog extends JDialog {
             });
     fileSyncPathButton.addActionListener(
         e -> {
-          JFileChooser fileChooser = new JFileChooser(AppPreferences.getFileSyncPath());
+          JFileChooser fileChooser = new JFileChooser(AppPreferences.fileSyncPath.get());
           fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
           int returnVal = fileChooser.showOpenDialog(null);
 
@@ -1302,7 +1315,7 @@ public class PreferencesDialog extends JDialog {
             fileSyncPath.setCaretPosition(0);
 
             // Save to preferences
-            AppPreferences.setFileSyncPath(selectedPath);
+            AppPreferences.fileSyncPath.set(selectedPath);
           }
         });
     jvmXmxTextField.addFocusListener(
@@ -1395,55 +1408,56 @@ public class PreferencesDialog extends JDialog {
 
     chatNotificationShowBackground.addActionListener(
         e ->
-            AppPreferences.setChatNotificationShowBackground(
+            AppPreferences.chatNotificationBackground.set(
                 chatNotificationShowBackground.isSelected()));
 
     defaultGridTypeCombo.setModel(
-        getLocalizedModel(defaultGridTypeComboItems, AppPreferences.getDefaultGridType()));
+        getLocalizedModel(defaultGridTypeComboItems, AppPreferences.defaultGridType.get()));
     defaultGridTypeCombo.addItemListener(
         e ->
-            AppPreferences.setDefaultGridType(
+            AppPreferences.defaultGridType.set(
                 ((LocalizedComboItem) (defaultGridTypeCombo.getSelectedItem())).getValue()));
 
     duplicateTokenCombo.setModel(
-        getLocalizedModel(duplicateTokenComboItems, AppPreferences.getDuplicateTokenNumber()));
+        getLocalizedModel(duplicateTokenComboItems, AppPreferences.duplicateTokenNumber.get()));
     duplicateTokenCombo.addItemListener(
         e ->
-            AppPreferences.setDuplicateTokenNumber(
+            AppPreferences.duplicateTokenNumber.set(
                 ((LocalizedComboItem) (duplicateTokenCombo.getSelectedItem())).getValue()));
 
     showNumberingCombo.setModel(
-        getLocalizedModel(showNumberingComboItems, AppPreferences.getTokenNumberDisplay()));
+        getLocalizedModel(showNumberingComboItems, AppPreferences.tokenNumberDisplay.get()));
     showNumberingCombo.addItemListener(
         e ->
-            AppPreferences.setTokenNumberDisplay(
+            AppPreferences.tokenNumberDisplay.set(
                 ((LocalizedComboItem) showNumberingCombo.getSelectedItem()).getValue()));
 
     tokenNamingCombo.setModel(
-        getLocalizedModel(tokenNamingComboItems, AppPreferences.getNewTokenNaming()));
+        getLocalizedModel(tokenNamingComboItems, AppPreferences.newTokenNaming.get()));
     tokenNamingCombo.addItemListener(
         e ->
-            AppPreferences.setNewTokenNaming(
+            AppPreferences.newTokenNaming.set(
                 ((LocalizedComboItem) (tokenNamingCombo.getSelectedItem())).getValue()));
 
     movementMetricCombo.setModel(new DefaultComboBoxModel<>(movementMetricComboItems));
-    movementMetricCombo.setSelectedItem(AppPreferences.getMovementMetric());
+    movementMetricCombo.setSelectedItem(AppPreferences.movementMetric.get());
     movementMetricCombo.addItemListener(
         e ->
-            AppPreferences.setMovementMetric((WalkerMetric) movementMetricCombo.getSelectedItem()));
+            AppPreferences.movementMetric.set(
+                (WalkerMetric) movementMetricCombo.getSelectedItem()));
 
     visionTypeCombo.setModel(new DefaultComboBoxModel<>(Zone.VisionType.values()));
-    visionTypeCombo.setSelectedItem(AppPreferences.getDefaultVisionType());
+    visionTypeCombo.setSelectedItem(AppPreferences.defaultVisionType.get());
     visionTypeCombo.addItemListener(
         e ->
-            AppPreferences.setDefaultVisionType(
+            AppPreferences.defaultVisionType.set(
                 (Zone.VisionType) visionTypeCombo.getSelectedItem()));
 
     mapSortType.setModel(new DefaultComboBoxModel<>(AppPreferences.MapSortType.values()));
-    mapSortType.setSelectedItem(AppPreferences.getMapSortType());
+    mapSortType.setSelectedItem(AppPreferences.mapSortType.get());
     mapSortType.addItemListener(
         e ->
-            AppPreferences.setMapSortType(
+            AppPreferences.mapSortType.set(
                 (AppPreferences.MapSortType) mapSortType.getSelectedItem()));
 
     macroEditorThemeCombo.setModel(new DefaultComboBoxModel<>());
@@ -1455,22 +1469,22 @@ public class PreferencesDialog extends JDialog {
               p ->
                   macroEditorThemeCombo.addItem(
                       FilenameUtils.removeExtension(p.getFileName().toString())));
-      macroEditorThemeCombo.setSelectedItem(AppPreferences.getDefaultMacroEditorTheme());
+      macroEditorThemeCombo.setSelectedItem(AppPreferences.defaultMacroEditorTheme.get());
     } catch (IOException ioe) {
       log.warn("Unable to list macro editor themes.", ioe);
       macroEditorThemeCombo.addItem("Default");
     }
     macroEditorThemeCombo.addItemListener(
         e ->
-            AppPreferences.setDefaultMacroEditorTheme(
+            AppPreferences.defaultMacroEditorTheme.set(
                 (String) macroEditorThemeCombo.getSelectedItem()));
 
     iconThemeCombo.setModel(new DefaultComboBoxModel<>());
     iconThemeCombo.addItem(RessourceManager.CLASSIC);
     iconThemeCombo.addItem(RessourceManager.ROD_TAKEHARA);
-    iconThemeCombo.setSelectedItem(AppPreferences.getIconTheme());
+    iconThemeCombo.setSelectedItem(AppPreferences.iconTheme.get());
     iconThemeCombo.addItemListener(
-        e -> AppPreferences.setIconTheme((String) iconThemeCombo.getSelectedItem()));
+        e -> AppPreferences.iconTheme.set((String) iconThemeCombo.getSelectedItem()));
 
     themeFilterCombo.setModel(getLocalizedModel(themeFilterComboItems, "All"));
     themeFilterCombo.addItemListener(
@@ -1527,92 +1541,94 @@ public class PreferencesDialog extends JDialog {
    * method is called during the initialization process.
    */
   private void setInitialState() {
-    showDialogOnNewToken.setSelected(AppPreferences.getShowDialogOnNewToken());
-    saveReminderCheckBox.setSelected(AppPreferences.getSaveReminder());
-    fillSelectionCheckBox.setSelected(AppPreferences.getFillSelectionBox());
-    frameRateCapTextField.setText(Integer.toString(AppPreferences.getFrameRateCap()));
-    defaultUsername.setText(AppPreferences.getDefaultUserName());
+    showDialogOnNewToken.setSelected(AppPreferences.showDialogOnNewToken.get());
+    saveReminderCheckBox.setSelected(AppPreferences.saveReminder.get());
+    fillSelectionCheckBox.setSelected(AppPreferences.fillSelectionBox.get());
+    frameRateCapTextField.setText(Integer.toString(AppPreferences.frameRateCap.get()));
+    defaultUsername.setText(AppPreferences.defaultUserName.get());
     // initEnableServerSyncCheckBox.setSelected(AppPreferences.getInitEnableServerSync());
-    autoSaveSpinner.setValue(AppPreferences.getAutoSaveIncrement());
-    loadMRUcheckbox.setSelected(AppPreferences.getLoadMRUCampaignAtStart());
-    newMapsHaveFOWCheckBox.setSelected(AppPreferences.getNewMapsHaveFOW());
-    tokensPopupWarningWhenDeletedCheckBox.setSelected(AppPreferences.getTokensWarnWhenDeleted());
-    tokensStartSnapToGridCheckBox.setSelected(AppPreferences.getTokensStartSnapToGrid());
-    tokensSnapWhileDraggingCheckBox.setSelected(AppPreferences.getTokensSnapWhileDragging());
+    autoSaveSpinner.setValue(AppPreferences.autoSaveIncrement.get());
+    loadMRUcheckbox.setSelected(AppPreferences.loadMruCampaignAtStart.get());
+    newMapsHaveFOWCheckBox.setSelected(AppPreferences.newMapsHaveFow.get());
+    tokensPopupWarningWhenDeletedCheckBox.setSelected(AppPreferences.tokensWarnWhenDeleted.get());
+    tokensStartSnapToGridCheckBox.setSelected(AppPreferences.tokensStartSnapToGrid.get());
+    tokensSnapWhileDraggingCheckBox.setSelected(AppPreferences.tokensSnapWhileDragging.get());
     hideMousePointerWhileDraggingCheckBox.setSelected(
-        AppPreferences.getHideMousePointerWhileDragging());
-    hideTokenStackIndicatorCheckBox.setSelected(AppPreferences.getHideTokenStackIndicator());
-    newMapsVisibleCheckBox.setSelected(AppPreferences.getNewMapsVisible());
-    newTokensVisibleCheckBox.setSelected(AppPreferences.getNewTokensVisible());
-    stampsStartFreeSizeCheckBox.setSelected(AppPreferences.getObjectsStartFreesize());
-    tokensStartFreeSizeCheckBox.setSelected(AppPreferences.getTokensStartFreesize());
-    stampsStartSnapToGridCheckBox.setSelected(AppPreferences.getObjectsStartSnapToGrid());
-    backgroundsStartFreeSizeCheckBox.setSelected(AppPreferences.getBackgroundsStartFreesize());
-    showStatSheetCheckBox.setSelected(AppPreferences.getShowStatSheet());
-    showPortraitCheckBox.setSelected(AppPreferences.getShowPortrait());
-    showStatSheetModifierCheckBox.setSelected(AppPreferences.getShowStatSheetModifier());
-    forceFacingArrowCheckBox.setSelected(AppPreferences.getForceFacingArrow());
-    backgroundsStartSnapToGridCheckBox.setSelected(AppPreferences.getBackgroundsStartSnapToGrid());
-    defaultGridSizeTextField.setText(Integer.toString(AppPreferences.getDefaultGridSize()));
+        AppPreferences.hideMousePointerWhileDragging.get());
+    hideTokenStackIndicatorCheckBox.setSelected(AppPreferences.hideTokenStackIndicator.get());
+    newMapsVisibleCheckBox.setSelected(AppPreferences.newMapsVisible.get());
+    newTokensVisibleCheckBox.setSelected(AppPreferences.newTokensVisible.get());
+    stampsStartFreeSizeCheckBox.setSelected(AppPreferences.objectsStartFreesize.get());
+    tokensStartFreeSizeCheckBox.setSelected(AppPreferences.tokensStartFreesize.get());
+    stampsStartSnapToGridCheckBox.setSelected(AppPreferences.objectsStartSnapToGrid.get());
+    backgroundsStartFreeSizeCheckBox.setSelected(AppPreferences.backgroundsStartFreesize.get());
+    showStatSheetCheckBox.setSelected(AppPreferences.showStatSheet.get());
+    showPortraitCheckBox.setSelected(AppPreferences.showPortrait.get());
+    showStatSheetModifierCheckBox.setSelected(
+        AppPreferences.showStatSheetRequiresModifierKey.get());
+    forceFacingArrowCheckBox.setSelected(AppPreferences.forceFacingArrow.get());
+    backgroundsStartSnapToGridCheckBox.setSelected(AppPreferences.backgroundsStartSnapToGrid.get());
+    defaultGridSizeTextField.setText(Integer.toString(AppPreferences.defaultGridSize.get()));
     // Localizes units per cell, using the proper separator. Fixes #507.
     defaultUnitsPerCellTextField.setText(
-        StringUtil.formatDecimal(AppPreferences.getDefaultUnitsPerCell(), 1));
+        StringUtil.formatDecimal(AppPreferences.defaultUnitsPerCell.get(), 1));
     defaultVisionDistanceTextField.setText(
-        Integer.toString(AppPreferences.getDefaultVisionDistance()));
-    statsheetPortraitSize.setText(Integer.toString(AppPreferences.getPortraitSize()));
-    fontSizeTextField.setText(Integer.toString(AppPreferences.getFontSize()));
-    haloLineWidthSpinner.setValue(AppPreferences.getHaloLineWidth());
-    mapVisibilityWarning.setSelected(AppPreferences.getMapVisibilityWarning());
+        Integer.toString(AppPreferences.defaultVisionDistance.get()));
+    statsheetPortraitSize.setText(Integer.toString(AppPreferences.portraitSize.get()));
+    fontSizeTextField.setText(Integer.toString(AppPreferences.fontSize.get()));
+    haloLineWidthSpinner.setValue(AppPreferences.haloLineWidth.get());
+    mapVisibilityWarning.setSelected(AppPreferences.mapVisibilityWarning.get());
 
     haloOverlayOpacitySpinner.setModel(
-        new SpinnerNumberModel(AppPreferences.getHaloOverlayOpacity(), 0, 255, 1));
+        new SpinnerNumberModel(AppPreferences.haloOverlayOpacity.get().intValue(), 0, 255, 1));
     auraOverlayOpacitySpinner.setModel(
-        new SpinnerNumberModel(AppPreferences.getAuraOverlayOpacity(), 0, 255, 1));
+        new SpinnerNumberModel(AppPreferences.auraOverlayOpacity.get().intValue(), 0, 255, 1));
     lightOverlayOpacitySpinner.setModel(
-        new SpinnerNumberModel(AppPreferences.getLightOverlayOpacity(), 0, 255, 1));
+        new SpinnerNumberModel(AppPreferences.lightOverlayOpacity.get().intValue(), 0, 255, 1));
     lumensOverlayOpacitySpinner.setModel(
-        new SpinnerNumberModel(AppPreferences.getLumensOverlayOpacity(), 0, 255, 1));
+        new SpinnerNumberModel(AppPreferences.lumensOverlayOpacity.get().intValue(), 0, 255, 1));
     lumensOverlayBorderThicknessSpinner.setModel(
         new SpinnerNumberModel(
-            AppPreferences.getLumensOverlayBorderThickness(), 0, Integer.MAX_VALUE, 1));
-    lumensOverlayShowByDefaultCheckBox.setSelected(AppPreferences.getLumensOverlayShowByDefault());
-    lightsShowByDefaultCheckBox.setSelected(AppPreferences.getLightsShowByDefault());
+            AppPreferences.lumensOverlayBorderThickness.get().intValue(), 0, Integer.MAX_VALUE, 1));
+    lumensOverlayShowByDefaultCheckBox.setSelected(AppPreferences.lumensOverlayShowByDefault.get());
+    lightsShowByDefaultCheckBox.setSelected(AppPreferences.lightsShowByDefault.get());
     fogOverlayOpacitySpinner.setModel(
-        new SpinnerNumberModel(AppPreferences.getFogOverlayOpacity(), 0, 255, 1));
+        new SpinnerNumberModel(AppPreferences.fogOverlayOpacity.get().intValue(), 0, 255, 1));
 
     useHaloColorAsVisionOverlayCheckBox.setSelected(
-        AppPreferences.getUseHaloColorOnVisionOverlay());
-    autoRevealVisionOnGMMoveCheckBox.setSelected(AppPreferences.getAutoRevealVisionOnGMMovement());
-    showSmiliesCheckBox.setSelected(AppPreferences.getShowSmilies());
-    playSystemSoundCheckBox.setSelected(AppPreferences.getPlaySystemSounds());
-    playStreamsCheckBox.setSelected(AppPreferences.getPlayStreams());
+        AppPreferences.useHaloColorOnVisionOverlay.get());
+    autoRevealVisionOnGMMoveCheckBox.setSelected(AppPreferences.autoRevealVisionOnGMMovement.get());
+    showSmiliesCheckBox.setSelected(AppPreferences.showSmilies.get());
+    playSystemSoundCheckBox.setSelected(AppPreferences.playSystemSounds.get());
+    playStreamsCheckBox.setSelected(AppPreferences.playStreams.get());
     playSystemSoundOnlyWhenNotFocusedCheckBox.setSelected(
-        AppPreferences.getPlaySystemSoundsOnlyWhenNotFocused());
-    syrinscapeActiveCheckBox.setSelected(AppPreferences.getSyrinscapeActive());
-    showAvatarInChat.setSelected(AppPreferences.getShowAvatarInChat());
-    allowPlayerMacroEditsDefault.setSelected(AppPreferences.getAllowPlayerMacroEditsDefault());
-    toolTipInlineRolls.setSelected(AppPreferences.getUseToolTipForInlineRoll());
-    suppressToolTipsMacroLinks.setSelected(AppPreferences.getSuppressToolTipsForMacroLinks());
-    trustedOutputForeground.setColor(AppPreferences.getTrustedPrefixFG());
-    trustedOutputBackground.setColor(AppPreferences.getTrustedPrefixBG());
-    toolTipInitialDelay.setText(Integer.toString(AppPreferences.getToolTipInitialDelay()));
-    toolTipDismissDelay.setText(Integer.toString(AppPreferences.getToolTipDismissDelay()));
-    facingFaceEdges.setSelected(AppPreferences.getFaceEdge());
-    facingFaceVertices.setSelected(AppPreferences.getFaceVertex());
+        AppPreferences.playSystemSoundsOnlyWhenNotFocused.get());
+    syrinscapeActiveCheckBox.setSelected(AppPreferences.syrinscapeActive.get());
+    showAvatarInChat.setSelected(AppPreferences.showAvatarInChat.get());
+    allowPlayerMacroEditsDefault.setSelected(AppPreferences.allowPlayerMacroEditsDefault.get());
+    toolTipInlineRolls.setSelected(AppPreferences.useToolTipForInlineRoll.get());
+    suppressToolTipsMacroLinks.setSelected(AppPreferences.suppressToolTipsForMacroLinks.get());
+    trustedOutputForeground.setColor(AppPreferences.trustedPrefixForeground.get());
+    trustedOutputBackground.setColor(AppPreferences.trustedPrefixBackground.get());
+    toolTipInitialDelay.setText(Integer.toString(AppPreferences.toolTipInitialDelay.get()));
+    toolTipDismissDelay.setText(Integer.toString(AppPreferences.toolTipDismissDelay.get()));
+    facingFaceEdges.setSelected(AppPreferences.faceEdge.get());
+    facingFaceVertices.setSelected(AppPreferences.faceVertex.get());
 
     chatAutosaveTime.setModel(
-        new SpinnerNumberModel(AppPreferences.getChatAutosaveTime(), 0, 24 * 60, 1));
-    chatFilenameFormat.setText(AppPreferences.getChatFilenameFormat());
+        new SpinnerNumberModel(
+            AppPreferences.chatAutoSaveTimeInMinutes.get().intValue(), 0, 24 * 60, 1));
+    chatFilenameFormat.setText(AppPreferences.chatFilenameFormat.get());
 
-    fitGMView.setSelected(AppPreferences.getFitGMView());
-    hideNPCs.setSelected(AppPreferences.getInitHideNpcs());
-    ownerPermissions.setSelected(AppPreferences.getInitOwnerPermissions());
-    lockMovement.setSelected(AppPreferences.getInitLockMovement());
-    showInitGainMessage.setSelected(AppPreferences.isShowInitGainMessage());
+    fitGMView.setSelected(AppPreferences.fitGmView.get());
+    hideNPCs.setSelected(AppPreferences.initiativePanelHidesNpcs.get());
+    ownerPermissions.setSelected(AppPreferences.initiativePanelAllowsOwnerPermissions.get());
+    lockMovement.setSelected(AppPreferences.initiativeMovementLocked.get());
+    showInitGainMessage.setSelected(AppPreferences.showInitiativeGainedMessage.get());
     upnpDiscoveryTimeoutTextField.setText(
-        Integer.toString(AppPreferences.getUpnpDiscoveryTimeout()));
-    allowExternalMacroAccessCheckBox.setSelected(AppPreferences.getAllowExternalMacroAccess());
-    fileSyncPath.setText(AppPreferences.getFileSyncPath());
+        Integer.toString(AppPreferences.upnpDiscoveryTimeout.get()));
+    allowExternalMacroAccessCheckBox.setSelected(AppPreferences.allowExternalMacroAccess.get());
+    fileSyncPath.setText(AppPreferences.fileSyncPath.get());
 
     // get JVM User Defaults/User override preferences
     if (!UserJvmOptions.loadAppCfg()) {
@@ -1637,7 +1653,7 @@ public class PreferencesDialog extends JDialog {
       }
     }
 
-    Integer rawVal = AppPreferences.getTypingNotificationDuration();
+    Integer rawVal = AppPreferences.typingNotificationDurationInSeconds.get();
     Integer typingVal = null;
     if (rawVal != null
         && rawVal > 99) { // backward compatibility -- used to be stored in ms, now in seconds
@@ -1651,14 +1667,15 @@ public class PreferencesDialog extends JDialog {
       }
     }
     int value = Math.abs((typingVal == null || typingVal > rawVal) ? rawVal : typingVal);
-    AppPreferences.setTypingNotificationDuration(value);
+    AppPreferences.typingNotificationDurationInSeconds.set(value);
 
     SpinnerNumberModel typingDurationModel =
-        new SpinnerNumberModel((int) AppPreferences.getTypingNotificationDuration(), 0, 99, 1);
+        new SpinnerNumberModel(
+            (int) AppPreferences.typingNotificationDurationInSeconds.get(), 0, 99, 1);
     typingNotificationDuration.setModel(typingDurationModel);
 
-    chatNotificationColor.setColor(AppPreferences.getChatNotificationColor());
-    chatNotificationShowBackground.setSelected(AppPreferences.getChatNotificationShowBackground());
+    chatNotificationColor.setColor(AppPreferences.chatNotificationColor.get());
+    chatNotificationShowBackground.setSelected(AppPreferences.chatNotificationBackground.get());
 
     CompletableFuture<CipherUtil.Key> keys = new PublicPrivateKeyStore().getKeys();
 

--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
@@ -39,8 +39,8 @@ public class StatSheetListener {
    */
   @Subscribe
   public void onHoverEnter(TokenHoverEnter event) {
-    if (AppPreferences.getShowStatSheet()
-        && AppPreferences.getShowStatSheetModifier() == event.shiftDown()) {
+    if (AppPreferences.showStatSheet.get()
+        && AppPreferences.showStatSheetRequiresModifierKey.get() == event.shiftDown()) {
       var ssManager = new StatSheetManager();
       if (statSheet == null && !ssManager.isLegacyStatSheet(event.token().getStatSheet())) {
         /*

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
@@ -143,7 +143,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
     movementMetricModel.addElement(WalkerMetric.ONE_ONE_ONE);
     movementMetricModel.addElement(WalkerMetric.MANHATTAN);
     movementMetricModel.addElement(WalkerMetric.NO_DIAGONALS);
-    movementMetricModel.setSelectedItem(AppPreferences.getMovementMetric());
+    movementMetricModel.setSelectedItem(AppPreferences.movementMetric.get());
 
     movementMetricCombo.setModel(movementMetricModel);
     movementMetricCombo.addItemListener(

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
@@ -182,7 +182,7 @@ public class StartServerDialogPreferences {
     // to the user to configure before the start server dialog. So if it has not been
     // specified we default to the users preferences.
     return Objects.requireNonNullElseGet(
-        useToolTipsForUnformattedRolls, AppPreferences::getUseToolTipForInlineRoll);
+        useToolTipsForUnformattedRolls, AppPreferences.useToolTipForInlineRoll::get);
   }
 
   public void setUseToolTipsForUnformattedRolls(boolean flag) {

--- a/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
@@ -501,7 +501,7 @@ public class RessourceManager {
 
   private static ImageIcon getIcon(Icons icon, int width, int height) {
     var iconPaths = classicIcons;
-    switch (AppPreferences.getIconTheme()) {
+    switch (AppPreferences.iconTheme.get()) {
       case ROD_TAKEHARA -> iconPaths = rodIcons;
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
@@ -179,7 +179,7 @@ public class NewTokenDialog extends AbeillePanel<Token> {
             e -> {
               success = true;
               if (!getShowDialogCheckbox().isSelected()) {
-                AppPreferences.setShowDialogOnNewToken(false);
+                AppPreferences.showDialogOnNewToken.set(false);
               }
               if (getNameTextField().getText().equals("")) {
                 MapTool.showError(I18N.getText("msg.error.emptyTokenName"));

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -1565,7 +1565,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     // Set the color style via Theme
     try {
       File themeFile =
-          new File(AppConstants.THEMES_DIR, AppPreferences.getDefaultMacroEditorTheme() + ".xml");
+          new File(AppConstants.THEMES_DIR, AppPreferences.defaultMacroEditorTheme.get() + ".xml");
       Theme theme = Theme.load(new FileInputStream(themeFile));
       theme.apply(xmlStatblockRSyntaxTextArea);
 
@@ -1587,7 +1587,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     // Set the color style via Theme
     try {
       File themeFile =
-          new File(AppConstants.THEMES_DIR, AppPreferences.getDefaultMacroEditorTheme() + ".xml");
+          new File(AppConstants.THEMES_DIR, AppPreferences.defaultMacroEditorTheme.get() + ".xml");
       Theme theme = Theme.load(new FileInputStream(themeFile));
       theme.apply(textStatblockRSyntaxTextArea);
 
@@ -1896,7 +1896,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       // Set the color style via Theme
       try {
         File themeFile =
-            new File(AppConstants.THEMES_DIR, AppPreferences.getDefaultMacroEditorTheme() + ".xml");
+            new File(
+                AppConstants.THEMES_DIR, AppPreferences.defaultMacroEditorTheme.get() + ".xml");
         Theme theme = Theme.load(new FileInputStream(themeFile));
         theme.apply(j);
 
@@ -1964,7 +1965,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       // Set the color style via Theme
       try {
         File themeFile =
-            new File(AppConstants.THEMES_DIR, AppPreferences.getDefaultMacroEditorTheme() + ".xml");
+            new File(
+                AppConstants.THEMES_DIR, AppPreferences.defaultMacroEditorTheme.get() + ".xml");
         Theme theme = Theme.load(new FileInputStream(themeFile));
         theme.apply(this);
 

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
@@ -349,7 +349,7 @@ public class InitiativeListCellRenderer extends JPanel
         Graphics2D g2d = (Graphics2D) g;
         Stroke oldStroke = g2d.getStroke();
         Color oldColor = g.getColor();
-        g2d.setStroke(new BasicStroke(AppPreferences.getHaloLineWidth()));
+        g2d.setStroke(new BasicStroke(AppPreferences.haloLineWidth.get()));
         g.setColor(token.getHaloColor());
         g2d.draw(new Rectangle2D.Double(x, y, ICON_SIZE, ICON_SIZE));
         g2d.setStroke(oldStroke);

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -75,22 +75,22 @@ public class InitiativePanel extends JPanel
   private final JList<TokenInitiative> displayList;
 
   /** Flag indicating that token images are shown in the list. */
-  private boolean showTokens = AppPreferences.getInitShowTokens();
+  private boolean showTokens = AppPreferences.initiativePanelShowsTokenImage.get();
 
   /**
    * Flag indicating that token states are shown in the list. Only valid if {@link #showTokens} is
    * <code>true</code>.
    */
-  private boolean showTokenStates = AppPreferences.getInitShowTokenStates();
+  private boolean showTokenStates = AppPreferences.initiativePanelShowsTokenState.get();
 
   /** Flag indicating that initiative state is shown in the list. */
-  private boolean showInitState = AppPreferences.getInitShowInitiative();
+  private boolean showInitState = AppPreferences.initiativePanelShowsInitiative.get();
 
   /**
    * Flag indicating that two lines are used for initiative stated. It is only valid if {@link
    * #showInitState} is <code>true</code>.
    */
-  private boolean initStateSecondLine = AppPreferences.getInitShow2ndLine();
+  private boolean initStateSecondLine = AppPreferences.initiativePanelShowsInitiativeOnLine2.get();
 
   /** The zone data being displayed. */
   private Zone zone;
@@ -592,7 +592,8 @@ public class InitiativePanel extends JPanel
       String s = I18N.getText("initPanel.displayMessage", t.getName());
       if (InitiativeListModel.isTokenVisible(t, list.isHideNPC())
           && t.getType() != Type.NPC
-          && AppPreferences.isShowInitGainMessage()) MapTool.addMessage(TextMessage.say(null, s));
+          && AppPreferences.showInitiativeGainedMessage.get())
+        MapTool.addMessage(TextMessage.say(null, s));
       displayList.ensureIndexIsVisible(model.getDisplayIndex(list.getCurrent()));
       NEXT_ACTION.setEnabled(
           !isInitPanelButtonsDisabled() && hasOwnerPermission(list.getCurrentToken()));
@@ -672,7 +673,7 @@ public class InitiativePanel extends JPanel
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
-          AppPreferences.setInitShowTokens(showTokens);
+          AppPreferences.initiativePanelShowsTokenImage.set(showTokens);
         }
       };
 
@@ -685,7 +686,7 @@ public class InitiativePanel extends JPanel
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
-          AppPreferences.setInitShowTokenStates(showTokenStates);
+          AppPreferences.initiativePanelShowsTokenState.set(showTokenStates);
         }
       };
 
@@ -698,7 +699,7 @@ public class InitiativePanel extends JPanel
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
-          AppPreferences.setInitShowInitiative(showInitState);
+          AppPreferences.initiativePanelShowsInitiative.set(showInitState);
         }
       };
 
@@ -711,7 +712,7 @@ public class InitiativePanel extends JPanel
           displayList.setCellRenderer(
               new InitiativeListCellRenderer(
                   InitiativePanel.this)); // Regenerates the size of each row.
-          AppPreferences.setInitShow2ndLine(initStateSecondLine);
+          AppPreferences.initiativePanelShowsInitiativeOnLine2.set(initStateSecondLine);
         }
       };
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
@@ -100,7 +100,7 @@ public class FogRenderer {
     timer.start("renderFog-softFow");
     if (!softFogArea.isEmpty()) {
       worldG.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC));
-      worldG.setColor(new Color(0, 0, 0, AppPreferences.getFogOverlayOpacity()));
+      worldG.setColor(new Color(0, 0, 0, AppPreferences.fogOverlayOpacity.get()));
       worldG.fill(softFogArea);
     }
     timer.stop("renderFog-softFow");

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -40,7 +40,7 @@ public class HaloRenderer {
   // Render Halos
   public void renderHalo(Graphics2D g2d, Token token, TokenLocation location) {
     if (token.hasHalo()) {
-      g2d.setStroke(new BasicStroke(AppPreferences.getHaloLineWidth()));
+      g2d.setStroke(new BasicStroke(AppPreferences.haloLineWidth.get()));
       g2d.setColor(token.getHaloColor());
       g2d.draw(location.bounds);
     }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LightsRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LightsRenderer.java
@@ -55,7 +55,7 @@ public class LightsRenderer {
       }
 
       final var lightBlending =
-          AlphaComposite.SrcOver.derive(AppPreferences.getAuraOverlayOpacity() / 255.0f);
+          AlphaComposite.SrcOver.derive(AppPreferences.auraOverlayOpacity.get() / 255.0f);
       final var overlayFillColor = new Color(0, 0, 0, 0);
 
       renderHelper.bufferedRender(
@@ -83,7 +83,7 @@ public class LightsRenderer {
       final var overlayBlending =
           switch (zone.getLightingStyle()) {
             case OVERTOP -> AlphaComposite.SrcOver.derive(
-                AppPreferences.getLightOverlayOpacity() / 255.f);
+                AppPreferences.lightOverlayOpacity.get() / 255.f);
             case ENVIRONMENTAL -> LightingComposite.OverlaidLights;
           };
       final var overlayFillColor =

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LumensRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LumensRenderer.java
@@ -59,7 +59,7 @@ public class LumensRenderer {
 
   private void renderWorld(Graphics2D worldG, PlayerView view) {
     var timer = CodeTimer.get();
-    var overlayOpacity = AppPreferences.getLumensOverlayOpacity() / 255.0f;
+    var overlayOpacity = AppPreferences.lumensOverlayOpacity.get() / 255.0f;
 
     var visibleArea = zoneView.getVisibleArea(view);
     final var disjointLumensLevels = zoneView.getDisjointObscuredLumensLevels(view);
@@ -116,7 +116,7 @@ public class LumensRenderer {
     }
 
     // Now draw borders around each region if configured.
-    final var borderThickness = AppPreferences.getLumensOverlayBorderThickness();
+    final var borderThickness = AppPreferences.lumensOverlayBorderThickness.get();
     if (borderThickness > 0) {
       worldG.setStroke(
           new BasicStroke((float) borderThickness, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
@@ -86,7 +86,7 @@ public class VisionOverlayRenderer {
     worldG.draw(currentTokenVisionArea);
 
     Color visionColor = token.getVisionOverlayColor();
-    if (visionColor == null && AppPreferences.getUseHaloColorOnVisionOverlay()) {
+    if (visionColor == null && AppPreferences.useHaloColorOnVisionOverlay.get()) {
       visionColor = token.getHaloColor();
     }
     if (visionColor != null) {
@@ -95,7 +95,7 @@ public class VisionOverlayRenderer {
               visionColor.getRed(),
               visionColor.getGreen(),
               visionColor.getBlue(),
-              AppPreferences.getHaloOverlayOpacity()));
+              AppPreferences.haloOverlayOpacity.get()));
       worldG.fill(currentTokenVisionArea);
     }
   }

--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -78,10 +78,11 @@ public class CampaignProperties {
   private Map<String, String> characterSheets = new HashMap<>();
 
   /** Flag indicating that owners have special permissions */
-  private boolean initiativeOwnerPermissions = AppPreferences.getInitOwnerPermissions();
+  private boolean initiativeOwnerPermissions =
+      AppPreferences.initiativePanelAllowsOwnerPermissions.get();
 
   /** Flag indicating that owners can only move tokens when they have initiative */
-  private boolean initiativeMovementLock = AppPreferences.getInitLockMovement();
+  private boolean initiativeMovementLock = AppPreferences.initiativeMovementLocked.get();
 
   /** Whether the default initiative sort order is reversed */
   private boolean initiativeUseReverseSort = false;

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -75,7 +75,7 @@ public abstract class Grid implements Cloneable {
   private int size;
 
   public Grid() {
-    setSize(AppPreferences.getDefaultGridSize());
+    setSize(AppPreferences.defaultGridSize.get());
   }
 
   public Grid(Grid grid) {
@@ -936,7 +936,7 @@ public abstract class Grid implements Cloneable {
    */
   protected WalkerMetric getCurrentMetric() {
     return MapTool.isPersonalServer()
-        ? AppPreferences.getMovementMetric()
+        ? AppPreferences.movementMetric.get()
         : MapTool.getServerPolicy().getMovementMetric();
   }
 

--- a/src/main/java/net/rptools/maptool/model/HeroLabData.java
+++ b/src/main/java/net/rptools/maptool/model/HeroLabData.java
@@ -291,7 +291,7 @@ public class HeroLabData {
   }
 
   public File getPortfolioFile() {
-    String fileSyncPath = AppPreferences.getFileSyncPath();
+    String fileSyncPath = AppPreferences.fileSyncPath.get();
 
     if (portfolioPath == null || portfolioPath.isEmpty() || fileSyncPath.isEmpty()) {
       return portfolioFile;
@@ -305,10 +305,10 @@ public class HeroLabData {
     this.portfolioFile = portfolioFile;
     lastModified = getPortfolioLastModified();
 
-    if (!AppPreferences.getFileSyncPath().isEmpty()) {
+    if (!AppPreferences.fileSyncPath.get().isEmpty()) {
       try {
         portfolioPath =
-            Paths.get(AppPreferences.getFileSyncPath())
+            Paths.get(AppPreferences.fileSyncPath.get())
                 .relativize(portfolioFile.toPath())
                 .toString();
       } catch (IllegalArgumentException e) {
@@ -316,7 +316,7 @@ public class HeroLabData {
             "Unable to relativize paths for: ["
                 + portfolioFile
                 + "] ["
-                + AppPreferences.getFileSyncPath()
+                + AppPreferences.fileSyncPath.get()
                 + "]");
         portfolioPath = "";
       }

--- a/src/main/java/net/rptools/maptool/model/InitiativeList.java
+++ b/src/main/java/net/rptools/maptool/model/InitiativeList.java
@@ -79,7 +79,7 @@ public class InitiativeList implements Serializable {
   private boolean fullUpdate;
 
   /** Hide all of the NPC's from the players. */
-  private boolean hideNPC = AppPreferences.getInitHideNpcs();
+  private boolean hideNPC = AppPreferences.initiativePanelHidesNpcs.get();
 
   /*---------------------------------------------------------------------------------------------
    * Class Variables

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -200,7 +200,7 @@ public class IsometricGrid extends Grid {
   public ZoneWalker createZoneWalker() {
     WalkerMetric metric =
         MapTool.isPersonalServer()
-            ? AppPreferences.getMovementMetric()
+            ? AppPreferences.movementMetric.get()
             : MapTool.getServerPolicy().getMovementMetric();
     return new AStarSquareEuclideanWalker(getZone(), metric);
   }

--- a/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
+++ b/src/main/java/net/rptools/maptool/model/MacroButtonProperties.java
@@ -73,7 +73,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
   private @Nonnull String fontSize = "1.00em";
   private @Nonnull String minWidth = "";
   private @Nonnull String maxWidth = "";
-  private @Nonnull Boolean allowPlayerEdits = AppPreferences.getAllowPlayerMacroEditsDefault();
+  private @Nonnull Boolean allowPlayerEdits = AppPreferences.allowPlayerMacroEditsDefault.get();
   private @Nonnull String toolTip = "";
   private @Nonnull Boolean displayHotKey = true;
 
@@ -174,7 +174,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setMaxWidth("");
     setTokenId((GUID) null);
     setSaveLocation("");
-    setAllowPlayerEdits(AppPreferences.getAllowPlayerMacroEditsDefault());
+    setAllowPlayerEdits(AppPreferences.allowPlayerMacroEditsDefault.get());
     setDisplayHotKey(true);
     setCompareGroup(true);
     setCompareSortPrefix(true);
@@ -190,7 +190,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     this(index);
     setSaveLocation(panelClass);
     setGroup(group);
-    setAllowPlayerEdits(AppPreferences.getAllowPlayerMacroEditsDefault());
+    setAllowPlayerEdits(AppPreferences.allowPlayerMacroEditsDefault.get());
     setDisplayHotKey(true);
     setCompareGroup(true);
     setCompareSortPrefix(true);
@@ -208,7 +208,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     setSaveLocation("Token");
     setTokenId(token);
     setGroup(group);
-    setAllowPlayerEdits(AppPreferences.getAllowPlayerMacroEditsDefault());
+    setAllowPlayerEdits(AppPreferences.allowPlayerMacroEditsDefault.get());
     setDisplayHotKey(true);
     setCompareGroup(true);
     setCompareSortPrefix(true);
@@ -815,7 +815,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
     fontSize = "1.00em";
     minWidth = "";
     maxWidth = "";
-    allowPlayerEdits = AppPreferences.getAllowPlayerMacroEditsDefault();
+    allowPlayerEdits = AppPreferences.allowPlayerMacroEditsDefault.get();
     toolTip = "";
   }
 
@@ -1058,7 +1058,7 @@ public class MacroButtonProperties implements Comparable<MacroButtonProperties> 
       compareApplyToSelectedTokens = true;
     }
     if (allowPlayerEdits == null) {
-      allowPlayerEdits = AppPreferences.getAllowPlayerMacroEditsDefault();
+      allowPlayerEdits = AppPreferences.allowPlayerMacroEditsDefault.get();
     }
     if (macroUUID == null) {
       macroUUID = UUID.randomUUID().toString();

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -290,7 +290,7 @@ public class SquareGrid extends Grid {
   public ZoneWalker createZoneWalker() {
     WalkerMetric metric =
         MapTool.isPersonalServer()
-            ? AppPreferences.getMovementMetric()
+            ? AppPreferences.movementMetric.get()
             : MapTool.getServerPolicy().getMovementMetric();
     return new AStarSquareEuclideanWalker(getZone(), metric);
   }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.lib.MD5Key;
-import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.tool.drawing.UndoPerZone;
@@ -1376,7 +1376,7 @@ public class Zone {
 
   public TopologyTypeSet getTopologyTypes() {
     if (topologyTypes == null) {
-      topologyTypes = AppPreferences.getTopologyTypes();
+      topologyTypes = AppStatePersisted.getTopologyTypes();
     }
 
     return topologyTypes;

--- a/src/main/java/net/rptools/maptool/model/ZoneFactory.java
+++ b/src/main/java/net/rptools/maptool/model/ZoneFactory.java
@@ -57,15 +57,15 @@ public class ZoneFactory {
     zone.setBackgroundPaint(new DrawableTexturePaint(defaultImageId));
     zone.setFogPaint(new DrawableColorPaint(Color.black));
 
-    zone.setVisible(AppPreferences.getNewMapsVisible());
-    zone.setHasFog(AppPreferences.getNewMapsHaveFOW());
-    zone.setUnitsPerCell(AppPreferences.getDefaultUnitsPerCell());
-    zone.setTokenVisionDistance(AppPreferences.getDefaultVisionDistance());
-    zone.setVisionType(AppPreferences.getDefaultVisionType());
+    zone.setVisible(AppPreferences.newMapsVisible.get());
+    zone.setHasFog(AppPreferences.newMapsHaveFow.get());
+    zone.setUnitsPerCell(AppPreferences.defaultUnitsPerCell.get());
+    zone.setTokenVisionDistance(AppPreferences.defaultVisionDistance.get());
+    zone.setVisionType(AppPreferences.defaultVisionType.get());
 
-    zone.setGrid(GridFactory.createGrid(AppPreferences.getDefaultGridType()));
-    zone.setGridColor(AppPreferences.getDefaultGridColor().getRGB());
-    zone.getGrid().setSize(AppPreferences.getDefaultGridSize());
+    zone.setGrid(GridFactory.createGrid(AppPreferences.defaultGridType.get()));
+    zone.setGridColor(AppPreferences.defaultGridColor.get().getRGB());
+    zone.getGrid().setSize(AppPreferences.defaultGridSize.get());
     zone.getGrid().setOffset(0, 0);
 
     return zone;

--- a/src/main/java/net/rptools/maptool/model/player/LocalPlayer.java
+++ b/src/main/java/net/rptools/maptool/model/player/LocalPlayer.java
@@ -28,7 +28,7 @@ public class LocalPlayer extends Player {
   private CipherUtil.Key password;
 
   public LocalPlayer() throws NoSuchAlgorithmException, InvalidKeySpecException {
-    this(AppPreferences.getDefaultUserName(), Role.GM, "");
+    this(AppPreferences.defaultUserName.get(), Role.GM, "");
   }
 
   public LocalPlayer(String name, Role role, String plainTextPassword)

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetContext.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetContext.java
@@ -187,7 +187,7 @@ public class StatSheetContext {
     notesType = AppUtil.playerOwns(token) ? token.getNotesType() : null;
     speechName = token.getSpeechName();
 
-    if (AppPreferences.getShowPortrait()) {
+    if (AppPreferences.showPortrait.get()) {
       imageAsset = token.getImageAssetId();
       portraitAsset = token.getPortraitImage();
     } else {
@@ -238,7 +238,7 @@ public class StatSheetContext {
       var image = ImageManager.getImage(token.getImageAssetId());
       dim = new Dimension(image.getWidth(), image.getHeight());
     }
-    SwingUtil.constrainTo(dim, AppPreferences.getPortraitSize());
+    SwingUtil.constrainTo(dim, AppPreferences.portraitSize.get());
     portraitWidth = dim.width;
     portraitHeight = dim.height;
 

--- a/src/main/java/net/rptools/maptool/server/ServerPolicy.java
+++ b/src/main/java/net/rptools/maptool/server/ServerPolicy.java
@@ -43,14 +43,14 @@ public class ServerPolicy {
   private boolean hidemapselectui;
   private boolean disablePlayerAssetPanel;
 
-  private boolean useAstarPathfinding = AppPreferences.isUsingAstarPathfinding();
-  private boolean vblBlocksMove = AppPreferences.getVblBlocksMove();
+  private boolean useAstarPathfinding = AppPreferences.pathfindingEnabled.get();
+  private boolean vblBlocksMove = AppPreferences.pathfindingBlockedByVbl.get();
 
   public ServerPolicy() {
     // Default tool tip usage for inline rolls to user preferences.
-    useToolTipsForDefaultRollFormat = AppPreferences.getUseToolTipForInlineRoll();
+    useToolTipsForDefaultRollFormat = AppPreferences.useToolTipForInlineRoll.get();
     // Default movement metric from preferences
-    movementMetric = AppPreferences.getMovementMetric();
+    movementMetric = AppPreferences.movementMetric.get();
   }
 
   public ServerPolicy(ServerPolicy other) {
@@ -290,7 +290,7 @@ public class ServerPolicy {
         getDisablePlayerAssetPanel() ? BigDecimal.ONE : BigDecimal.ZERO);
 
     WalkerMetric metric =
-        MapTool.isPersonalServer() ? AppPreferences.getMovementMetric() : getMovementMetric();
+        MapTool.isPersonalServer() ? AppPreferences.movementMetric.get() : getMovementMetric();
     sinfo.addProperty("movement metric", metric.name());
 
     sinfo.addProperty("using ai", isUsingAstarPathfinding() ? BigDecimal.ONE : BigDecimal.ZERO);

--- a/src/main/java/net/rptools/maptool/util/ExtractHeroLab.java
+++ b/src/main/java/net/rptools/maptool/util/ExtractHeroLab.java
@@ -104,7 +104,7 @@ public final class ExtractHeroLab {
   private File validatePortfolioFile(File heroLabPortfolio) {
     // If unable to find file, prompt user to point to new location or fail
     if (!heroLabPortfolio.exists()) {
-      JFileChooser fileChooser = new JFileChooser(AppPreferences.getFileSyncPath());
+      JFileChooser fileChooser = new JFileChooser(AppPreferences.fileSyncPath.get());
       fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
       FileNameExtensionFilter filter = new FileNameExtensionFilter("Hero Lab Portfolio", "por");
       fileChooser.setFileFilter(filter);

--- a/src/main/java/net/rptools/maptool/util/MessageUtil.java
+++ b/src/main/java/net/rptools/maptool/util/MessageUtil.java
@@ -137,7 +137,7 @@ public class MessageUtil {
 
     sb.append("<table class='ava-msg'><tr valign='top'>");
 
-    if (AppPreferences.getShowAvatarInChat()) {
+    if (AppPreferences.showAvatarInChat.get()) {
       if (token == null && MapTool.getFrame().getCommandPanel().isImpersonating()) {
         GUID guid = MapTool.getFrame().getCommandPanel().getIdentityGUID();
         if (guid != null)

--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -660,7 +660,7 @@ public class PersistenceUtil {
 
     BufferedImage thumb = new BufferedImage(sz.width, sz.height, BufferedImage.TRANSLUCENT);
     Graphics2D g = thumb.createGraphics();
-    AppPreferences.getRenderQuality().setShrinkRenderingHints(g);
+    AppPreferences.renderQuality.get().setShrinkRenderingHints(g);
     g.drawImage(image, 0, 0, sz.width, sz.height, null);
     g.dispose();
 
@@ -672,7 +672,7 @@ public class PersistenceUtil {
             Math.min(image.getHeight(), MapTool.getThumbnailSize().height));
     BufferedImage thumbLarge = new BufferedImage(sz.width, sz.height, BufferedImage.TRANSLUCENT);
     g = thumbLarge.createGraphics();
-    AppPreferences.getRenderQuality().setShrinkRenderingHints(g);
+    AppPreferences.renderQuality.get().setShrinkRenderingHints(g);
     g.drawImage(image, 0, 0, sz.width, sz.height, null);
     g.dispose();
 

--- a/src/main/java/net/rptools/maptool/util/UPnPUtil.java
+++ b/src/main/java/net/rptools/maptool/util/UPnPUtil.java
@@ -77,7 +77,7 @@ public class UPnPUtil {
               InternetGatewayDevice[] thisNI;
               thisNI =
                   InternetGatewayDevice.getDevices(
-                      AppPreferences.getUpnpDiscoveryTimeout(),
+                      AppPreferences.upnpDiscoveryTimeout.get(),
                       Discovery.DEFAULT_TTL,
                       Discovery.DEFAULT_MX,
                       ni);


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #4985

### Description of the Change

This add a new `AppPreferences.Preference<T>` type to represent user preferences. Preferences are defined by instantiatng this class and assigning to a static field of `AppPreferences`.

A new `AppStatePersisted` captures those parts of `AppPReferences` that are not related to user preference but are actually about tracking application state across runs of MT. These have more specialized logic as well, so they do not use the new preference types.

That sums up the bulk of the changes, but a couple tweaks were made beyond that:
- The default value for the `typingNotificationDuration` preference was reduced from 5000 seconds to 5 seconds.
- `ChatAutoSave` is no longer a single with a static interface. Instead, we just choose to create only one in `MapTool` and interact with it normally.

### Possible Drawbacks

Assuming no typos in the new preference spellings, should be none.

### Documentation Notes

N/A

### Release Notes

- Refactored `AppPreferences`  to be more declarative.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4986)
<!-- Reviewable:end -->
