### PR TITLE
Fix deadlock in 1.16.0.rc-1 - release-1.16

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1033,11 +1033,14 @@ public class MapTool {
     connections.serverSide().open();
     server.addLocalConnection(connections.serverSide(), player);
     // Update the client, including running onCampaignLoad.
-    setCampaign(
-        client.getCampaign(),
-        Optional.ofNullable(clientFrame.getCurrentZoneRenderer())
-            .map(zr -> zr.getZone().getId())
-            .orElse(null));
+    EventQueue.invokeLater(
+        () -> {
+          setCampaign(
+              client.getCampaign(),
+              Optional.ofNullable(clientFrame.getCurrentZoneRenderer())
+                  .map(zr -> zr.getZone().getId())
+                  .orElse(null));
+        });
   }
 
   public static ThumbnailManager getThumbnailManager() {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5268

### Description of the Change

PR #5269 accidentally targetted `develop` instead of `release-1.16`. This PR ports it to 1.16 so the RC can be fixed.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where macros were run on the wrong thread and could deadlock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5270)
<!-- Reviewable:end -->
