### PR TITLE
Fix hex grid dimensions when reading from GridDto

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -1035,18 +1035,29 @@ public abstract class Grid implements Cloneable {
   }
 
   public static Grid fromDto(GridDto dto) {
-    Grid grid = null;
-    switch (dto.getTypeCase()) {
-      case GRIDLESS_GRID -> grid = new GridlessGrid();
-      case HEX_GRID -> {
-        grid = HexGrid.fromDto(dto.getHexGrid());
-      }
-      case SQUARE_GRID -> grid = new SquareGrid();
-      case ISOMETRIC_GRID -> grid = new IsometricGrid();
-    }
+    Runnable postProcess = () -> {};
+    Grid grid =
+        switch (dto.getTypeCase()) {
+          case GRIDLESS_GRID -> new GridlessGrid();
+          case HEX_GRID -> {
+            var hexDto = dto.getHexGrid();
+            var hexGrid = hexDto.getVertical() ? new HexGridVertical() : new HexGridHorizontal();
+            postProcess = () -> hexGrid.readDto(hexDto);
+            yield hexGrid;
+          }
+          case SQUARE_GRID -> new SquareGrid();
+          case ISOMETRIC_GRID -> new IsometricGrid();
+          default -> {
+            log.error("Unrecognized Grid DTO: {}. Defaulting to square grid", dto.getTypeCase());
+            yield new SquareGrid();
+          }
+        };
+
     grid.offsetX = dto.getOffsetX();
     grid.offsetY = dto.getOffsetY();
     grid.size = dto.getSize();
+    postProcess.run();
+
     grid.cellShape = grid.createCellShape();
 
     return grid;

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -603,17 +603,9 @@ public abstract class HexGrid extends Grid {
 
   protected abstract OffsetTranslator getOffsetTranslator();
 
-  public static HexGrid fromDto(HexGridDto dto) {
-    HexGrid grid = null;
-    if (dto.getVertical()) {
-      grid = new HexGridVertical();
-    } else {
-      grid = new HexGridHorizontal();
-    }
-
-    // Exact values do not matter, just the proportions. Grid itself will scale to the right size.
-    grid.setDimensions(100, 100 / grid.hexRatio);
-    return grid;
+  protected void readDto(HexGridDto dto) {
+    hexRatio = dto.getHexRatio();
+    setDimensions(getSize(), getSize() / hexRatio);
   }
 
   protected void fillDto(GridDto.Builder dto) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5307

### Description of the Change

Hex grids have a `hexRatio` property that relates their grid size (first dimension) to their second dimension. In 1.16, this `hexRatio` property was missed during deserializing of `GridDto` messages. But we also need to set hex dimension after the grid size is known, so that various internal properties can be properly calculated - this was also not handled correctly.

This PR change `Grid.fromDto()` to set up the common properties, then run a post-processing step where hex grids can fill in the rest.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where hex grids would not be sized correctly on connected clients if the grid size was not 100.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5310)
<!-- Reviewable:end -->
