### PR TITLE
Bring back some old AreaTree concepts when preparing BL and FoW

### DIFF
--- a/src/test/java/net/rptools/lib/GeometryUtilTest.java
+++ b/src/test/java/net/rptools/lib/GeometryUtilTest.java
@@ -94,6 +94,233 @@ public class GeometryUtilTest {
     }
     // endregion
 
+    // region Simple ring with highly precise backstep
+    {
+      final var path = new Path2D.Double();
+      path.moveTo(-50.095238095238095, 1300.0);
+      path.lineTo(-47.56210321998909, 1302.0459935530857);
+      path.lineTo(-47.56210321998924, 1302.0459935530857);
+      path.lineTo(-47.56211853027344, 1302.0460205078125);
+      path.lineTo(-34.0, 1313.0);
+      path.lineTo(-22.296453965448677, 1316.0530989655351);
+      path.lineTo(-22.296453965448904, 1316.0530989655351);
+      path.lineTo(-22.29646110534668, 1316.0531005859375);
+      path.lineTo(-11.0, 1319.0);
+      path.lineTo(-4.618527782440651E-14, 1331.2222222222222);
+      path.lineTo(0.0, 1331.2222222222222);
+      path.lineTo(0.0, 1300.0);
+      path.closePath();
+      final var area = new Area(path);
+      final var polygons =
+          new Polygon[] {
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(-47.56210321998909, 1302.0459935530857),
+                  new Coordinate(-47.56211853027344, 1302.0460205078125),
+                  new Coordinate(-34, 1313.0),
+                  // Bit odd that this points comes first, but it gives good geometry.
+                  new Coordinate(-22.29646110534668, 1316.0531005859375),
+                  new Coordinate(-22.296453965448677, 1316.0530989655351),
+                  new Coordinate(-11.0, 1319.0),
+                  new Coordinate(0, 1331.22222),
+                  new Coordinate(0, 1300),
+                  new Coordinate(-50.095238095238095, 1300.0),
+                  new Coordinate(-47.56210321998909, 1302.0459935530857)
+                }),
+          };
+
+      argumentsList.add(
+          Arguments.of(
+              Named.of("Simple ring with highly precise backstep", area), List.of(polygons)));
+    }
+    // endregion
+
+    // region Geometry with a collapsible tiny polygon.
+    {
+      final var path = new Path2D.Double();
+      // This first polygon is completely normal.
+      path.moveTo(0, 0);
+      path.lineTo(400, 0);
+      path.lineTo(400, 400);
+      path.lineTo(0, 400);
+      path.closePath();
+      // But this one is so tiny it must be eliminated.
+      path.moveTo(-332.37481837239756, 1635.6524985778758);
+      path.lineTo(-332.3748183723977, 1635.652498577876);
+      path.lineTo(-332.37481837239727, 1635.652498577876);
+      path.lineTo(-332.3748183723976, 1635.6524985778758);
+      path.closePath();
+      final var area = new Area(path);
+      final var polygons =
+          new Polygon[] {
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(0, 400),
+                  new Coordinate(400, 400),
+                  new Coordinate(400, 0),
+                  new Coordinate(0, 0),
+                  new Coordinate(0, 400),
+                }),
+          };
+
+      argumentsList.add(
+          Arguments.of(
+              Named.of("Geometry with a collapsible tiny polygon.", area), List.of(polygons)));
+    }
+    // endregion
+
+    // region Ocean contained in island's bounding box but not actually a child of that island.
+    {
+      final var path = new Path2D.Double();
+      // Main big island.
+      path.moveTo(-200, -100);
+      path.lineTo(200, -100);
+      path.lineTo(200, 200);
+      path.lineTo(-200, 200);
+      path.lineTo(-200, 1000);
+      path.lineTo(-500, 1000);
+      path.lineTo(-500, -1000);
+      path.lineTo(-200, -1000);
+      path.closePath();
+      // Cut out an ocean
+      path.moveTo(0, 0);
+      path.lineTo(0, 100);
+      path.lineTo(100, 100);
+      path.lineTo(100, 0);
+      path.closePath();
+      // Smaller island whose bounding box encompasses the above ocean.
+      path.moveTo(-100, -200);
+      path.lineTo(-100, -300);
+      path.lineTo(400, -300);
+      path.lineTo(400, 400);
+      path.lineTo(-100, 400);
+      path.lineTo(-100, 300);
+      path.lineTo(300, 300);
+      path.lineTo(300, -200);
+      path.closePath();
+
+      final var area = new Area(path);
+      final var polygons =
+          new Polygon[] {
+
+            // Second polygon is the smaller island.
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(-100, -200),
+                  new Coordinate(300, -200),
+                  new Coordinate(300, 300),
+                  new Coordinate(-100, 300),
+                  new Coordinate(-100, 400),
+                  new Coordinate(400, 400),
+                  new Coordinate(400, -300),
+                  new Coordinate(-100, -300),
+                  new Coordinate(-100, -200),
+                }),
+
+            // First polygon is the big island with the ocean.
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(-200, 1000),
+                  new Coordinate(-200, 200),
+                  new Coordinate(200, 200),
+                  new Coordinate(200, -100),
+                  new Coordinate(-200, -100),
+                  new Coordinate(-200, -1000),
+                  new Coordinate(-500, -1000),
+                  new Coordinate(-500, 1000),
+                  new Coordinate(-200, 1000),
+                },
+                new Coordinate[] {
+                  new Coordinate(0, 100),
+                  new Coordinate(0, 0),
+                  new Coordinate(100, 0),
+                  new Coordinate(100, 100),
+                  new Coordinate(0, 100),
+                }),
+          };
+
+      argumentsList.add(
+          Arguments.of(
+              Named.of(
+                  "Ocean contained in island's bounding box but not actually a child of that island.",
+                  area),
+              List.of(polygons)));
+    }
+    // endregion
+
+    // region Self-intersection must be handled reasonably
+    {
+      final var path = new Path2D.Double();
+      // A simple bow-tie.
+      path.moveTo(0, 0);
+      path.lineTo(100, 0);
+      path.lineTo(0, 100);
+      path.lineTo(100, 100);
+      path.closePath();
+
+      final var area = new Area(path);
+      final var polygons =
+          new Polygon[] {
+            // Reduces to two triangular polygons.
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(50, 50),
+                  new Coordinate(100, 0),
+                  new Coordinate(0, 0),
+                  new Coordinate(50, 50),
+                }),
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(0, 100),
+                  new Coordinate(100, 100),
+                  new Coordinate(50, 50),
+                  new Coordinate(0, 100),
+                }),
+          };
+
+      argumentsList.add(
+          Arguments.of(
+              Named.of("Self-intersection must be handled reasonably", area), List.of(polygons)));
+    }
+    // endregion
+
+    // region Tiny self-intersection must not affect topological structure
+    {
+      final var path = new Path2D.Double();
+      // A box with a self-intersection along one edge.
+      path.moveTo(0, 0);
+      path.lineTo(100, 0);
+
+      // Introduce a tiny error that causes a self-intersection in the edge of the box.
+      final var error = 1e-6;
+      path.lineTo(100 + error, 50 + error);
+      path.lineTo(100 + error, 50 - error);
+
+      path.lineTo(100, 100);
+      path.lineTo(0, 100);
+      path.closePath();
+
+      final var area = new Area(path);
+      final var polygons =
+          new Polygon[] {
+            // Reduces to a single square.
+            createPrecisePolygon(
+                new Coordinate[] {
+                  new Coordinate(0, 0),
+                  new Coordinate(100, 0),
+                  new Coordinate(100, 100),
+                  new Coordinate(0, 100),
+                  new Coordinate(0, 0),
+                }),
+          };
+
+      argumentsList.add(
+          Arguments.of(
+              Named.of("Tiny self-intersection must not affect topological structure", area),
+              List.of(polygons)));
+    }
+    // endregion
+
     // region Cut and paste back connected areas
     {
       /*

--- a/src/test/java/net/rptools/lib/GeometryUtilTest.java
+++ b/src/test/java/net/rptools/lib/GeometryUtilTest.java
@@ -14,6 +14,8 @@
  */
 package net.rptools.lib;
 
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
 import java.awt.geom.Area;
 import java.awt.geom.Path2D;
 import java.util.ArrayList;
@@ -21,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,8 +40,8 @@ public class GeometryUtilTest {
   @ParameterizedTest
   @DisplayName(
       "Verify that meaningful topology is returned when converting AWT Area to JTS Geometry")
-  @MethodSource("areaProvider2")
-  void testConversionFromAreaToGeometry2(Area area, List<Polygon> expectedPolygons) {
+  @MethodSource("areaProvider")
+  void testConversionFromAreaToGeometry(Area area, List<Polygon> expectedPolygons) {
     var expectedGeometry =
         geometryFactory.createMultiPolygon(expectedPolygons.toArray(Polygon[]::new));
 
@@ -53,7 +54,7 @@ public class GeometryUtilTest {
     assert expectedGeometry.equalsTopo(multiPolygon) : "Polygons must have the correct topology";
   }
 
-  private static Iterable<Arguments> areaProvider2() {
+  private static Iterable<Arguments> areaProvider() {
     final var argumentsList = new ArrayList<Arguments>();
 
     // region Connected boxes
@@ -90,7 +91,7 @@ public class GeometryUtilTest {
                 new Coordinate(500, -300),
               });
 
-      argumentsList.add(Arguments.of(Named.of("Connected boxes", area), List.of(polygon)));
+      argumentsList.add(argumentSet("Connected boxes", area, List.of(polygon)));
     }
     // endregion
 
@@ -130,8 +131,7 @@ public class GeometryUtilTest {
           };
 
       argumentsList.add(
-          Arguments.of(
-              Named.of("Simple ring with highly precise backstep", area), List.of(polygons)));
+          argumentSet("Simple ring with highly precise backstep", area, List.of(polygons)));
     }
     // endregion
 
@@ -164,8 +164,7 @@ public class GeometryUtilTest {
           };
 
       argumentsList.add(
-          Arguments.of(
-              Named.of("Geometry with a collapsible tiny polygon.", area), List.of(polygons)));
+          argumentSet("Geometry with a collapsible tiny polygon.", area, List.of(polygons)));
     }
     // endregion
 
