### PR TITLE
1.16 - Make tooltips show again for drawing tools, fog of war tools, and topology tools

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingLikeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingLikeTool.java
@@ -22,10 +22,30 @@ import net.rptools.maptool.client.tool.DefaultTool;
 import net.rptools.maptool.client.tool.ToolHelper;
 import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.ZonePoint;
 
 public abstract class AbstractDrawingLikeTool extends DefaultTool implements ZoneOverlay {
+  private final String instructionKey;
+  private final String tooltipKey;
   private boolean isEraser;
+
+  protected AbstractDrawingLikeTool(String instructionKey, String tooltipKey) {
+    this.instructionKey = instructionKey;
+    this.tooltipKey = tooltipKey;
+
+    setToolTipText(I18N.getText(tooltipKey));
+  }
+
+  @Override
+  public String getInstructions() {
+    return instructionKey;
+  }
+
+  @Override
+  public String getTooltip() {
+    return tooltipKey;
+  }
 
   protected void setIsEraser(boolean eraser) {
     isEraser = eraser;

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
@@ -22,6 +22,7 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
+import net.rptools.maptool.client.tool.DefaultTool;
 import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.Zone.Layer;
@@ -29,12 +30,13 @@ import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.Pen;
 
 /** Base class for tools that draw templates. */
-public abstract class AbstractTemplateTool extends AbstractDrawingLikeTool implements ZoneOverlay {
+public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOverlay {
 
   private static final long serialVersionUID = 9121558405484986225L;
 
   private boolean isSnapToGridSelected;
   private boolean isEraseSelected;
+  private boolean isEraser;
 
   protected AffineTransform getPaintTransform(ZoneRenderer renderer) {
     AffineTransform transform = new AffineTransform();
@@ -69,18 +71,17 @@ public abstract class AbstractTemplateTool extends AbstractDrawingLikeTool imple
     super.detachFrom(renderer);
   }
 
+  protected void setIsEraser(boolean eraser) {
+    isEraser = eraser;
+  }
+
+  protected boolean isEraser() {
+    return isEraser;
+  }
+
   protected boolean isEraser(MouseEvent e) {
     boolean defaultValue = MapTool.getFrame().getColorPicker().isEraseSelected();
     if (SwingUtil.isShiftDown(e)) {
-      // Invert from the color panel
-      defaultValue = !defaultValue;
-    }
-    return defaultValue;
-  }
-
-  protected boolean isSnapToGrid(MouseEvent e) {
-    boolean defaultValue = MapTool.getFrame().getColorPicker().isSnapSelected();
-    if (SwingUtil.isControlDown(e)) {
       // Invert from the color panel
       defaultValue = !defaultValue;
     }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -36,8 +36,6 @@ import net.rptools.maptool.model.drawing.Pen;
 import net.rptools.maptool.model.drawing.ShapeDrawable;
 
 public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
-  private final String instructionKey;
-  private final String tooltipKey;
   private final Strategy<StateT> strategy;
 
   /** The current state of the tool. If {@code null}, nothing is being drawn right now. */
@@ -47,19 +45,9 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
   private boolean centerOnOrigin = false;
 
   public DrawingTool(String instructionKey, String tooltipKey, Strategy<StateT> strategy) {
-    this.instructionKey = instructionKey;
-    this.tooltipKey = tooltipKey;
+    super(instructionKey, tooltipKey);
+
     this.strategy = strategy;
-  }
-
-  @Override
-  public String getInstructions() {
-    return instructionKey;
-  }
-
-  @Override
-  public String getTooltip() {
-    return tooltipKey;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
@@ -30,8 +30,6 @@ import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
 
 public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
-  private final String instructionKey;
-  private final String tooltipKey;
   private final Strategy<StateT> strategy;
 
   /** The current state of the tool. If {@code null}, nothing is being drawn right now. */
@@ -41,19 +39,9 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
   private boolean centerOnOrigin = false;
 
   public ExposeTool(String instructionKey, String tooltipKey, Strategy<StateT> strategy) {
-    this.instructionKey = instructionKey;
-    this.tooltipKey = tooltipKey;
+    super(instructionKey, tooltipKey);
+
     this.strategy = strategy;
-  }
-
-  @Override
-  public String getInstructions() {
-    return instructionKey;
-  }
-
-  @Override
-  public String getTooltip() {
-    return tooltipKey;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
@@ -32,8 +32,6 @@ import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
 
 public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
-  private final String instructionKey;
-  private final String tooltipKey;
   private final boolean isFilled;
   private final Strategy<StateT> strategy;
   private final TopologyModeSelectionPanel topologyModeSelectionPanel;
@@ -54,8 +52,8 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
       boolean isFilled,
       Strategy<StateT> strategy,
       TopologyModeSelectionPanel topologyModeSelectionPanel) {
-    this.instructionKey = instructionKey;
-    this.tooltipKey = tooltipKey;
+    super(instructionKey, tooltipKey);
+
     this.isFilled = isFilled;
     this.strategy = strategy;
     // Consistency with topology tools before refactoring. Can be updated as part of #5002.
@@ -63,16 +61,6 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
     this.topologyModeSelectionPanel = topologyModeSelectionPanel;
 
     this.maskOverlay = new MaskOverlay();
-  }
-
-  @Override
-  public String getInstructions() {
-    return instructionKey;
-  }
-
-  @Override
-  public String getTooltip() {
-    return tooltipKey;
   }
 
   @Override


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5313

### Description of the Change

The `Tool` constructor sets the tool's tooltip using `getTooltip()` which subclasses must implement. This worked when all tools had a hardcoded key in their overrides. But it does not work for instance-based tools as the override relies on subclass state that has not had a chance to be initialized yet.

This PR changes `AbstractDrawingLikeTool` to accept the tooltip (and instructions) as constructor parameters and sets the tooltip based on that. It also changes `AbstractTemplateTool` to not inherit from `AbstractDrawingLikeTool` since it reallly has nothing in common with it and I did't want to pipe this constructor change throughout the template hierarchy.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where tooltips were not showing for drawing tools, fog of war tools, or topology tools.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5315)
<!-- Reviewable:end -->
