### PR TITLE
Retain null in json.indent

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -785,7 +785,7 @@ public class JSONMacroFunctions extends AbstractFunction {
    */
   public String jsonIndent(JsonElement json, int indent) {
     final Gson gsonPrettyPrinting =
-        new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+        new GsonBuilder().setPrettyPrinting().serializeNulls().disableHtmlEscaping().create();
 
     try (final Writer writer = new StringWriter()) {
       final JsonWriter jWriter = gsonPrettyPrinting.newJsonWriter(writer);


### PR DESCRIPTION

### Identify the Bug or Feature request
Fixes #5358

### Description of the Change
JSON fields that are set to null are once more retained after passing the JSON to `json.indent`


### Possible Drawbacks

Should be none as its just reverting the output to the old behaviour


### Documentation Notes
JSON fields that are set to null are once more retained after passing the JSON to `json.indent`, mimicking the old behaviour


### Release Notes

- JSON fields that are set to null are once more retained after passing the JSON to `json.indent`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5359)
<!-- Reviewable:end -->