@@ -240,10 +239,9 @@ public class GeometryUtilTest {
           };
 
       argumentsList.add(
-          Arguments.of(
-              Named.of(
-                  "Ocean contained in island's bounding box but not actually a child of that island.",
-                  area),
+          argumentSet(
+              "Ocean contained in island's bounding box but not actually a child of that island.",
+              area,
               List.of(polygons)));
     }
     // endregion
@@ -279,8 +277,7 @@ public class GeometryUtilTest {
           };
 
       argumentsList.add(
-          Arguments.of(
-              Named.of("Self-intersection must be handled reasonably", area), List.of(polygons)));
+          argumentSet("Self-intersection must be handled reasonably", area, List.of(polygons)));
     }
     // endregion
 
@@ -315,8 +312,9 @@ public class GeometryUtilTest {
           };
 
       argumentsList.add(
-          Arguments.of(
-              Named.of("Tiny self-intersection must not affect topological structure", area),
+          argumentSet(
+              "Tiny self-intersection must not affect topological structure",
+              area,
               List.of(polygons)));
     }
     // endregion
@@ -392,8 +390,7 @@ public class GeometryUtilTest {
                 }),
           };
 
-      argumentsList.add(
-          Arguments.of(Named.of("Cut and paste back connected areas", area), List.of(polygons)));
+      argumentsList.add(argumentSet("Cut and paste back connected areas", area, List.of(polygons)));
     }
     // endregion
 
