### PR TITLE
Bump upnplib to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -383,7 +383,7 @@ dependencies {
 
     //maybe replace with jupnp
     implementation 'commons-jxpath:commons-jxpath:1.3'
-    implementation 'net.sbbi.upnp:upnplib:1.0.9-nodebug'
+    implementation 'com.github.fishface60:upnplib:0351d7502a57f6c5dc8653220bc03ad99af58b21'
 
     // custom binding stuff, should probably be replace with Beans Binding (JSR 295)
     implementation 'yasb:yasb:0.2-21012007'


### PR DESCRIPTION
### Identify the Bug or Feature request

closes https://github.com/RPTools/maptool/issues/5123

### Description of the Change

This updates the gradle config to use an updated version of the [MapTool fork of UPnPlib](https://github.com/RPTools/upnplib).

This is an alternative to https://github.com/RPTools/maptool/pull/5124

### Possible Drawbacks

Some routers support both InternetGatewayDevice:1 and InternetGatewayDevice:2 interfaces and it's implementation defined what to do. For the Unifi it accepts duplicate port mapping requests. MapTool will attempt to unmap twice but it gracefully handles failures.

Another router which rejects duplicate mappings _shouldn't_ cause problems since UPnPUtil considers it a success if at least one mapping is successful, but this code path is untested and could cause confusing spurious error messages.

### Release Notes

* Updated UPnPlib to support newer routers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5131)
<!-- Reviewable:end -->
