### PR TITLE
Disable overlay menu items when overlay is locked

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -432,12 +432,25 @@ public class AppMenuBar extends JMenuBar {
         new RPCheckBoxMenuItem(new AppActions.ToggleOverlayAction(overlayManager), overlayMenu);
     menuItem.setText(overlayManager.getName());
     if (overlayManager.getLocked() && !MapTool.getPlayer().isGM()) {
-      overlayMenu.add(menuItem).setEnabled(false);
-    } else {
-      overlayMenu.add(menuItem);
+      menuItem.setEnabled(false);
     }
+    overlayMenu.add(menuItem);
     overlayMenu.setEnabled(true);
     overlayItems.put(overlayManager.getName(), menuItem);
+  }
+
+  /**
+   * Enables or disables an overlay menu item based on whether the overlay is locked.
+   *
+   * @param overlayManager The overlay being updated.
+   */
+  public static void updateOverlayMenuLocked(HTMLOverlayManager overlayManager) {
+    // Never lock out a GM.
+    boolean enabled = MapTool.getPlayer().isGM() ? true : !overlayManager.getLocked();
+    JCheckBoxMenuItem menuItem = overlayItems.get(overlayManager.getName());
+    if (menuItem != null) {
+      menuItem.setEnabled(enabled);
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -268,6 +268,7 @@ public class HTMLOverlayPanel extends JFXPanel {
                 overlays.add(overlayManager);
               }
               overlayManager.setLocked(locked);
+              AppMenuBar.updateOverlayMenuLocked(overlayManager);
             }
 
           } else {


### PR DESCRIPTION
### Identify the Bug or Feature request

#5235

### Description of the Change

This fixes an issue where an overlay that transitions from unlocked to locked remains togglable under the Windwos menu.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5282)
<!-- Reviewable:end -->
