### PR TITLE
Consolidate scattered protobuf versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,6 @@ buildscript {
     repositories {
         mavenCentral()
     }
-    dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.4'
-    }
 }
 
 // Access Git info from build script
@@ -134,7 +131,9 @@ javafx {
 }
 
 protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:4.29.1" }
+    protoc {
+        artifact = libs.protobuf.protoc.get()
+    }
 }
 
 // Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
@@ -366,7 +365,7 @@ dependencies {
     implementation(libs.upnplib)
     implementation(libs.okhttp)
     implementation(libs.protobuf.grpc)
-    implementation(libs.protobuf.java.util)
+    implementation(libs.protobuf.java)
 
     implementation(libs.bundles.imageio)
     implementation(libs.batik)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ handlebars = "4.4.0"
 jai-imageio = "1.4.0"
 graalvm-js = "21.2.0"
 pdfbox = "3.0.0"
+protoc = "4.29.1"
 
 [libraries]
 findbugs-jsr305              = { group = "com.google.code.findbugs",    name = "jsr305",                  version     = "3.0.2"       }
@@ -33,7 +34,8 @@ apache-commons-compress      = { group = "org.apache.commons",          name = "
 zstd                         = { group = "com.github.luben",            name = "zstd-jni",                version = "1.5.5-11"        }
 # Protobuf
 protobuf-grpc                = { group = "io.grpc",                     name = "grpc-protobuf",           version = "1.61.1"          }
-protobuf-java-util           = { group = "com.google.protobuf",         name = "protobuf-java-util",      version = "4.29.1"          }
+protobuf-java                = { group = "com.google.protobuf",         name = "protobuf-java-util",      version.ref = "protoc"      }
+protobuf-protoc              = { group = "com.google.protobuf",         name = "protoc",                  version.ref = "protoc"      }
 # find running instances in LAN
 servicediscovery             = { group = "net.tsc.servicediscovery",    name = "servicediscovery",        version = "1.0.b5"          }
 # UPNP. Maybe replace with jupnp


### PR DESCRIPTION
### Identify the Bug or Feature request

Missed one commit in PR #5237 for #5214

### Description of the Change

Changes the varios protobuf artifact references in `build.gradle` to use the version catalogue like everything else.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5244)
<!-- Reviewable:end -->
