### PR TITLE
Add gradle version catalogue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,177 +354,77 @@ def zipJpackageImage = tasks.register('zipJpackageImage', Zip) {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    forms group: 'com.jetbrains.intellij.java', name: 'java-compiler-ant-tasks', version: '233.14475.56'
-
     implementation project(':clientserver')
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.20.0'	// Bridges v1 to v2 for other code in other libs
-    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.16'
-    implementation group: 'commons-logging', name: 'commons-logging', version: '1.3.0'
+    implementation(libs.bundles.log4j)
+    implementation(libs.slf4j.simple)
+    implementation(libs.apache.commons.logging)
+    implementation(libs.bundles.sentry)
 
-    // Image processing lib
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.10.1'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.12.0'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.10.1'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tiff', version: '3.12.0'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-batik', version: '3.12.0'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-tga', version: '3.12.0'
-    implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-bmp', version: '3.10.1'
-    // For Twelvemonkey SVG
-    implementation 'org.apache.xmlgraphics:batik-all:1.17'
+    implementation(libs.servicediscovery)
+    implementation(libs.upnplib)
+    implementation(libs.okhttp)
+    implementation(libs.protobuf.grpc)
+    implementation(libs.protobuf.java.util)
 
+    implementation(libs.bundles.imageio)
+    implementation(libs.batik)
+    implementation(libs.bundles.pdfbox)
+    implementation(libs.bcmail)
+    implementation(libs.bundles.jai.imageio)
+    implementation(libs.webp.imageio)
 
-    // For Sentry bug reporting
-    implementation group: 'io.sentry', name: 'sentry', version: '1.7.29'
-    implementation group: 'io.sentry', name: 'sentry-log4j2', version: '1.7.29'
+    implementation(libs.bundles.jide) // Currently hosted on nerps.net/repo
+    implementation(libs.fifesoft.rsyntaxtexxtarea)
+    implementation(libs.fifesoft.rstaui)
+    implementation(libs.fifesoft.autocomplete)
+    implementation(libs.fifesoft.languagesupport)
+    implementation(libs.bundles.flatlaf)
+    implementation(libs.tinylaf.nocp)
+    implementation(libs.jsvg)
 
-    // parsing of configuration data
-    implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.11.0'
-    // Specialized collections: ReferenceMap, LinkedMap.
-    implementation 'org.apache.commons:commons-collections4:4.4'
-    // Various file utilities
-    implementation 'commons-io:commons-io:2.15.1'
-    // ftp client
-    implementation 'commons-net:commons-net:3.11.1'
-    // commandline parsing
-    implementation 'commons-cli:commons-cli:1.6.0'
-    implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation(libs.bundles.handlebars)
 
-    // needed for preference dialog at runtime
-    implementation 'commons-beanutils:commons-beanutils:1.9.4'
+    implementation(libs.apache.commons.configuration)
+    implementation(libs.apache.commons.collections)
+    implementation(libs.apache.commons.io)
+    implementation(libs.apache.commons.net)
+    implementation(libs.apache.commons.cli)
+    implementation(libs.apache.commons.lang)
+    implementation(libs.apache.commons.beanutils)
+    implementation(libs.apache.commons.jxpath)
+    implementation(libs.apache.tika)
 
-    // RPTool Libs
-    // default ressources (token, textures etc.)
-    implementation 'com.github.RPTools:maptool-resources:1.6.0'
-    // parser for macros
-    implementation 'com.github.RPTools:parser:1.8.3'
+    implementation(libs.gson)
+    implementation(libs.jsonpath)
+    implementation(libs.jsoup)
+    implementation(libs.jcabi.xml)
+    implementation(libs.xstream)
 
-    // Currently hosted on nerps.net/repo
-    implementation group: 'com.jidesoft', name: 'jide-common', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-components', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-dialogs', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-dock', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-editor', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-grids', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-properties', version: '3.7.9'
-    implementation group: 'com.jidesoft', name: 'jide-shortcut', version: '3.7.9'
+    implementation(libs.javatuples)
+    implementation(libs.guava)
+    implementation(libs.jts.core)
+    implementation(libs.jgrapht.core)
+    implementation(libs.flexmark.all)
+    implementation(libs.reflections)
+    implementation(libs.yasb)
 
-    // utils for handling reflection
-    implementation 'org.reflections:reflections:0.10.2'
+    implementation(libs.bundles.graalvm.js)
 
-    // find running instances in LAN
-    implementation 'net.tsc.servicediscovery:servicediscovery:1.0.b5'
+    forms(libs.intellij.forms.tasks)
+    implementation(libs.intellij.forms.runtime)
+    implementation(libs.miglayout.swing)
 
-    //maybe replace with jupnp
-    implementation 'commons-jxpath:commons-jxpath:1.3'
-    implementation 'com.github.fishface60:upnplib:0351d7502a57f6c5dc8653220bc03ad99af58b21'
+    implementation(libs.rptools.maptool.resources)
+    implementation(libs.rptools.parser)
+    implementation(libs.rptools.maptool.addons)
+    implementation(libs.rptools.dice.roller)
+    implementation(libs.noiselib)
 
-    // custom binding stuff, should probably be replace with Beans Binding (JSR 295)
-    implementation 'yasb:yasb:0.2-21012007'
-
-    implementation 'de.muntjak.tinylookandfeel:tinylaf-nocp:1.4.0'
-
-    // serialize to and from xml
-    implementation 'com.thoughtworks.xstream:xstream:1.4.21'
-
-    // themes
-    implementation 'com.formdev:flatlaf:3.5.4'
-    implementation 'com.formdev:flatlaf-intellij-themes:3.5.4'
-    implementation 'com.formdev:flatlaf-extras:3.5.4'
-    implementation 'com.github.weisj:jsvg:1.4.0'
-    implementation 'com.formdev:flatlaf-jide-oss:3.5.4'
-
-    // JS support for macros
-    implementation group: 'org.graalvm.js', name: 'js', version: '21.2.0'
-    implementation group: 'org.graalvm.js', name: 'js-scriptengine', version: '21.1.0'
-
-    implementation 'com.jayway.jsonpath:json-path:2.9.0'
-
-    // For PDF image extraction
-    implementation 'org.apache.pdfbox:pdfbox:3.0.0'
-    implementation 'org.apache.pdfbox:pdfbox-tools:3.0.0'
-    implementation 'org.bouncycastle:bcmail-jdk15on:1.70'								// To decrypt passworded/secured pdf's
-    implementation 'com.github.jai-imageio:jai-imageio-core:1.4.0'						// For pdf image extraction, specifically for jpeg2000 (jpx) support.
-    implementation 'com.github.jai-imageio:jai-imageio-jpeg2000:1.4.0'					// For pdf image extraction, specifically for jpeg2000 (jpx) support.
-
-    implementation 'com.github.gotson:webp-imageio:0.2.2' // webp support https://search.maven.org/artifact/com.github.gotson/webp-imageio/0.2.2/jar
-
-    // For syntax highlighting in macro editor
-    implementation "com.fifesoft:rsyntaxtextarea:3.5.3"		// https://mvnrepository.com/artifact/com.fifesoft/rsyntaxtextarea
-    implementation "com.fifesoft:rstaui:3.3.1"				// https://mvnrepository.com/artifact/com.fifesoft/rstaui
-    implementation "com.fifesoft:autocomplete:3.3.1"		// https://mvnrepository.com/artifact/com.fifesoft/autocomplete
-    implementation "com.fifesoft:languagesupport:3.3.0"
-
-    // For simple xml work in Hero Lab integration
-    implementation group: 'com.jcabi', name: 'jcabi-xml', version: '0.33.5'				// https://mvnrepository.com/artifact/com.jcabi/jcabi-xml
-
-    // For some math functions used in the A* Pathfinding
-    // https://locationtech.github.io/jts/jts-features.html
-    implementation group: 'org.locationtech.jts', name: 'jts-core', version: '1.19.0'	// https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
-
-    // For RESTful functions
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
-
-    // Better JSON functions...
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'		// https://mvnrepository.com/artifact/com.google.code.gson/gson
-
-    // Declare the dependency for your favourite test framework you want to use in your tests.
-    // TestNG is also supported by the Gradle Test task. Just change the
-    // testimplementation dependency to testimplementation 'org.testng:testng:6.8.1' and add
-    // 'test.useTestNG()' to your build script.
-    //testCompile 'junit:junit:4.12'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'		// https://mvnrepository.com/artifact/com.google.code.gson/gson
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.4'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
-
-    // For mocking features during unit tests
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.15.2'
-
-    // flexmark markdown parsing / conversion
-    implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
-
-    // Apache Tika Parsers for determining file type
-    implementation 'org.apache.tika:tika-core:3.0.0'
-
-    // Noise Generator
-    implementation 'com.github.cwisniew:NoiseLib:1.0.0' // The most recent version, 1.0.0 is build for a later java version: major version 55 is newer than 54, the highest major version supported by this compiler
-
-    // protobuf
-    implementation "io.grpc:grpc-protobuf:1.61.1"
-    implementation "com.google.protobuf:protobuf-java-util:4.29.1"
-
-    // Java Tuples
-    implementation 'com.flipkart.utils:javatuples:3.0'
-
-    // HTTP End Point
-    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-
-    // HTML Parsing
-    implementation 'org.jsoup:jsoup:1.17.2'
-    // eventbus
-    implementation 'com.google.guava:guava:33.0.0-jre'
-    // intellij forms runtime
-    implementation 'com.jetbrains.intellij.java:java-gui-forms-rt:241.12019'
-    // layout for forms created in code
-    implementation 'com.miglayout:miglayout-swing:11.3'
-
-    implementation 'com.github.jknack:handlebars:4.3.1'
-    implementation 'com.github.jknack:handlebars-helpers:4.4.0'
-
-    implementation 'org.jgrapht:jgrapht-core:1.5.2'
-
-
-    // Built In Add-on Libraries
-    implementation 'com.github.RPTools:maptool-builtin-addons:1.3'
-
-    // For advanced dice roller
-    implementation 'com.github.RPTools:advanced-dice-roller:1.0.3'
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.junit.engine)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.mockito.core)
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,14 @@ plugins {
     id "application"
     id "base"
     id "java"
-    id "org.ajoberstar.grgit" version "5.2.1"
-    id 'org.openjfx.javafxplugin' version '0.0.14'
-    id 'org.beryx.runtime' version '1.13.1'
-    id "com.google.protobuf" version "0.9.4"
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
 
-    id "com.diffplug.spotless" version "6.25.0" apply false
+    alias(libs.plugins.grgit)
+    alias(libs.plugins.javafx)
+    alias(libs.plugins.jpackage.runtime)
+    alias(libs.plugins.protobuf)
+    alias(libs.plugins.shadow)
+
+    alias(libs.plugins.spotless) apply false
 }
 
 allprojects {

--- a/clientserver/build.gradle
+++ b/clientserver/build.gradle
@@ -7,39 +7,32 @@ apply from: rootProject.file('buildSrc/shared.gradle')
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
+    implementation(libs.findbugs.jsr305)
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.20.0'	// Bridges v1 to v2 for other code in other libs
-    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.16'
-    implementation group: 'commons-logging', name: 'commons-logging', version: '1.3.0'
+    implementation(libs.bundles.log4j)
+    implementation(libs.slf4j.simple)
+    implementation(libs.apache.commons.logging)
 
-    // Better JSON functions...
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'		// https://mvnrepository.com/artifact/com.google.code.gson/gson
+    implementation(libs.gson)
 
     // webrtc
-    implementation group: 'org.java-websocket', name: 'Java-WebSocket', version: '1.5.7'
-    // Needs to be API since WebRTCConnection implements PeerConnectionObserver and RTCDataChannelObserver.
-    implementation 'dev.onvoid.webrtc:webrtc-java:0.9.0'
+    implementation(libs.websocket)
+    implementation(libs.webrtc)
     if (osdetector.os.is('windows'))
-        implementation 'dev.onvoid.webrtc:webrtc-java:0.9.0:windows-x86_64'
+        implementation(variantOf(libs.webrtc) { classifier('windows-x86_64')})
     else if (osdetector.os.is('osx'))
-        implementation 'dev.onvoid.webrtc:webrtc-java:0.9.0:macos-x86_64'
+        implementation(variantOf(libs.webrtc) { classifier('macos-x86_64')})
     else if (osdetector.os.is('linux'))
-        implementation 'dev.onvoid.webrtc:webrtc-java:0.9.0:linux-x86_64'
+        implementation(variantOf(libs.webrtc) { classifier('linux-x86_64')})
 
     // compression of messages between client and server
-    implementation 'org.apache.commons:commons-compress:1.27.1'
-    implementation 'com.github.luben:zstd-jni:1.5.5-11'
+    implementation(libs.apache.commons.compress)
+    implementation(libs.zstd)
 
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.4'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
-    // For mocking features during unit tests
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.15.2'
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.junit.engine)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.mockito.core)
 }
 
 test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -177,3 +177,11 @@ handlebars  = [ "handlebars", "handlebars-helpers" ]
 junit       = [ "junit-api", "junit-engine", "junit-params" ]
 jai-imageio = [ "jai-imageio-core", "jai-imageio-jpeg" ]
 graalvm-js  = [ "graalvm-js", "graalvm-js-scriptengine" ]
