### PR TITLE
Only show drawing layer in Draw Explorer if it is not empty

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
@@ -207,17 +207,16 @@ public class DrawPanelTreeModel implements TreeModel {
         }
 
         View v = View.getByLayer(layer);
-        var drawableList = zone.getDrawnElements(layer);
-        if (drawableList.size() > 0) {
-          // Reverse the list so that the element drawn last, is shown at the top of the tree
-          // Be careful to clone the list so you don't damage the map
-          List<DrawnElement> reverseList = new ArrayList<DrawnElement>(drawableList);
-          // Players can only see _templates_ on player layers.
-          if (!MapTool.getPlayer().isGM()) {
-            reverseList.removeIf(de -> !(de.getDrawable() instanceof AbstractTemplate));
-          }
-          Collections.reverse(reverseList);
-          viewMap.put(v, reverseList);
+
+        var drawableList = new ArrayList<DrawnElement>(zone.getDrawnElements(layer));
+        // Players can only see _templates_ on player layers.
+        if (!MapTool.getPlayer().isGM()) {
+          drawableList.removeIf(de -> !(de.getDrawable() instanceof AbstractTemplate));
+        }
+        if (!drawableList.isEmpty()) {
+          // Reverse the list so that the element drawn last is shown at the top of the tree.
+          Collections.reverse(drawableList);
+          viewMap.put(v, drawableList);
           currentViewList.add(v);
         }
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5167

### Description of the Change

Moves the empty check in `DrawPanelTreeModel.updateInternal()` to _after_ the list is filtered. This avoids adding an player entry for layers that have drawings but no templates.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the Draw Explorer would include an empty Token layer for players when Token drawings were present with no templates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5170)
<!-- Reviewable:end -->