@@ -488,7 +485,7 @@ public class GeometryUtilTest {
                 new Coordinate(383.37867981847495, 129.5),
               });
 
-      argumentsList.add(Arguments.of(Named.of("Tiny crack in area", area), List.of(polygon)));
+      argumentsList.add(argumentSet("Tiny crack in area", area, List.of(polygon)));
     }
     // endregion
 
@@ -601,8 +598,7 @@ public class GeometryUtilTest {
                 }),
           };
 
-      argumentsList.add(
-          Arguments.of(Named.of("Polygon vertices touching edges", area), List.of(polygons)));
+      argumentsList.add(argumentSet("Polygon vertices touching edges", area, List.of(polygons)));
     }
     // endregion
 
@@ -736,7 +732,7 @@ public class GeometryUtilTest {
                 new Coordinate(4999.0, 6201.0),
               });
 
-      argumentsList.add(Arguments.of(Named.of("Butt joint accuracy", area), List.of(polygon)));
+      argumentsList.add(argumentSet("Butt joint accuracy", area, List.of(polygon)));
     }
     // endregion
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5159

### Description of the Change

First, some history:
- In **1.12**, we started restricting pathfinding to exposed FoW areas, converting these areas to JTS `Geometry` in the same way as MBL was already.
- In **1.13**, the MBL and FoW areas were converted to `Geometry` using `GeometryUtil.toJts()`, which was based on JTS `Polygonizer` for simplicity.
- In **1.14** and prior, we used an `AreaTree` representation of *BL for vision and lighting that was based on a hierarchy of oceans (clear space) and islands (filled space). Converting from `Area` to `AreaTree` was done through custom logic that detected the orientation of each ring in the `Area`.
- In **1.15**, we still used the `AreaTree` for *BL, but built it using JTS's `Polygonizer` as it was faster and simpler. This is the same polygonizer used for pathfinding since 1.13.
- In **1.16**, we no longer built an entire `AreaTree`, but let each island live on its own as a JTS `Polygon`. Buillding these polygons was still based on the `Polygonizer` as in 1.15.

