### PR TITLE
Revert "Support strformat literals without passing args"

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StringFunctions.java
@@ -230,7 +230,11 @@ public class StringFunctions extends AbstractFunction {
       }
       if (functionName.equalsIgnoreCase("strformat")) {
         int size = parameters.size();
-        return format(parameters.get(0).toString(), resolver, parameters.subList(1, size));
+        if (size > 1) {
+          return format(parameters.get(0).toString(), resolver, parameters.subList(1, size));
+        } else {
+          return format(parameters.get(0).toString(), resolver, null);
+        }
       }
       if (functionName.equalsIgnoreCase("matches")) {
         if (parameters.size() < 2) {
@@ -437,6 +441,10 @@ public class StringFunctions extends AbstractFunction {
       }
     }
     m.appendTail(sb);
+
+    if (args == null) {
+      return sb.toString();
+    }
 
     Object[] argArray = args.toArray();
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Reverts #5227

### Description of the Change

There are a lot of occurrences out in the wild already where standalone `%` characters are used with the one-argument form of `strformat()`. The change to be more consistent is breaking a lot of these cases. This PR reverts the change so these existing uses of `strformat()` will continue to work in 1.17 and beyond.

### Possible Drawbacks

No more sane one-argument `strformat()`.

### Documentation Notes

When used with only one argument - the format string - `strformat()` does not interpret special format specifiers such as `%n`. When used with multiple arguments, `strformat()` will respect these sequences.

### Release Notes

- Reverted `strformat()` to not respect format specifiers when used with only one argument.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5343)
<!-- Reviewable:end -->
