### PR TITLE
1.16 - Fix bad FoW check in PointerTool

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1932,10 +1932,8 @@ public class PointerTool extends DefaultTool {
       // Make sure it's a valid move
       boolean isValid =
           (renderer.getZone().getGrid().getSize() >= 9)
-              ? validateMove(
-                  tokenBeingDragged, renderer.getSelectedTokenSet(), newAnchorPoint, dirx, diry)
-              : validateMove_legacy(
-                  tokenBeingDragged, renderer.getSelectedTokenSet(), newAnchorPoint);
+              ? validateMove(renderer.getSelectedTokenSet(), newAnchorPoint, dirx, diry)
+              : validateMove_legacy(renderer.getSelectedTokenSet(), newAnchorPoint);
       if (!isValid) {
         return;
       }
@@ -2001,7 +1999,7 @@ public class PointerTool extends DefaultTool {
     }
 
     private boolean validateMove(
-        Token leadToken, Set<GUID> tokenSet, ZonePoint point, int dirx, int diry) {
+        Set<GUID> tokenSet, ZonePoint leadTokenNewAnchor, int dirx, int diry) {
       if (MapTool.getPlayer().isGM()) {
         return true;
       }
@@ -2014,8 +2012,8 @@ public class PointerTool extends DefaultTool {
         boolean useTokenExposedArea =
             MapTool.getServerPolicy().isUseIndividualFOW()
                 && zone.getVisionType() != VisionType.OFF;
-        int deltaX = point.x - leadToken.getX();
-        int deltaY = point.y - leadToken.getY();
+        int deltaX = leadTokenNewAnchor.x - this.dragAnchor.x;
+        int deltaY = leadTokenNewAnchor.y - this.dragAnchor.y;
         Grid grid = zone.getGrid();
         // Loop through all tokens. As soon as one of them is blocked, stop processing and
         // return
@@ -2054,7 +2052,7 @@ public class PointerTool extends DefaultTool {
       return !isBlocked;
     }
 
-    private boolean validateMove_legacy(Token leadToken, Set<GUID> tokenSet, ZonePoint point) {
+    private boolean validateMove_legacy(Set<GUID> tokenSet, ZonePoint leadTokenNewAnchor) {
       Zone zone = renderer.getZone();
       if (MapTool.getPlayer().isGM()) {
         return true;
@@ -2068,8 +2066,8 @@ public class PointerTool extends DefaultTool {
         }
         isVisible = false;
         int fudgeSize = Math.max(Math.min((zone.getGrid().getSize() - 2) / 3 - 1, 8), 0);
-        int deltaX = point.x - leadToken.getX();
-        int deltaY = point.y - leadToken.getY();
+        int deltaX = leadTokenNewAnchor.x - this.dragAnchor.x;
+        int deltaY = leadTokenNewAnchor.y - this.dragAnchor.y;
         Rectangle bounds = new Rectangle();
         for (GUID tokenGUID : tokenSet) {
           Token token = zone.getToken(tokenGUID);

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1859,36 +1859,13 @@ public class PointerTool extends DefaultTool {
       }
 
       ZonePoint zonePoint = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
-
-      zonePoint.x = this.dragAnchor.x + zonePoint.x - tokenDragStart.x;
-      zonePoint.y = this.dragAnchor.y + zonePoint.y - tokenDragStart.y;
-
-      var grid = renderer.getZone().getGrid();
-      if (tokenBeingDragged.isSnapToGrid()
-          && grid.getCapabilities().isSnapToGridSupported()
-          && AppPreferences.tokensSnapWhileDragging.get()) {
-        // Snap to grid point.
-        zonePoint = grid.convert(grid.convert(zonePoint));
-
-        if (debugEnabled) {
-          renderer.setShape(new Rectangle2D.Double(zonePoint.x - 5, zonePoint.y - 5, 10, 10));
-        }
-
-        // Adjust given offet from grid to anchor point.
-        zonePoint.x += this.snapOffsetX;
-        zonePoint.y += this.snapOffsetY;
-      }
+      zonePoint.x += dragAnchor.x - tokenDragStart.x;
+      zonePoint.y += dragAnchor.y - tokenDragStart.y;
 
       if (debugEnabled) {
         renderer.setShape2(new Rectangle2D.Double(zonePoint.x - 5, zonePoint.y - 5, 10, 10));
       }
-
-      @Nullable ZonePoint previous = renderer.getLastWaypoint(tokenBeingDragged.getId());
-      if (previous == null) {
-        doDragTo(zonePoint, 0, 0);
-      } else {
-        doDragTo(zonePoint, zonePoint.x - previous.x, zonePoint.y - previous.y);
-      }
+      doDragTo(zonePoint);
     }
 
     public void moveByKey(double dx, double dy) {
@@ -1904,9 +1881,6 @@ public class PointerTool extends DefaultTool {
 
         zp.x += snapOffsetX;
         zp.y += snapOffsetY;
-
-        dx = zp.x - tokenBeingDragged.getX();
-        dy = zp.y - tokenBeingDragged.getY();
       } else {
         // Scalar for dx/dy in zone space. Defaulting to essentially 1 pixel.
         int moveFactor = 1;
@@ -1920,20 +1894,45 @@ public class PointerTool extends DefaultTool {
         zp = new ZonePoint(x, y);
       }
 
-      doDragTo(zp, (int) dx, (int) dy);
+      doDragTo(zp);
     }
 
-    private void doDragTo(ZonePoint newAnchorPoint, int dirx, int diry) {
+    private void doDragTo(ZonePoint newAnchorPoint) {
+
+      // For snapped tokens, validation is done snapped as well, even if the "snap token while
+      // dragging preference" if disabled.
+      var validationAnchorPoint = newAnchorPoint;
+      var grid = renderer.getZone().getGrid();
+      ZonePoint previousAnchorPoint = tokenDragCurrent;
+      if (tokenBeingDragged.isSnapToGrid() && grid.getCapabilities().isSnapToGridSupported()) {
+        // Snap to grid point.
+        validationAnchorPoint = grid.convert(grid.convert(validationAnchorPoint));
+
+        // Adjust given offset from grid to anchor point.
+        validationAnchorPoint.x += this.snapOffsetX;
+        validationAnchorPoint.y += this.snapOffsetY;
+
+        previousAnchorPoint = grid.convert(grid.convert(previousAnchorPoint));
+        previousAnchorPoint.x += this.snapOffsetX;
+        previousAnchorPoint.y += this.snapOffsetY;
+      }
+      if (AppPreferences.tokensSnapWhileDragging.get()) {
+        newAnchorPoint = validationAnchorPoint;
+      }
+
       // Don't bother if there isn't any movement
       if (!renderer.hasMoveSelectionSetMoved(tokenBeingDragged.getId(), newAnchorPoint)) {
         return;
       }
 
-      // Make sure it's a valid move
+      // Make sure it's a valid move.
+      int dirx = validationAnchorPoint.x - previousAnchorPoint.x;
+      int diry = validationAnchorPoint.y - previousAnchorPoint.y;
       boolean isValid =
-          (renderer.getZone().getGrid().getSize() >= 9)
-              ? validateMove(renderer.getSelectedTokenSet(), newAnchorPoint, dirx, diry)
-              : validateMove_legacy(renderer.getSelectedTokenSet(), newAnchorPoint);
+          previousAnchorPoint.equals(validationAnchorPoint)
+              || ((renderer.getZone().getGrid().getSize() >= 9)
+                  ? validateMove(renderer.getSelectedTokenSet(), validationAnchorPoint, dirx, diry)
+                  : validateMove_legacy(renderer.getSelectedTokenSet(), validationAnchorPoint));
       if (!isValid) {
         return;
       }

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -1195,23 +1195,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
       }
 
       ZonePoint zonePoint = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
-
-      zonePoint.x = this.dragAnchor.x + zonePoint.x - tokenDragStart.x;
-      zonePoint.y = this.dragAnchor.y + zonePoint.y - tokenDragStart.y;
-
-      var grid = renderer.getZone().getGrid();
-      if (tokenBeingDragged.isSnapToGrid() && grid.getCapabilities().isSnapToGridSupported()) {
-        // Snap to grid point.
-        zonePoint = grid.convert(grid.convert(zonePoint));
-
-        if (debugEnabled) {
-          renderer.setShape(new Rectangle2D.Double(zonePoint.x - 5, zonePoint.y - 5, 10, 10));
-        }
-
-        // Adjust given offet from grid to anchor point.
-        zonePoint.x += this.snapOffsetX;
-        zonePoint.y += this.snapOffsetY;
-      }
+      zonePoint.x += dragAnchor.x - tokenDragStart.x;
+      zonePoint.y += dragAnchor.y - tokenDragStart.y;
 
       if (debugEnabled) {
         renderer.setShape2(new Rectangle2D.Double(zonePoint.x - 5, zonePoint.y - 5, 10, 10));
@@ -1244,11 +1229,21 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     }
 
     private void doDragTo(ZonePoint newAnchorPoint) {
-      tokenDragCurrent = new ZonePoint(newAnchorPoint);
-
       // Don't bother if there isn't any movement
       if (!renderer.hasMoveSelectionSetMoved(tokenBeingDragged.getId(), newAnchorPoint)) {
         return;
+      }
+
+      tokenDragCurrent = new ZonePoint(newAnchorPoint);
+
+      var grid = renderer.getZone().getGrid();
+      if (tokenBeingDragged.isSnapToGrid() && grid.getCapabilities().isSnapToGridSupported()) {
+        // Snap to grid point.
+        newAnchorPoint = grid.convert(grid.convert(newAnchorPoint));
+
+        // Adjust given offset from grid to anchor point.
+        newAnchorPoint.x += this.snapOffsetX;
+        newAnchorPoint.y += this.snapOffsetY;
       }
 
       renderer.updateMoveSelectionSet(tokenBeingDragged.getId(), newAnchorPoint);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5308

### Description of the Change

This fixes two issues with `PointerTool`:
1. During validation, token bounds must offset based on the lead token anchor position instead of it's regular x/y coordinates. The rest of the drag logic works off anchor position since 1.16, so this needed an update as well.
2. Separates the validation logic from the "Snap Token while dragging" preference so it isn't required to get consistent validation for snap-to-grid tokens.

`StampTool` was updated in a similar way to stay as much in line with `PointerTool` as possible, even though it doesn't have the same underlying issue due to not validating stamp moves.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where hard FoW would erroneously block token moves in some cases and fail to moves in other cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5309)
<!-- Reviewable:end -->
