### PR TITLE
Recognise empty files in addons with .mts suffix as text files

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Asset.java
+++ b/src/main/java/net/rptools/maptool/model/Asset.java
@@ -184,6 +184,11 @@ public final class Asset {
 
               default -> Type.INVALID;
             };
+        case "model" ->
+            switch (subType) {
+              case "vnd.mts" -> Type.TEXT;
+              default -> Type.INVALID;
+            };
         default -> Type.INVALID;
       };
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes https://github.com/RPTools/maptool/issues/5229

### Description of the Change

If an addon contains an empty script file it doesn't detect as text and the .mts suffix heuristically makes it "model/vnd.mts".

This would get mapped to INVALID and thus a broken image which would not have a string representation and when the add-on loader attempts to load the asset as a string it would assert.

I think this is because it falls back to guessing based on filename and some other program used the .mts suffix first, so adding another case to the mapping between mime types and asset types should be the appropriate fix.

### Possible Drawbacks

None that I can think of.

### Release Notes

* Fixed empty mts scripts in addons being interpreted as broken images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5230)
<!-- Reviewable:end -->
