### PR TITLE
Feature to lock an overlay

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroDialogFunctions.java
@@ -26,11 +26,8 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.ui.htmlframe.HTMLDialog;
-import net.rptools.maptool.client.ui.htmlframe.HTMLFrame;
-import net.rptools.maptool.client.ui.htmlframe.HTMLFrameFactory;
+import net.rptools.maptool.client.ui.htmlframe.*;
 import net.rptools.maptool.client.ui.htmlframe.HTMLFrameFactory.FrameType;
-import net.rptools.maptool.client.ui.htmlframe.HTMLOverlayManager;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.library.Library;
 import net.rptools.maptool.model.library.LibraryManager;
@@ -57,6 +54,7 @@ public class MacroDialogFunctions extends AbstractFunction {
         "closeOverlay",
         "setOverlayVisible",
         "isOverlayVisible",
+        "isOverlayLocked",
         "getFrameProperties",
         "getDialogProperties",
         "getOverlayProperties",
@@ -126,6 +124,11 @@ public class MacroDialogFunctions extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
       String name = parameters.get(0).toString();
       return isOverlayVisible(name) ? BigDecimal.ONE : BigDecimal.ZERO;
+    }
+    if (functionName.equalsIgnoreCase("isOverlayLocked")) {
+      FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
+      String name = parameters.get(0).toString();
+      return isOverlayLocked(name) ? BigDecimal.ONE : BigDecimal.ZERO;
     }
     if (functionName.equalsIgnoreCase("resetFrame")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 1);
@@ -268,6 +271,14 @@ public class MacroDialogFunctions extends AbstractFunction {
     HTMLOverlayManager overlay = MapTool.getFrame().getOverlayPanel().getOverlay(name);
     if (overlay != null) {
       return overlay.isVisible();
+    }
+    return false;
+  }
+
+  private boolean isOverlayLocked(String name) {
+    HTMLOverlayManager overlay = MapTool.getFrame().getOverlayPanel().getOverlay(name);
+    if (overlay != null) {
+      return overlay.getLocked();
     }
     return false;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -432,7 +432,11 @@ public class AppMenuBar extends JMenuBar {
     JCheckBoxMenuItem menuItem =
         new RPCheckBoxMenuItem(new AppActions.ToggleOverlayAction(overlayManager), overlayMenu);
     menuItem.setText(overlayManager.getName());
-    overlayMenu.add(menuItem);
+    if (overlayManager.getLocked()) {
+      overlayMenu.add(menuItem).setEnabled(false);
+    } else {
+      overlayMenu.add(menuItem);
+    }
     overlayMenu.setEnabled(true);
     overlayItems.put(overlayManager.getName(), menuItem);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLFrameFactory.java
@@ -59,6 +59,7 @@ public class HTMLFrameFactory {
     int width = -1;
     int height = -1;
     int zOrder = 0;
+    boolean locked = false;
     String title = name;
     String tabTitle = null;
     Object frameValue = null;
@@ -114,6 +115,15 @@ public class HTMLFrameFactory {
             String msg = I18N.getText("macro.function.general.argumentKeyTypeI", funcName, keyLC);
             throw new ParserException(msg);
           }
+        } else if (keyLC.equals("locked")) {
+          try {
+            int v = Integer.parseInt(value);
+            if (v != 0) {
+              locked = true;
+            }
+          } catch (NumberFormatException e) {
+            // Ignoring the value; shouldn't we warn the user?
+          }
         } else if (keyLC.equals("title")) {
           title = value;
         } else if (keyLC.equals("noframe")) {
@@ -165,7 +175,7 @@ public class HTMLFrameFactory {
           frameValue,
           html);
     } else if (frameType == FrameType.OVERLAY) {
-      MapTool.getFrame().getOverlayPanel().showOverlay(name, zOrder, html, frameValue);
+      MapTool.getFrame().getOverlayPanel().showOverlay(name, zOrder, locked, html, frameValue);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
@@ -73,6 +73,8 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
   /** The ZOrder of the overlay. */
   private int zOrder;
 
+  private boolean locked;
+
   /** The name of the overlay. */
   private final String name;
 
@@ -82,11 +84,12 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
   /** The map of the macro callbacks. */
   private final Map<String, String> macroCallbacks = new HashMap<>();
 
-  HTMLOverlayManager(String name, int zOrder) {
+  HTMLOverlayManager(String name, int zOrder, boolean locked) {
     super("overlay", name);
     addActionListener(this); // add the action listeners for form events
     this.name = name;
     this.zOrder = zOrder;
+    this.locked = locked;
   }
 
   @Override
@@ -99,6 +102,10 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
    */
   public int getZOrder() {
     return zOrder;
+  }
+
+  public boolean getLocked() {
+    return locked;
   }
 
   /**
@@ -246,7 +253,8 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
   public void remove(Component component) {}
 
   /**
-   * Returns a JsonObject with the properties of the overlay. Includes name, zorder, and visible.
+   * Returns a JsonObject with the properties of the overlay. Includes name, zorder, locked, and
+   * visible.
    *
    * @return the properties
    */
@@ -254,6 +262,7 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
     JsonObject jobj = new JsonObject();
     jobj.addProperty("name", getName());
     jobj.addProperty("zorder", getZOrder());
+    jobj.addProperty("locked", getLocked() ? BigDecimal.ONE : BigDecimal.ZERO);
     jobj.addProperty("visible", isVisible() ? BigDecimal.ONE : BigDecimal.ZERO);
     return jobj;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -238,9 +238,10 @@ public class HTMLOverlayPanel extends JFXPanel {
    *
    * @param name the name of the overlay
    * @param zOrder the zOrder of the overlay
+   * @param locked the locked state of the overlay
    * @param html the HTML of the overlay
    */
-  public void showOverlay(String name, int zOrder, String html, Object frameValue) {
+  public void showOverlay(String name, int zOrder, boolean locked, String html, Object frameValue) {
     getDropTarget().setActive(false); // disables drop on overlay, drop goes to map
     setVisible(true);
     Platform.runLater(
@@ -258,7 +259,7 @@ public class HTMLOverlayPanel extends JFXPanel {
               overlays.add(overlayManager);
             }
           } else {
-            overlayManager = new HTMLOverlayManager(name, zOrder);
+            overlayManager = new HTMLOverlayManager(name, zOrder, locked);
             overlayManager.setupWebView(new WebView());
             overlays.add(overlayManager);
             root.getChildren().add(overlayManager.getWebView());

--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheet.java
@@ -60,6 +60,7 @@ public class StatSheet {
                   .showOverlay(
                       AppConstants.INTERNAL_MAP_UNDER_POINTER_HTML_OVERLAY_NAME,
                       Integer.MAX_VALUE,
+                      Boolean.TRUE,
                       output,
                       null);
             }


### PR DESCRIPTION
Closes #3414 by adding a `locked` option in `overlay`

### Description of the Change
Extended the 2nd parameter offered in `overlay`.
Like `zorder=<num>` you can now add `locked=<0/1>`. 
`locked` defaults to `0` (not locked)

Locked overlays appear in the **Window** -> **Overlays** menu but are _greyed out_ and can't be _unchecked_
### Possible Drawbacks
None
### Release Notes
Examples:
`[overlay("Test","zOrder=10;locked=1;"):[ { content to display }]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5051)
<!-- Reviewable:end -->
