### PR TITLE
Defer initialization of addons until after campaign load

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2635,6 +2635,7 @@ public class AppActions {
 
         MapTool.serverCommand().setCampaign(campaign.campaign);
 
+        // NOTE: Addons are initialized in here
         MapTool.setCampaign(campaign.campaign, campaign.currentZoneId);
         ZoneRenderer current = MapTool.getFrame().getCurrentZoneRenderer();
         if (current != null) {

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -498,7 +498,7 @@ public class ClientMessageHandler implements MessageHandler {
             Asset asset = AssetManager.getAsset(a);
             try {
               var addOnLibrary = new AddOnLibraryImporter().importFromAsset(asset);
-              new LibraryManager().reregisterAddOnLibrary(addOnLibrary);
+              new LibraryManager().reregisterAddOnLibrary(addOnLibrary, true);
             } catch (IOException e) {
               SwingUtilities.invokeLater(
                   () ->
@@ -658,6 +658,7 @@ public class ClientMessageHandler implements MessageHandler {
     EventQueue.invokeLater(
         () -> {
           Campaign campaign = Campaign.fromDto(msg.getCampaign());
+          // NOTE: Addons are initialized in here
           MapTool.setCampaign(campaign, null);
 
           // Hide the "Connecting" overlay

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -957,6 +957,7 @@ public class MapTool {
     MapTool.getFrame().getCampaignPanel().reset();
     MapTool.getFrame().getGmPanel().reset();
     UserDefinedMacroFunctions.getInstance().handleCampaignLoadMacroEvent();
+    new LibraryManager().initializeAddOnLibraries();
   }
 
   public static AssetTransferManager getAssetTransferManager() {

--- a/src/main/java/net/rptools/maptool/client/TransferableHelper.java
+++ b/src/main/java/net/rptools/maptool/client/TransferableHelper.java
@@ -628,7 +628,7 @@ public class TransferableHelper extends TransferHandler {
             if (MapTool.getPlayer().isGM()) {
               try {
                 var addOnLibrary = new AddOnLibraryImporter().importFromAsset(asset);
-                new LibraryManager().reregisterAddOnLibrary(addOnLibrary);
+                new LibraryManager().reregisterAddOnLibrary(addOnLibrary, true);
                 SwingUtilities.invokeLater(
                     () -> {
                       MapTool.showInformation(

--- a/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogController.java
@@ -339,7 +339,7 @@ public class AddOnLibrariesDialogController extends AbstractSwingJavaFXDialogCon
                 }
                 libraryManager.deregisterAddOnLibrary(namespace);
               }
-              libraryManager.reregisterAddOnLibrary(addOnLibrary);
+              libraryManager.reregisterAddOnLibrary(addOnLibrary, true);
             } catch (IOException | InterruptedException | ExecutionException e) {
               MapTool.showError("library.import.ioError", e);
             }

--- a/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.java
@@ -267,7 +267,7 @@ public class AddOnLibrariesDialogView extends JDialog {
           }
           libraryManager.deregisterAddOnLibrary(namespace);
         }
-        libraryManager.reregisterAddOnLibrary(addOnLibrary);
+        libraryManager.reregisterAddOnLibrary(addOnLibrary, true);
       } catch (IOException | InterruptedException | ExecutionException e) {
         MapTool.showError("library.import.ioError", e);
       }

--- a/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/LibraryManager.java
@@ -163,9 +163,9 @@ public class LibraryManager {
    *
    * @param addOn the Add On to register.
    */
-  public boolean registerAddOnLibrary(AddOnLibrary addOn) {
+  public boolean registerAddOnLibrary(AddOnLibrary addOn, boolean initialize) {
     try {
-      addOnLibraryManager.registerLibrary(addOn);
+      addOnLibraryManager.registerLibrary(addOn, initialize);
       if (MapTool.isHostingServer()) {
         MapTool.serverCommand().addAddOnLibrary(List.of(new TransferableAddOnLibrary(addOn)));
       }
@@ -193,10 +193,10 @@ public class LibraryManager {
    *
    * @param addOnLibrary the add-on in library to register.
    */
-  public boolean reregisterAddOnLibrary(AddOnLibrary addOnLibrary) {
+  public boolean reregisterAddOnLibrary(AddOnLibrary addOnLibrary, boolean initialize) {
     try {
       addOnLibraryManager.deregisterLibrary(addOnLibrary.getNamespace().get());
-      addOnLibraryManager.registerLibrary(addOnLibrary);
+      addOnLibraryManager.registerLibrary(addOnLibrary, initialize);
       if (MapTool.isHostingServer()) {
         MapTool.serverCommand()
             .addAddOnLibrary(List.of(new TransferableAddOnLibrary(addOnLibrary)));
@@ -296,6 +296,11 @@ public class LibraryManager {
    */
   public CompletableFuture<AddOnLibraryListDto> addOnLibrariesToDto() {
     return addOnLibraryManager.toDto();
+  }
+
+  /** initializes all add-on libraries. */
+  public void initializeAddOnLibraries() {
+    addOnLibraryManager.initializeLibraries();
   }
 
   /** de-registers all libraries from the library manager. */

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibraryManager.java
@@ -71,7 +71,7 @@ public class AddOnLibraryManager {
    * @param library The add-on library to register.
    * @throws IllegalStateException if there is already a add-on library with the same namespace.
    */
-  public void registerLibrary(AddOnLibrary library) {
+  public void registerLibrary(AddOnLibrary library, boolean initialize) {
     String namespace = library.getNamespace().join().toLowerCase();
 
     var registeredLib = namespaceLibraryMap.computeIfAbsent(namespace, k -> library);
@@ -79,10 +79,19 @@ public class AddOnLibraryManager {
       throw new IllegalStateException("Library is already registered");
     }
 
-    library.initialize();
+    if (initialize) {
+      library.initialize();
+    }
     new MapToolEventBus()
         .getMainEventBus()
         .post(new AddOnsAddedEvent(Set.of(library.getLibraryInfo().join())));
+  }
+
+  /** initializes all libraries. */
+  public void initializeLibraries() {
+    for (var library : namespaceLibraryMap.values()) {
+      library.initialize();
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/server/ClientHandshake.java
+++ b/src/main/java/net/rptools/maptool/server/ClientHandshake.java
@@ -371,7 +371,9 @@ public class ClientHandshake implements Handshake<Void>, MessageHandler {
                 Asset asset = AssetManager.getAsset(a);
                 try {
                   var addOnLibrary = new AddOnLibraryImporter().importFromAsset(asset);
-                  libraryManager.reregisterAddOnLibrary(addOnLibrary);
+                  // Library explicitly not initialized here because scripts need
+                  // content from the campaign that has yet to be loaded.
+                  libraryManager.reregisterAddOnLibrary(addOnLibrary, false);
                 } catch (IOException e) {
                   SwingUtilities.invokeLater(
                       () -> {

--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -852,7 +852,10 @@ public class PersistenceUtil {
         AssetManager.putAsset(asset);
       }
       AddOnLibrary addOnLibrary = new AddOnLibraryImporter().importFromAsset(asset);
-      libraryManager.registerAddOnLibrary(addOnLibrary);
+      // Addons explicitly not initialized here (see AppActions MapTool.setCampaign)
+      // because the campaign is not loaded yet and addon init scripts
+      // need access to campaign state.
+      libraryManager.registerAddOnLibrary(addOnLibrary, false);
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes https://github.com/RPTools/maptool/issues/5178

### Description of the Change

This changes the register/reregister functions to conditionally initialize and adds a method to the Library Manager to initialize all addons, so that when an addon is added to a running campaign it is initialized immediately, but when initializing from connecting to a server or loading from a file addon initialization is deferred until after the campaign is loaded.

### Possible Drawbacks

There may be a cleaner way to handle this than changes all over the place.

### Release Notes

* Deferred running Add-on onInit/onFirstInit scripts until after the campaign is loaded so that their changes aren't trampled during campaign load and they can depend on campaign state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5231)
<!-- Reviewable:end -->
