### PR TITLE
Add "Is landing map?" checkbox to map properties dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
@@ -273,6 +273,10 @@ public class MapPropertiesDialog extends JDialog {
     return formPanel.getComboBox("lightingStyle");
   }
 
+  public JCheckBox getIsLandingMapCheckBox() {
+    return formPanel.getCheckBox("isLandingMap");
+  }
+
   public JComboBox getAStarRoundingOptionsComboBox() {
     return formPanel.getComboBox("aStarRoundingOptionsComboBox");
   }
@@ -283,6 +287,8 @@ public class MapPropertiesDialog extends JDialog {
   }
 
   private void copyZoneToUI() {
+    var campaign = MapTool.getClient().getCampaign();
+
     getNameTextField().setText(zone.getName());
     getPlayerAliasTextField().setText(zone.getPlayerAlias());
     // Localizes units per cell, using the proper separator. Fixes #507.
@@ -297,6 +303,7 @@ public class MapPropertiesDialog extends JDialog {
     getVisionTypeCombo().setSelectedItem(zone.getVisionType());
     getLightingStyleCombo().setSelectedItem(zone.getLightingStyle());
     getAStarRoundingOptionsComboBox().setSelectedItem(zone.getAStarRounding());
+    getIsLandingMapCheckBox().setSelected(zone.getId().equals(campaign.getLandingMapId()));
 
     gridOffsetX = zone.getGrid().getOffsetX();
     gridOffsetY = zone.getGrid().getOffsetY();
@@ -324,6 +331,15 @@ public class MapPropertiesDialog extends JDialog {
     zone.setFogPaint(fogPaint);
     zone.setBackgroundPaint(backgroundPaint);
     zone.setMapAsset(mapAsset != null ? mapAsset.getMD5Key() : null);
+
+    var campaign = MapTool.getClient().getCampaign();
+    if (getIsLandingMapCheckBox().isSelected()) {
+      campaign.setLandingMapId(zone.getId());
+    } else if (zone.getId().equals(campaign.getLandingMapId())) {
+      // This zone was the landing map but got toggled off.
+      campaign.setLandingMapId(null);
+    }
+
     // TODO: Handle grid type changes
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialogView.form
@@ -3,14 +3,14 @@
   <grid id="775b6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="813" height="401"/>
+      <xy x="10" y="10" width="813" height="422"/>
     </constraints>
     <properties>
       <name value="root"/>
     </properties>
     <border type="none"/>
     <children>
-      <grid id="aa2a3" layout-manager="GridLayoutManager" row-count="10" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="aa2a3" layout-manager="GridLayoutManager" row-count="10" column-count="6" same-size-horizontally="false" same-size-vertically="true" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -341,11 +341,23 @@
               <name value="lightingStyle"/>
             </properties>
           </component>
-          <vspacer id="fe121">
+          <component id="52be" class="javax.swing.JLabel">
             <constraints>
-              <grid row="9" column="5" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
-          </vspacer>
+            <properties>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="MapPropertiesDialog.label.landingMap"/>
+            </properties>
+          </component>
+          <component id="f6573" class="javax.swing.JCheckBox" default-binding="true">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <name value="isLandingMap"/>
+              <text value=""/>
+            </properties>
+          </component>
         </children>
       </grid>
       <grid id="218f9" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialogView.form
@@ -347,6 +347,7 @@
             </constraints>
             <properties>
               <text resource-bundle="net/rptools/maptool/language/i18n" key="MapPropertiesDialog.label.landingMap"/>
+              <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="MapPropertiesDialog.label.landingMap.tooltip"/>
             </properties>
           </component>
           <component id="f6573" class="javax.swing.JCheckBox" default-binding="true">

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -374,6 +374,7 @@ EditTokenDialog.libTokenURI.error.reserved      = lib:Tokens can not be named {0
 MapPropertiesDialog.label.playerMapAlias = Display Name:
 MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
+MapPropertiesDialog.label.landingMap     = Is landing map?
 MapPropertiesDialog.label.cell.type      = Cell Type:
 MapPropertiesDialog.label.cell.dist      = Distance per cell:
 MapPropertiesDialog.label.cell.pixels    = Pixels per Cell:

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -375,6 +375,7 @@ MapPropertiesDialog.label.playerMapAlias = Display Name:
 MapPropertiesDialog.label.playerMapAlias.tooltip = This is how players will see the map identified. Must be unique within campaign.
 MapPropertiesDialog.label.Name.tooltip = This is how the map is referred to in macros and is only visible to the GM.
 MapPropertiesDialog.label.landingMap     = Is landing map?
+MapPropertiesDialog.label.landingMap.tooltip = Make this map the first one that players see when they connect.
 MapPropertiesDialog.label.cell.type      = Cell Type:
 MapPropertiesDialog.label.cell.dist      = Distance per cell:
 MapPropertiesDialog.label.cell.pixels    = Pixels per Cell:


### PR DESCRIPTION
### Identify the Bug or Feature request

Improves #75

### Description of the Change

This adds a new checkbox to the Map Properties dialog to mark or unmark the map as the landing map.

### Possible Drawbacks

None

### Documentation Notes

The landing map can be set in the Map Properties dialog when editing an existing map or creating a new map.

![landing-map-checkbox](https://github.com/user-attachments/assets/57c12f1d-e0a9-4897-ae74-15712b800ea0)


### Release Notes

- Allow setting a map as the landing map via the Map Properties dialog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5064)
<!-- Reviewable:end -->
