### PR TITLE
Drawing tools should always be available, even for players

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -63,11 +63,6 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
   }
 
   @Override
-  public boolean isAvailable() {
-    return MapTool.getPlayer().isGM();
-  }
-
-  @Override
   protected boolean isLinearTool() {
     return strategy.isLinear();
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5168 introduced by #5011

### Description of the Change

The new `DrawingTool` was accidentally restricted to GMs. This PR removes the offending override so that there is no restriction, allowing players to use the drawing tools as they did on 1.15.2 and earlier.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where players were not able to draw drawings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5169)
<!-- Reviewable:end -->
