### PR TITLE
update crowdin.yml to force escaping single quotes with ''

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
 files:
   - source: /src/main/resources/net/rptools/maptool/language/i18n.properties
     translation: /%original_path%/%file_name%_%locale_with_underscore%.%file_extension%
-    escape_quotes: 1
+    escape_quotes: 3

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
 files:
   - source: /src/main/resources/net/rptools/maptool/language/i18n.properties
     translation: /%original_path%/%file_name%_%locale_with_underscore%.%file_extension%
+    escape_quotes: 1


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5116

### Description of the Change
updated Crowdin config to hopefully enforce escaped quotes.


### Possible Drawbacks
might not work

### Documentation Notes
n/a

### Release Notes
translation apostrophe fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5119)
<!-- Reviewable:end -->
