### PR TITLE
Fix threading issue with external links in HTML5 contexts

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -480,11 +480,15 @@ public class MapTool {
    * be called from any uncontrolled macros as there are both security and denial-of-service attacks
    * possible.
    *
+   * <p>This should not be called from any uncontrolled macros as there are both security and
+   * denial-of-service attacks possible.
+   *
+   * <p>This must be called on the AWT thread.
+   *
    * @param url the URL to pass to the browser.
    */
   public static void showDocument(String url) {
-    if (Desktop.isDesktopSupported()) {
-      String lowerCaseUrl = url.toLowerCase();
+    if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
       String urlToBrowse = url;
       Desktop desktop = Desktop.getDesktop();
       URI uri = null;
@@ -492,8 +496,8 @@ public class MapTool {
         uri = new URI(urlToBrowse);
         if (uri.getScheme() == null) {
           urlToBrowse = "https://" + urlToBrowse;
+          uri = new URI(urlToBrowse);
         }
-        uri = new URI(urlToBrowse);
         desktop.browse(uri);
       } catch (Exception e) {
         MapTool.showError(I18N.getText("msg.error.browser.cannotStart", uri), e);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -585,8 +585,8 @@ public class HTMLWebViewManager {
           // Java bug JDK-8199014 workaround
           webEngine.executeScript(String.format(SCRIPT_ANCHOR, href.substring(1)));
         } else if (!href2.startsWith("javascript")) {
-          // non-macrolink, non-anchor link, non-javascript code
-          MapTool.showDocument(href); // show in usual browser
+          // non-macrolink, non-anchor link, non-javascript code. Show in usual browser
+          SwingUtilities.invokeLater(() -> MapTool.showDocument(href));
         }
         event.preventDefault(); // don't change webview
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5077

### Description of the Change

The click handler for HTML5 links now calls `MapTool.showDocument()` on the swing thread to avoid conflicts with the JFX thread where the handler runs.

We also now check that the browse action is supported by the `Desktop` before entering the associated code branch.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where clicking external links in HTML5 contexts would cause MapTool to hang.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5078)
<!-- Reviewable:end -->
