### PR TITLE
Plural/Possessive emote fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/macro/MacroManager.java
+++ b/src/main/java/net/rptools/maptool/client/macro/MacroManager.java
@@ -112,7 +112,7 @@ public class MacroManager {
     registerMacro(new OOCMacro());
     registerMacro(new ChangeColorMacro());
     registerMacro(new WhisperReplyMacro());
-    registerMacro(new EmotePluralMacro());
+    registerMacro(new EmotePossessiveMacro());
     registerMacro(new TextureNoise());
     registerMacro(new VersionMacro());
     registerMacro(new AboutMacro());

--- a/src/main/java/net/rptools/maptool/client/macro/impl/EmotePossessiveMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/EmotePossessiveMacro.java
@@ -24,13 +24,13 @@ import net.rptools.maptool.util.MessageUtil;
 @MacroDefinition(
     name = "emotes",
     aliases = {"mes"},
-    description = "emoteplural.description")
-public class EmotePluralMacro extends AbstractMacro {
+    description = "emotePossessive.description")
+public class EmotePossessiveMacro extends AbstractMacro {
   public void execute(MacroContext context, String macro, MapToolMacroContext executionContext) {
     macro = processText(macro);
 
     MapTool.addMessage(
         TextMessage.say(
-            context.getTransformationHistory(), MessageUtil.getFormattedEmotePlural(macro, null)));
+            context.getTransformationHistory(), MessageUtil.getFormattedEmotePossessive(macro, null)));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/macro/impl/EmotePossessiveMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/EmotePossessiveMacro.java
@@ -31,6 +31,7 @@ public class EmotePossessiveMacro extends AbstractMacro {
 
     MapTool.addMessage(
         TextMessage.say(
-            context.getTransformationHistory(), MessageUtil.getFormattedEmotePossessive(macro, null)));
+            context.getTransformationHistory(),
+            MessageUtil.getFormattedEmotePossessive(macro, null)));
   }
 }

--- a/src/main/java/net/rptools/maptool/util/MessageUtil.java
+++ b/src/main/java/net/rptools/maptool/util/MessageUtil.java
@@ -15,7 +15,15 @@
 package net.rptools.maptool.util;
 
 import java.awt.Color;
+import java.util.Locale;
 import javax.swing.UIManager;
+
+import com.ibm.icu.impl.FormattedStringBuilder;
+import com.ibm.icu.impl.personname.PersonNameFormatterImpl;
+import com.ibm.icu.text.MessageFormat;
+import com.ibm.icu.text.PersonName;
+import com.ibm.icu.text.PersonNameFormatter;
+import com.ibm.icu.text.SimplePersonName;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
@@ -78,10 +86,11 @@ public class MessageUtil {
     return "<div class='emote'>" + getAvatarMessage(msg, token, identity) + "</div>";
   }
 
-  public static String getFormattedEmotePlural(String msg, Token token) {
+  public static String getFormattedEmotePossessive(String msg, Token token) {
     String identity =
         token == null ? MapTool.getFrame().getCommandPanel().getIdentity() : token.getName();
-    msg = applyChatColor(identity + "'s " + msg);
+    identity += identity.endsWith("s") ? "' " : "'s ";
+    msg = applyChatColor(identity + msg);
 
     return "<div class='emote'>" + getAvatarMessage(msg, token, identity) + "</div>";
   }

--- a/src/main/java/net/rptools/maptool/util/MessageUtil.java
+++ b/src/main/java/net/rptools/maptool/util/MessageUtil.java
@@ -15,15 +15,7 @@
 package net.rptools.maptool.util;
 
 import java.awt.Color;
-import java.util.Locale;
 import javax.swing.UIManager;
-
-import com.ibm.icu.impl.FormattedStringBuilder;
-import com.ibm.icu.impl.personname.PersonNameFormatterImpl;
-import com.ibm.icu.text.MessageFormat;
-import com.ibm.icu.text.PersonName;
-import com.ibm.icu.text.PersonNameFormatter;
-import com.ibm.icu.text.SimplePersonName;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1788,7 +1788,7 @@ emit.description = Broadcast text to all connected players without indicating wh
 
 emote.description       = Broadcast an emote to all connected players.
 
-emoteplural.description = Broadcast plural emote to all connected players.
+emotePossessive.description = Broadcast possessive emote to all connected players.
 
 experiments.description = Start experimental features.
 # Experimental features


### PR DESCRIPTION
### Identify the Bug or Feature request
resolves #5367

### Description of the Change
refactor plural emote to possessive emote.
changed output string to apostrophe only on noun ending in "s"

### Possible Drawbacks
none

### Documentation Notes
n/a

### Release Notes
n/a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5368)
<!-- Reviewable:end -->
