### PR TITLE
Simplify SelectionSet null checks case work

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/RenderPathWorker.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/RenderPathWorker.java
@@ -27,14 +27,14 @@ public class RenderPathWorker extends SwingWorker<Void, Void> {
   // private static final Logger log = LogManager.getLogger(RenderPathWorker.class);
 
   ZoneRenderer zoneRenderer;
-  ZoneWalker walker;
+  @Nonnull ZoneWalker walker;
   CellPoint startPoint, endPoint;
   private final boolean restrictMovement;
   private final Set<TerrainModifierOperation> terrainModifiersIgnored;
   private final @Nonnull Token keyToken;
 
   public RenderPathWorker(
-      ZoneWalker walker,
+      @Nonnull ZoneWalker walker,
       CellPoint endPoint,
       boolean restrictMovement,
       Set<TerrainModifierOperation> terrainModifiersIgnored,

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.Logger;
 public class SelectionSet {
 
   private final ZoneRenderer renderer;
+  private final Grid grid;
   private final Logger log = LogManager.getLogger(SelectionSet.class);
 
   private final Set<GUID> selectionSet = new HashSet<GUID>();
@@ -70,12 +71,13 @@ public class SelectionSet {
     startPoint = new ZonePoint(anchorPoint);
     currentPoint = new ZonePoint(anchorPoint);
 
-    if (token.isSnapToGrid() && renderer.zone.getGrid().getCapabilities().isSnapToGridSupported()) {
-      if (renderer.zone.getGrid().getCapabilities().isPathingSupported()) {
-        CellPoint tokenPoint = renderer.zone.getGrid().convert(currentPoint);
+    grid = renderer.getZone().getGrid();
+    if (token.isSnapToGrid() && grid.getCapabilities().isSnapToGridSupported()) {
+      if (grid.getCapabilities().isPathingSupported()) {
+        CellPoint tokenPoint = grid.convert(currentPoint);
 
-        walker = renderer.zone.getGrid().createZoneWalker();
-        walker.setFootprint(token.getFootprint(renderer.zone.getGrid()));
+        walker = grid.createZoneWalker();
+        walker.setFootprint(token.getFootprint(grid));
         walker.setWaypoints(tokenPoint, tokenPoint);
       }
     } else {
@@ -151,7 +153,7 @@ public class SelectionSet {
     currentPoint.y = newAnchorPosition.y;
 
     if (walker != null) {
-      CellPoint point = renderer.zone.getGrid().convert(currentPoint);
+      CellPoint point = grid.convert(currentPoint);
       // walker.replaceLastWaypoint(point, restrictMovement); // OLD WAY
 
       // New way threaded, off the swing UI thread...
@@ -179,7 +181,7 @@ public class SelectionSet {
    */
   public void toggleWaypoint(ZonePoint location) {
     if (walker != null) {
-      walker.toggleWaypoint(renderer.getZone().getGrid().convert(location));
+      walker.toggleWaypoint(grid.convert(location));
     } else {
       gridlessPath.appendWaypoint(location);
     }
@@ -197,10 +199,10 @@ public class SelectionSet {
       CellPoint cp = walker.getLastPoint();
 
       if (cp == null) {
-        cp = renderer.zone.getGrid().convert(token.getDragAnchor(renderer.zone));
+        cp = grid.convert(token.getDragAnchor(renderer.zone));
       }
 
-      zp = renderer.getZone().getGrid().convert(cp);
+      zp = grid.convert(cp);
     } else {
       // Gridless path will never be empty if set.
       zp = gridlessPath.getWayPointList().getLast();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/SelectionSet.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.RenderPathWorker;
 import net.rptools.maptool.client.walker.ZoneWalker;
@@ -36,7 +37,7 @@ public class SelectionSet {
   private final Set<GUID> selectionSet = new HashSet<GUID>();
   private final GUID keyToken;
   private final String playerId;
-  private ZoneWalker walker;
+  private @Nullable ZoneWalker walker;
   private final Token token;
 
   private Path<ZonePoint> gridlessPath;
@@ -114,29 +115,32 @@ public class SelectionSet {
 
   /** Aborts the movement for this selection. */
   public void cancel() {
-    walker.close();
+    if (walker != null) {
+      walker.close();
 
-    renderPathTask.cancel(true);
+      if (renderPathTask != null) {
+        renderPathTask.cancel(true);
+      }
+    }
   }
 
   // This is called when movement is committed/done. It'll let the last thread either finish or
   // timeout
   public void renderFinalPath() {
-    walker.close();
+    if (walker != null) {
+      walker.close();
 
-    if (renderer.zone.getGrid().getCapabilities().isPathingSupported()
-        && token.isSnapToGrid()
-        && renderPathTask != null) {
-
-      log.trace("Waiting on Path Rendering... ");
-      while (true) {
-        try {
-          renderPathTask.get();
-          break;
-        } catch (InterruptedException e) {
-        } catch (ExecutionException e) {
-          log.error("Error while waiting for task to finish", e);
-          break;
+      if (renderPathTask != null) {
+        log.trace("Waiting on Path Rendering... ");
+        while (true) {
+          try {
+            renderPathTask.get();
+            break;
+          } catch (InterruptedException e) {
+          } catch (ExecutionException e) {
+            log.error("Error while waiting for task to finish", e);
+            break;
+          }
         }
       }
     }
@@ -146,7 +150,7 @@ public class SelectionSet {
     currentPoint.x = newAnchorPosition.x;
     currentPoint.y = newAnchorPosition.y;
 
-    if (renderer.zone.getGrid().getCapabilities().isPathingSupported() && token.isSnapToGrid()) {
+    if (walker != null) {
       CellPoint point = renderer.zone.getGrid().convert(currentPoint);
       // walker.replaceLastWaypoint(point, restrictMovement); // OLD WAY
 
@@ -174,7 +178,7 @@ public class SelectionSet {
    * @param location The point where the waypoint is toggled.
    */
   public void toggleWaypoint(ZonePoint location) {
-    if (walker != null && token.isSnapToGrid() && renderer.getZone().getGrid() != null) {
+    if (walker != null) {
       walker.toggleWaypoint(renderer.getZone().getGrid().convert(location));
     } else {
       gridlessPath.appendWaypoint(location);
@@ -189,14 +193,11 @@ public class SelectionSet {
    */
   public ZonePoint getLastWaypoint() {
     ZonePoint zp;
-    if (walker != null && token.isSnapToGrid() && renderer.getZone().getGrid() != null) {
+    if (walker != null) {
       CellPoint cp = walker.getLastPoint();
 
       if (cp == null) {
-        // log.info("cellpoint is null! FIXME! You have Walker class updating outside of
-        // thread..."); // Why not save last waypoint to this class?
         cp = renderer.zone.getGrid().convert(token.getDragAnchor(renderer.zone));
-        // log.info("So I set it to: " + cp);
       }
 
       zp = renderer.getZone().getGrid().convert(cp);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5089

### Description of the Change

Whenever the walker is used, we check it for `null` now, and same for the `renderPathTask`, and when both are needed we consistently check the walker first and only bother with `renderPathTask` if it is set.

We also avoid checking zone and token properties to decide whether we are using the walker or not, and instead only use the above null checks. The zone and token properties can change over time, and modifying them while a token is in transit used to also result in error (this is a long-standing issue with `SelectionSet`). Changing these avoids these errors, though it means `SelectionSet` still doesn't react to the changes. This is something that can be handled separately and is not urgent.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where non-snap-to-grid tokens would generate an error when moved.
- Fixed a bug where toggline snap-to-grid on a moving token would generate an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5098)
<!-- Reviewable:end -->
