### PR TITLE
Add archives of the app-images as release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Build with Gradle
-      run: ./gradlew jpackage
+      run: ./gradlew jpackage zipJpackageImage
     - name: Copy the RPM to the location required to build the ArchLinux package
       if: matrix.os == 'ubuntu-latest'
       run: cp releases/maptool-*.rpm package/archlinux/maptool/maptool.rpm
@@ -75,6 +75,7 @@ jobs:
         cp releases/MapTool*.exe releases/renamed/MapTool-${{ github.event.release.tag_name }}.exe
         cp releases/MapTool*.msi releases/renamed/MapTool-${{ github.event.release.tag_name }}.msi
         cp releases/MapTool*.jar releases/renamed/MapTool-${{ github.event.release.tag_name }}.jar
+        cp releases/MapTool*-win.zip releases/renamed/MapTool-${{ github.event.release.tag_name }}-win.zip
       continue-on-error: true
     - name: Upload Windows EXE Release Asset
       id: upload-release-asset-exe
@@ -97,6 +98,17 @@ jobs:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}.msi
         asset_name: MapTool-${{ github.event.release.tag_name }}.msi
+        asset_content_type: application/octet-stream
+    - name: Upload Windows Image Release Asset
+      id: upload-release-asset-windows-image
+      uses: actions/upload-release-asset@v1
+      if: matrix.os == 'windows-latest'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-win.zip
+        asset_name: MapTool-${{ github.event.release.tag_name }}-win.zip
         asset_content_type: application/octet-stream
     - name: Upload Uber Jar Release Asset
       id: upload-release-asset-jar
@@ -122,6 +134,7 @@ jobs:
         cp releases/maptool*.x86_64.rpm releases/renamed/maptool-${{ github.event.release.tag_name }}.x86_64.rpm
         cp releases/maptool*_amd64.deb releases/renamed/maptool_${{ github.event.release.tag_name }}_amd64.deb
         find package/archlinux/maptool/ -maxdepth 1 -type f -name 'maptool-*-x86_64.pkg.tar.zst' -not -name '*debug*' -exec cp {} releases/renamed/maptool-${{ github.event.release.tag_name }}-x86_64.pkg.tar.zst \;
+        cp releases/MapTool*-linux.zip releases/renamed/MapTool-${{ github.event.release.tag_name }}-linux.zip
       continue-on-error: true
     - name: Upload Linux RPM Release Asset
       id: upload-release-asset-rpm
@@ -156,6 +169,17 @@ jobs:
         asset_path: releases/renamed/maptool-${{ github.event.release.tag_name }}-x86_64.pkg.tar.zst
         asset_name: maptool-${{ github.event.release.tag_name }}-x86_64.pkg.tar.zst
         asset_content_type: application/octet-stream
+    - name: Upload Linux Image Release Asset
+      id: upload-release-asset-linux-image
+      uses: actions/upload-release-asset@v1
+      if: matrix.os == 'ubuntu-latest'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-linux.zip
+        asset_name: MapTool-${{ github.event.release.tag_name }}-linux.zip
+        asset_content_type: application/octet-stream
       #                               ____  _____
       #      ____ ___   ____ _ _____ / __ \/ ___/
       #     / __ `__ \ / __ `// ___// / / /\__ \
@@ -168,6 +192,7 @@ jobs:
         mkdir releases/renamed/
         cp releases/MapTool*.dmg releases/renamed/MapTool-${{ github.event.release.tag_name }}.dmg
         cp releases/MapTool*.pkg releases/renamed/MapTool-${{ github.event.release.tag_name }}.pkg
+        cp releases/MapTool*-mac.app.zip releases/renamed/MapTool-${{ github.event.release.tag_name }}-mac.app.zip
       continue-on-error: true
     - name: Upload Mac DMG Release Asset
       id: upload-release-asset-dmg
@@ -190,4 +215,15 @@ jobs:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}.pkg
         asset_name: MapTool-${{ github.event.release.tag_name }}.pkg
