### PR TITLE
Disable escaping of HTML characters in json.indent()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -784,7 +784,9 @@ public class JSONMacroFunctions extends AbstractFunction {
    * @return The json as a formatted string.
    */
   public String jsonIndent(JsonElement json, int indent) {
-    final Gson gsonPrettyPrinting = new GsonBuilder().setPrettyPrinting().create();
+    final Gson gsonPrettyPrinting =
+        new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
     try (final Writer writer = new StringWriter()) {
       final JsonWriter jWriter = gsonPrettyPrinting.newJsonWriter(writer);
       jWriter.setIndent(" ".repeat(indent));


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5301 resulting from #5217

### Description of the Change

Despite not being required by the JSON spec, GSON by default escapes `<`, `>`, `&`, `=` and `'` to `\u003c`, `\u003e`, `\u0026`, `\u003d`, and `\u0027`, respectively. This commit changes that so these characters are left unescaped. This makes the results of `json.indent()` more readable as they were in 1.16 and earlier (actually, a little more so since `/` is not escaped by GSON).

### Possible Drawbacks

Dumping raw `json.indent()` results to chat will result in some stuff being parsed as HTML tags and entities.

### Documentation Notes

N/A

### Release Notes

- Fixed an issue with `json.indent()` unnecessarily escaping HTML characters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5303)
<!-- Reviewable:end -->
