### PR TITLE
Add logic to delete old nightly builds and tags

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron:  '13 2 * * *' # Odd time so that it doesn't run afoul of busy periods everyone picks
+    - cron: '13 2 * * *' # Odd time so that it doesn't run afoul of busy periods everyone picks
 
 jobs:
   build:
@@ -23,3 +23,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
           gh release create  nightly-${NIGHTLY_DATE} -R ${{github.repository}} --title "MapTool Nightly ${NIGHTLY_DATE}"  --notes "MapTool Nightly Build for ${NIGHTLY_DATE}" --generate-notes -p --target develop
+      - name: Delete old Nightly releases
+        id: delete-old
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
+        run: |
+          gh release list -R ${{ github.repository}} | grep nightly | awk '{ print $1}' | xargs -n 1 gh release delete -R ${{ github.repository}} -y

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
-          gh release list -R ${{ github.repository}} | grep nightly | awk '{ print $1}' | xargs -n 1 gh release delete -R ${{ github.repository}} -y
+          gh release list -R ${{ github.repository}} | grep nightly | awk '{ print $5}' | xargs -n 1 gh release delete -R ${{ github.repository}} -y

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
-          gh release list -R ${{ github.repository}} | grep nightly | awk '{ print $5}' | xargs -n 1 gh release delete -R ${{ github.repository}} -y
+          gh release list -R ${{ github.repository}} | grep nightly | tail +2 |  awk '{ print $5}' | xargs -n 1 gh release delete -R ${{ github.repository}} -y --cleanup-tag

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
-          gh release list -R ${{ github.repository}} | grep nightly | tail +2 |  awk '{ print $5}' | xargs -n 1 gh release delete -R ${{ github.repository}} -y --cleanup-tag
+          gh release list -R ${{ github.repository }} --json 'name,tagName' --jq '.[] | select(.tagName | startswith("nightly"))|.tagName' | tail +2 | xargs -n 1 gh release delete -R ${{ github.repository}} -y --cleanup-tag


### PR DESCRIPTION

### Identify the Bug or Feature request
resolves #5293 5293


### Description of the Change
This will purge the old nightly builds and the tags associated with them so they don't build up and create a lot of "noise"

### Possible Drawbacks

Some one may want the old nightlies? Its unlikely though as the vast majority of them have 0 downloads

### Release Notes

-- Remove old nightly builds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5294)
<!-- Reviewable:end -->
