### PR TITLE
Scrolling status bar messages and associated app preferences

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client;
 
+import com.sun.jdi.FloatType;
 import com.twelvemonkeys.image.ResampleOp;
 import java.awt.Color;
 import java.awt.Graphics2D;
@@ -343,6 +344,19 @@ public class AppPreferences {
   public static final Preference<Integer> frameRateCap =
       IntegerType.create("frameRateCap", 60).validateIt(cap -> cap > 0);
 
+  /* Scroll status bar information messages that exceed the available size */
+  public static final Preference<Boolean> scrollStatusMessages =
+      BooleanType.create("statusBarScroll", true);
+  /* Scroll status bar scrolling speed */
+  public static final Preference<Float> scrollStatusSpeed =
+      FloatType.create("statusBarSpeed", 0.85f);
+  /* Scroll status bar scrolling start delay */
+  public static final Preference<Double> scrollStatusStartDelay =
+      DoubleType.create("statusBarDelay", 2.4);
+  /* Scroll status bar scrolling end pause */
+  public static final Preference<Double> scrollStatusEndPause =
+      DoubleType.create("statusBarDelay", 1.8);
+
   public static final Preference<Integer> upnpDiscoveryTimeout =
       IntegerType.create("upnpDiscoveryTimeout", 5000);
 
@@ -668,6 +682,22 @@ public class AppPreferences {
     @Override
     public Double get(Preferences prefs, String key, Supplier<Double> defaultValue) {
       return prefs.getDouble(key, defaultValue.get());
+    }
+  }
+
+  private static final class FloatType implements Type<Float> {
+    public static Preference<Float> create(String key, float defaultValue) {
+      return new Preference<>(key, defaultValue, new FloatType());
+    }
+
+    @Override
+    public void set(Preferences prefs, String key, Float value) {
+      prefs.putDouble(key, value);
+    }
+
+    @Override
+    public Float get(Preferences prefs, String key, Supplier<Float> defaultValue) {
+      return prefs.getFloat(key, defaultValue.get());
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -445,6 +445,18 @@ public class PreferencesDialog extends JDialog {
   // ** Checkbox for loading the most recently used campaign on startup */
   private final JCheckBox loadMRUcheckbox;
 
+  /** status bar scrolling checkbox */
+  private final JCheckBox statusScrollEnable;
+
+  /** status bar scrolling speed */
+  private final JSpinner statusScrollSpeedSpinner;
+
+  /** status bar scroll start delay */
+  private final JSpinner statusScrollStartDelaySpinner;
+
+  /** status bar scroll end delay */
+  private final JSpinner statusScrollEndPause;
+
   /**
    * Array of LocalizedComboItems representing the default grid types for the preferences dialog.
    * Each item in the array consists of a grid type and its corresponding localized display name.
@@ -730,6 +742,43 @@ public class PreferencesDialog extends JDialog {
     labelBorderWidthSpinner.setValue(AppPreferences.mapLabelBorderWidth.get());
     labelBorderArcSpinner = (JSpinner) panel.getComponent("labelBorderArcSpinner");
     labelBorderArcSpinner.setValue(AppPreferences.mapLabelBorderArc.get());
+
+    statusScrollEnable = panel.getCheckBox("statusScrollEnable");
+    statusScrollEnable.setSelected(AppPreferences.scrollStatusMessages.get());
+    statusScrollEnable.addChangeListener(
+        e -> AppPreferences.scrollStatusMessages.set(((JCheckBox) e.getSource()).isSelected()));
+
+    statusScrollSpeedSpinner = panel.getSpinner("statusScrollSpeedSpinner");
+    statusScrollSpeedSpinner.setModel(
+        new SpinnerNumberModel(
+            AppPreferences.scrollStatusSpeed.get().doubleValue(), 0.1, 5d, 0.01));
+    statusScrollSpeedSpinner.addChangeListener(
+        e ->
+            AppPreferences.scrollStatusSpeed.set(
+                ((SpinnerNumberModel) ((JSpinner) e.getSource()).getModel())
+                    .getNumber()
+                    .floatValue()));
+
+    statusScrollStartDelaySpinner = panel.getSpinner("statusScrollStartDelaySpinner");
+    statusScrollStartDelaySpinner.setModel(
+        new SpinnerNumberModel(
+            AppPreferences.scrollStatusStartDelay.get().doubleValue(), 0, 10d, 0.1));
+    statusScrollStartDelaySpinner.addChangeListener(
+        e ->
+            AppPreferences.scrollStatusStartDelay.set(
+                ((SpinnerNumberModel) ((JSpinner) e.getSource()).getModel())
+                    .getNumber()
+                    .doubleValue()));
+    statusScrollEndPause = panel.getSpinner("statusScrollEndPause");
+    statusScrollEndPause.setModel(
+        new SpinnerNumberModel(
+            AppPreferences.scrollStatusEndPause.get().doubleValue(), 0, 10d, 0.1));
+    statusScrollEndPause.addChangeListener(
+        e ->
+            AppPreferences.scrollStatusEndPause.set(
+                ((SpinnerNumberModel) ((JSpinner) e.getSource()).getModel())
+                    .getNumber()
+                    .doubleValue()));
     showLabelBorderCheckBox = (JCheckBox) panel.getComponent("showLabelBorder");
     showLabelBorderCheckBox.addActionListener(
         e -> {

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -900,19 +900,19 @@
               </grid>
             </children>
           </grid>
-          <grid id="f8e61" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="f8e61" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.accessibility"/>
             </constraints>
             <properties>
-              <visible value="false"/>
+              <visible value="true"/>
             </properties>
             <border type="none"/>
             <children>
               <component id="9b2c0" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.size"/>
@@ -921,7 +921,7 @@
               </component>
               <component id="2f928" class="javax.swing.JTextField">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <columns value="4"/>
@@ -929,68 +929,20 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="df5a8" class="javax.swing.JLabel">
-                <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay"/>
-                  <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay.tooltip"/>
-                </properties>
-              </component>
-              <component id="3c1d7" class="javax.swing.JLabel">
-                <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay.dismiss"/>
-                  <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay.dismiss.tooltip"/>
-                </properties>
-              </component>
-              <component id="387f7" class="javax.swing.JTextField">
-                <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <columns value="4"/>
-                  <name value="toolTipInitialDelay"/>
-                  <text value=""/>
-                </properties>
-              </component>
-              <vspacer id="f517b">
-                <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </vspacer>
-              <hspacer id="20d6e">
-                <constraints>
-                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </hspacer>
-              <component id="434ae" class="javax.swing.JTextField">
-                <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <columns value="4"/>
-                  <name value="toolTipDismissDelay"/>
-                  <text value=""/>
-                </properties>
-              </component>
               <grid id="85d76" layout-manager="GridLayoutManager" row-count="13" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
+                <margin top="4" left="4" bottom="4" right="4"/>
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="2" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                 </constraints>
                 <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.access.tokenLabel">
+                <border type="etched" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.access.tokenLabel">
                   <font/>
                   <title-color color="-13538620"/>
                 </border>
                 <children>
                   <component id="8e6c3" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.size"/>
@@ -1007,7 +959,7 @@
                   </component>
                   <component id="4fce9" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.pcBackground"/>
@@ -1015,7 +967,7 @@
                   </component>
                   <component id="f4912" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.pcForeground"/>
@@ -1023,7 +975,7 @@
                   </component>
                   <component id="1c56f" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.npcBackground"/>
@@ -1031,7 +983,7 @@
                   </component>
                   <component id="bf81b" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.npcForeground"/>
@@ -1039,7 +991,7 @@
                   </component>
                   <component id="e7462" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.nonVisBackground"/>
@@ -1047,7 +999,7 @@
                   </component>
                   <component id="f8c81" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.nonVisForeground"/>
@@ -1109,7 +1061,7 @@
                   </component>
                   <component id="63dcd" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.pcBorderColor"/>
@@ -1126,7 +1078,7 @@
                   </component>
                   <component id="8623a" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.npcBorderColor"/>
@@ -1143,7 +1095,7 @@
                   </component>
                   <component id="b5320" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.nonVisBorderColor"/>
@@ -1160,7 +1112,7 @@
                   </component>
                   <component id="2dbf5" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Label.borderWidth"/>
@@ -1177,7 +1129,7 @@
                   </component>
                   <component id="29fc9" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.tokenLabel.borderArc"/>
@@ -1194,7 +1146,7 @@
                   </component>
                   <component id="6e64c" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="Label.showBorder"/>
@@ -1212,6 +1164,148 @@
                   </component>
                 </children>
               </grid>
+              <vspacer id="6c56f">
+                <constraints>
+                  <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </vspacer>
+              <grid id="2b571" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="4" left="4" bottom="4" right="4"/>
+                <constraints>
+                  <grid row="1" column="0" row-span="2" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                </constraints>
+                <properties/>
+                <border type="etched" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.access.tooltip"/>
+                <children>
+                  <component id="df5a8" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay.tooltip"/>
+                    </properties>
+                  </component>
+                  <component id="387f7" class="javax.swing.JTextField">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <columns value="4"/>
+                      <name value="toolTipInitialDelay"/>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="434ae" class="javax.swing.JTextField">
+                    <constraints>
+                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <columns value="4"/>
+                      <name value="toolTipDismissDelay"/>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="3c1d7" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay.dismiss"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.delay.dismiss.tooltip"/>
+                    </properties>
+                  </component>
+                </children>
+              </grid>
+              <grid id="1d15a" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="4" left="4" bottom="4" right="4"/>
+                <constraints>
+                  <grid row="0" column="2" row-span="4" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="etched" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.access.status.options"/>
+                <children>
+                  <component id="d8c7a" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.status.allowScroll"/>
+                    </properties>
+                  </component>
+                  <component id="7e1b0" class="javax.swing.JCheckBox" default-binding="true">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <hideActionText value="true"/>
+                      <name value="statusScrollEnable"/>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="627f5" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.status.scrollSpeed"/>
+                    </properties>
+                  </component>
+                  <component id="e7ead" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.status.scrollStartDelay"/>
+                    </properties>
+                  </component>
+                  <component id="4f380" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.access.status.scrollEndPause"/>
+                    </properties>
+                  </component>
+                  <component id="d6c1e" class="javax.swing.JSpinner" default-binding="true">
+                    <constraints>
+                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <name value="statusScrollSpeedSpinner"/>
+                      <opaque value="false"/>
+                    </properties>
+                  </component>
+                  <component id="b368a" class="javax.swing.JSpinner" default-binding="true">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <name value="statusScrollStartDelaySpinner"/>
+                      <opaque value="false"/>
+                    </properties>
+                  </component>
+                  <component id="2a7ed" class="javax.swing.JSpinner" default-binding="true">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <name value="statusScrollEndPause"/>
+                      <opaque value="false"/>
+                    </properties>
+                  </component>
+                </children>
+              </grid>
+              <vspacer id="13336">
+                <constraints>
+                  <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </vspacer>
+              <hspacer id="27abd">
+                <constraints>
+                  <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
             </children>
           </grid>
           <grid id="70c12" layout-manager="GridLayoutManager" row-count="1" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -1220,7 +1314,7 @@
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.application"/>
             </constraints>
             <properties>
-              <visible value="true"/>
+              <visible value="false"/>
             </properties>
             <border type="none"/>
             <children>

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -651,6 +651,7 @@ Preferences.label.facing.edge                     = On Edges
 Preferences.label.facing.edge.tooltip             = Causes token facing rotation to snap to edges of the grid cell.
 Preferences.label.facing.vertices                 = On Vertices
 Preferences.label.facing.vertices.tooltip         = Causes token facing rotation to snap to the vertices of the grid cell.
+Preferences.label.access.tooltip                  = ToolTip Options
 Preferences.label.access.delay                    = ToolTip Initial Delay
 Preferences.label.access.delay.tooltip            = The initial delay (in milliseconds) before a tooltip is displayed.
 Preferences.label.access.delay.dismiss            = ToolTip Dismiss Delay
@@ -670,6 +671,13 @@ Preferences.label.access.tokenLabel.npcBorderColor    = NPC Border Color
 Preferences.label.access.tokenLabel.nonVisBorderColor = Non Visible Border Color
 Preferences.label.access.tokenLabel.borderArc         = Border Arc
 Preferences.label.access.tokenLabel.borderSize        = Border Size
+
+Preferences.label.access.status.options           = Status-Bar Options
+Preferences.label.access.status.allowScroll       = Scroll over-sized messages
+Preferences.label.access.status.scrollSpeed       = Scroll speed
+Preferences.label.access.status.scrollStartDelay  = Scroll start delay
+Preferences.label.access.status.scrollEndPause    = Scroll end pause
+
 Preferences.label.sound.system                    = Play system sounds
 Preferences.label.sound.system.tooltip            = Turn this off to prevent all sounds from within MapTool.  Needed for some Java implementations as too many sounds queued up can crash the JVM.
 Preferences.label.sound.stream                    = Play clips and streams


### PR DESCRIPTION
### Identify the Bug or Feature request
partial fixes #5353

### Description of the Change
Status bar messages now scroll if they do not fit the available space.
In addition:
1. the message becomes a tooltip on the status bar which is limited in width and has force-wrapped text.
2. app preferences added to control scroll features
3. status bar responds to mourse events; LMB pause/resume scrolling, RMB enable/disable scrolling


### Possible Drawbacks
scrolling is annoying and default is set to scroll

### Documentation Notes
Implemented scrolling of oversized status messages.

### Release Notes
Implemented scrolling of oversized status messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5383)
<!-- Reviewable:end -->
