### PR TITLE
Add back the AbstractTemplate.zoneId field so XStream can reference it

### DIFF
--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractTemplate.java
@@ -41,6 +41,13 @@ public abstract class AbstractTemplate extends AbstractDrawing {
   /** The location of the vertex where painting starts. */
   private ZonePoint vertex = new ZonePoint(0, 0);
 
+  /**
+   * @deprecated This used to indicate the zone where this drawable is painted. We no longer track
+   *     this in the drawing, but old campaign files may keep a reference to this field. So we have
+   *     to keep this around so XStream can find the value if it needs it.
+   */
+  @Deprecated private GUID zoneId;
+
   protected AbstractTemplate() {}
 
   protected AbstractTemplate(GUID id) {
@@ -51,6 +58,11 @@ public abstract class AbstractTemplate extends AbstractDrawing {
     super(other);
     this.radius = other.radius;
     this.vertex = new ZonePoint(other.vertex);
+  }
+
+  public Object readResolve() {
+    zoneId = null;
+    return this;
   }
 
   /*---------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5285

### Description of the Change

Adds back the `AbstractTemplate.zoneId`. XStream likes to use it as a target for references pre-1.16, but can't find the value back if the field is removed.

We null it out in `readResolve()` so the field isn't serialized going forward and won't be the target of a reference.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where copying maps with templates on 1.15 can make the campaign unable to be opened in 1.16.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5287)
<!-- Reviewable:end -->
