### PR TITLE
Fix noded topology cache invalidation

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -31,6 +31,7 @@ import net.rptools.maptool.client.ui.zone.Illumination.LumensLevel;
 import net.rptools.maptool.client.ui.zone.IlluminationModel.ContributedLight;
 import net.rptools.maptool.client.ui.zone.IlluminationModel.LightInfo;
 import net.rptools.maptool.client.ui.zone.Illuminator.LitArea;
+import net.rptools.maptool.client.ui.zone.vbl.NodedTopology;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.player.Player;
@@ -150,6 +151,9 @@ public class ZoneView {
   /** Holds the auras from lightSourceMap after they have been combined. */
   private final Map<PlayerView, List<DrawableLight>> drawableAuras = new HashMap<>();
 
+  /** Cached version of the zone's topology which is fully noded. */
+  private NodedTopology nodedTopology = null;
+
   /**
    * Construct ZoneView from zone. Build lightSourceMap, and add ZoneView to Zone as listener.
    *
@@ -226,6 +230,19 @@ public class ZoneView {
     return zone.getVisionType() != Zone.VisionType.OFF;
   }
 
+  /**
+   * Packages mask topology, including token masks, together with wall topology, adding nodes at any
+   * intersection points.
+   */
+  private synchronized NodedTopology prepareNodedTopology() {
+    if (nodedTopology == null) {
+      var walls = zone.getWalls();
+      var masks = zone.getMasks(EnumSet.allOf(Zone.TopologyType.class), null);
+      nodedTopology = NodedTopology.prepare(walls, masks);
+    }
+    return nodedTopology;
+  }
+
   private IlluminationModel getIlluminationModel(IlluminationKey illuminationKey) {
     final var illuminationModel =
         illuminationModels.computeIfAbsent(illuminationKey, key -> new IlluminationModel());
@@ -287,7 +304,7 @@ public class ZoneView {
 
     if (!lightSource.isIgnoresVBL()) {
       lightSourceVisibleArea =
-          FogUtil.calculateVisibility(p, lightSourceArea, zone.prepareNodedTopologies());
+          FogUtil.calculateVisibility(p, lightSourceArea, prepareNodedTopology());
     }
     if (lightSourceVisibleArea.isEmpty()) {
       // Nothing illuminated for this source.
@@ -526,7 +543,7 @@ public class ZoneView {
       Point p = FogUtil.calculateVisionCenter(token, zone);
       Area visibleArea = sight.getVisionShape(token, zone);
       visibleArea.transform(AffineTransform.getTranslateInstance(p.x, p.y));
-      tokenVisibleArea = FogUtil.calculateVisibility(p, visibleArea, zone.prepareNodedTopologies());
+      tokenVisibleArea = FogUtil.calculateVisibility(p, visibleArea, prepareNodedTopology());
       tokenVisibleAreaCache.put(token.getId(), tokenVisibleArea);
     }
 
@@ -612,8 +629,7 @@ public class ZoneView {
 
                   if (!lightSource.isIgnoresVBL()) {
                     visibleArea =
-                        FogUtil.calculateVisibility(
-                            p, lightSourceArea, zone.prepareNodedTopologies());
+                        FogUtil.calculateVisibility(p, lightSourceArea, prepareNodedTopology());
                   }
 
                   // This needs to be cached somehow
@@ -788,6 +804,7 @@ public class ZoneView {
 
   private void onTopologyChanged() {
     flush();
+    nodedTopology = null;
   }
 
   @Subscribe
@@ -856,6 +873,7 @@ public class ZoneView {
 
     if (event.tokens().stream().anyMatch(Token::hasAnyMaskTopology)) {
       flush();
+      nodedTopology = null;
     }
   }
 
@@ -885,6 +903,7 @@ public class ZoneView {
 
     if (tokens.stream().anyMatch(Token::hasAnyMaskTopology)) {
       flush();
+      nodedTopology = null;
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5137

### Description of the Change

The noded topology cache is moved to `ZoneView` to better match the 1.15.2 and earlier cache. The cache is now cleared on `TokensChanged` events as well as `TopologyChanged`, as it was done on 1.15.2.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where token topology would not be updated when token facing is changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5148)
<!-- Reviewable:end -->