Since 1.15 especially, we've had various reports of existing VBL and FoW breaking pathfinding and vision. Despite trying to tune the `Polygonizer` to fix these reports, cases have continued to be reported..

In an attempt to fix these issues, I've added several new test cases that are based on real-world issues encountered in recent MT versions. I tried a wide range of techniques to produce acceptable results for all of these cases, but I could not get any `Polygonizer`-based solution to work - different cases needed different incompatible fixes to be applid. And JTS's `Polygonizer` itself is not interested in (or is not capable of) preserving the specific structures that we rely on (nested polygons).

In the end, I just removed the `Polygonizer` from `GeometryUtil.toJts()` and `GeometryUtil.toJtsPolygons()` and went back to the custom logic we used to use when building `AreaTree`. We don't build an entire tree as that would be quite wasteful, and we're not reintroducing any of the related types that have long been removed. We are only incorporating just enough of the concept to produce `Polygon` objects from an `Area`:
1. Every clockwise ring is considered an island boundary.
2. Every counterclockwise ring is considered an ocean boundary.
3. Each ocean is attached to the smallest parent island containing the ocean (there is no global ocean in this concept).
4. Islands are not attached to any parent (we could do this, but it would be wasteful as mentioned above).

Once all oceans are associated with their parent islands, we convert each island into a `Polygon`. At this point, the resulting geometry is structurally valid, but there can still be small defects with the boundary of any given polygon or its holes. To address this, we pipe the polygon through a `GeometryPrecisionReducer` that will remove any ultra-precise defects from a polygon, possibly dividing an invalid polygon into more than one valid polygon.

There is finally a change to `MovementBlockingTopology` to filter out empty geometry as this can cause issues witth `PreparedGeometry`.

### Possible Drawbacks

Hopefully none as this seems to work for more cases than ever. But it's possible there is some other existing combination of VBL, MBL and FoW that will still cause issues.

### Documentation Notes

N/A

### Release Notes

- Modified how we handle vision and fog-of-war geometry to avoid problematic cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5355)
<!-- Reviewable:end -->
