### PR TITLE
Revert "Bump org.graalvm.js:js-scriptengine from 21.1.0 to 24.1.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -402,7 +402,7 @@ dependencies {
 
     // JS support for macros
     implementation group: 'org.graalvm.js', name: 'js', version: '21.2.0'
-    implementation group: 'org.graalvm.js', name: 'js-scriptengine', version: '24.1.1'
+    implementation group: 'org.graalvm.js', name: 'js-scriptengine', version: '21.1.0'
 
     implementation 'com.jayway.jsonpath:json-path:2.9.0'
 


### PR DESCRIPTION
Reverts RPTools/maptool#4997

Causes issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5106)
<!-- Reviewable:end -->