+
+[plugins]
+grgit = { id = "org.ajoberstar.grgit", version = "5.2.1" }
+javafx = { id = "org.openjfx.javafxplugin", version = "0.0.14" }
+jpackage-runtime = { id = "org.beryx.runtime", version = "1.13.1" }
+protobuf = { id = "com.google.protobuf", version = "0.9.4" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+spotless = { id = "com.diffplug.spotless", version = "6.25.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,179 @@
+[versions]
+log4j = "2.22.1"
+junit = "5.11.4"
+imageio = "3.12.0"
+sentry = "1.7.29"
+jide = "3.7.9"
+flatlaf = "3.5.4"
+handlebars = "4.4.0"
+jai-imageio = "1.4.0"
+graalvm-js = "21.2.0"
+pdfbox = "3.0.0"
+
+[libraries]
+findbugs-jsr305              = { group = "com.google.code.findbugs",    name = "jsr305",                  version     = "3.0.2"       }
+
+# Logging
+log4j-core                   = { group = "org.apache.logging.log4j",    name = "log4j-core",              version.ref = "log4j"       }
+log4j-api                    = { group = "org.apache.logging.log4j",    name = "log4j-api",               version.ref = "log4j"       }
+# Bridges v1 to v2 for other code in other libs
+log4j-1_2-api                = { group = "org.apache.logging.log4j",    name = "log4j-1.2-api",           version.ref = "log4j"       }
+slf4j-simple                 = { group = "org.slf4j",                   name = "slf4j-simple",            version     = "2.0.16"      }
+apache-commons-logging       = { group = "commons-logging",             name = "commons-logging",         version     = "1.3.0"       }
+# For Sentry bug reporting
+sentry                       = { group = "io.sentry",                   name = "sentry",                  version.ref = "sentry"      }
+sentry-log4j                 = { group = "io.sentry",                   name = "sentry-log4j2",           version.ref = "sentry"      }
+
+# Networking
+# Web RTC
+websocket                    = { group = "org.java-websocket",          name = "Java-WebSocket",          version = "1.5.7"           }
+webrtc                       = { group = "dev.onvoid.webrtc",           name = "webrtc-java",             version = "0.9.0"           }
+# compression of messages between client and server
+apache-commons-compress      = { group = "org.apache.commons",          name = "commons-compress",        version = "1.27.1"          }
+zstd                         = { group = "com.github.luben",            name = "zstd-jni",                version = "1.5.5-11"        }
+# Protobuf
+protobuf-grpc                = { group = "io.grpc",                     name = "grpc-protobuf",           version = "1.61.1"          }
+protobuf-java-util           = { group = "com.google.protobuf",         name = "protobuf-java-util",      version = "4.29.1"          }
+# find running instances in LAN
+servicediscovery             = { group = "net.tsc.servicediscovery",    name = "servicediscovery",        version = "1.0.b5"          }
+# UPNP. Maybe replace with jupnp
+upnplib                      = { group = "com.github.fishface60",       name = "upnplib",                 version = "0351d7502a57f6c5dc8653220bc03ad99af58b21" }
+# For RESTful functions
+okhttp                       = { group = "com.squareup.okhttp3",        name = "okhttp",                  version = "4.12.0"          }
+
+# Image processing lib
+imageio-core                 = { group = "com.twelvemonkeys.imageio",   name = "imageio-core",            version.ref = "imageio"     }
+imageio-jpeg                 = { group = "com.twelvemonkeys.imageio",   name = "imageio-jpeg",            version.ref = "imageio"     }
+imageio-psd                  = { group = "com.twelvemonkeys.imageio",   name = "imageio-psd",             version.ref = "imageio"     }
+imageio-tiff                 = { group = "com.twelvemonkeys.imageio",   name = "imageio-tiff",            version.ref = "imageio"     }
+imageio-batik                = { group = "com.twelvemonkeys.imageio",   name = "imageio-batik",           version.ref = "imageio"     }
+imageio-tga                  = { group = "com.twelvemonkeys.imageio",   name = "imageio-tga",             version.ref = "imageio"     }
+imageio-bmp                  = { group = "com.twelvemonkeys.imageio",   name = "imageio-bmp",             version.ref = "imageio"     }
+batik                        = { group = "org.apache.xmlgraphics",      name = "batik-all",               version     = "1.17"        }
+# PDF image extraction
+pdfbox                       = { group = "org.apache.pdfbox",           name = "pdfbox",                  version.ref = "pdfbox"      }
+pdfbox-tools                 = { group = "org.apache.pdfbox",           name = "pdfbox-tools",            version.ref = "pdfbox"      }
+# To decrypt passworded/secured PDFs
+bcmail                       = { group = "org.bouncycastle",            name = "bcmail-jdk15on",          version     = "1.70"        }
+# For pdf image extraction, specifically for jpeg2000 (jpx) support.
+jai-imageio-core             = { group = "com.github.jai-imageio",      name = "jai-imageio-core",        version.ref = "jai-imageio" }
+jai-imageio-jpeg             = { group = "com.github.jai-imageio",      name = "jai-imageio-jpeg2000",    version.ref = "jai-imageio" }
+# WebP support
+webp-imageio                 = { group = "com.github.gotson",           name = "webp-imageio",            version     = "0.2.2"       }
+
+# JIDE UI libraries. Currently hosted on nerps.net/repo
+jide-common                  = { group = "com.jidesoft",                name = "jide-common",             version.ref = "jide"        }
+jide-components              = { group = "com.jidesoft",                name = "jide-components",         version.ref = "jide"        }
+jide-dialogs                 = { group = "com.jidesoft",                name = "jide-dialogs",            version.ref = "jide"        }
+jide-dock                    = { group = "com.jidesoft",                name = "jide-dock",               version.ref = "jide"        }
+jide-editor                  = { group = "com.jidesoft",                name = "jide-editor",             version.ref = "jide"        }
+jide-grids                   = { group = "com.jidesoft",                name = "jide-grids",              version.ref = "jide"        }
+jide-properties              = { group = "com.jidesoft",                name = "jide-properties",         version.ref = "jide"        }
+jide-shortcut                = { group = "com.jidesoft",                name = "jide-shortcut",           version.ref = "jide"        }
+
+# Syntax highlighting in macro editor
+fifesoft-rsyntaxtexxtarea    = { group = "com.fifesoft",                name = "rsyntaxtextarea",         version = "3.5.3"           }
+fifesoft-rstaui              = { group = "com.fifesoft",                name = "rstaui",                  version = "3.3.1"           }
+fifesoft-autocomplete        = { group = "com.fifesoft",                name = "autocomplete",            version = "3.3.1"           }
+fifesoft-languagesupport     = { group = "com.fifesoft",                name = "languagesupport",         version = "3.3.0"           }
+
+# Themes
+flatlaf                      = { group = "com.formdev",                 name = "flatlaf",                 version.ref = "flatlaf"     }
+flatlaf-intellij-themes      = { group = "com.formdev",                 name = "flatlaf-intellij-themes", version.ref = "flatlaf"     }
+flatlaf-extras               = { group = "com.formdev",                 name = "flatlaf-extras",          version.ref = "flatlaf"     }
+flatlaf-jide-oss             = { group = "com.formdev",                 name = "flatlaf-jide-oss",        version.ref = "flatlaf"     }
+tinylaf-nocp                 = { group = "de.muntjak.tinylookandfeel",  name = "tinylaf-nocp",            version     = "1.4.0"       }
+jsvg                         = { group = "com.github.weisj",            name = "jsvg",                    version     = "1.4.0"       }
+
+handlebars                   = { group = "com.github.jknack",           name = "handlebars",              version.ref = "handlebars"  }
+handlebars-helpers           = { group = "com.github.jknack",           name = "handlebars-helpers",      version.ref = "handlebars"  }
+
+# Apache commons and other utilities
+# parsing of configuration data
+apache-commons-configuration = { group = "org.apache.commons",          name = "commons-configuration2",  version = "2.11.0"          }
+# Specialized collections: ReferenceMap, LinkedMap.
+apache-commons-collections   = { group = "org.apache.commons",          name = "commons-collections4",    version = "4.4"             }
+# Various file utilities
+apache-commons-io            = { group = "commons-io",                  name = "commons-io",              version = "2.15.1"          }
+#  ftp client
+apache-commons-net           = { group = "commons-net",                 name = "commons-net",             version = "3.11.1"          }
+# commandline parsing
+apache-commons-cli           = { group = "commons-cli",                 name = "commons-cli",             version = "1.6.0"           }
+# String utilities
+apache-commons-lang          = { group = "org.apache.commons",          name = "commons-lang3",           version = "3.17.0"          }
+# needed for preference dialog at runtime
+apache-commons-beanutils     = { group = "commons-beanutils",           name = "commons-beanutils",       version = "1.9.0"           }
+# XPath parsing, used for UPNP
+apache-commons-jxpath        = { group = "commons-jxpath",              name = "commons-jxpath",          version = "1.3"             }
+# For determining file type
+apache-tika                  = { group = "org.apache.tika",             name = "tika-core",               version = "3.0.0"           }
+
+# Parsing and serialization
+# Better JSON functions
+gson                         = { group = "com.google.code.gson",        name = "gson",                    version = "2.10.1"          }
+# JsonPath for java
+jsonpath                     = { group = "com.jayway.jsonpath",         name = "json-path",               version = "2.9.0"           }
+# HTML parsing
+jsoup                        = { group = "org.jsoup",                   name = "jsoup",                   version = "1.17.2"          }
+# XML utilities, for Hero Lab integration
+jcabi-xml                    = { group = "com.jcabi",                   name = "jcabi-xml",               version = "0.33.5"          }
+# Serialization for saving campaigns, maps, tokens, etc.
+xstream                      = { group = "com.thoughtworks.xstream",    name = "xstream",                 version = "1.4.21"          }
+
+# Java tuples
+javatuples                   = { group = "com.flipkart.utils",          name = "javatuples",              version = "3.0"             }
+# Event bus, collections, and other utilities
+guava                        = { group = "com.google.guava",            name = "guava",                   version = "33.0.0-jre"      }
+# Geometry library for pathfinding, vision, etc.
+jts-core                     = { group = "org.locationtech.jts",        name = "jts-core",                version = "1.19.0"          }
+# Graph library used for walls
+jgrapht-core                 = { group = "org.jgrapht",                 name = "jgrapht-core",            version = "1.5.2"           }
+# Markdown parsing
+flexmark-all                 = { group = "com.vladsch.flexmark",        name = "flexmark-all",            version = "0.64.8"          }
+# Utils for handling reflection
+reflections                  = { group = "org.reflections",             name = "reflections",             version = "0.10.2"          }
+# Custom binding stuff. Should probably be replaced with Beans Binding (JSR 295)
+yasb                         = { group = "yasb",                        name = "yasb",                    version = "0.2-21012007"    }
+# For map noise
+noiselib                     = { group = "com.github.cwisniew",         name = "NoiseLib",                version = "1.0.0"           }
+
+# JS support for macros
+graalvm-js                   = { group = "org.graalvm.js",              name = "js",                      version.ref = "graalvm-js"  }
+graalvm-js-scriptengine      = { group = "org.graalvm.js",              name = "js-scriptengine",         version.ref = "graalvm-js"  }
+
+# GUI forms
+intellij-forms-tasks         = { group = "com.jetbrains.intellij.java", name = "java-compiler-ant-tasks", version = "233.14475.56"    }
+intellij-forms-runtime       = { group = "com.jetbrains.intellij.java", name = "java-gui-forms-rt",       version = "241.12019"       }
+# layout for forms created in code
+miglayout-swing              = { group = "com.miglayout",               name = "miglayout-swing",         version = "11.3"            }
+
+# RPTools libs
+# default resources (token, textures etc.)
+rptools-maptool-resources    = { group = "com.github.RPTools",          name = "maptool-resources",       version = "1.6.0"           }
+# parser for macros
+rptools-parser               = { group = "com.github.RPTools",          name = "parser",                  version = "1.8.3"           }
+# Built In Add-on Libraries
+rptools-maptool-addons       = { group = "com.github.RPTools",          name = "maptool-builtin-addons",  version = "1.3"             }
+# For advanced dice roller
+rptools-dice-roller          = { group = "com.github.RPTools",          name = "advanced-dice-roller",    version = "1.0.3"           }
+
+# Test only
+junit-platform-launcher      = { group = "org.junit.platform",          name = "junit-platform-launcher", version     = "1.11.4"      }
+junit-engine                 = { group = "org.junit.jupiter",           name = "junit-jupiter-engine",    version.ref = "junit"       }
+junit-api                    = { group = "org.junit.jupiter",           name = "junit-jupiter-api",       version.ref = "junit"       }
+junit-params                 = { group = "org.junit.jupiter",           name = "junit-jupiter-params",    version.ref = "junit"       }
+# For mocking features during unit tests
+mockito-core                 = { group = "org.mockito",                 name = "mockito-core",            version     = "5.15.2"      }
+
+
+[bundles]
+log4j       = [ "log4j-core", "log4j-api", "log4j-1_2-api" ]
+sentry      = [ "sentry", "sentry-log4j" ]
+imageio     = [ "imageio-core", "imageio-jpeg", "imageio-psd", "imageio-tiff", "imageio-batik", "imageio-tga", "imageio-bmp" ]
+pdfbox      = [ "pdfbox", "pdfbox-tools" ]
+jide        = [ "jide-common", "jide-components", "jide-dialogs", "jide-dock", "jide-editor", "jide-grids", "jide-properties", "jide-shortcut" ]
+flatlaf     = [ "flatlaf", "flatlaf-intellij-themes", "flatlaf-extras", "flatlaf-jide-oss" ]
+handlebars  = [ "handlebars", "handlebars-helpers" ]
+junit       = [ "junit-api", "junit-engine", "junit-params" ]
+jai-imageio = [ "jai-imageio-core", "jai-imageio-jpeg" ]
+graalvm-js  = [ "graalvm-js", "graalvm-js-scriptengine" ]


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #5214

### Description of the Change

Add a `libs.versions.toml` for tracking desired versions of packages. These are referenced in the `build.gradle` files via the `libs.*` variables in the `plugins { .. }` and `dependencies { ... }` blocks.

Largely the dependencies have been kept identical to the current state of develop. Exceptions are:
- `imageio-*` packages are all on 3.12.0 instead of a mix of 3.10.1 and 3.12.0
- `handlerbars*` packages are both on 4.4.0 instead of a mix of 4.3.1 and 4.4.0
- `graalvm*` packages are both on 21.2.0 instead of a mix of 21.1.0 and 21.2.0
- `junit-` packages are all on 5.11.4 instead of a mix of 5.10.2 and 5.11.4
- `junit-platform-launcher` has a version specified now

### Possible Drawbacks

It's unclear how well dependabot will handle this.

### Documentation Notes

N/A

### Release Notes

- Changed the build scripts to use a central version catalogue for all dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5237)
<!-- Reviewable:end -->
