### PR TITLE
Restore circular "unlimited" vision for grid sights

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -537,10 +537,8 @@ public abstract class Grid implements Cloneable {
       double arcAngle,
       int offsetAngle,
       boolean scaleWithToken) {
-    if (range == 0) {
-      range = zone.getTokenVisionDistance();
-    }
-    double visionRange = range * getSize() / zone.getUnitsPerCell();
+    double visionRange =
+        ((range == 0) ? zone.getTokenVisionDistance() : range) * getSize() / zone.getUnitsPerCell();
 
     Rectangle footprint = token.getFootprint(this).getBounds(this);
 
@@ -852,7 +850,8 @@ public abstract class Grid implements Cloneable {
    * Returns an Area with a given radius that is shaped and aligned to the current grid
    *
    * @param token token which to center the grid area on
-   * @param range range in units grid area extends out to
+   * @param range range in units grid area extends out to. if set to {@code 0}, the result will be a
+   *     circular area extending out to {@code visionRange}.
    * @param scaleWithToken whether grid area should expand by the size of the token
    * @param visionRange token's vision in pixels
    * @return the {@link Area} conforming to the current grid layout

--- a/src/main/java/net/rptools/maptool/model/GridlessGrid.java
+++ b/src/main/java/net/rptools/maptool/model/GridlessGrid.java
@@ -29,7 +29,6 @@ import net.rptools.maptool.client.tool.PointerTool;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.server.proto.GridDto;
 import net.rptools.maptool.server.proto.GridlessGridDto;
-import net.rptools.maptool.util.GraphicsUtil;
 
 public class GridlessGrid extends Grid {
   private static List<TokenFootprint> footprintList;
@@ -198,8 +197,7 @@ public class GridlessGrid extends Grid {
   protected Area getGridArea(
       Token token, double range, boolean scaleWithToken, double visionRange) {
     // A grid area isn't well-defined when there is no grid, so fall back to a circle.
-    return GraphicsUtil.createLineSegmentEllipse(
-        -visionRange, -visionRange, visionRange, visionRange, CIRCLE_SEGMENTS);
+    return super.getGridArea(token, 0, scaleWithToken, visionRange);
   }
 
   @Override


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes performance issue for #4980

### Description of the Change

This restores the special case where a sight with no distance will produce a circular visible area that goes out to the map's _Vision Distance_ setting. Grid shapes are not nearly performant enough yet to support that case, and it's not clear whether it's even desirable behaviour.

The key to the change is to hit the special case of `range == 0` for `Grid.getGridArea()`. This case is now documented, and the override in `GridlessGrid` relies on it instead of duplicating the case logic.

### Possible Drawbacks

None, this bring back long-standing behaviour.

### Documentation Notes

N/A

### Release Notes

- Fixed grid sights without a distance to produce circular areas instead of grid shapes. Personal lights still follow the grid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5135)
<!-- Reviewable:end -->
