### PR TITLE
Remove topology type selections from zones

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppStatePersisted.java
+++ b/src/main/java/net/rptools/maptool/client/AppStatePersisted.java
@@ -67,6 +67,9 @@ public class AppStatePersisted {
   /** Represents the key used to save the paint textures to the preferences. */
   private static final String KEY_SAVED_PAINT_TEXTURES = "savedTextures";
 
+  /** Will be null until read from preferences. */
+  private static EnumSet<Zone.TopologyType> topologyTypes = null;
+
   public static void clearAssetRoots() {
     prefs.put(KEY_ASSET_ROOTS, "");
   }
@@ -169,7 +172,7 @@ public class AppStatePersisted {
     return mruCampaigns;
   }
 
-  public static Set<Zone.TopologyType> getTopologyTypes() {
+  private static EnumSet<Zone.TopologyType> readTopologyTypes() {
     try {
       String typeNames = prefs.get(KEY_TOPOLOGY_TYPES, "");
       if ("".equals(typeNames)) {
@@ -195,14 +198,31 @@ public class AppStatePersisted {
     }
   }
 
+  private static void writeTopologyTypes(Set<Zone.TopologyType> types) {
+    String joined = types.stream().map(Enum::name).collect(Collectors.joining(",", "[", "]"));
+    prefs.put(KEY_TOPOLOGY_TYPES, joined);
+  }
+
+  public static Set<Zone.TopologyType> getTopologyTypes() {
+    if (topologyTypes == null) {
+      topologyTypes = readTopologyTypes();
+    }
+    return topologyTypes;
+  }
+
   /**
    * Sets the selected topology modes.
    *
    * @param types the topology types.
    */
   public static void setTopologyTypes(Set<Zone.TopologyType> types) {
-    String joined = types.stream().map(Enum::name).collect(Collectors.joining(",", "[", "]"));
-    prefs.put(KEY_TOPOLOGY_TYPES, joined);
+    if (topologyTypes == null) {
+      topologyTypes = EnumSet.noneOf(Zone.TopologyType.class);
+    }
+    topologyTypes.clear();
+    topologyTypes.addAll(types);
+
+    writeTopologyTypes(topologyTypes);
   }
 
   public static void setSavedPaintTextures(List<File> savedTextures) {

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -671,9 +671,6 @@ public class MapTool {
       zoneLoadedListener = new ZoneLoadedListener();
 
       Campaign cmpgn = CampaignFactory.createBasicCampaign();
-      // Set the Topology drawing mode to the last mode used for convenience
-      // Should only be one zone, but let's cover our bases.
-      cmpgn.getZones().forEach(zone -> zone.setTopologyTypes(AppStatePersisted.getTopologyTypes()));
 
       // Stop the pre-init client/server.
       disconnect();

--- a/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.client.swing;
 
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Set;
 import javax.swing.Box;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
@@ -89,7 +90,7 @@ public class TopologyModeSelectionPanel extends JToolBar {
       final Icons icon,
       final Icons offIcon,
       String toolTipKey,
-      Zone.TopologyTypeSet initiallySelectedTypes) {
+      Set<Zone.TopologyType> initiallySelectedTypes) {
     final var button = new JToggleButton();
 
     button.setIcon(RessourceManager.getBigIcon(offIcon));
@@ -108,20 +109,21 @@ public class TopologyModeSelectionPanel extends JToolBar {
               var zone = zr.getZone();
               var mode = zone.getTopologyTypes();
               if (button.isSelected()) {
-                mode = mode.with(type);
+                mode.add(type);
               } else {
-                mode = mode.without(type);
+                mode.remove(type);
               }
-
               setMode(mode);
             }
           }
         });
   }
 
-  public void setMode(Zone.TopologyTypeSet topologyTypes) {
+  // TODO Why are we accepting null? Shouldn't the caller read the persisted types?
+  public void setMode(Set<Zone.TopologyType> topologyTypes) {
     AppStatePersisted.setTopologyTypes(topologyTypes);
     if (topologyTypes == null) {
+      // Read back a default if necessary.
       topologyTypes = AppStatePersisted.getTopologyTypes();
     }
 

--- a/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import javax.swing.Box;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
@@ -97,6 +99,14 @@ public class TopologyModeSelectionPanel extends JToolBar {
     button.setSelected(initiallySelectedTypes.contains(type));
     this.add(button);
     modeButtons.put(type, button);
+    button.addChangeListener(
+        new ChangeListener() {
+          @Override
+          public void stateChanged(ChangeEvent e) {
+            // Remember the selection for the next time MT starts.
+            AppStatePersisted.setTopologyTypes(getMode());
+          }
+        });
   }
 
   public Set<Zone.TopologyType> getMode() {

--- a/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
@@ -30,18 +30,9 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Zone;
 
 public class TopologyModeSelectionPanel extends JToolBar {
-  /** The instance. Used to update the button when the ZoneRenderer is changed. */
-  private static TopologyModeSelectionPanel instance;
-
-  public static TopologyModeSelectionPanel getInstance() {
-    return instance;
-  }
-
   private final Map<Zone.TopologyType, JToggleButton> modeButtons;
 
   public TopologyModeSelectionPanel() {
-    instance = this;
-
     setFloatable(false);
     setRollover(true);
     setBorder(null);

--- a/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/TopologyModeSelectionPanel.java
@@ -15,18 +15,15 @@
 package net.rptools.maptool.client.swing;
 
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import javax.swing.Box;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import net.rptools.maptool.client.AppStatePersisted;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Zone;
 
@@ -100,45 +97,17 @@ public class TopologyModeSelectionPanel extends JToolBar {
     button.setSelected(initiallySelectedTypes.contains(type));
     this.add(button);
     modeButtons.put(type, button);
-    button.addChangeListener(
-        new ChangeListener() {
-          @Override
-          public void stateChanged(ChangeEvent e) {
-            ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
-            if (zr != null) {
-              var zone = zr.getZone();
-              var mode = zone.getTopologyTypes();
-              if (button.isSelected()) {
-                mode.add(type);
-              } else {
-                mode.remove(type);
-              }
-              setMode(mode);
-            }
-          }
-        });
   }
 
-  // TODO Why are we accepting null? Shouldn't the caller read the persisted types?
-  public void setMode(Set<Zone.TopologyType> topologyTypes) {
-    AppStatePersisted.setTopologyTypes(topologyTypes);
-    if (topologyTypes == null) {
-      // Read back a default if necessary.
-      topologyTypes = AppStatePersisted.getTopologyTypes();
-    }
-
+  public Set<Zone.TopologyType> getMode() {
+    var result = EnumSet.noneOf(Zone.TopologyType.class);
     for (final var entry : modeButtons.entrySet()) {
       final var topologyType = entry.getKey();
       final var button = entry.getValue();
-
-      button.setSelected(topologyTypes.contains(topologyType));
+      if (button.isSelected()) {
+        result.add(topologyType);
+      }
     }
-
-    // Since setting selection also triggers change listeners, we need this work even early on.
-    ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
-    // Check if there is a map. Fix #1605
-    if (zr != null) {
-      zr.getZone().setTopologyTypes(topologyTypes);
-    }
+    return result;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.swing.TopologyModeSelectionPanel;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
@@ -35,6 +36,7 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
   private final String tooltipKey;
   private final boolean isFilled;
   private final Strategy<StateT> strategy;
+  private final TopologyModeSelectionPanel modeSelectionPanel;
 
   /** The current state of the tool. If {@code null}, nothing is being drawn right now. */
   private @Nullable StateT state;
@@ -44,11 +46,17 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
   private boolean centerOnOrigin;
 
   public TopologyTool(
-      String instructionKey, String tooltipKey, boolean isFilled, Strategy<StateT> strategy) {
+      String instructionKey,
+      String tooltipKey,
+      boolean isFilled,
+      Strategy<StateT> strategy,
+      TopologyModeSelectionPanel modeSelectionPanel) {
     this.instructionKey = instructionKey;
     this.tooltipKey = tooltipKey;
     this.isFilled = isFilled;
     this.strategy = strategy;
+    this.modeSelectionPanel = modeSelectionPanel;
+
     // Consistency with topology tools before refactoring. Can be updated as part of #5002.
     this.centerOnOrigin = this.strategy instanceof OvalStrategy;
   }
@@ -102,7 +110,7 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
     }
 
     MapTool.serverCommand()
-        .updateTopology(getZone(), area, isEraser(), getZone().getTopologyTypes());
+        .updateTopology(getZone(), area, isEraser(), modeSelectionPanel.getMode());
   }
 
   private Area getTokenTopology(Zone.TopologyType topologyType) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
@@ -23,9 +23,9 @@ import java.awt.geom.Area;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
+import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.swing.TopologyModeSelectionPanel;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
@@ -36,7 +36,6 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
   private final String tooltipKey;
   private final boolean isFilled;
   private final Strategy<StateT> strategy;
-  private final TopologyModeSelectionPanel modeSelectionPanel;
 
   /** The current state of the tool. If {@code null}, nothing is being drawn right now. */
   private @Nullable StateT state;
@@ -46,17 +45,11 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
   private boolean centerOnOrigin;
 
   public TopologyTool(
-      String instructionKey,
-      String tooltipKey,
-      boolean isFilled,
-      Strategy<StateT> strategy,
-      TopologyModeSelectionPanel modeSelectionPanel) {
+      String instructionKey, String tooltipKey, boolean isFilled, Strategy<StateT> strategy) {
     this.instructionKey = instructionKey;
     this.tooltipKey = tooltipKey;
     this.isFilled = isFilled;
     this.strategy = strategy;
-    this.modeSelectionPanel = modeSelectionPanel;
-
     // Consistency with topology tools before refactoring. Can be updated as part of #5002.
     this.centerOnOrigin = this.strategy instanceof OvalStrategy;
   }
@@ -110,7 +103,7 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
     }
 
     MapTool.serverCommand()
-        .updateTopology(getZone(), area, isEraser(), modeSelectionPanel.getMode());
+        .updateTopology(getZone(), area, isEraser(), AppStatePersisted.getTopologyTypes());
   }
 
   private Area getTokenTopology(Zone.TopologyType topologyType) {

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -62,7 +62,6 @@ import net.rptools.maptool.client.swing.ProgressStatusBar;
 import net.rptools.maptool.client.swing.SpacerStatusBar;
 import net.rptools.maptool.client.swing.StatusPanel;
 import net.rptools.maptool.client.swing.SwingUtil;
-import net.rptools.maptool.client.swing.TopologyModeSelectionPanel;
 import net.rptools.maptool.client.swing.ZoomStatusBar;
 import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.swing.preference.WindowPreferences;
@@ -1625,8 +1624,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
       eventBus.post(new ZoneActivated(renderer.getZone()));
 
       renderer.requestFocusInWindow();
-      // Updates the VBL/MBL button. Fixes #1642.
-      TopologyModeSelectionPanel.getInstance().setMode(renderer.getZone().getTopologyTypes());
     }
     AppActions.updateActions();
     repaint();

--- a/src/main/java/net/rptools/maptool/client/ui/ToolbarPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ToolbarPanel.java
@@ -380,13 +380,15 @@ public class ToolbarPanel extends JToolBar {
   private OptionPanel createTopologyPanel() {
     OptionPanel panel = new OptionPanel();
 
+    var topologyModeSelectionPanel = new TopologyModeSelectionPanel();
     panel
         .addTool(
             new TopologyTool<>(
                 "tool.recttopology.instructions",
                 "tool.recttopology.tooltip",
                 true,
-                new RectangleStrategy()))
+                new RectangleStrategy(),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_BOX));
     panel
         .addTool(
@@ -394,7 +396,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.recttopology.instructions",
                 "tool.recttopologyhollow.tooltip",
                 false,
-                new RectangleStrategy()))
+                new RectangleStrategy(),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_BOX_HOLLOW));
     panel
         .addTool(
@@ -403,7 +406,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.ovaltopology.tooltip",
                 true,
                 // 10 steps to keep number of topology vertices reasonable.
-                new OvalStrategy(10)))
+                new OvalStrategy(10),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_OVAL));
     panel
         .addTool(
@@ -412,7 +416,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.ovaltopologyhollow.tooltip",
                 false,
                 // 10 steps to keep number of topology vertices reasonable.
-                new OvalStrategy(10)))
+                new OvalStrategy(10),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_OVAL_HOLLOW));
     panel
         .addTool(
@@ -420,7 +425,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.poly.instructions",
                 "tool.polytopo.tooltip",
                 true,
-                new PolyLineStrategy(false)))
+                new PolyLineStrategy(false),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_POLYGON));
     panel
         .addTool(
@@ -428,7 +434,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.poly.instructions",
                 "tool.polylinetopo.tooltip",
                 false,
-                new PolyLineStrategy(false)))
+                new PolyLineStrategy(false),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_POLYLINE));
     panel
         .addTool(
@@ -436,7 +443,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.crosstopology.instructions",
                 "tool.crosstopology.tooltip",
                 false,
-                new CrossStrategy()))
+                new CrossStrategy(),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_CROSS));
     panel
         .addTool(
@@ -444,7 +452,8 @@ public class ToolbarPanel extends JToolBar {
                 "tool.isorectangletopology.instructions",
                 "tool.isorectangletopology.tooltip",
                 true,
-                new IsoRectangleStrategy()))
+                new IsoRectangleStrategy(),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_DIAMOND));
     panel
         .addTool(
@@ -452,13 +461,13 @@ public class ToolbarPanel extends JToolBar {
                 "tool.isorectangletopology.instructions",
                 "tool.isorectangletopologyhollow.tooltip",
                 false,
-                new IsoRectangleStrategy()))
+                new IsoRectangleStrategy(),
+                topologyModeSelectionPanel))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_DIAMOND_HOLLOW));
 
     // Add with separator to separate mode button group from shape button group.
     addSeparator(panel, 11);
 
