### PR TITLE
Add a start/stop lifecycle for ServerCommandClientImpl

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -819,10 +819,6 @@ public class ServerCommandClientImpl implements ServerCommand {
     private final long delay;
     private Message msg;
 
-    // TODO Remove the semaphore. The thread only runs once, so it has no reason to synchronize with
-    // itself.
-    final Object sleepSemaphore = new Object();
-
     public TimedEventQueue(long millidelay) {
       setName("ServerCommandClientImpl.TimedEventQueue");
       delay = millidelay;
@@ -853,12 +849,10 @@ public class ServerCommandClientImpl implements ServerCommand {
     public void run() {
       while (!done.get()) {
         flush();
-        synchronized (sleepSemaphore) {
-          try {
-            Thread.sleep(delay);
-          } catch (InterruptedException ie) {
-            // nothing to do
-          }
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException ie) {
+          // nothing to do
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.rptools.lib.MD5Key;
@@ -58,7 +59,18 @@ public class ServerCommandClientImpl implements ServerCommand {
 
   public ServerCommandClientImpl(MapToolClient client) {
     this.client = client;
-    movementUpdateQueue.start();
+  }
+
+  public void start() {
+    try {
+      movementUpdateQueue.start();
+    } catch (IllegalThreadStateException e) {
+      log.error("ServerCommand was already started", e);
+    }
+  }
+
+  public void stop() {
+    movementUpdateQueue.stopRunning();
   }
 
   public void heartbeat(String data) {
@@ -803,10 +815,12 @@ public class ServerCommandClientImpl implements ServerCommand {
    * this way, only the most current version of the event is released.
    */
   private class TimedEventQueue extends Thread {
+    private final AtomicBoolean done = new AtomicBoolean(false);
+    private final long delay;
+    private Message msg;
 
-    Message msg;
-    long delay;
-
+    // TODO Remove the semaphore. The thread only runs once, so it has no reason to synchronize with
+    // itself.
     final Object sleepSemaphore = new Object();
 
     public TimedEventQueue(long millidelay) {
@@ -814,12 +828,21 @@ public class ServerCommandClientImpl implements ServerCommand {
       delay = millidelay;
     }
 
+    public void stopRunning() {
+      done.set(true);
+      try {
+        interrupt();
+        join();
+      } catch (InterruptedException e) {
+        log.error("Interrupted thread join. Thread may not be done running.", e);
+      }
+    }
+
     public void enqueue(Message message) {
       msg = message;
     }
 
     public synchronized void flush() {
-
       if (msg != null) {
         makeServerCall(msg);
         msg = null;
@@ -828,9 +851,7 @@ public class ServerCommandClientImpl implements ServerCommand {
 
     @Override
     public void run() {
-
-      while (true) {
-
+      while (!done.get()) {
         flush();
         synchronized (sleepSemaphore) {
           try {

--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import net.rptools.clientserver.ConnectionFactory;
@@ -536,7 +537,7 @@ public class MapToolServer {
   ////
   // CLASSES
   private class AssetProducerThread extends Thread {
-    private boolean stop = false;
+    private final AtomicBoolean stop = new AtomicBoolean(false);
 
     public AssetProducerThread() {
       setName("AssetProducerThread");
@@ -544,7 +545,7 @@ public class MapToolServer {
 
     @Override
     public void run() {
-      while (!stop) {
+      while (!stop.get()) {
         Entry<String, AssetTransferManager> entryForException = null;
         try {
           boolean lookForMore = false;
@@ -575,7 +576,7 @@ public class MapToolServer {
     }
 
     public void shutdown() {
-      stop = true;
+      stop.set(true);
     }
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5052

### Description of the Change

`ServerCommandClientimpl` can now be stopped when the `MapToolClient` is closed. This shuts down the `TimedEventQueue` thread, in turn allowing the `ServerCommandClientImpl`, `MapToolClient` and `Campaign` to be garbage collected.

Some minor related edits:
- Removed an unncessary `synchronized` block from `TimedEventQueue`.
- Fixed `AssetProducerThread.shutdown()` to use an `AtomicBoolean` instead of a plain `boolean`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where unloaded campaigns would remain in memory.`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5053)
<!-- Reviewable:end -->
