### PR TITLE
Port fix for hanging Gather Debug Information to 1.16

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/SysInfoDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/SysInfoDialog.java
@@ -47,7 +47,7 @@ public class SysInfoDialog {
     infoTextArea.setWrapStyleWord(true);
     infoTextArea.setFont(new Font("Monospaced", Font.PLAIN, 13));
     infoTextArea.setText(I18N.getText("action.gatherDebugInfoWait"));
-    EventQueue.invokeLater(new InfoTextSwingWorker());
+    new InfoTextSwingWorker().execute();
 
     JScrollPane scrollPane = new JScrollPane(infoTextArea);
     scrollPane.setHorizontalScrollBarPolicy(31);


### PR DESCRIPTION
### Identify the Bug or Feature request

Ports #4802 for #4801 from 1.15 to 1.16

### Description of the Change

Change 70556be6e was among the various fixes in 1.15 that never got merged to develop. This PR fixes that so that 1.16 users will be able to open the Gather Debug Window again.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where Gather Debug Information... would permanently hang MapTool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5218)
<!-- Reviewable:end -->
