### PR TITLE
Reimplement json-indent to remove json-lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -390,6 +390,7 @@ dependencies {
     implementation 'commons-net:commons-net:3.11.1'
     // commandline parsing
     implementation 'commons-cli:commons-cli:1.6.0'
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
 
     // needed for preference dialog at runtime
     implementation 'commons-beanutils:commons-beanutils:1.9.4'
@@ -409,9 +410,6 @@ dependencies {
     implementation group: 'com.jidesoft', name: 'jide-grids', version: '3.7.9'
     implementation group: 'com.jidesoft', name: 'jide-properties', version: '3.7.9'
     implementation group: 'com.jidesoft', name: 'jide-shortcut', version: '3.7.9'
-
-    // old json lib only used for one macro function. Use gson instead
-    implementation 'net.sf.json-lib:json-lib:2.4:jdk15'
 
     // utils for handling reflection
     implementation 'org.reflections:reflections:0.10.2'

--- a/src/main/java/net/rptools/lib/ModelVersionManager.java
+++ b/src/main/java/net/rptools/lib/ModelVersionManager.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import net.rptools.lib.io.PackedFile;
 import net.rptools.maptool.util.PersistenceUtil;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * An object of this class is created in the {@link PersistenceUtil} code for the purpose of

--- a/src/main/java/net/rptools/lib/net/FTPLocation.java
+++ b/src/main/java/net/rptools/lib/net/FTPLocation.java
@@ -23,7 +23,7 @@ import javax.imageio.ImageWriter;
 import net.rptools.maptool.server.proto.FtpLocationDto;
 import net.rptools.maptool.server.proto.LocationDto;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class FTPLocation implements Location {
   private final String username;

--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -33,7 +33,7 @@ import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.player.Player;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -36,7 +36,7 @@ import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.library.LibraryManager;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.Function;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/HeroLabFunctions.java
@@ -28,7 +28,7 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * @author Jamz

--- a/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/InputFunction.java
@@ -45,7 +45,7 @@ import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.ParameterException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 // @formatter:off
 // Jamz: Had to remove <pre> tags and add formatter:off due to Spotless 3.x error, still not fixed

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -31,7 +31,7 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class LookupTableFunction extends AbstractFunction {
 

--- a/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StrListFunctions.java
@@ -26,7 +26,7 @@ import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.ParameterException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 /**

--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -29,8 +29,8 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
-import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.text.WordUtils;
 
 public class StringFunctions extends AbstractFunction {
   private int matchNo = 0;

--- a/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/UserDefinedMacroFunctions.java
@@ -41,7 +41,7 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.Function;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -38,7 +38,7 @@ import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -58,7 +58,7 @@ import net.rptools.maptool.model.sheet.stats.StatSheetManager;
 import net.rptools.maptool.util.GraphicsUtil;
 import net.rptools.maptool.util.ImageManager;
 import net.rptools.maptool.util.StringUtil;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This is the pointer tool from the top-level of the toolbar. It allows tokens to be selected and

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -110,7 +110,7 @@ import net.rptools.maptool.model.drawing.DrawnElement;
 import net.rptools.maptool.model.drawing.Pen;
 import net.rptools.maptool.util.ImageManager;
 import org.apache.commons.collections4.map.LinkedMap;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.xml.sax.SAXException;

--- a/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
@@ -50,7 +50,7 @@ import net.rptools.maptool.client.swing.GenericDialog;
 import net.rptools.maptool.client.ui.theme.Icons;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
 import net.rptools.maptool.language.I18N;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/ButtonGroupPopupMenu.java
@@ -40,7 +40,7 @@ import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.MacroButtonProperties;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.util.PersistenceUtil;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @SuppressWarnings("serial")
 public class ButtonGroupPopupMenu extends JPopupMenu {

--- a/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptAutoComplete.java
+++ b/src/main/java/net/rptools/maptool/client/ui/syntax/MapToolScriptAutoComplete.java
@@ -22,7 +22,7 @@ import net.rptools.maptool.client.functions.DefinesSpecialVariables;
 import net.rptools.maptool.client.functions.UserDefinedMacroFunctions;
 import net.rptools.maptool.language.I18N;
 import net.rptools.parser.function.Function;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fife.ui.autocomplete.BasicCompletion;

--- a/src/main/java/net/rptools/maptool/model/GUID.java
+++ b/src/main/java/net/rptools/maptool/model/GUID.java
@@ -17,7 +17,7 @@ package net.rptools.maptool.model;
 import java.io.Serializable;
 import java.util.HexFormat;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 /** Global unique identificator object. */

--- a/src/main/java/net/rptools/maptool/model/LightSource.java
+++ b/src/main/java/net/rptools/maptool/model/LightSource.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.lib.FileUtil;
 import net.rptools.maptool.server.proto.LightSourceDto;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * Represents a light source that can be attached to tokens.

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.library.Library;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Manages the stat sheets that are available to the system. This includes the legacy stat sheet.

--- a/src/main/java/net/rptools/maptool/util/StringUtil.java
+++ b/src/main/java/net/rptools/maptool/util/StringUtil.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 
 /**

--- a/src/test/java/net/rptools/maptool/client/functions/json/JSONMacroFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JSONMacroFunctionsTest.java
@@ -1,0 +1,128 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class JSONMacroFunctionsTest {
+  private JSONMacroFunctions jsonMacroFunctions;
+
+  @BeforeEach
+  void setup() {
+    jsonMacroFunctions = JSONMacroFunctions.getInstance();
+  }
+
+  @ParameterizedTest
+  @MethodSource("indentSource")
+  void testIndent(JsonElement input, int indent, String expectedOutput) {
+    expectedOutput = expectedOutput.trim();
+
+    String indented = jsonMacroFunctions.jsonIndent(input, indent);
+    indented = indented.trim();
+
+    assertEquals(expectedOutput, indented);
+  }
+
+  static List<Arguments> indentSource() {
+    var simpleObject = new JsonObject();
+    simpleObject.addProperty("a", 1);
+    simpleObject.addProperty("b", "2");
+    simpleObject.addProperty("c", true);
+
+    var simpleArray = new JsonArray();
+    simpleArray.add(1);
+    simpleArray.add("2");
+    simpleArray.add(true);
+
+    var complexObject = new JsonObject();
+    complexObject.addProperty("x", 1);
+    complexObject.addProperty("y", "2");
+    var complexObjectSubObject = new JsonArray();
+    complexObjectSubObject.add(false);
+    complexObjectSubObject.add("1");
+    complexObjectSubObject.add(2);
+    complexObject.add("z", complexObjectSubObject);
+
+    return List.of(
+        Arguments.argumentSet(
+            "Simple object, indent = 2",
+            simpleObject,
+            2,
+            """
+            {
+              "a": 1,
+              "b": "2",
+              "c": true
+            }
+            """),
+        Arguments.argumentSet(
+            "Simple object, indent = 4",
+            simpleObject,
+            4,
+            """
+            {
+                "a": 1,
+                "b": "2",
+                "c": true
+            }
+            """),
+        Arguments.argumentSet(
+            "Simple array, indent = 2",
+            simpleArray,
+            2,
+            """
+                [
+                  1,
+                  "2",
+                  true
+                ]
+                """),
+        Arguments.argumentSet(
+            "Simple array, indent = 4",
+            simpleArray,
+            4,
+            """
+                [
+                    1,
+                    "2",
+                    true
+                ]
+                """),
+        Arguments.argumentSet(
+            "Complex object, indent = 2",
+            complexObject,
+            2,
+            """
+            {
+              "x": 1,
+              "y": "2",
+              "z":   [
+                false,
+                "1",
+                2
+              ]
+            }
+            """));
+  }
+}

--- a/src/test/java/net/rptools/maptool/client/functions/json/JSONMacroFunctionsTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/JSONMacroFunctionsTest.java
@@ -117,7 +117,7 @@ public class JSONMacroFunctionsTest {
             {
               "x": 1,
               "y": "2",
-              "z":   [
+              "z": [
                 false,
                 "1",
                 2


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5216

### Description of the Change

The implementation for `json.indent()` is now based on GSON's `JsonWriter`. In addition to avoiding `json-lib`, this also means `json.indent()` doesn't have to convert to two intermediate representations (`String`, then `JSONArray` / `JSONObject`) before producing a final result.

With json-lib gone, we need an explicit dependency on `commons-lang`. But that library is almost as old as `json-lib`, so I swapped it out with the latest `commons-lang3`.

### Possible Drawbacks

There is a slight difference in formatting. E.g., tests showed there is now less whitespace after `:` when the value is an array.

### Documentation Notes

N/A

### Release Notes

- Changed `json.indent()` implementation to use GSON instead of json-lib.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5217)
<!-- Reviewable:end -->
