### PR TITLE
Support strformat literals without passing args

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -230,11 +230,7 @@ public class StringFunctions extends AbstractFunction {
       }
       if (functionName.equalsIgnoreCase("strformat")) {
         int size = parameters.size();
-        if (size > 1) {
-          return format(parameters.get(0).toString(), resolver, parameters.subList(1, size));
-        } else {
-          return format(parameters.get(0).toString(), resolver, null);
-        }
+        return format(parameters.get(0).toString(), resolver, parameters.subList(1, size));
       }
       if (functionName.equalsIgnoreCase("matches")) {
         if (parameters.size() < 2) {
@@ -442,10 +438,6 @@ public class StringFunctions extends AbstractFunction {
       }
     }
     m.appendTail(sb);
-
-    if (args == null) {
-      return sb.toString();
-    }
 
     Object[] argArray = args.toArray();
 


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes https://github.com/RPTools/maptool/issues/5226

### Description of the Change

`strformat` has an optimisation to skip calling `String.format` if there are no format args. This change removes the optimisation.

### Possible Drawbacks

* Someone might be using `strformat` in an undocumented manner and depends on % formats not being processed when no arguments are passed.
* `strformat` with only `%{variable}` interpolations is now slower.

### Release Notes

* Fixed strformat formatting literals such as %n being ignored if no arguments were passed. strformat can now be used to create string literals with embedded newlines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5227)
<!-- Reviewable:end -->
