### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Cache Gradle
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       # Cache only seems to work on ubuntu right now...
       if: matrix.os == 'ubuntu-latest'
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,6 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Cache Gradle
       uses: actions/cache@v4
-      # Cache only seems to work on ubuntu right now...
-      if: matrix.os == 'ubuntu-latest'
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -50,7 +50,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #5200

### Description of the Change

Replaces `actions/cache@v3` with `actions/cache@v4` to take advantage of the early exit built into the newer versions.

Also enables the cache for the "Publish Assets" workflow on all platforms. This has been tested for both cache hits and misses and works as expected.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5201)
<!-- Reviewable:end -->
