### PR TITLE
Support Ephemeral ports

### DIFF
--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/AbstractServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/AbstractServer.java
@@ -20,7 +20,7 @@ import net.rptools.clientserver.simple.connection.Connection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public abstract class AbstractServer implements Server {
+public abstract class AbstractServer {
 
   private static final Logger log = LogManager.getLogger(AbstractServer.class);
 

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/NilServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/NilServer.java
@@ -15,7 +15,7 @@
 package net.rptools.clientserver.simple.server;
 
 /** A server implementation that never receives connections */
-public class NilServer extends AbstractServer {
+public final class NilServer extends AbstractServer implements Server {
   @Override
   public void start() {}
 

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/Server.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/Server.java
@@ -16,7 +16,7 @@ package net.rptools.clientserver.simple.server;
 
 import java.io.IOException;
 
-public interface Server extends AutoCloseable {
+public sealed interface Server extends AutoCloseable permits NilServer, SocketServer, WebRTCServer {
   void start() throws IOException;
 
   void close();

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/SocketServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/SocketServer.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * @author drice
  */
-public class SocketServer extends AbstractServer {
+public final class SocketServer extends AbstractServer implements Server {
 
   private static final Logger log = LogManager.getLogger(SocketServer.class);
   private final int port;

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/SocketServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/SocketServer.java
@@ -39,6 +39,9 @@ public final class SocketServer extends AbstractServer implements Server {
   @Override
   public void start() throws IOException {
     var serverSocket = new ServerSocket(port);
+    if (serverSocket.getLocalPort() == -1) {
+      throw new AssertionError("Socket not bound yet");
+    }
     // If the above throws, it will be as though we never started.
 
     socket = serverSocket;
@@ -68,6 +71,16 @@ public final class SocketServer extends AbstractServer implements Server {
 
   public String getError() {
     return null;
+  }
+
+  /** Get the port of the socket the server is running on or -1. */
+  public int getPort() {
+    // NOTE: We do not use this.port because the socket's bound port can be different
+    if (socket == null || socket.isClosed()) {
+      return -1;
+    }
+
+    return socket.getLocalPort();
   }
 
   ////

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/WebRTCServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/WebRTCServer.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
-public class WebRTCServer extends AbstractServer {
+public final class WebRTCServer extends AbstractServer implements Server {
   private static final Logger log = LogManager.getLogger(WebRTCServer.class);
 
   public interface Listener {

--- a/src/main/java/net/rptools/clientserver/ConnectionFactory.java
+++ b/src/main/java/net/rptools/clientserver/ConnectionFactory.java
@@ -15,6 +15,7 @@
 package net.rptools.clientserver;
 
 import java.awt.EventQueue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.clientserver.simple.connection.Connection;
 import net.rptools.clientserver.simple.connection.SocketConnection;
@@ -49,6 +50,7 @@ public class ConnectionFactory {
         });
   }
 
+  @Nonnull
   public Server createServer(@Nullable ServerConfig config) {
     if (config == null) {
       return new NilServer();

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2209,7 +2209,7 @@ public class AppActions {
                 StartServerDialogPreferences serverProps =
                     new StartServerDialogPreferences(); // data retrieved from
                 // Preferences.userRoot()
-                if (serverProps.getPort() == 0 || serverProps.getPort() > 65535) {
+                if (serverProps.getPort() > 65535) {
                   MapTool.showError("ServerDialog.error.port.outOfRange");
                   return;
                 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -185,7 +185,7 @@ public class MapTool {
       var campaign = CampaignFactory.createBasicCampaign();
       var policy = new ServerPolicy();
 
-      server = new MapToolServer("", new Campaign(campaign), null, false, policy, playerDB);
+      server = new MapToolServer(null, new Campaign(campaign), null, false, policy, playerDB);
       client = new MapToolClient(server, campaign, playerDB.getPlayer(), connections.clientSide());
     } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
       throw new RuntimeException("Unable to create default personal server", e);

--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -83,7 +83,7 @@ public class MapToolServer {
   private final AssetProducerThread assetProducerThread;
 
   private final boolean useUPnP;
-  private final ServiceAnnouncer announcer;
+  @Nullable private ServiceAnnouncer announcer;
   private Campaign campaign;
   private ServerPolicy policy;
   private HeartbeatThread heartbeatThread;
@@ -104,11 +104,6 @@ public class MapToolServer {
     this.useUPnP = useUPnP;
     this.policy = new ServerPolicy(policy);
     this.playerDatabase = playerDb;
-
-    this.announcer =
-        config == null || id == null
-            ? null
-            : new ServiceAnnouncer(id, config.getPort(), AppConstants.SERVICE_GROUP);
 
     server = ConnectionFactory.getInstance().createServer(this.config);
     messageHandler = new ServerMessageHandler(this);
@@ -370,6 +365,7 @@ public class MapToolServer {
 
     if (announcer != null) {
       announcer.stop();
+      announcer = null;
     }
 
     // Unregister ourselves
@@ -434,7 +430,8 @@ public class MapToolServer {
       }
     }
 
-    if (announcer != null) {
+    if (serviceIdentifier != null && config != null) {
+      announcer = new ServiceAnnouncer(serviceIdentifier, config.getPort(), AppConstants.SERVICE_GROUP);
       announcer.start();
     }
 

--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -93,7 +93,7 @@ public class MapToolServer {
   private State currentState;
 
   public MapToolServer(
-      String id,
+      @Nullable String id,
       Campaign campaign,
       @Nullable ServerConfig config,
       boolean useUPnP,
@@ -106,7 +106,7 @@ public class MapToolServer {
     this.playerDatabase = playerDb;
 
     this.announcer =
-        config == null
+        config == null || id == null
             ? null
             : new ServiceAnnouncer(id, config.getPort(), AppConstants.SERVICE_GROUP);
 

--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -348,21 +348,6 @@ public class MapToolServer {
       return;
     }
 
-    server.close();
-    for (var connection : router.removeAll()) {
-      connection.removeDisconnectHandler(onConnectionDisconnected);
-      connection.close();
-    }
-
-    assetManagerMap.clear();
-
-    if (heartbeatThread != null) {
-      heartbeatThread.shutdown();
-    }
-    if (assetProducerThread != null) {
-      assetProducerThread.shutdown();
-    }
-
     if (announcer != null) {
       announcer.stop();
       announcer = null;
@@ -381,6 +366,21 @@ public class MapToolServer {
     if (useUPnP && config != null) {
       int port = config.getPort();
       UPnPUtil.closePort(port);
+    }
+
+    server.close();
+    for (var connection : router.removeAll()) {
+      connection.removeDisconnectHandler(onConnectionDisconnected);
+      connection.close();
+    }
+
+    assetManagerMap.clear();
+
+    if (heartbeatThread != null) {
+      heartbeatThread.shutdown();
+    }
+    if (assetProducerThread != null) {
+      assetProducerThread.shutdown();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import net.rptools.clientserver.ConnectionFactory;
@@ -67,6 +68,7 @@ public class MapToolServer {
     Stopped
   }
 
+  @Nonnull private final String serviceIdentifier;
   private final Server server;
   private final MessageHandler messageHandler;
   private final Router router;
@@ -97,6 +99,7 @@ public class MapToolServer {
       boolean useUPnP,
       ServerPolicy policy,
       ServerSidePlayerDatabase playerDb) {
+    this.serviceIdentifier = id;
     this.config = config;
     this.useUPnP = useUPnP;
     this.policy = new ServerPolicy(policy);
@@ -202,6 +205,19 @@ public class MapToolServer {
 
   public int getPort() {
     return config == null ? -1 : config.getPort();
+  }
+
+  /**
+   * Get the ID that this server responds to service announcement requests with.
+   *
+   * @return The identifier or null if it's not being announced.
+   */
+  @Nullable
+  public String getServiceIdentifier() {
+    if (announcer == null) {
+      return null;
+    }
+    return serviceIdentifier;
   }
 
   private void connectionAdded(Connection conn) {

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_cs.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_cs.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_cs_CZ.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_cs_CZ.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_da.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_da.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Du skal angive en numerisk port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Serveren "{0}" blev ikke fundet.

--- a/src/main/resources/net/rptools/maptool/language/i18n_da_DK.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_da_DK.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Du skal angive en numerisk port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Serveren "{0}" blev ikke fundet.

--- a/src/main/resources/net/rptools/maptool/language/i18n_de.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_de.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dunkel
 Preferences.combo.themes.filter.light             = Hell
 
 ServerDialog.error.port                = Du musst eine Zahl als Port angeben.
-ServerDialog.error.port.outOfRange     = Der Port-Bereich muss zwischen 1 und 65535 liegen.
+ServerDialog.error.port.outOfRange     = Der Port-Bereich muss zwischen 0 und 65535 liegen.
 ServerDialog.error.portNumberException = Port aus der RPTools Registrierung ist keine Zahl?\!  Webserver Fehler?
 ServerDialog.error.server              = Servernamen oder IP-Adresse eingeben.
 ServerDialog.error.serverNotFound      = Server "{0}" nicht gefunden.

--- a/src/main/resources/net/rptools/maptool/language/i18n_de_DE.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_de_DE.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Letzte Kampagne beim Start l
 Preferences.label.loadMRU.tooltip                 = Starte MapTool mit letzter verwendeter Kampagne
 
 ServerDialog.error.port                = Du musst eine Zahl als Port angeben.
-ServerDialog.error.port.outOfRange     = Der Port-Bereich muss zwischen 1 und 65535 liegen.
+ServerDialog.error.port.outOfRange     = Der Port-Bereich muss zwischen 0 und 65535 liegen.
 ServerDialog.error.portNumberException = Port aus der RPTools Registrierung ist keine Zahl?\!  Webserver Fehler?
 ServerDialog.error.server              = Servernamen oder IP-Adresse eingeben.
 ServerDialog.error.serverNotFound      = Server "{0}" nicht gefunden.

--- a/src/main/resources/net/rptools/maptool/language/i18n_en.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_en_AU.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en_AU.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_en_GB.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en_GB.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_es.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_es.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Debes ingresar un puerto numérico.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = El puerto desde el registro de RPTools no es numérico?\!  Error de servidor web?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Servidor "{0}" no se encuentra.

--- a/src/main/resources/net/rptools/maptool/language/i18n_es_ES.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_es_ES.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Debes ingresar un puerto numérico.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = El puerto desde el registro de RPTools no es numérico?\!  Error de servidor web?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Servidor "{0}" no se encuentra.

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Vous devez entrer un port numérique.
-ServerDialog.error.port.outOfRange     = Le numéro de port doit être compris entre 1 et 65535.
+ServerDialog.error.port.outOfRange     = Le numéro de port doit être compris entre 0 et 65535.
 ServerDialog.error.portNumberException = Le port issu du registre RPTools n'est pas numérique?\! Un bug du serveur Web?
 ServerDialog.error.server              = Vous devez entrer un serveur ou une adresse IP.
 ServerDialog.error.serverNotFound      = Serveur\: {0} introuvable.

--- a/src/main/resources/net/rptools/maptool/language/i18n_fr_FR.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_fr_FR.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Vous devez entrer un port numérique.
-ServerDialog.error.port.outOfRange     = Le numéro de port doit être compris entre 1 et 65535.
+ServerDialog.error.port.outOfRange     = Le numéro de port doit être compris entre 0 et 65535.
 ServerDialog.error.portNumberException = Le port issu du registre RPTools n'est pas numérique?\! Un bug du serveur Web?
 ServerDialog.error.server              = Vous devez entrer un serveur ou une adresse IP.
 ServerDialog.error.serverNotFound      = Serveur\: {0} introuvable.

--- a/src/main/resources/net/rptools/maptool/language/i18n_it.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_it.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Scuro
 Preferences.combo.themes.filter.light             = Chiaro
 
 ServerDialog.error.port                = Devi inserire il numero di una porta.
-ServerDialog.error.port.outOfRange     = L'intervallo delle porte deve essere compreso tra 1 e 65535.
+ServerDialog.error.port.outOfRange     = L'intervallo delle porte deve essere compreso tra 0 e 65535.
 ServerDialog.error.portNumberException = La porta dal registro di RPTools non è numerica?\! Bug del server web?
 ServerDialog.error.server              = Devi inserire un nome server o un indirizzo IP.
 ServerDialog.error.serverNotFound      = Server "{0}" non trovato.

--- a/src/main/resources/net/rptools/maptool/language/i18n_it_IT.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_it_IT.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Devi inserire il numero di una porta.
-ServerDialog.error.port.outOfRange     = L'intervallo delle porte deve essere compreso tra 1 e 65535.
+ServerDialog.error.port.outOfRange     = L'intervallo delle porte deve essere compreso tra 0 e 65535.
 ServerDialog.error.portNumberException = La porta dal registro di RPTools non è numerica?\! Bug del server web?
 ServerDialog.error.server              = Devi inserire un nome server o un indirizzo IP.
 ServerDialog.error.serverNotFound      = Server "{0}" non trovato.

--- a/src/main/resources/net/rptools/maptool/language/i18n_ja.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ja.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = 暗いテーマ
 Preferences.combo.themes.filter.light             = 明るいテーマ
 
 ServerDialog.error.port                = ポート番号を入力する必要があります。
-ServerDialog.error.port.outOfRange     = ポート番号は1から65535の間でなければなりません。
+ServerDialog.error.port.outOfRange     = ポート番号は0から65535の間でなければなりません。
 ServerDialog.error.portNumberException = RPTools 登録所より取得したポート番号が数字ではない？！WEBサーバーのバグかもしれません。
 ServerDialog.error.server              = サーバー名またはIPアドレスを入力する必要があります。
 ServerDialog.error.serverNotFound      = サーバー『{0}』が見つかりません。

--- a/src/main/resources/net/rptools/maptool/language/i18n_ja_JP.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ja_JP.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = 起動時に最後のキャ�
 Preferences.label.loadMRU.tooltip                 = 最後に使用したキャンペーンと共に MapTool を起動する
 
 ServerDialog.error.port                = ポート番号を入力する必要があります。
-ServerDialog.error.port.outOfRange     = ポート番号は1から65535の間でなければなりません。
+ServerDialog.error.port.outOfRange     = ポート番号は0から65535の間でなければなりません。
 ServerDialog.error.portNumberException = RPTools 登録所より取得したポート番号が数字ではない？！WEBサーバーのバグかもしれません。
 ServerDialog.error.server              = サーバー名またはIPアドレスを入力する必要があります。
 ServerDialog.error.serverNotFound      = サーバー『{0}』が見つかりません。

--- a/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_nl.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = U moet een getal invullen voor deze poort.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Poort van RPTools register is niet numeriek?\! Webserver bug?
 ServerDialog.error.server              = U moet een servernaam of IP-adres invoeren.
 ServerDialog.error.serverNotFound      = Server "{0}" niet gevonden.

--- a/src/main/resources/net/rptools/maptool/language/i18n_nl_NL.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_nl_NL.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Laad vorige campagne bij ops
 Preferences.label.loadMRU.tooltip                 = Start MapTool met de campagne die u het laatst gebruikte
 
 ServerDialog.error.port                = U moet een getal invullen voor deze poort.
-ServerDialog.error.port.outOfRange     = Poort moet tussen 1 en 65535 liggen.
+ServerDialog.error.port.outOfRange     = Poort moet tussen 0 en 65535 liggen.
 ServerDialog.error.portNumberException = Poort van RPTools register is niet numeriek?\! Webserver bug?
 ServerDialog.error.server              = U moet een servernaam of IP-adres invoeren.
 ServerDialog.error.serverNotFound      = Server "{0}" niet gevonden.

--- a/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pl.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Ciemny
 Preferences.combo.themes.filter.light             = Jasny
 
 ServerDialog.error.port                = Musisz wprowadzić wartość numeryczną portu.
-ServerDialog.error.port.outOfRange     = Zakres portów musi wynosić od 1 do 65535.
+ServerDialog.error.port.outOfRange     = Zakres portów musi wynosić od 0 do 65535.
 ServerDialog.error.portNumberException = Port z rejestru RPTools nie jest liczbą?\!  Błąd serwera?
 ServerDialog.error.server              = Musisz wprowadzić nazwę serwera lub adres IP.
 ServerDialog.error.serverNotFound      = Serwer „{0}” nie odnaleziony.

--- a/src/main/resources/net/rptools/maptool/language/i18n_pl_PL.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pl_PL.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Musisz wprowadzić wartość numeryczną portu.
-ServerDialog.error.port.outOfRange     = Zakres portów musi wynosić od 1 do 65535.
+ServerDialog.error.port.outOfRange     = Zakres portów musi wynosić od 0 do 65535.
 ServerDialog.error.portNumberException = Port z rejestru RPTools nie jest liczbą?\!  Błąd serwera?
 ServerDialog.error.server              = Musisz wprowadzić nazwę serwera lub adres IP.
 ServerDialog.error.serverNotFound      = Serwer „{0}” nie odnaleziony.

--- a/src/main/resources/net/rptools/maptool/language/i18n_pt.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pt.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Você deve digitar uma porta numérica.
-ServerDialog.error.port.outOfRange     = O intervalo de portas deve estar entre 1 e 65535.
+ServerDialog.error.port.outOfRange     = O intervalo de portas deve estar entre 0 e 65535.
 ServerDialog.error.portNumberException = Porta do registro RPTools não é numérico?\! Erro no servidor web?
 ServerDialog.error.server              = Você deve digitar um nome de servidor ou endereço IP.
 ServerDialog.error.serverNotFound      = Servidor "{0}" não encontrado.

--- a/src/main/resources/net/rptools/maptool/language/i18n_pt_BR.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_pt_BR.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Você deve digitar uma porta numérica.
-ServerDialog.error.port.outOfRange     = O intervalo de portas deve estar entre 1 e 65535.
+ServerDialog.error.port.outOfRange     = O intervalo de portas deve estar entre 0 e 65535.
 ServerDialog.error.portNumberException = Porta do registro RPTools não é numérico?\! Erro no servidor web?
 ServerDialog.error.server              = Você deve digitar um nome de servidor ou endereço IP.
 ServerDialog.error.serverNotFound      = Servidor "{0}" não encontrado.

--- a/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ru.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Вы должны ввести номер порта.
-ServerDialog.error.port.outOfRange     = Диапазон портов должен быть от 1 до 65535.
+ServerDialog.error.port.outOfRange     = Диапазон портов должен быть от 0 до 65535.
 ServerDialog.error.portNumberException = Порт из реестра RPTools не числовой? Ошибка веб-сервера?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Сервер\: {0} не найден.

--- a/src/main/resources/net/rptools/maptool/language/i18n_ru_RU.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_ru_RU.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Вы должны ввести номер порта.
-ServerDialog.error.port.outOfRange     = Диапазон портов должен быть от 1 до 65535.
+ServerDialog.error.port.outOfRange     = Диапазон портов должен быть от 0 до 65535.
 ServerDialog.error.portNumberException = Порт из реестра RPTools не числовой? Ошибка веб-сервера?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Сервер\: {0} не найден.

--- a/src/main/resources/net/rptools/maptool/language/i18n_si.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_si.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_si_LK.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_si_LK.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = You must enter a numeric port.
-ServerDialog.error.port.outOfRange     = Port range must be between 1 and 65535.
+ServerDialog.error.port.outOfRange     = Port range must be between 0 and 65535.
 ServerDialog.error.portNumberException = Port from RPTools registry is not numeric?\!  Web server bug?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Server "{0}" not found.

--- a/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_sv.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Du måste ange en numerisk port.
-ServerDialog.error.port.outOfRange     = Port måste vara mellan 1 och 65535.
+ServerDialog.error.port.outOfRange     = Port måste vara mellan 0 och 65535.
 ServerDialog.error.portNumberException = Port från RPTools register är inte numerisk ?\! Webbserver bugg?
 ServerDialog.error.server              = Du måste ange ett servernamn eller en IP-adress.
 ServerDialog.error.serverNotFound      = Server "{0}" hittades inte.

--- a/src/main/resources/net/rptools/maptool/language/i18n_sv_SE.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_sv_SE.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Du måste ange en numerisk port.
-ServerDialog.error.port.outOfRange     = Port måste vara mellan 1 och 65535.
+ServerDialog.error.port.outOfRange     = Port måste vara mellan 0 och 65535.
 ServerDialog.error.portNumberException = Port från RPTools register är inte numerisk ?\! Webbserver bugg?
 ServerDialog.error.server              = Du måste ange ett servernamn eller en IP-adress.
 ServerDialog.error.serverNotFound      = Server "{0}" hittades inte.

--- a/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_uk.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = Необхідно ввести номер порту.
-ServerDialog.error.port.outOfRange     = Порт має бути у діапазоні від 1 до 65535.
+ServerDialog.error.port.outOfRange     = Порт має бути у діапазоні від 0 до 65535.
 ServerDialog.error.portNumberException = Порт з реєстру RPTools не є цифровим?\! Помилка веб-сервера?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Сервер "{0}" не знайдено.

--- a/src/main/resources/net/rptools/maptool/language/i18n_uk_UA.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_uk_UA.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = Необхідно ввести номер порту.
-ServerDialog.error.port.outOfRange     = Порт має бути у діапазоні від 1 до 65535.
+ServerDialog.error.port.outOfRange     = Порт має бути у діапазоні від 0 до 65535.
 ServerDialog.error.portNumberException = Порт з реєстру RPTools не є цифровим?\! Помилка веб-сервера?
 ServerDialog.error.server              = You must enter a server name or IP address.
 ServerDialog.error.serverNotFound      = Сервер "{0}" не знайдено.

--- a/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_zh.properties
@@ -714,7 +714,7 @@ Preferences.combo.themes.filter.dark              = Dark
 Preferences.combo.themes.filter.light             = Light
 
 ServerDialog.error.port                = 你必须输入端口数值。
-ServerDialog.error.port.outOfRange     = 端口范围必须介于 1 到 65535 之间。
+ServerDialog.error.port.outOfRange     = 端口范围必须介于 0 到 65535 之间。
 ServerDialog.error.portNumberException = RPTools注册端口不是数值？！网络服务器bug？
 ServerDialog.error.server              = 您必须输入服务器名称或IP地址。
 ServerDialog.error.serverNotFound      = 服务器"{0}"未找到。

--- a/src/main/resources/net/rptools/maptool/language/i18n_zh_CN.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_zh_CN.properties
@@ -742,7 +742,7 @@ Preferences.label.loadMRU                         = Load last campaign on start
 Preferences.label.loadMRU.tooltip                 = Start MapTool with the last campaign you were using
 
 ServerDialog.error.port                = 你必须输入端口数值。
-ServerDialog.error.port.outOfRange     = 端口范围必须介于 1 到 65535 之间。
+ServerDialog.error.port.outOfRange     = 端口范围必须介于 0 到 65535 之间。
 ServerDialog.error.portNumberException = RPTools注册端口不是数值？！网络服务器bug？
 ServerDialog.error.server              = 您必须输入服务器名称或IP地址。
 ServerDialog.error.serverNotFound      = 服务器"{0}"未找到。


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes https://github.com/RPTools/maptool/issues/5125

Depends on https://github.com/RPTools/maptool/pull/5143

### Description of the Change

This relaxes the validation of the server port field to allow 0, changes code that used the configured port for sending to the registry or advertising with service discovery to use the value from the bound socket, and ensures they are configured after the socket has been bound so the port can be correctly determined.

### Possible Drawbacks

If a user specifies it as 0 without using UPnP then connections will probably fail and those error messages are less informative than having picked an invalid port.

### Release Notes

* The server port may be specified as 0 to use a random port that may be mapped with UPnP and configured with the rptools.net server registry or advertised on LAN.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5126)
<!-- Reviewable:end -->
