### PR TITLE
Campaign props export file type fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppConstants.java
+++ b/src/main/java/net/rptools/maptool/client/AppConstants.java
@@ -24,7 +24,7 @@ import net.tsc.servicediscovery.ServiceGroup;
 public class AppConstants {
 
   public static final String APP_NAME = "MapTool";
-  public static final String APP_LOCAL_NAME = I18N.getString("application.name");
+  public static final String APP_LOCAL_NAME = I18N.getString("ApplicationName");
 
   public static final File UNZIP_DIR = AppUtil.getAppHome("resource");
 

--- a/src/main/java/net/rptools/maptool/client/swing/SwingUtil.java
+++ b/src/main/java/net/rptools/maptool/client/swing/SwingUtil.java
@@ -392,7 +392,7 @@ public class SwingUtil {
   }
 
   /**
-   * Recursively searches a container for JTextFields. Useful for extracting text fields from
+   * Recursively search a container for JTextFields. Useful for extracting text fields from
    * components like JFileChooser where it is not readily available.
    *
    * @param cont Container

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -953,7 +953,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
               String fileName = file.getName();
               boolean isAcceptAll = savePropsFileChooser.getAcceptAllFileFilter().equals(filter);
               if (!isAcceptAll && filter.accept(file)) {
-                // extension matches filter and not "accept all"
+                // file name extension matches filter and is not "accept all"
                 return;
               } else {
                 // clean the file name of extensions

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/CampaignPropertiesDialog.java
@@ -417,15 +417,15 @@ public class CampaignPropertiesDialog extends JDialog {
               copyUIToCampaign();
               // END HACK
 
-              JFileChooser chooser = MapTool.getFrame().getSaveCampaignPropsFileChooser();
+              JFileChooser fileChooser = MapTool.getFrame().getSaveCampaignPropsFileChooser();
 
               boolean tryAgain = true;
               while (tryAgain) {
-                if (chooser.showSaveDialog(MapTool.getFrame()) != JFileChooser.APPROVE_OPTION) {
+                if (fileChooser.showSaveDialog(MapTool.getFrame()) != JFileChooser.APPROVE_OPTION) {
                   return;
                 }
                 var installDir = AppUtil.getInstallDirectory().toAbsolutePath();
-                var saveDir = chooser.getSelectedFile().toPath().getParent().toAbsolutePath();
+                var saveDir = fileChooser.getSelectedFile().toPath().getParent().toAbsolutePath();
                 if (saveDir.startsWith(installDir)) {
                   MapTool.showWarning("msg.warning.savePropToInstallDir");
                 } else {
@@ -433,7 +433,7 @@ public class CampaignPropertiesDialog extends JDialog {
                 }
               }
 
-              File selectedFile = chooser.getSelectedFile();
+              File selectedFile = fileChooser.getSelectedFile();
               if (selectedFile.exists()) {
                 if (selectedFile.getName().endsWith(".rpgame")) {
                   if (!MapTool.confirm("Import into game settings file?")) {
@@ -445,7 +445,7 @@ public class CampaignPropertiesDialog extends JDialog {
               }
               try {
                 if (selectedFile.getName().endsWith(".mtprops")) {
-                  PersistenceUtil.saveCampaignProperties(campaign, chooser.getSelectedFile());
+                  PersistenceUtil.saveCampaignProperties(campaign, fileChooser.getSelectedFile());
                   MapTool.showInformation("Properties Saved.");
                 } else {
                   MapTool.showMessage(
@@ -454,7 +454,7 @@ public class CampaignPropertiesDialog extends JDialog {
                       JOptionPane.INFORMATION_MESSAGE);
                   CampaignPropertiesDto campaignPropertiesDto =
                       MapTool.getCampaign().getCampaignProperties().toDto();
-                  FileOutputStream fos = new FileOutputStream(chooser.getSelectedFile());
+                  FileOutputStream fos = new FileOutputStream(fileChooser.getSelectedFile());
                   fos.write(JsonFormat.printer().print(campaignPropertiesDto).getBytes());
                   fos.close();
                 }

--- a/src/main/resources/net/rptools/maptool/language/i18n_en.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n_en.properties
@@ -53,7 +53,7 @@
 #  http://download.oracle.com/javase/7/docs/api/java/text/MessageFormat.html
 # Localization contributed by David Herman ("aku" on forums.rptools.net)
 
-application.name = MapTool
+ApplicationName = MapTool
 
 ActivityMonitorPanel.colorDefinition = Green\:Sending, Red\:Receiving
 


### PR DESCRIPTION
resolves #5173

### Description of the Change
without a file extension in the file name text field, file was defaulting to the incorrect type.
Added listeners to update the file name text field text with the selected file type extension
Added localised app name on a whim because I needed something new to commit.

### Possible Drawbacks
Behaviour is now different to other file choosers

### Documentation Notes
Fixed Campaign Properties Export exporting to incorrect file type.
### Release Notes
Fixed Campaign Properties Export exporting to incorrect file type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5186)
<!-- Reviewable:end -->
