### PR TITLE
1.16 - fix map dragging for drawing tools and expose tools

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -291,5 +291,7 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
         submit(result.shape());
       }
     }
+
+    super.mouseReleased(e);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
@@ -200,5 +200,7 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
         submit(result.shape());
       }
     }
+
+    super.mouseReleased(e);
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5312

### Description of the Change

Releases of right mouse buttons were not being sent to `DefaultTool`, so drags were never properly "completed". This make the next drag carry over some old state.

This PR changes `DrawingTool` and `ExposeTool` to forward mouse releases to `DefaultTool`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the map would jump when dragging it with drawing tools or fog of war tools.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5314)
<!-- Reviewable:end -->
