### PR TITLE
Fix map dragging state management in DefaultTool

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -495,7 +495,7 @@ public class PointerTool extends DefaultTool {
     // WAYPOINT
     if (SwingUtilities.isRightMouseButton(e) && tokenDragOp != null) {
       tokenDragOp.setWaypoint();
-      setDraggingMap(false); // We no longer drag the map. Fixes bug #616
+      cancelMapDrag(); // We no longer drag the map. Fixes bug #616
       return;
     }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5032 

### Description of the Change

The issue was caused by the combination of `DefaultTool` keeping around previous drag positions, and the surprising ability for `mouseDragged()` events to start before corresponding `mousePressed()` events if other mouse buttons are already presssed. This PR fixes the problem by clearing drag state whenever a drag completes, and double-checking that a map drag has actually begun when in `mouseDragged()`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the map can jump wildly if starting to drag it with other mouse buttons pressed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5033)
<!-- Reviewable:end -->
