### PR TITLE
Hide statsheet overlay when no statsheet visible, and overlay panel when no overlay is visible

### DIFF
--- a/src/main/java/net/rptools/maptool/client/events/OverlayVisibilityChanged.java
+++ b/src/main/java/net/rptools/maptool/client/events/OverlayVisibilityChanged.java
@@ -1,0 +1,19 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.events;
+
+import net.rptools.maptool.client.ui.htmlframe.HTMLOverlayManager;
+
+public record OverlayVisibilityChanged(HTMLOverlayManager overlay, boolean isVisible) {}

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayManager.java
@@ -27,8 +27,10 @@ import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.events.OverlayVisibilityChanged;
 import net.rptools.maptool.client.functions.MacroLinkFunction;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.events.MapToolEventBus;
 import netscape.javascript.JSObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -224,6 +226,7 @@ public class HTMLOverlayManager extends HTMLWebViewManager implements HTMLPanelC
   @Override
   public void setVisible(boolean visible) {
     getWebView().setVisible(visible);
+    new MapToolEventBus().getMainEventBus().post(new OverlayVisibilityChanged(this, visible));
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.ui.htmlframe;
 
+import com.google.common.eventbus.Subscribe;
 import java.awt.*;
 import java.awt.event.*;
 import java.awt.image.BufferedImage;
@@ -32,10 +33,12 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.web.WebView;
 import javax.swing.*;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.events.OverlayVisibilityChanged;
 import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.tool.DefaultTool;
 import net.rptools.maptool.client.tool.Tool;
 import net.rptools.maptool.client.ui.AppMenuBar;
+import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.Token;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -71,6 +74,8 @@ public class HTMLOverlayPanel extends JFXPanel {
 
     Platform.runLater(this::setupScene);
     setVisible(false); // disabled by default
+
+    new MapToolEventBus().getMainEventBus().register(this);
   }
 
   /** Setups the scene of the JFXPanel. */
@@ -273,6 +278,11 @@ public class HTMLOverlayPanel extends JFXPanel {
             overlayManager.setValue(frameValue);
           }
         });
+  }
+
+  @Subscribe
+  private void onOverlayVisibilityChanged(OverlayVisibilityChanged event) {
+    Platform.runLater(() -> setVisible(overlays.stream().anyMatch(HTMLOverlayManager::isVisible)));
   }
 
   /** Display the overlays according to their zOrder. */

--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheet.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheet.java
@@ -54,6 +54,7 @@ public class StatSheet {
                     .getOverlay(AppConstants.INTERNAL_MAP_UNDER_POINTER_HTML_OVERLAY_NAME);
             if (overlay != null) {
               overlay.updateContents(output, true);
+              overlay.setVisible(true);
             } else {
               MapTool.getFrame()
                   .getOverlayPanel()
@@ -79,6 +80,7 @@ public class StatSheet {
                   .getOverlayPanel()
                   .getOverlay(AppConstants.INTERNAL_MAP_UNDER_POINTER_HTML_OVERLAY_NAME);
           if (overlay != null) {
+            overlay.setVisible(false);
             overlay.updateContents("", true);
           }
         });


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5238

### Description of the Change

This changes stat sheets specifically so the internal overlay is hidden when no stat sheets are displayed. Existing behaviour is that the overlay remains visible but has no content.

Overlays in general are changed to hide themselves if all overlays are hidden. It will show itself again when any overlay becomes visible. This is handled through a new `OverlayVisibilityChanged` event. Newly shown overlays also cause the panel to be shown, e.g., in response to an `overlay()` roll.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Hide stat sheet overlays when no stat sheet is being displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5264)
<!-- Reviewable:end -->
