### PR TITLE
Fixed campaign properties export file format bug

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/SwingUtil.java
+++ b/src/main/java/net/rptools/maptool/client/swing/SwingUtil.java
@@ -373,4 +373,16 @@ public class SwingUtil {
         });
     return button;
   }
+
+  public static JTextField getFilenameTextField(Container cont) {
+    for (Component c : cont.getComponents()) {
+      if (c instanceof JTextField) {
+        return (JTextField) c;
+      } else if (c instanceof Container) {
+        JTextField textField = getFilenameTextField(((Container) c));
+        if (textField != null) return textField;
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -884,19 +884,116 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     return saveCmpgnFileChooser;
   }
 
-  public JFileChooser getSavePropsFileChooser() {
+  public JFileChooser getSaveCampaignPropsFileChooser() {
     if (savePropsFileChooser == null) {
       savePropsFileChooser = new JFileChooser();
       savePropsFileChooser.setCurrentDirectory(AppPreferences.saveDirectory.get());
+      savePropsFileChooser.setSelectedFile(
+          new File(propertiesFilter.getDescription() + ".mtprops"));
       savePropsFileChooser.addChoosableFileFilter(propertiesFilter);
       savePropsFileChooser.setFileFilter(propertiesFilter);
       savePropsFileChooser.setFileFilter(new FileNameExtensionFilter("JSON", "json"));
-      savePropsFileChooser.setFileFilter(new FileNameExtensionFilter("Text", "txt"));
+      savePropsFileChooser.setFileFilter(
+          new FileNameExtensionFilter(I18N.getText("file.ext.text"), "txt"));
       savePropsFileChooser.setFileFilter(savePropsFileChooser.getChoosableFileFilters()[0]);
       savePropsFileChooser.setDialogTitle(I18N.getText("msg.title.exportProperties"));
+
+      String[] extensions =
+          new String[] {"json", "txt", ((MTFileFilter) propertiesFilter).extensions[0]};
+      JTextField textField = SwingUtil.getFilenameTextField(savePropsFileChooser);
+
+      // file type/extension change listener
+      savePropsFileChooser.addPropertyChangeListener(
+          JFileChooser.FILE_FILTER_CHANGED_PROPERTY,
+          evt -> {
+            File file = savePropsFileChooser.getSelectedFile();
+            String fName;
+            FileFilter fNew = (FileFilter) evt.getNewValue();
+
+            // using file name or name in text field
+            if (file == null) {
+              assert textField != null;
+              fName = textField.getText();
+              if (fName.isEmpty()) {
+                return;
+              }
+            } else if (fNew.accept(file)) {
+              // extension matches file, no further action
+              return;
+            } else {
+              fName = file.getName();
+            }
+            // just to stop accruing lots of extensions, remove them all
+            fName = removeExtensions(fName, extensions);
+
+            // add new extension to file name
+            if (fNew instanceof MTFileFilter) {
+              fName = String.format("%s.%s", fName, ((MTFileFilter) fNew).extensions[0]);
+            } else if (fNew instanceof FileNameExtensionFilter) {
+              fName =
+                  String.format(
+                      "%s.%s", fName, ((FileNameExtensionFilter) fNew).getExtensions()[0]);
+            }
+            // set with new file
+            if (file == null) {
+              savePropsFileChooser.setSelectedFile(new File(fName));
+            } else {
+              savePropsFileChooser.setSelectedFile(new File(file.getParentFile(), fName));
+            }
+            // update the text field
+            assert textField != null;
+            textField.setText(fName);
+          });
+
+      // the save action
+      savePropsFileChooser.addActionListener(
+          e -> {
+            if (e.getActionCommand().equals(JFileChooser.APPROVE_SELECTION)) {
+              File file = savePropsFileChooser.getSelectedFile();
+              if (file == null) {
+                return; // d'uh
+              }
+              FileFilter filter = savePropsFileChooser.getFileFilter();
+              String fileName = file.getName();
+              boolean isAcceptAll = savePropsFileChooser.getAcceptAllFileFilter().equals(filter);
+              if (!isAcceptAll && filter.accept(file)) {
+                // extension matches filter and not "accept all"
+                return;
+              } else {
+                // clean the file name of extensions
+                fileName = removeExtensions(fileName, extensions);
+              }
+              // set the file with new extension appended
+              if (filter instanceof MTFileFilter || isAcceptAll) {
+                savePropsFileChooser.setSelectedFile(
+                    new File(
+                        savePropsFileChooser.getSelectedFile().getParentFile(),
+                        String.format(
+                            "%s.%s", fileName, ((MTFileFilter) propertiesFilter).extensions[0])));
+              } else if (filter instanceof FileNameExtensionFilter) {
+                savePropsFileChooser.setSelectedFile(
+                    new File(
+                        savePropsFileChooser.getSelectedFile().getParentFile(),
+                        String.format(
+                            "%s.%s",
+                            fileName, ((FileNameExtensionFilter) filter).getExtensions()[0])));
+              }
+            }
+          });
     }
+    System.out.println(Arrays.toString(savePropsFileChooser.getComponents()));
     savePropsFileChooser.setAcceptAllFileFilterUsed(true);
     return savePropsFileChooser;
+  }
+
+  private String removeExtensions(String fileName, String... extensions) {
+    for (String extension : extensions) {
+      String replaceThis = "." + extension;
+      while (fileName.contains(replaceThis)) {
+        fileName = fileName.replace(replaceThis, "");
+      }
+    }
+    return fileName;
   }
 
   public JFileChooser getSaveTokenFileChooser() {

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -417,7 +417,7 @@ public class CampaignPropertiesDialog extends JDialog {
               copyUIToCampaign();
               // END HACK
 
-              JFileChooser chooser = MapTool.getFrame().getSavePropsFileChooser();
+              JFileChooser chooser = MapTool.getFrame().getSaveCampaignPropsFileChooser();
 
               boolean tryAgain = true;
               while (tryAgain) {

--- a/src/main/resources/net/rptools/maptool/language/i18n_en.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en.properties
@@ -1593,6 +1593,7 @@ file.ext.rpmap    = MapTool Map
 file.ext.rptok    = MapTool Token
 file.ext.dungeondraft = Universal VTT Map (.dd2vtt, .df2vtt, .uvtt)
 file.ext.addOnLib    = Maptool Add-On Library
+file.ext.text    = Text
 
 goto.description = Goto location or token.  /goto X,Y or /goto tokenname.
 


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5173 

### Description of the Change
file extension now gets set according to file type set in file filter.

### Possible Drawbacks
none

### Documentation Notes
Fixed bug with Campaign Properties Exporting to incorrect format.

### Release Notes
n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5174)
<!-- Reviewable:end -->
