### PR TITLE
Fix jumpy map drags

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/MeasureTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/MeasureTool.java
@@ -182,13 +182,15 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
         gridlessPath.appendWaypoint(currentGridlessPoint);
       }
       renderer.repaint();
-      return;
+    } else {
+      super.mousePressed(e);
     }
-    super.mousePressed(e);
   }
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    super.mouseReleased(e);
+
     ZoneRenderer renderer = (ZoneRenderer) e.getSource();
 
     if (SwingUtilities.isLeftMouseButton(e)) {
@@ -199,9 +201,7 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
       gridlessPath = null;
       currentGridlessPoint = null;
       renderer.repaint();
-      return;
     }
-    super.mouseReleased(e);
   }
 
   ////
@@ -210,15 +210,15 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
   public void mouseDragged(MouseEvent e) {
     if (SwingUtilities.isRightMouseButton(e)) {
       super.mouseDragged(e);
-      return;
+    } else {
+      ZoneRenderer renderer = (ZoneRenderer) e.getSource();
+      if (walker != null && renderer.getZone().getGrid().getCapabilities().isPathingSupported()) {
+        CellPoint cellPoint = renderer.getCellAt(new ScreenPoint(e.getX(), e.getY()));
+        walker.replaceLastWaypoint(cellPoint);
+      } else if (gridlessPath != null) {
+        currentGridlessPoint = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      }
+      renderer.repaint();
     }
-    ZoneRenderer renderer = (ZoneRenderer) e.getSource();
-    if (walker != null && renderer.getZone().getGrid().getCapabilities().isPathingSupported()) {
-      CellPoint cellPoint = renderer.getCellAt(new ScreenPoint(e.getX(), e.getY()));
-      walker.replaceLastWaypoint(cellPoint);
-    } else if (gridlessPath != null) {
-      currentGridlessPoint = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
-    }
-    renderer.repaint();
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -480,6 +480,8 @@ public class PointerTool extends DefaultTool {
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    super.mouseReleased(e);
+
     mouseButtonDown = false;
 
     if (isShowingTokenStackPopup) {

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -377,6 +377,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    super.mouseReleased(e);
+
     if (isShowingTokenStackPopup) {
       if (tokenStackPanel.contains(e.getX(), e.getY())) {
         tokenStackPanel.handleMouseEvent(e);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -219,12 +219,15 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
     if (state == null) {
       // We're not doing anything, so delegate to default behaviour.
       super.mouseDragged(e);
-    } else if (strategy.isFreehand()) {
-      // Extend the line.
+    } else {
+      cancelMapDrag();
       setIsEraser(isEraser(e));
       currentPoint = getPoint(e);
-      centerOnOrigin = e.isAltDown(); // Pointless, but it doesn't hurt for consistency.
-      strategy.pushPoint(state, currentPoint);
+      centerOnOrigin = e.isAltDown();
+      if (strategy.isFreehand()) {
+        // Extend the line.
+        strategy.pushPoint(state, currentPoint);
+      }
       renderer.repaint();
     }
   }
@@ -265,7 +268,10 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
       renderer.repaint();
     }
 
-    super.mousePressed(e);
+    if (state == null) {
+      // We're not doing anything, so delegate to default behaviour.
+      super.mousePressed(e);
+    }
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -270,6 +270,8 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    super.mouseReleased(e);
+
     if (strategy.isFreehand() && SwingUtilities.isLeftMouseButton(e)) {
       currentPoint = getPoint(e);
       centerOnOrigin = e.isAltDown();
@@ -279,7 +281,5 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
         submit(result.shape());
       }
     }
-
-    super.mouseReleased(e);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
@@ -128,12 +128,15 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
     if (state == null) {
       // We're not doing anything, so delegate to default behaviour.
       super.mouseDragged(e);
-    } else if (strategy.isFreehand()) {
-      // Extend the line.
+    } else {
+      cancelMapDrag();
       setIsEraser(isEraser(e));
       currentPoint = getPoint(e);
-      centerOnOrigin = e.isAltDown(); // Pointless, but it doesn't hurt for consistency.
-      strategy.pushPoint(state, currentPoint);
+      centerOnOrigin = e.isAltDown();
+      if (strategy.isFreehand()) {
+        // Extend the line.
+        strategy.pushPoint(state, currentPoint);
+      }
       renderer.repaint();
     }
   }
@@ -174,7 +177,10 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
       renderer.repaint();
     }
 
-    super.mousePressed(e);
+    if (state == null) {
+      // We're not doing anything, so delegate to default behaviour.
+      super.mousePressed(e);
+    }
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
@@ -179,6 +179,8 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    super.mouseReleased(e);
+
     if (strategy.isFreehand() && SwingUtilities.isLeftMouseButton(e)) {
       currentPoint = getPoint(e);
       centerOnOrigin = e.isAltDown();
@@ -188,7 +190,5 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
         submit(result.shape());
       }
     }
-
-    super.mouseReleased(e);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
@@ -158,6 +158,10 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
     if (state == null) {
       // We're not doing anything, so delegate to default behaviour.
       super.mouseDragged(e);
+    } else {
+      cancelMapDrag();
+      currentPoint = getPoint(e);
+      renderer.repaint();
     }
   }
 
@@ -194,7 +198,10 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
       renderer.repaint();
     }
 
-    super.mousePressed(e);
+    if (state == null) {
+      // We're not doing anything, so delegate to default behaviour.
+      super.mousePressed(e);
+    }
   }
 
   public static final class MaskOverlay implements ZoneOverlay {

--- a/src/main/java/net/rptools/maptool/client/tool/texttool/TextTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/texttool/TextTool.java
@@ -125,6 +125,8 @@ public class TextTool extends DefaultTool implements ZoneOverlay {
   // MOUSE
   @Override
   public void mousePressed(MouseEvent e) {
+    super.mousePressed(e);
+
     Label label = renderer.getLabelAt(e.getX(), e.getY());
     if (label != selectedLabel) {
       selectedNewLabel = true;
@@ -137,11 +139,12 @@ public class TextTool extends DefaultTool implements ZoneOverlay {
       dragOffsetX = (int) (e.getX() - sp.x);
       dragOffsetY = (int) (e.getY() - sp.y);
     }
-    super.mousePressed(e);
   }
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    super.mouseReleased(e);
+
     if (SwingUtilities.isLeftMouseButton(e)) {
       if (!isDragging) {
         Label label = renderer.getLabelAt(e.getX(), e.getY());
@@ -176,7 +179,6 @@ public class TextTool extends DefaultTool implements ZoneOverlay {
       }
     }
     isDragging = false;
-    super.mouseReleased(e);
   }
 
   @Override


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5328

### Description of the Change

This fixes tools to make sure they call `DefaultTool.mouseReleased()`. Doing so ensures that previous drag state is properly cleared when the drag is completed.

Beyond that, this just makes some of the conditions in tools be written more consistently, so that relationships between different event methods - especially `mousePressed()` and `mouseDragged()` - are easier to see. The `AbstractDrawingLikeTool` implementations have especially been tightened up in this regard.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where right-clicking a token could cause the map to jump the next time the user starts to drag it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5387)
<!-- Reviewable:end -->