-    final var topologyModeSelectionPanel = new TopologyModeSelectionPanel();
     panel.add(topologyModeSelectionPanel);
 
     return panel;

--- a/src/main/java/net/rptools/maptool/client/ui/ToolbarPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ToolbarPanel.java
@@ -380,15 +380,13 @@ public class ToolbarPanel extends JToolBar {
   private OptionPanel createTopologyPanel() {
     OptionPanel panel = new OptionPanel();
 
-    var topologyModeSelectionPanel = new TopologyModeSelectionPanel();
     panel
         .addTool(
             new TopologyTool<>(
                 "tool.recttopology.instructions",
                 "tool.recttopology.tooltip",
                 true,
-                new RectangleStrategy(),
-                topologyModeSelectionPanel))
+                new RectangleStrategy()))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_BOX));
     panel
         .addTool(
@@ -396,8 +394,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.recttopology.instructions",
                 "tool.recttopologyhollow.tooltip",
                 false,
-                new RectangleStrategy(),
-                topologyModeSelectionPanel))
+                new RectangleStrategy()))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_BOX_HOLLOW));
     panel
         .addTool(
@@ -406,8 +403,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.ovaltopology.tooltip",
                 true,
                 // 10 steps to keep number of topology vertices reasonable.
-                new OvalStrategy(10),
-                topologyModeSelectionPanel))
+                new OvalStrategy(10)))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_OVAL));
     panel
         .addTool(
@@ -416,8 +412,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.ovaltopologyhollow.tooltip",
                 false,
                 // 10 steps to keep number of topology vertices reasonable.
-                new OvalStrategy(10),
-                topologyModeSelectionPanel))
+                new OvalStrategy(10)))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_OVAL_HOLLOW));
     panel
         .addTool(
@@ -425,8 +420,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.poly.instructions",
                 "tool.polytopo.tooltip",
                 true,
-                new PolyLineStrategy(false),
-                topologyModeSelectionPanel))
+                new PolyLineStrategy(false)))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_POLYGON));
     panel
         .addTool(
@@ -434,8 +428,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.poly.instructions",
                 "tool.polylinetopo.tooltip",
                 false,
-                new PolyLineStrategy(false),
-                topologyModeSelectionPanel))
+                new PolyLineStrategy(false)))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_POLYLINE));
     panel
         .addTool(
@@ -443,8 +436,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.crosstopology.instructions",
                 "tool.crosstopology.tooltip",
                 false,
-                new CrossStrategy(),
-                topologyModeSelectionPanel))
+                new CrossStrategy()))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_CROSS));
     panel
         .addTool(
@@ -452,8 +444,7 @@ public class ToolbarPanel extends JToolBar {
                 "tool.isorectangletopology.instructions",
                 "tool.isorectangletopology.tooltip",
                 true,
-                new IsoRectangleStrategy(),
-                topologyModeSelectionPanel))
+                new IsoRectangleStrategy()))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_DIAMOND));
     panel
         .addTool(
@@ -461,13 +452,13 @@ public class ToolbarPanel extends JToolBar {
                 "tool.isorectangletopology.instructions",
                 "tool.isorectangletopologyhollow.tooltip",
                 false,
-                new IsoRectangleStrategy(),
-                topologyModeSelectionPanel))
+                new IsoRectangleStrategy()))
         .setIcon(RessourceManager.getBigIcon(Icons.TOOLBAR_TOPOLOGY_DIAMOND_HOLLOW));
 
     // Add with separator to separate mode button group from shape button group.
     addSeparator(panel, 11);
 
