### PR TITLE
Register mockito as a java agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ def appSemVer = ""
 
 configurations {
     forms.extendsFrom implementation
-    mockitoAgent
 }
 
 // Custom properties
@@ -421,14 +420,6 @@ dependencies {
     implementation(libs.rptools.maptool.addons)
     implementation(libs.rptools.dice.roller)
     implementation(libs.noiselib)
-
-    testRuntimeOnly(libs.junit.platform.launcher)
-    testRuntimeOnly(libs.junit.engine)
-    testImplementation(libs.bundles.junit)
-    testImplementation(libs.mockito.core)
-    mockitoAgent(libs.mockito.core) {
-        transitive = false
-    }
 }
 
 processResources {
@@ -508,11 +499,6 @@ javadoc {
     options.addStringOption('Xmaxwarns', '2000')
     options.addBooleanOption('html5', true)
     options.tags("note:a:<strong><u>Note:</u></strong>")
-}
-
-test {
-    useJUnitPlatform()
-    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
 }
 
 task createWrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ def appSemVer = ""
 
 configurations {
     forms.extendsFrom implementation
+    mockitoAgent
 }
 
 // Custom properties
@@ -425,6 +426,9 @@ dependencies {
     testRuntimeOnly(libs.junit.engine)
     testImplementation(libs.bundles.junit)
     testImplementation(libs.mockito.core)
+    mockitoAgent(libs.mockito.core) {
+        transitive = false
+    }
 }
 
 processResources {
@@ -508,6 +512,7 @@ javadoc {
 
 test {
     useJUnitPlatform()
+    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
 }
 
 task createWrapper(type: Wrapper) {

--- a/buildSrc/shared.gradle
+++ b/buildSrc/shared.gradle
@@ -33,3 +33,22 @@ spotless {
         indentWithSpaces(4)
     }
 }
+
+configurations {
+    mockitoAgent
+}
+
+dependencies {
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.junit.engine)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.mockito.core)
+    mockitoAgent(libs.mockito.core) {
+        transitive = false
+    }
+}
+
+test {
+    useJUnitPlatform()
+    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
+}

--- a/clientserver/build.gradle
+++ b/clientserver/build.gradle
@@ -5,10 +5,6 @@ plugins {
 
 apply from: rootProject.file('buildSrc/shared.gradle')
 
-configurations {
-    mockitoAgent
-}
-
 // In this section you declare the dependencies for your production and test code
 dependencies {
     implementation(libs.findbugs.jsr305)
@@ -32,17 +28,4 @@ dependencies {
     // compression of messages between client and server
     implementation(libs.apache.commons.compress)
     implementation(libs.zstd)
-
-    testRuntimeOnly(libs.junit.platform.launcher)
-    testRuntimeOnly(libs.junit.engine)
-    testImplementation(libs.bundles.junit)
-    testImplementation(libs.mockito.core)
-    mockitoAgent(libs.mockito.core) {
-        transitive = false
-    }
-}
-
-test {
-    useJUnitPlatform()
-    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
 }

--- a/clientserver/build.gradle
+++ b/clientserver/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 apply from: rootProject.file('buildSrc/shared.gradle')
 
+configurations {
+    mockitoAgent
+}
+
 // In this section you declare the dependencies for your production and test code
 dependencies {
     implementation(libs.findbugs.jsr305)
@@ -33,8 +37,12 @@ dependencies {
     testRuntimeOnly(libs.junit.engine)
     testImplementation(libs.bundles.junit)
     testImplementation(libs.mockito.core)
+    mockitoAgent(libs.mockito.core) {
+        transitive = false
+    }
 }
 
 test {
     useJUnitPlatform()
+    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5215

### Description of the Change

Incorporates the suggested fix from the [Mockito documentation](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3). This adds Mockito as a Java agent so that it can create mocks in tests without warnings.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Addressed a warning regarding use of Mockito in test cases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5261)
<!-- Reviewable:end -->
