### PR TITLE
Disable focusable tooltips for RSyntaxTextAreas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -435,7 +435,7 @@ dependencies {
     implementation 'com.github.gotson:webp-imageio:0.2.2' // webp support https://search.maven.org/artifact/com.github.gotson/webp-imageio/0.2.2/jar
 
     // For syntax highlighting in macro editor
-    implementation "com.fifesoft:rsyntaxtextarea:3.4.0"		// https://mvnrepository.com/artifact/com.fifesoft/rsyntaxtextarea
+    implementation "com.fifesoft:rsyntaxtextarea:3.5.3"		// https://mvnrepository.com/artifact/com.fifesoft/rsyntaxtextarea
     implementation "com.fifesoft:rstaui:3.3.1"				// https://mvnrepository.com/artifact/com.fifesoft/rstaui
     implementation "com.fifesoft:autocomplete:3.3.1"		// https://mvnrepository.com/artifact/com.fifesoft/autocomplete
     implementation "com.fifesoft:languagesupport:3.3.0"

--- a/src/main/java/net/rptools/maptool/client/swing/htmleditorsplit/HtmlEditorSplitGui.form
+++ b/src/main/java/net/rptools/maptool/client/swing/htmleditorsplit/HtmlEditorSplitGui.form
@@ -59,6 +59,7 @@
                           <selectionStart value="0"/>
                           <syntaxEditingStyle value="text/html"/>
                           <text value=""/>
+                          <useFocusableTips value="false"/>
                         </properties>
                       </component>
                     </children>

--- a/src/main/java/net/rptools/maptool/client/ui/logger/LogConsoleFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/logger/LogConsoleFrame.java
@@ -39,8 +39,6 @@ import org.apache.logging.log4j.Logger;
 public class LogConsoleFrame extends JFrame {
   private static final Logger log = LogManager.getLogger(LogConsoleFrame.class);
 
-  // private RSyntaxTextArea jLoggingConsole; // Doesn't look like RSyntaxTextArea can keep up with
-  // large amounts of logging
   private JTextArea jLoggingConsole;
   private static final Font LOGGER_FONT = new Font("Lucida Console", Font.PLAIN, 12);
 
@@ -82,7 +80,6 @@ public class LogConsoleFrame extends JFrame {
 
   private JTextComponent getNoteArea() {
     if (jLoggingConsole == null) {
-      // jLoggingConsole = new RSyntaxTextArea();
       jLoggingConsole = new JTextArea();
       jLoggingConsole.setBorder(BorderFactory.createLineBorder(Color.black));
 

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroButtonDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroButtonDialogView.form
@@ -352,6 +352,7 @@
                           <lineWrap value="true"/>
                           <name value="toolTip"/>
                           <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="component.tooltip.macro.tooltip"/>
+                          <useFocusableTips value="false"/>
                         </properties>
                       </component>
                     </children>

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
@@ -470,6 +470,7 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
     getToolTipTextField().setTabSize(2);
 
     // Macro Editor setup
+    macroEditorRSyntaxTextArea.setUseFocusableTips(false);
     macroEditorRSyntaxTextArea.setSyntaxEditingStyle("text/MapToolScript");
     macroEditorRSyntaxTextArea.setInsertPairedCharacters(false);
     macroEditorRSyntaxTextArea.setEditable(true);

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -463,6 +463,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       getHtmlStatblockEditor().setText(heroLabData.getStatBlock_html());
       getHtmlStatblockEditor().setCaretPosition(0);
 
+      xmlStatblockRSyntaxTextArea.setUseFocusableTips(false);
       xmlStatblockRSyntaxTextArea.setText(heroLabData.getStatBlock_xml());
       xmlStatblockRSyntaxTextArea.setCaretPosition(0);
 
@@ -1605,6 +1606,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         "xmlStatblockPanel", "xmlStatblockRTextScrollPane", xmlStatblockRTextScrollPane);
 
     // Setup the TEXT panel
+    textStatblockRSyntaxTextArea.setUseFocusableTips(false);
     textStatblockRSyntaxTextArea.setEditable(false);
     textStatblockRSyntaxTextArea.setLineWrap(true);
     textStatblockRSyntaxTextArea.setWrapStyleWord(true);
@@ -1972,6 +1974,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     protected RSyntaxTextArea createTextArea() {
       RSyntaxTextArea textArea = new RSyntaxTextArea();
+      textArea.setUseFocusableTips(false);
       textArea.setAnimateBracketMatching(true);
       textArea.setBracketMatchingEnabled(true);
       textArea.setLineWrap(false);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5194

### Description of the Change

Only one of our `RSyntaxTextArea` actually uses tooltips, and that is ironically the _Tooltip_ field in the macro editor dialog. Focusable tooltips has been disabled on that field so that it no longer steals focus when the mouse hovers over it.

For good measure, all other `RSyntaxTextArea` now disable focusable tooltips so that the same issue won't arise should any of them be given a tooltip.

Also bumps the `rsyntaxtextarea` library version to 3.5.3 since we were still on 3.4.0 from a year ago.

### Possible Drawbacks

Someone surely has gotten used to this specific behaviour but now it's gone.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where hovering the mouse over the Tooltip field of the macro editor would give it focus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5195)
<!-- Reviewable:end -->
