### PR TITLE
Use a variable sized thread pool in AssetManager

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import net.rptools.lib.FileUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppUtil;
@@ -90,7 +91,7 @@ public class AssetManager {
   /** Used to load assets from storage */
   private static AssetLoader assetLoader = new AssetLoader();
 
-  private static ExecutorService assetLoaderThreadPool = Executors.newFixedThreadPool(1);
+  private static ExecutorService assetLoaderThreadPool = ForkJoinPool.commonPool();
   private static ExecutorService assetWriterThreadPool = Executors.newFixedThreadPool(1);
 
   static {


### PR DESCRIPTION
This is the version of this patch targeting 1.16, for the version targeting 1.17 see https://github.com/RPTools/maptool/pull/5151

### Identify the Bug or Feature request

fixes https://github.com/RPTools/maptool/issues/4962

### Description of the Change

AssetManager has a thread pool for loading assets that prevents the network handler thread from blocking when it receives a message that requires an asset load.

It is a single thread, which effectively serialises loading. 

Unfortunately this means that if the appropriate action after loading an asset is to load a subsequent asset (such as AddOns loading the onInit script in order to run them when the AddOn has been loaded) then this deadlocks.

If the asset is not already cached then instead of the load callbacks being called in the loader thread the assetLoader class' thread pool handles the callbacks, so it should be safe to use a larger thread pool to load assets.

This patch switches the single thread pool with a reference to the `ForkJoinPool.commonPool()` which is used by CompletableFutures as the "default" thread pool.

### Possible Drawbacks

Supporting parallel loading of assets could potentially have observable changes that cause other bugs, but there are circumstances already that allow assets to load in parallel, so these code paths aren't untested.

### Release Notes

* Fixed a deadlock when joining a server if it included an AddOn that had an onInit script and the AddOn was already cached.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5153)
<!-- Reviewable:end -->
