### PR TITLE
Fix Easy Connect handshake control flow once public key is requested

### DIFF
--- a/clientserver/src/main/java/net/rptools/clientserver/simple/server/WebRTCServer.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/server/WebRTCServer.java
@@ -105,7 +105,7 @@ public class WebRTCServer extends AbstractServer {
       @Override
       public void onError(Exception ex) {
         lastError = "WebSocket error: " + ex.toString() + "\n";
-        log.error("S " + lastError);
+        log.error("S " + lastError, ex);
         // onClose will be called after this method
       }
     };
@@ -147,7 +147,7 @@ public class WebRTCServer extends AbstractServer {
     try {
       fireClientConnect(connection);
     } catch (Exception e) {
-      log.error(e);
+      log.error("Unexpected error while handling new data channel", e);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/server/ServerHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ServerHandshake.java
@@ -523,19 +523,19 @@ public class ServerHandshake implements Handshake<Player>, MessageHandler {
       } else {
         sendErrorResponseAndNotify(HandshakeResponseCodeMsg.INVALID_PUBLIC_KEY);
       }
-      return;
-    }
-    CipherUtil.Key publicKey = playerDatabase.getPublicKey(player, playerPublicKeyMD5).get();
-    String password = new PasswordGenerator().getPassword();
-    handshakeChallenges[0] =
-        HandshakeChallenge.createAsymmetricChallenge(player.getName(), password, publicKey);
+    } else {
+      CipherUtil.Key publicKey = playerDatabase.getPublicKey(player, playerPublicKeyMD5).get();
+      String password = new PasswordGenerator().getPassword();
+      handshakeChallenges[0] =
+          HandshakeChallenge.createAsymmetricChallenge(player.getName(), password, publicKey);
 
-    var authTypeMsg =
-        UseAuthTypeMsg.newBuilder()
-            .setAuthType(AuthTypeEnum.ASYMMETRIC_KEY)
-            .addChallenge(ByteString.copyFrom(handshakeChallenges[0].getChallenge()));
-    var handshakeMsg = HandshakeMsg.newBuilder().setUseAuthTypeMsg(authTypeMsg).build();
-    sendMessage(State.AwaitingClientPublicKeyAuth, handshakeMsg);
+      var authTypeMsg =
+          UseAuthTypeMsg.newBuilder()
+              .setAuthType(AuthTypeEnum.ASYMMETRIC_KEY)
+              .addChallenge(ByteString.copyFrom(handshakeChallenges[0].getChallenge()));
+      var handshakeMsg = HandshakeMsg.newBuilder().setUseAuthTypeMsg(authTypeMsg).build();
+      sendMessage(State.AwaitingClientPublicKeyAuth, handshakeMsg);
+    }
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/server/ServerHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ServerHandshake.java
@@ -523,6 +523,7 @@ public class ServerHandshake implements Handshake<Player>, MessageHandler {
       } else {
         sendErrorResponseAndNotify(HandshakeResponseCodeMsg.INVALID_PUBLIC_KEY);
       }
+      return;
     }
     CipherUtil.Key publicKey = playerDatabase.getPublicKey(player, playerPublicKeyMD5).get();
     String password = new PasswordGenerator().getPassword();


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5212

### Description of the Change

As part of the refactoring in #4771, the control flow in `ServerHandshake.sendAsymmetricKeyAuthType()` was accidentally modified to no longer return after the Easy Connect public key request message has been sent. Without this critical `return`, the precondition of the second half of the method is not met (`!playerDatabase.hasPublicKey(...)`) which results in the error shown in the linked issue.

Instead of just reinserting a `return`, the latter part of the method is now wrapped in an `else` to more clearly show the importance of the `playerDatabase.hasPublicKey(...)` check.

Also included is a tweak to `WebRTCServer` to log the stack traces of the exceptions it catches.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where Easy Connect would fail if a player switched to a new computer and tried to connect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5213)
<!-- Reviewable:end -->
