### PR TITLE
Fix deadlock in 1.16.0.rc-1

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1033,11 +1033,14 @@ public class MapTool {
     connections.serverSide().open();
     server.addLocalConnection(connections.serverSide(), player);
     // Update the client, including running onCampaignLoad.
-    setCampaign(
-        client.getCampaign(),
-        Optional.ofNullable(clientFrame.getCurrentZoneRenderer())
-            .map(zr -> zr.getZone().getId())
-            .orElse(null));
+    EventQueue.invokeLater(
+        () -> {
+          setCampaign(
+              client.getCampaign(),
+              Optional.ofNullable(clientFrame.getCurrentZoneRenderer())
+                  .map(zr -> zr.getZone().getId())
+                  .orElse(null));
+        });
   }
 
   public static ThumbnailManager getThumbnailManager() {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5268

### Description of the Change

As part of the streamlining of server starts, the local clients run `MapTool.setCampaign()` on the server start background thread. This includes running `onCampaignLoad` macros, so is obviously incorrect. It also does not match what happens with remote connections, where they handle the `SetCampaignMsg` by running a task on the Swing thread.

This PR changes the `setCampaign()` call to run on the Swing thread after the server is initialized.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where macros were run on the wrong thread and could deadlock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5269)
<!-- Reviewable:end -->
