### PR TITLE
Fix background and fog paints returned by getInfo("map")

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -186,7 +186,7 @@ public class getInfoFunction extends AbstractFunction {
       final var backgroundPaint = zone.getBackgroundPaint();
       String background = null;
       if (backgroundPaint instanceof DrawableColorPaint dcp) {
-        background = String.format("#%h", zone.getGridColor());
+        background = String.format("#%h", dcp.getColor());
       } else if (backgroundPaint instanceof DrawableTexturePaint dtp) {
         background = "asset://" + dtp.getAssetId().toString();
       }
@@ -196,7 +196,7 @@ public class getInfoFunction extends AbstractFunction {
       final var fogPaint = zone.getFogPaint();
       String fog = null;
       if (fogPaint instanceof DrawableColorPaint dcp) {
-        fog = String.format("#%h", zone.getGridColor());
+        fog = String.format("#%h", dcp.getColor());
       } else if (fogPaint instanceof DrawableTexturePaint dtp) {
         fog = "asset://" + dtp.getAssetId().toString();
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5177

### Description of the Change

When a `DrawableColorPaint` is detected, its colour is now properly used instead of using the zone's grid colour.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where `getInfo("map")` would set the `"background paint"` and `"fog paint"` values to the grid colour instead of the background and fog colours.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5181)
<!-- Reviewable:end -->
