### PR TITLE
Add property default and reset js bindings

### DIFF
--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -23,7 +23,6 @@ import net.rptools.maptool.client.script.javascript.*;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.model.TokenProperty;
 import net.rptools.maptool.model.Zone;
 import net.rptools.parser.ParserException;
 import org.graalvm.polyglot.HostAccess;
@@ -140,33 +139,23 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   public String getProperty(String name) {
     boolean trusted = JSScriptEngine.inTrustedContext();
     String playerId = MapTool.getPlayer().getName();
-    if (trusted || token.isOwner(playerId)) {
-      Object val = this.token.getProperty(name);
-      // Fall back to the property type's default value
-      // since it's not useful to return nulls and require
-      // javascript to have to handle defaults when getInfo isn't even bound,
-      // especially when the value gets unset if it matches the default.
-      // Evaluation is not performed automatically, use getEvaluatedProperty for that.
-      if (val == null) {
-        List<TokenProperty> propertyList =
-            MapTool.getCampaign()
-                .getCampaignProperties()
-                .getTokenPropertyList(this.token.getPropertyType());
-        if (propertyList != null) {
-          for (TokenProperty property : propertyList) {
-            if (name.equalsIgnoreCase(property.getName())) {
-              val = property.getDefaultValue();
-              break;
-            }
-          }
-        }
-      }
-      if (val == null) {
-        return null;
-      }
-      return "" + val;
+    if (!trusted && !token.isOwner(playerId)) {
+      return null;
     }
-    return null;
+
+    Object val = this.token.getProperty(name);
+    // Fall back to the property type's default value
+    // since it's not useful to return nulls and require
+    // javascript to have to handle defaults when getInfo isn't even bound,
+    // especially when the value gets unset if it matches the default.
+    // Evaluation is not performed automatically, use getEvaluatedProperty for that.
+    if (val == null) {
+      val = this.token.getPropertyDefault(name);
+    }
+    if (val == null) {
+      return null;
+    }
+    return "" + val;
   }
 
   @HostAccess.Export

--- a/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
+++ b/src/main/java/net/rptools/maptool/client/script/javascript/api/JSAPIToken.java
@@ -159,6 +159,17 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   }
 
   @HostAccess.Export
+  public String getPropertyDefault(String name) {
+    boolean trusted = JSScriptEngine.inTrustedContext();
+    String playerId = MapTool.getPlayer().getName();
+    if (!trusted && !token.isOwner(playerId)) {
+      return null;
+    }
+
+    return this.token.getPropertyDefault(name);
+  }
+
+  @HostAccess.Export
   public String getEvaluatedProperty(String name) {
     boolean trusted = JSScriptEngine.inTrustedContext();
     String playerId = MapTool.getPlayer().getName();
@@ -170,6 +181,22 @@ public class JSAPIToken implements MapToolJSAPIInterface {
   }
 
   @HostAccess.Export
+  public String getEvaluatedPropertyDefault(String name) {
+    boolean trusted = JSScriptEngine.inTrustedContext();
+    String playerId = MapTool.getPlayer().getName();
+    if (!trusted && !token.isOwner(playerId)) {
+      return null;
+    }
+
+    var res = this.token.getPropertyDefault(name);
+    if (res == null) {
+      return null;
+    }
+
+    return "" + this.token.evaluateProperty(null, name, res);
+  }
+
+  @HostAccess.Export
   public void setProperty(String name, Object value) {
     boolean trusted = JSScriptEngine.inTrustedContext();
     String playerId = MapTool.getPlayer().getName();
@@ -178,6 +205,19 @@ public class JSAPIToken implements MapToolJSAPIInterface {
       MapTool.serverCommand()
           .updateTokenProperty(token, Token.Update.setProperty, name, value.toString());
     }
+  }
+
+  @HostAccess.Export
+  public boolean resetProperty(String name) {
+    boolean trusted = JSScriptEngine.inTrustedContext();
+    String playerId = MapTool.getPlayer().getName();
+    if (!trusted && !token.isOwner(playerId)) {
+      return false;
+    }
+
+    this.token.resetProperty(name);
+    MapTool.serverCommand().updateTokenProperty(token, Token.Update.resetProperty, name);
+    return true;
   }
 
   @HostAccess.Export


### PR DESCRIPTION
### Identify the Bug or Feature request

resolves https://github.com/RPTools/maptool/issues/5152

The linked issue misdiagnoses the issue as `Token.setProperty` setting a value differently and not being identified as equalling the default to reset.

Actually it's only the Edit Token dialog that resets properties that way.

The lack of functions for resetting properties and determining what the default is however prevents implementing this behaviour yourself, so this patch resolves it by adding required functions.

### Description of the Change

This refactors the Token functions slightly to make the property default code and property evaluator reusable, and adds javascript bindings.

### Possible Drawbacks

This allows evaluating the defaults even if there is a value set, and an obscure enough campaign might hide logic in there that is usually obscured by a non-default value being present in that property.

### Documentation Notes

#### token.resetProperty(name) Function

• Introduced in version 1.17

Returns true if the property was reset, false if it was not e.g. because you don't own it.

Usage
```javascript
function fullHeal(token) {
  token.resetProperty("HP");
}
```

* name - The name of the property to reset.

See [resetProperty()](https://wiki.rptools.info/index.php/resetProperty) for MTScript equivalent.

#### token.getPropertyDefault(name) Function

• Introduced in version 1.17

Returns the text of the default value if it exists, null if it didn't or you don't own the token.

Usage
```javascript
function changeHP(token, value) {
  if (value == token.getPropertyDefault("HP")) {
    token.resetProperty("HP");
  } else {
    token.setProperty("HP", value);
  }
}
```

* name - The name of the property to retrieve the default for.

See [getPropertyDefault()](https://wiki.rptools.info/index.php/getPropertyDefault) for MTScript equivalent.

#### token.getEvaluatedPropertyDefault(name) Function

• Introduced in version 1.17

Returns the value of the default's expression, evaluated in the context of the token if it exists, null if it didn't or you don't own the token.

Usage
```javascript
function changeHP(token, value) {
  if (value == token.getEvaluatedPropertyDefault("HP")) {
    token.resetProperty("HP");
  } else {
    token.setProperty("HP", value);
  }
}
```

* name - The name of the property to reset.

See [getPropertyDefault()](https://wiki.rptools.info/index.php/getPropertyDefault) and [evalMacro()](https://wiki.rptools.info/index.php/evalMacro) for MTScript equivalent.

### Release Notes

* Added `Token.resetProperty`, `Token.getPropertyDefault` and `Token.getEvaluatedPropertyDefault` so JavaScript macros can reset properties if they match their default value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5156)
<!-- Reviewable:end -->
