### PR TITLE
Bring back unique light sources (no new macro functions)

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -641,6 +641,18 @@ public class ServerCommandClientImpl implements ServerCommand {
   }
 
   @Override
+  public void toggleLightSourceOnToken(Token token, boolean toggleOn, LightSource lightSource) {
+    var update = toggleOn ? Token.Update.addLightSource : Token.Update.removeLightSource;
+    // We only need to send the ID of the light source.
+    updateTokenProperty(
+        token,
+        update,
+        TokenPropertyValueDto.newBuilder()
+            .setLightSourceId(lightSource.getId().toString())
+            .build());
+  }
+
+  @Override
   public void setTokenTopology(Token token, @Nullable Area area, Zone.TopologyType topologyType) {
     if (area == null) {
       // Will be converted back to null on the other end.
@@ -706,14 +718,6 @@ public class ServerCommandClientImpl implements ServerCommand {
   public void updateTokenProperty(Token token, Token.Update update, String value) {
     updateTokenProperty(
         token, update, TokenPropertyValueDto.newBuilder().setStringValue(value).build());
-  }
-
-  @Override
-  public void updateTokenProperty(Token token, Token.Update update, LightSource value) {
-    updateTokenProperty(
-        token,
-        update,
-        TokenPropertyValueDto.newBuilder().setLightSourceId(value.getId().toString()).build());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
@@ -32,6 +32,8 @@ import net.rptools.parser.function.AbstractFunction;
 public class TokenLightFunctions extends AbstractFunction {
   private static final TokenLightFunctions instance = new TokenLightFunctions();
 
+  private static final String TOKEN_CATEGORY = "$token";
+
   private TokenLightFunctions() {
     super(0, 5, "hasLightSource", "clearLights", "setLight", "getLights");
   }
@@ -84,7 +86,8 @@ public class TokenLightFunctions extends AbstractFunction {
    *
    * @param token The token to get the light sources for.
    * @param category The category to get the light sources for. If "*" then the light sources for
-   *     all categories will be returned.
+   *     all categories will be returned. If "$token" then only light sources defined on the token
+   *     will be returned.
    * @param delim the delimiter for the list.
    * @return a string list containing the lights that are on.
    * @throws ParserException if the light type can't be found.
@@ -96,11 +99,23 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     if (category.equals("*")) {
+      // Look up on both token and campaign.
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if (token.hasLightSource(ls)) {
+          lightList.add(ls.getName());
+        }
+      }
       for (Map<GUID, LightSource> lsMap : lightSourcesMap.values()) {
         for (LightSource ls : lsMap.values()) {
           if (token.hasLightSource(ls)) {
             lightList.add(ls.getName());
           }
+        }
+      }
+    } else if (TOKEN_CATEGORY.equals(category)) {
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if (token.hasLightSource(ls)) {
+          lightList.add(ls.getName());
         }
       }
     } else if (lightSourcesMap.containsKey(category)) {
@@ -127,7 +142,8 @@ public class TokenLightFunctions extends AbstractFunction {
    * Sets the light value for a token.
    *
    * @param token the token to set the light for.
-   * @param category the category of the light source.
+   * @param category the category of the light source. Use "$token" for light sources defined on the
+   *     token.
    * @param name the name of the light source.
    * @param val the value to set for the light source, 0 for off non 0 for on.
    * @return 0 if the light was not found, otherwise 1;
@@ -140,7 +156,9 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     Iterable<LightSource> sources;
-    if (lightSourcesMap.containsKey(category)) {
+    if (TOKEN_CATEGORY.equals(category)) {
+      sources = token.getUniqueLightSources();
+    } else if (lightSourcesMap.containsKey(category)) {
       sources = lightSourcesMap.get(category).values();
     } else {
       throw new ParserException(
@@ -162,6 +180,7 @@ public class TokenLightFunctions extends AbstractFunction {
    * Checks to see if the token has a light source. The token is checked to see if it has a light
    * source with the name in the second parameter from the category in the first parameter. A "*"
    * for category indicates all categories are checked; a "*" for name indicates all names are
+   * checked. The "$token" category indicates that only light sources defined on the token are
    * checked.
    *
    * @param token the token to check.
@@ -180,6 +199,12 @@ public class TokenLightFunctions extends AbstractFunction {
         MapTool.getCampaign().getLightSourcesMap();
 
     if ("*".equals(category)) {
+      // Look up on both token and campaign.
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if (ls.getName().equals(name) && token.hasLightSource(ls)) {
+          return true;
+        }
+      }
       for (Map<GUID, LightSource> lsMap : lightSourcesMap.values()) {
         for (LightSource ls : lsMap.values()) {
           if (ls.getName().equals(name) && token.hasLightSource(ls)) {
@@ -188,8 +213,13 @@ public class TokenLightFunctions extends AbstractFunction {
         }
         return false;
       }
-    }
-    if (lightSourcesMap.containsKey(category)) {
+    } else if (TOKEN_CATEGORY.equals(category)) {
+      for (LightSource ls : token.getUniqueLightSources()) {
+        if ((ls.getName().equals(name) || "*".equals(name)) && token.hasLightSource(ls)) {
+          return true;
+        }
+      }
+    } else if (lightSourcesMap.containsKey(category)) {
       for (LightSource ls : lightSourcesMap.get(category).values()) {
         if ((ls.getName().equals(name) || "*".equals(name)) && token.hasLightSource(ls)) {
           return true;

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLightFunctions.java
@@ -147,12 +147,11 @@ public class TokenLightFunctions extends AbstractFunction {
           I18N.getText("macro.function.tokenLight.unknownLightType", "setLights", category));
     }
 
-    final var updateAction =
-        BigDecimal.ZERO.equals(val) ? Token.Update.removeLightSource : Token.Update.addLightSource;
+    final var add = !BigDecimal.ZERO.equals(val);
     for (LightSource ls : sources) {
       if (name.equals(ls.getName())) {
         found = true;
-        MapTool.serverCommand().updateTokenProperty(token, updateAction, ls);
+        MapTool.serverCommand().toggleLightSourceOnToken(token, add, ls);
       }
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -151,6 +151,15 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       menu.addSeparator();
     }
 
+    // Add unique light sources for the token.
+    {
+      JMenu subMenu = createLightCategoryMenu("Unique", tokenUnderMouse.getUniqueLightSources());
+      if (subMenu.getItemCount() != 0) {
+        menu.add(subMenu);
+        menu.addSeparator();
+      }
+    }
+
     for (Entry<String, Map<GUID, LightSource>> entry :
         MapTool.getCampaign().getLightSourcesMap().entrySet()) {
       JMenu subMenu = createLightCategoryMenu(entry.getKey(), entry.getValue().values());

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -87,6 +87,7 @@ import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
 import net.rptools.maptool.util.ExtractHeroLab;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.maptool.util.ImageManager;
+import net.rptools.maptool.util.LightSyntax;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
@@ -172,6 +173,10 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     EnumSet.allOf(TerrainModifierOperation.class).forEach(operationModel::addElement);
   }
 
+  public void initUniqueLightSourcesTextPane() {
+    setUniqueLightSourcesEnabled(MapTool.getPlayer().isGM());
+  }
+
   public void initJtsMethodComboBox() {
     getJtsMethodComboBox().setModel(new DefaultComboBoxModel<>(JTS_SimplifyMethodType.values()));
   }
@@ -200,6 +205,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     getRootPane().setDefaultButton(getOKButton());
     setGmNotesEnabled(MapTool.getPlayer().isGM());
     getComponent("@GMName").setEnabled(MapTool.getPlayer().isGM());
+
+    setUniqueLightSourcesEnabled(MapTool.getPlayer().isGM());
 
     dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
@@ -370,6 +377,9 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                 .stream()
                 .mapToInt(Integer::valueOf)
                 .toArray());
+
+    getUniqueLightSourcesTextPane()
+        .setText(new LightSyntax().stringifyLights(token.getUniqueLightSources()));
 
     // Jamz: Init the Topology tab...
     JTabbedPane tabbedPane = getTabbedPane();
@@ -709,6 +719,15 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     return (JList<TerrainModifierOperation>) getComponent("terrainModifiersIgnored");
   }
 
+  public void setUniqueLightSourcesEnabled(boolean enabled) {
+    getUniqueLightSourcesTextPane().setEnabled(enabled);
+    getLabel("uniqueLightSourcesLabel").setEnabled(enabled);
+  }
+
+  public JTextPane getUniqueLightSourcesTextPane() {
+    return (JTextPane) getComponent("uniqueLightSources");
+  }
+
   public JLabel getLibTokenURIErrorLabel() {
     return (JLabel) getComponent("Label.LibURIError");
   }
@@ -782,6 +801,14 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     token.setTerrainModifiersIgnored(
         new HashSet<>(getTerrainModifiersIgnoredList().getSelectedValuesList()));
+
+    var uniqueLightSources =
+        new LightSyntax()
+            .parseLights(getUniqueLightSourcesTextPane().getText(), token.getUniqueLightSources());
+    token.removeAllUniqueLightsources();
+    for (var lightSource : uniqueLightSources.values()) {
+      token.addUniqueLightSource(lightSource);
+    }
 
     // Get the states
     Component[] stateComponents = getStatesPanel().getComponents();

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -550,7 +550,7 @@
               </vspacer>
             </children>
           </grid>
-          <grid id="3a658" layout-manager="GridLayoutManager" row-count="9" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="3a658" layout-manager="GridLayoutManager" row-count="10" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="4" left="4" bottom="4" right="4"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="EditTokenDialog.tab.config"/>
@@ -710,7 +710,7 @@
               <grid id="d2ea5" layout-manager="GridLayoutManager" row-count="2" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="8" column="0" row-span="1" col-span="9" vsize-policy="2" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="9" column="0" row-span="1" col-span="9" vsize-policy="2" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
@@ -937,14 +937,40 @@
                   <name value="statSheetLocationComboBox"/>
                 </properties>
               </component>
+              <component id="86a4f" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="7" column="0" row-span="1" col-span="6" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <labelFor value="c3057"/>
+                  <name value="uniqueLightSourcesLabel"/>
+                  <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.uniqueLightSources"/>
+                </properties>
+              </component>
+              <scrollpane id="45ccf">
+                <constraints>
+                  <grid row="8" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                    <preferred-size width="-1" height="100"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <background color="-1"/>
+                  <name value="uniqueLights"/>
+                </properties>
+                <border type="none"/>
+                <children>
+                  <component id="c3057" class="javax.swing.JTextPane">
+                    <constraints/>
+                    <properties>
+                      <background color="-1"/>
+                      <name value="uniqueLightSources"/>
+                    </properties>
+                  </component>
+                </children>
+              </scrollpane>
               <vspacer id="57cb0">
                 <constraints>
                   <grid row="6" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </vspacer>
-              <vspacer id="341a0">
-                <constraints>
-                  <grid row="7" column="5" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
             </children>

--- a/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
@@ -35,7 +35,7 @@ public class LightSourceIconOverlay implements ZoneOverlay {
       if (token.hasLightSources()) {
         boolean foundNormalLight = false;
         for (AttachedLightSource attachedLightSource : token.getLightSources()) {
-          LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
+          LightSource lightSource = attachedLightSource.resolve(token, MapTool.getCampaign());
           if (lightSource != null && lightSource.getType() == LightSource.Type.NORMAL) {
             foundNormalLight = true;
             break;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -78,7 +78,7 @@ public class ZoneView {
 
   private void addLightSourceToken(Token token, Set<Player.Role> roles) {
     for (AttachedLightSource als : token.getLightSources()) {
-      LightSource lightSource = als.resolve(MapTool.getCampaign());
+      LightSource lightSource = als.resolve(token, MapTool.getCampaign());
       if (lightSource == null) {
         continue;
       }
@@ -316,7 +316,8 @@ public class ZoneView {
     final var result = new ArrayList<ContributedLight>();
 
     for (final var attachedLightSource : lightSourceToken.getLightSources()) {
-      LightSource lightSource = attachedLightSource.resolve(MapTool.getCampaign());
+      LightSource lightSource =
+          attachedLightSource.resolve(lightSourceToken, MapTool.getCampaign());
       if (lightSource == null) {
         continue;
       }
@@ -669,7 +670,7 @@ public class ZoneView {
                 Point p = FogUtil.calculateVisionCenter(token, zone);
 
                 for (AttachedLightSource als : token.getLightSources()) {
-                  LightSource lightSource = als.resolve(MapTool.getCampaign());
+                  LightSource lightSource = als.resolve(token, MapTool.getCampaign());
                   if (lightSource == null) {
                     continue;
                   }

--- a/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
+++ b/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
@@ -31,8 +31,8 @@ public final class AttachedLightSource {
    * Get the ID of the attached light source.
    *
    * <p>If you're trying to use this to look up a {@link net.rptools.maptool.model.LightSource},
-   * consider using {@link #resolve(Campaign)} instead. If you're trying to compare to another
-   * {@code GUID}, consider using {@link #matches(GUID)}.
+   * consider using {@link #resolve(Token, Campaign)} instead. If you're trying to compare to
+   * another {@code GUID}, consider using {@link #matches(GUID)}.
    *
    * @return The ID of the attached light source.
    */
@@ -41,13 +41,19 @@ public final class AttachedLightSource {
   }
 
   /**
-   * Obtain the attached {@code LightSource} from the campaign.
+   * Obtain the attached {@code LightSource} from the token or campaign.
    *
+   * @param token The token in which to look up light source IDs.
    * @param campaign The campaign in which to look up light source IDs.
    * @return The {@code LightSource} referenced by this {@code AttachedLightSource}, or {@code null}
    *     if no such light source exists.
    */
-  public @Nullable LightSource resolve(Campaign campaign) {
+  public @Nullable LightSource resolve(Token token, Campaign campaign) {
+    final var uniqueLightSource = token.getUniqueLightSource(lightSourceId);
+    if (uniqueLightSource != null) {
+      return uniqueLightSource;
+    }
+
     for (Map<GUID, LightSource> map : campaign.getLightSourcesMap().values()) {
       if (map.containsKey(lightSourceId)) {
         return map.get(lightSourceId);

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -185,6 +185,16 @@ public interface ServerCommand {
 
   void removeData(String type, String namespace, String name);
 
+  /**
+   * Adds or removes a light source on {@code token}.
+   *
+   * @param token The token to modify
+   * @param toggleOn If {@code true}, the light source is turned on for the token. Otherwise, it is
+   *     turned off.
+   * @param lightSource The light source to add.
+   */
+  void toggleLightSourceOnToken(Token token, boolean toggleOn, LightSource lightSource);
+
   void setTokenTopology(Token token, @Nullable Area area, Zone.TopologyType topologyType);
 
   void updateTokenProperty(Token token, Token.Update update, int value);
@@ -199,8 +209,6 @@ public interface ServerCommand {
   void updateTokenProperty(Token token, Token.Update update, MacroButtonProperties value);
 
   void updateTokenProperty(Token token, Token.Update update, String value);
-
-  void updateTokenProperty(Token token, Token.Update update, LightSource value);
 
   void updateTokenProperty(Token token, Token.Update update, int value1, int value2);
 

--- a/src/main/proto/data_transfer_objects.proto
+++ b/src/main/proto/data_transfer_objects.proto
@@ -347,6 +347,7 @@ message TokenDto {
   bool is_flipped_iso = 47;
   google.protobuf.StringValue charsheet_image = 48;
   google.protobuf.StringValue portrait_image = 49;
+  repeated LightSourceDto unique_light_sources = 72;
   repeated AttachedLightSourceDto light_sources = 50;
   google.protobuf.StringValue sight_type = 51;
   bool has_sight = 52;


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #3087

### Description of the Change

This adds unique light sources, originally from #4356. Unlike before, this change focuses primarily on UI changes and does not include any macro functions for manipulating unique light sources.

#### UI changes

The only way to define unique light sources for now is through the **Edit Token** dialog's _Config_ tab. It has a textbox for entering light source definitions, following the same syntax as lights in the **Campaign Properties** dialog, minus the support for groups.

The token context menu's "Light Sources" sub-menu now shows a "Unique" group containing the token's unique light sources. If the token has none, this group will not be shown. Attaching and detaching unique lights works exactly the same as for campaign lights.

#### UVTT importer

The UVTT importer now defines and attaches a unique light source on the light tokens it produces. The range of the light source is taken from the light's `"range"` field. The color is taken from the `"color"` field, but only if the imported map does not have baked lighting. Clear lights are produced if lighting is baked since the light color is already present on the map. 

The light's properties are still written to the token's GM notes as JSON, but now all properties are written rather than a hand-picked subset.

There are two limitations on this part of the importer:
- The `"intensity"` field goes unused as we don't have a equivalent concept.
- The UVTT format includes no shape information for lights, so the shape will always be set to "circle".

#### Macro function changes

The only change to macro functions is to add the `"$token"` type to [`getLights()`](https://wiki.rptools.info/index.php/getLights), [`setLight()`](https://wiki.rptools.info/index.php/setLight), and [`hasLightSource`](https://wiki.rptools.info/index.php/hasLightSource). The `"*"` wildcard type will also include any unique light sources on the token in addition to those in the campaign.

### Possible Drawbacks

Existing macros may fail if they try to match up the results of `getLights("*")` with the lighting info in `getInfo("campaign")`, without validating that the keys exist. This would not immediately impact existing campaigns since it is only an issue if run against tokens with unique light sources added to them.

### Documentation Notes

How the Edit Token dialog looks for defining unique light sources:
![defining via Edit Token dialog](https://github.com/user-attachments/assets/33e73350-db7d-44ce-addc-509755086ff9)

How the token context menu looks for turning unique light sources on and off:
![attaching via token context menu](https://github.com/user-attachments/assets/1588d06e-84ce-4566-9d29-667aac2b94bc)

For `getLights()` **type** parameter:
- If set to `"$token"`, unique light sources on the token are returned.
- If set to `"*"`, all light sources - including unique light sources on the token - are returned.

For `setLight()` **type** parameter:
- If set to `"$token"`, `name` refers to a unique light source on the token.

For `hasLightSource()` **type** parameter:
- If set to `"$token"`, only unique light sources on the token are checked.
- If set to `"*"`, all light sources - including unique light source on the token - are returned

### Release Notes

- Added unique lights to tokens, with support in UVTT importer for creating them on imported lights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5067)
<!-- Reviewable:end -->
