### PR TITLE
Bump copy-issue-labels to latest (1.3.0) - take 2

### DIFF
--- a/.github/workflows/copy-label-to-pr.yml
+++ b/.github/workflows/copy-label-to-pr.yml
@@ -1,13 +1,13 @@
 name: Copy Labels to PR
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
   copy-labels:
     permissions:
       contents: read
-      issues: write
+      issues: read
       pull-requests: write
     runs-on: ubuntu-latest
     name: Copy labels from linked issues

--- a/.github/workflows/copy-label-to-pr.yml
+++ b/.github/workflows/copy-label-to-pr.yml
@@ -13,7 +13,7 @@ jobs:
     name: Copy labels from linked issues
     steps:
       - name: copy-labels
-        uses: michalvankodev/copy-issue-labels@v1.2.1
+        uses: michalvankodev/copy-issue-labels@v1.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels-to-include: |


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes (hopefully) #5056

### Description of the Change

This updates the action to the latest version.

It also changes the action to run on `pull_request_target` following the notes [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target). I've also referenced other projects and found they have also used `pull_request_target` to support this job with cross-repo forks. Unfortunately I can't verify that it works until it is merged.

### Possible Drawbacks

Should be none. We'll see.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5059)
<!-- Reviewable:end -->
