### PR TITLE
Fix erase flag when DungeonDraftImporter adds topology to the zone

### DIFF
--- a/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
+++ b/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
@@ -203,8 +203,8 @@ public class DungeonDraftImporter {
                     WALL_VBL_STROKE.createStrokedShape(
                         getVBLPath(v.getAsJsonArray(), pixelsPerCell)));
             if (finalDo_transform) vblArea.transform(at);
-            zone.updateTopology(vblArea, true, Zone.TopologyType.WALL_VBL);
-            zone.updateTopology(vblArea, true, Zone.TopologyType.MBL);
+            zone.updateTopology(vblArea, false, Zone.TopologyType.WALL_VBL);
+            zone.updateTopology(vblArea, false, Zone.TopologyType.MBL);
           });
     }
 
@@ -215,8 +215,8 @@ public class DungeonDraftImporter {
           v -> {
             Area vblArea = new Area(getVBLPath(v.getAsJsonArray(), pixelsPerCell));
             if (finalDo_transform) vblArea.transform(at);
-            zone.updateTopology(vblArea, true, Zone.TopologyType.HILL_VBL);
-            zone.updateTopology(vblArea, true, Zone.TopologyType.PIT_VBL);
+            zone.updateTopology(vblArea, false, Zone.TopologyType.HILL_VBL);
+            zone.updateTopology(vblArea, false, Zone.TopologyType.PIT_VBL);
           });
     }
 
@@ -239,8 +239,8 @@ public class DungeonDraftImporter {
               Area vblArea =
                   new Area(DOOR_VBL_STROKE.createStrokedShape(getVBLPath(bounds, pixelsPerCell)));
               if (finalDo_transform) vblArea.transform(at);
-              zone.updateTopology(vblArea, true, Zone.TopologyType.WALL_VBL);
-              zone.updateTopology(vblArea, true, Zone.TopologyType.MBL);
+              zone.updateTopology(vblArea, false, Zone.TopologyType.WALL_VBL);
+              zone.updateTopology(vblArea, false, Zone.TopologyType.MBL);
             }
           });
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes PR #5019, related to #5018

### Description of the Change

PR #5019 had the erase flag flipped in the `DungeonDraftImporter`, which is now fixed.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5027)
<!-- Reviewable:end -->
