### PR TITLE
Add StartupWMClass so MT windows are properly recognized on Linux.

### DIFF
--- a/package/linux/launcher.desktop
+++ b/package/linux/launcher.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Type=Application
 Categories=Game
 MimeType=application/maptool;x-scheme-handler/rptools-maptool+registry;x-scheme-handler/rptools-maptool+lan;x-scheme-handler/rptools-maptool+tcp
+StartupWMClass=net-rptools-maptool-client-LaunchInstructions


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5160

### Description of the Change

This adds the `StartupWMClass` property commonly used to associate windows with applications. This will better enable desktop environments to recognize MT windows as belonging to MT rather than being treated as independent windows.

The class was obtained by running `xprop WM_CLASS` on a recent MT version.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed the linux launcher to recognize MT windows as belonging to the same application.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5162)
<!-- Reviewable:end -->
