### PR TITLE
Fix new compile warning

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -451,8 +451,7 @@ public class CampaignPropertiesDialog extends JDialog {
                   MapTool.showMessage(
                       "CampaignPropertiesDialog.export.message",
                       "msg.title.exportProperties",
-                      JOptionPane.INFORMATION_MESSAGE,
-                      null);
+                      JOptionPane.INFORMATION_MESSAGE);
                   CampaignPropertiesDto campaignPropertiesDto =
                       MapTool.getCampaign().getCampaignProperties().toDto();
                   FileOutputStream fos = new FileOutputStream(chooser.getSelectedFile());


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves on PR #4972

### Description of the Change

Removes an unused `null` var-args parameter that was causing warnings.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/4993)
<!-- Reviewable:end -->
