### PR TITLE
Exclude all bin/ directories from git source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ Thumbs.db
 .gradle
 .gradletasknamecache
 build/
-/bin/
+bin/
 target/
 out/
 /releases/


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #5319 


### Description of the Change
Changes the .gitignore line from `/bin/` to `bin/` so all bin directories are excluded not just the one in the root directory

### Possible Drawbacks
Should be none 

### Documentation Notes

All "bin" directories are now excluded from source control

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in MapTools's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- Fixed an issue where `getMapVisible()` returned strings instead of numbers
- Added the option for overriding players name in token speech/thought bubble.

-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5320)
<!-- Reviewable:end -->