+    final var topologyModeSelectionPanel = new TopologyModeSelectionPanel();
     panel.add(topologyModeSelectionPanel);
 
     return panel;

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -34,9 +34,9 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
+import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.macro.MacroContext;
-import net.rptools.maptool.client.swing.TopologyModeSelectionPanel;
 import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.ui.AssetPaint;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
@@ -591,8 +591,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
     }
 
     MapTool.serverCommand()
-        .updateTopology(
-            renderer.getZone(), area, isEraser, TopologyModeSelectionPanel.getInstance().getMode());
+        .updateTopology(renderer.getZone(), area, isEraser, AppStatePersisted.getTopologyTypes());
   }
 
   private Path2D getPath(Drawable drawable) {

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -36,6 +36,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.macro.MacroContext;
+import net.rptools.maptool.client.swing.TopologyModeSelectionPanel;
 import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.ui.AssetPaint;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
@@ -590,7 +591,8 @@ public class DrawPanelPopupMenu extends JPopupMenu {
     }
 
     MapTool.serverCommand()
-        .updateTopology(renderer.getZone(), area, isEraser, renderer.getZone().getTopologyTypes());
+        .updateTopology(
+            renderer.getZone(), area, isEraser, TopologyModeSelectionPanel.getInstance().getMode());
   }
 
   private Path2D getPath(Drawable drawable) {

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -308,7 +308,7 @@ public class Zone {
     MBL;
   }
 
-  public static final class TopologyTypeSet implements Iterable<TopologyType> {
+  private static final class TopologyTypeSet implements Iterable<TopologyType> {
     private final Set<TopologyType> topologyTypes;
 
     public static TopologyTypeSet valueOf(String value) {
@@ -327,6 +327,10 @@ public class Zone {
       // I would prefer using an enum set, but Hessian can't handle it properly.
       topologyTypes = new HashSet<>();
       topologyTypes.addAll(Arrays.asList(types));
+    }
+
+    public Set<TopologyType> asSet() {
+      return topologyTypes;
     }
 
     public boolean contains(TopologyType type) {
@@ -1336,16 +1340,20 @@ public class Zone {
     this.aStarRounding = aStarRounding;
   }
 
-  public TopologyTypeSet getTopologyTypes() {
+  public Set<TopologyType> getTopologyTypes() {
     if (topologyTypes == null) {
-      topologyTypes = AppStatePersisted.getTopologyTypes();
+      setTopologyTypes(AppStatePersisted.getTopologyTypes());
     }
 
-    return topologyTypes;
+    var result = EnumSet.noneOf(TopologyType.class);
+    for (var type : topologyTypes) {
+      result.add(type);
+    }
+    return result;
   }
 
-  public void setTopologyTypes(TopologyTypeSet topologyTypes) {
-    this.topologyTypes = topologyTypes;
+  public void setTopologyTypes(Set<TopologyType> topologyTypes) {
+    this.topologyTypes = new TopologyTypeSet(topologyTypes.toArray(TopologyType[]::new));
   }
 
   public int getLargestZOrder() {

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.lib.MD5Key;
-import net.rptools.maptool.client.AppStatePersisted;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.tool.drawing.UndoPerZone;
@@ -1338,22 +1337,6 @@ public class Zone {
 
   public void setAStarRounding(AStarRoundingOptions aStarRounding) {
     this.aStarRounding = aStarRounding;
-  }
-
-  public Set<TopologyType> getTopologyTypes() {
-    if (topologyTypes == null) {
-      setTopologyTypes(AppStatePersisted.getTopologyTypes());
-    }
-
-    var result = EnumSet.noneOf(TopologyType.class);
-    for (var type : topologyTypes) {
-      result.add(type);
-    }
-    return result;
-  }
-
-  public void setTopologyTypes(Set<TopologyType> topologyTypes) {
-    this.topologyTypes = new TopologyTypeSet(topologyTypes.toArray(TopologyType[]::new));
   }
 
   public int getLargestZOrder() {

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -63,7 +63,6 @@ import net.rptools.maptool.model.zones.TopologyChanged;
 import net.rptools.maptool.model.zones.ZoneLightingChanged;
 import net.rptools.maptool.server.Mapper;
 import net.rptools.maptool.server.proto.DrawnElementListDto;
-import net.rptools.maptool.server.proto.TopologyTypeDto;
 import net.rptools.maptool.server.proto.ZoneDto;
 import net.rptools.maptool.util.StringUtil;
 import org.apache.logging.log4j.LogManager;
@@ -307,60 +306,6 @@ public class Zone {
     MBL;
   }
 
-  private static final class TopologyTypeSet implements Iterable<TopologyType> {
-    private final Set<TopologyType> topologyTypes;
-
-    public static TopologyTypeSet valueOf(String value) {
-      List<TopologyType> topologyTypes = new ArrayList<>();
-      for (var topologyType : TopologyType.values()) {
-        var topologyTypeName = topologyType.toString();
-        if (value.contains(topologyTypeName)) {
-          topologyTypes.add(topologyType);
-        }
-      }
-
-      return new TopologyTypeSet(topologyTypes.toArray(TopologyType[]::new));
-    }
-
-    public TopologyTypeSet(TopologyType... types) {
-      // I would prefer using an enum set, but Hessian can't handle it properly.
-      topologyTypes = new HashSet<>();
-      topologyTypes.addAll(Arrays.asList(types));
-    }
-
-    public Set<TopologyType> asSet() {
-      return topologyTypes;
-    }
-
-    public boolean contains(TopologyType type) {
-      return topologyTypes.contains(type);
-    }
-
-    public TopologyTypeSet with(TopologyType type) {
-      var newMode = new TopologyTypeSet();
-      newMode.topologyTypes.addAll(this.topologyTypes);
-      newMode.topologyTypes.add(type);
-      return newMode;
-    }
-
-    public TopologyTypeSet without(TopologyType type) {
-      var newMode = new TopologyTypeSet();
-      newMode.topologyTypes.addAll(this.topologyTypes);
-      newMode.topologyTypes.remove(type);
-      return newMode;
-    }
-
-    @Nonnull
-    @Override
-    public Iterator<TopologyType> iterator() {
-      return topologyTypes.iterator();
-    }
-
-    public String toString() {
-      return topologyTypes.toString();
-    }
-  }
-
   public static final int DEFAULT_TOKEN_VISION_DISTANCE = 250; // In units
   public static final int DEFAULT_PIXELS_CELL = 50;
   public static final int DEFAULT_UNITS_PER_CELL = 5;
@@ -380,7 +325,6 @@ public class Zone {
 
   private double unitsPerCell = DEFAULT_UNITS_PER_CELL;
   private AStarRoundingOptions aStarRounding = AStarRoundingOptions.NONE;
-  private TopologyTypeSet topologyTypes = null; // get default from AppPreferences
 
   // region Keeping these for serialization only. Otherwise, use {@link #drawablesByLayer} instead.
   @Deprecated private @Nonnull LinkedList<DrawnElement> drawables = new LinkedList<DrawnElement>();
@@ -724,7 +668,6 @@ public class Zone {
     coverVbl = (Area) zone.coverVbl.clone();
     topologyTerrain = (Area) zone.topologyTerrain.clone();
     aStarRounding = zone.aStarRounding;
-    topologyTypes = zone.topologyTypes;
     isVisible = zone.isVisible;
     hasFog = zone.hasFog;
   }
@@ -2233,11 +2176,6 @@ public class Zone {
     zone.tokenVisionDistance = dto.getTokenVisionDistance();
     zone.unitsPerCell = dto.getUnitsPerCell();
     zone.aStarRounding = AStarRoundingOptions.valueOf(dto.getAStarRounding().name());
-    zone.topologyTypes = new TopologyTypeSet();
-    zone.topologyTypes.topologyTypes.addAll(
-        dto.getTopologyTypesList().stream()
-            .map(t -> TopologyType.valueOf(t.name()))
-            .collect(Collectors.toList()));
 
     dto.getDrawablesMap()
         .forEach(
@@ -2304,12 +2242,6 @@ public class Zone {
     dto.setTokenVisionDistance(tokenVisionDistance);
     dto.setUnitsPerCell(unitsPerCell);
     dto.setAStarRounding(ZoneDto.AStarRoundingOptionsDto.valueOf(aStarRounding.name()));
-    if (topologyTypes != null) {
-      dto.addAllTopologyTypes(
-          topologyTypes.topologyTypes.stream()
-              .map(t -> TopologyTypeDto.valueOf(t.name()))
-              .collect(Collectors.toList()));
-    }
 
     drawablesByLayer.forEach(
         (layer, drawables) ->

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -43,7 +43,7 @@ public interface ServerCommand {
   void setFoW(GUID zoneGUID, Area area, Set<GUID> selectedToks);
 
   default void updateTopology(
-      Zone zone, Area area, boolean erase, Zone.TopologyTypeSet topologyTypes) {
+      Zone zone, Area area, boolean erase, Set<Zone.TopologyType> topologyTypes) {
     for (var topologyType : topologyTypes) {
       updateTopology(zone, area, erase, topologyType);
     }

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -536,7 +536,6 @@ message ZoneDto {
   int32 token_vision_distance = 7;
   double units_per_cell = 8;
   AStarRoundingOptionsDto a_star_rounding = 9;
-  repeated TopologyTypeDto topologyTypes = 10;
   map<string, DrawnElementListDto> drawables = 11;
   repeated LabelDto labels = 15;
   repeated TokenDto tokens = 16;


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #5014

### Description of the Change

Individual zones no longer keep their own topology type selection. Instead this state is kept in `AppStatePersisted` and is reflected in the toolbar's topology type selector. There is no more bookkeeping required to keep the toolbar and the current zone's topology types in sync with each other.

The `Zone.TopologyTypeSet` class is also redundant now that `Zone` no longer has a field of that type to serialize. It has been removed in favour of `Set<TopologyTypeSet>` / `EnumSet<TopologyTypeSet>`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Changed topology type selection so it is no longer dependent on the current map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5042)
<!-- Reviewable:end -->
