### PR TITLE
Update parser library to get its unicode-safe parser

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -153,7 +153,7 @@ miglayout-swing              = { group = "com.miglayout",               name = "
 # default resources (token, textures etc.)
 rptools-maptool-resources    = { group = "com.github.RPTools",          name = "maptool-resources",       version = "1.6.0"           }
 # parser for macros
-rptools-parser               = { group = "com.github.RPTools",          name = "parser",                  version = "1.8.3"           }
+rptools-parser               = { group = "com.github.RPTools",          name = "parser",                  version = "2.0.0"           }
 # Built In Add-on Libraries
 rptools-maptool-addons       = { group = "com.github.RPTools",          name = "maptool-builtin-addons",  version = "1.3"             }
 # For advanced dice roller

--- a/src/test/java/net/rptools/dicelib/expression/ExpressionParserTest.java
+++ b/src/test/java/net/rptools/dicelib/expression/ExpressionParserTest.java
@@ -243,7 +243,6 @@ public class ExpressionParserTest {
     assertEquals(new BigDecimal(4), result.getValue());
   }
 
-  @Test
   private VariableResolver initVar(String name, Object value) throws ParserException {
     VariableResolver result = new MapVariableResolver();
     result.setVariable(name, value);
@@ -384,7 +383,6 @@ public class ExpressionParserTest {
     assertEquals(flattenings[0], 1);
   }
 
-  @Test
   private void evaluateExpression(ExpressionParser p, String expression, BigDecimal answer)
       throws ParserException {
     Result result = p.evaluate(expression);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #3076

### Description of the Change

Since 2.0, RPTools/parser uses a unicode-safe antlr4 parser instead of the latin1 antlr2 parser used previously. As such, unicode characters should no longer be eaten or mangled the parser.

### Possible Drawbacks

The new parser is rewritten from the ground up. So there's a chance some existing valid inputs will be rejected, or invalid inputs will be accepted.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where unicode characters would not have handled properly in macros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5345)
<!-- Reviewable:end -->
