### PR TITLE
Remove max size for blast templates

### DIFF
--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
@@ -57,9 +57,6 @@ public abstract class AbstractTemplate extends AbstractDrawing {
    * Class Variables
    *-------------------------------------------------------------------------------------------*/
 
-  /** Maximum radius value allowed. */
-  public static final int MAX_RADIUS = 100;
-
   /** Minimum radius value allowed. */
   public static final int MIN_RADIUS = 1;
 

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -98,10 +98,6 @@ public class BlastTemplate extends ConeTemplate {
    * @param relY The Y coordinate of the control square relative to the origin square
    */
   public void setControlCellRelative(int relX, int relY) {
-
-    relX = Math.max(Math.min(relX, MAX_RADIUS), -MAX_RADIUS);
-    relY = Math.max(Math.min(relY, MAX_RADIUS), -MAX_RADIUS);
-
     int radius = Math.max(Math.abs(relX), Math.abs(relY));
     // Number of cells along axis of smaller offset we need to shift the square in order to "center"
     // the blast


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4994

### Description of the Change

The template `MAX_RADIUS` was only used to constrain blast templates, but does so no longer.

### Possible Drawbacks

None

### Documentation Notes

Blast templates can be of any size.

### Release Notes

- Removed the maximum size for blast templates

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5060)
<!-- Reviewable:end -->