+        asset_content_type: application/octet-stream
+    - name: Upload Mac Image Release Asset
+      id: upload-release-asset-mac-image
+      uses: actions/upload-release-asset@v1
+      if: matrix.os == 'macOS-13'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-mac.app.zip
+        asset_name: MapTool-${{ github.event.release.tag_name }}-mac.app.zip
         asset_content_type: application/octet-stream

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ application {
     }
 }
 def appSemVer = ""
-def winUpgradeUUID = UUID.randomUUID().toString();
 
 configurations {
     forms.extendsFrom implementation
@@ -279,6 +278,7 @@ runtime {
         ]
 
         if (osdetector.os.is('windows')) {
+            def winUpgradeUUID = "74d934b9-5fb5-433e-aca4-c6f14bd9aa6b"
             println "Setting Windows installer options with upgrade uuid = " + winUpgradeUUID
             resourceDir = file('package/windows')
             imageOptions += ['--icon', 'package/windows/' + project.name + developerRelease + '.ico']

--- a/build.gradle
+++ b/build.gradle
@@ -280,6 +280,7 @@ runtime {
         if (osdetector.os.is('windows')) {
             def winUpgradeUUID = "74d934b9-5fb5-433e-aca4-c6f14bd9aa6b"
             println "Setting Windows installer options with upgrade uuid = " + winUpgradeUUID
+            targetPlatformName = "win"
             resourceDir = file('package/windows')
             imageOptions += ['--icon', 'package/windows/' + project.name + developerRelease + '.ico']
             installerOptions += [
@@ -296,6 +297,7 @@ runtime {
 
         if (osdetector.os.is('osx')) {
             println "Setting MacOS installer options"
+            targetPlatformName = "mac"
             imageOptions += ['--icon', 'package/macosx/' + project.name + developerRelease + '.icns']
             installerOptions += [
                     '--mac-package-name', project.name + developerRelease
@@ -308,6 +310,7 @@ runtime {
 
         if (osdetector.os.is('linux')) {
             println "Setting Linux installer options"
+            targetPlatformName = "linux"
             resourceDir = file('package/linux')
             imageOptions += ['--icon', 'package/linux/' + project.name + developerRelease + '.png']
             installerOptions += [
@@ -331,6 +334,22 @@ runtime {
             }
         }
     }
+}
+
+def zipJpackageImage = tasks.register('zipJpackageImage', Zip) {
+    // Really we depend on the app-image produce by the jpackageImage task, but for some reason it
+    // is defined as an output of the jpackage task. As a result, Gradle will get mad at us if we
+    // say we depend directly on jpackageImage.
+    dependsOn tasks.jpackage
+
+    def extension = ''
+    if (osdetector.os.is('osx')) {
+        extension = '.app'
+    }
+
+    from "${jpackageImage.jpackageData.imageOutputDirOrDefault}${File.separator}${jpackageImage.jpackageData.imageNameOrDefault}${extension}"
+    destinationDirectory = jpackageImage.jpackageData.installerOutputDir
+    archiveFileName = project.name + "-" + appSemVer + "-" + jpackageImage.jpackageData.targetPlatformName + "${extension}.zip"
 }
 
 // In this section you declare the dependencies for your production and test code


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #3055

### Description of the Change

The first part is simple: use a constant windows upgrade UUID so that the windows installer for newer versions of MT can uninstall older versions.

The second part bundles the app-image build produced by the `:jpackageImage` task as a ZIP file. One ZIP is produced for each platform (windows, mac, and linux) and is published as part of the release.

### Possible Drawbacks

Change in flow for those who want multiple versions of MT.

### Documentation Notes

In a few releases from now, we can remove this warning text from the release notes:
> _**Note: Do not install over the top of an old version, either install into a new directory or uninstall the old version first. If you have installed a beta version of 1.15.0, uninstall that first.**_

### Release Notes

- Windows installers will now uninstall older (1.17+) MT versions before installing the new version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5198)
<!-- Reviewable:end -->
