### PR TITLE
Retain serviceIdentifier in MapToolServer objects

### DIFF
--- a/src/main/java/net/rptools/maptool/server/MapToolServer.java
+++ b/src/main/java/net/rptools/maptool/server/MapToolServer.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import net.rptools.clientserver.ConnectionFactory;
@@ -67,6 +68,7 @@ public class MapToolServer {
     Stopped
   }
 
+  @Nonnull private final String serviceIdentifier;
   private final Server server;
   private final MessageHandler messageHandler;
   private final Router router;
@@ -97,6 +99,7 @@ public class MapToolServer {
       boolean useUPnP,
       ServerPolicy policy,
       ServerSidePlayerDatabase playerDb) {
+    this.serviceIdentifier = id;
     this.config = config;
     this.useUPnP = useUPnP;
     this.policy = new ServerPolicy(policy);
@@ -202,6 +205,19 @@ public class MapToolServer {
 
   public int getPort() {
     return config == null ? -1 : config.getPort();
+  }
+
+  /**
+   * Get the ID that this server responds to service announcement requests with.
+   *
+   * @return The identifier or null if it's not being announced.
+   */
+  @Nullable
+  public String getServiceIdentifier() {
+    if (announcer == null) {
+      return null;
+    }
+    return serviceIdentifier;
   }
 
   private void connectionAdded(Connection conn) {


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes https://github.com/RPTools/maptool/issues/5142
depended on by https://github.com/RPTools/maptool/pull/5126
depended on by https://github.com/RPTools/maptool/pull/5076

### Description of the Change

This retains the service ID that's announced by the ServiceIdentifier in the MapToolServer class, so that it can be returned elsewhere.

### Possible Drawbacks

`serviceIdentifier` is a bit opaque compared to LAN ID, but service is the nomenclaiture of the ServiceAnnouncer and `Identifier` has more consistent capitalisation rules than `ID`, as older code expects acronyms to remain capitalised and would be `serviceID`, but the rust style is also popular in the codebase and would be `serviceId`.

### Documentation Notes

Not applicable

### Release Notes

Not applicable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5143)
<!-- Reviewable:end -->
