### PR TITLE
1.16 - Do not detach tool if new tool is not available to the player

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/Toolbox.java
+++ b/src/main/java/net/rptools/maptool/client/tool/Toolbox.java
@@ -118,15 +118,19 @@ public class Toolbox {
   public void setSelectedTool(final Tool tool) {
     EventQueue.invokeLater(
         () -> {
-          if (tool == currentTool) {
+          if (tool == null || tool == currentTool || !tool.isAvailable()) {
             return;
           }
 
           detach();
-          var accepted = makeCurrent(tool);
-          if (accepted) {
-            attach();
+
+          currentTool = tool;
+          tool.setSelected(true);
+          if (MapTool.getFrame() != null) {
+            MapTool.getFrame().setStatusMessage(I18N.getText(currentTool.getInstructions()));
           }
+
+          attach();
         });
   }
 
@@ -156,19 +160,5 @@ public class Toolbox {
         currentRenderer.removeOverlay((ZoneOverlay) currentTool);
       }
     }
-  }
-
-  private boolean makeCurrent(Tool tool) {
-    if (tool == null || !tool.isAvailable()) {
-      return false;
-    }
-
-    currentTool = tool;
-    tool.setSelected(true);
-    if (MapTool.getFrame() != null) {
-      MapTool.getFrame().setStatusMessage(I18N.getText(currentTool.getInstructions()));
-    }
-
-    return true;
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5377

### Description of the Change

This fixes an oversight in the `Toolbox` state machine where an outgoing tool would be disabled before checking whether the incoming tool is available to the player. So, for example, when a player switches from the Pointer tool to the Wall Topology tool (by clicking on the VBL tools), the Pointer tool is detached but remains current, and the Wall Topology tool is never attached since it is not available to the player. This leaves the player unable to interact with the map. If they then attempt to switch back to the Pointer tool, since it is already the current tool, none of its listeners are reattached. This leaves the user unable to interact until they switch to a tool that is available to them, such as the measurement tool.

This PR fixes that possibility by checking tool availability before detaching or doing anything else related to switching the tool.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where users could no longer interact with the map if they click on the FoW tools or the VBL tools.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5378)
<!-- Reviewable:end -->
