### PR TITLE
Move heart beat task into MapToolClient

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -686,8 +686,6 @@ public class MapTool {
     chatAutoSave = new ChatAutoSave();
     chatAutoSave.setTimeout(AppPreferences.chatAutoSaveTimeInMinutes.get());
     AppPreferences.chatAutoSaveTimeInMinutes.onChange(chatAutoSave::setTimeout);
-
-    new ServerHeartBeatThread().start();
   }
 
   public static NoteFrame getProfilingNoteFrame() {
@@ -1391,30 +1389,6 @@ public class MapTool {
 
   public static String getClientId() {
     return clientId;
-  }
-
-  private static class ServerHeartBeatThread extends Thread {
-
-    public ServerHeartBeatThread() {
-      super("MapTool.ServerHeartBeatThread");
-    }
-
-    @Override
-    public void run() {
-
-      // This should always run, so we should be able to safely
-      // loop forever
-      while (true) {
-        try {
-          Thread.sleep(20000);
-        } catch (InterruptedException e) {
-          log.warn("Heartbeat thread interrupted", e);
-        }
-
-        ServerCommand command = client.getServerCommand();
-        command.heartbeat(getPlayer().getName());
-      }
-    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/MapToolConnection.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolConnection.java
@@ -97,6 +97,10 @@ public class MapToolConnection {
     connection.addDisconnectHandler(serverDisconnectHandler);
   }
 
+  public String getId() {
+    return connection.getId();
+  }
+
   public boolean isAlive() {
     return connection.isAlive();
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #5262

### Description of the Change

The `ServerHeartBeatThread` thread is removed in favour of a task (`Runnable`) scheduled repeatedly with an executor. This task is only scheduled when `MapToolClient` is started, and it is canceled when `MapToolClient` is stopped. So each connection will get its own heart beat unlike before.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Modify server heart beats to not busy-wait on a thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5263)
<!-- Reviewable:end -->
