### PR TITLE
Generate walls from UVTT line-of-sight data

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -193,6 +193,9 @@ public class AppPreferences {
   public static final Preference<MapSortType> mapSortType =
       EnumType.create(MapSortType.class, "sortByGMName", MapSortType.GMNAME);
 
+  public static final Preference<UvttLosImportType> uvttLosImportType =
+      EnumType.create(UvttLosImportType.class, "uvttLosImportType", UvttLosImportType.Prompt);
+
   public static final Preference<Boolean> useSoftFogEdges = BooleanType.create("useSoftFog", true);
 
   public static final Preference<Boolean> newMapsHaveFow =
@@ -506,6 +509,23 @@ public class AppPreferences {
 
     MapSortType() {
       displayName = I18N.getString("mapSortType." + name());
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
+  }
+
+  public enum UvttLosImportType {
+    Walls("uvttLosImportType.walls"),
+    Masks("uvttLosImportType.masks"),
+    Prompt("uvttLosImportType.prompt");
+
+    private final String displayName;
+
+    UvttLosImportType(String key) {
+      displayName = I18N.getString(key);
     }
 
     @Override

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -40,6 +40,7 @@ import javax.swing.event.DocumentListener;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppPreferences.RenderQuality;
+import net.rptools.maptool.client.AppPreferences.UvttLosImportType;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.DeveloperOptions;
 import net.rptools.maptool.client.MapTool;
@@ -145,6 +146,8 @@ public class PreferencesDialog extends JDialog {
 
   /** JComboBox variable used to display map sorting options. */
   private final JComboBox<AppPreferences.MapSortType> mapSortType;
+
+  private final JComboBox<UvttLosImportType> uvttLosImportType;
 
   /** Checkbox for displaying or hiding * the statistics sheet on token mouseover. */
   private final JCheckBox showStatSheetCheckBox;
@@ -652,6 +655,7 @@ public class PreferencesDialog extends JDialog {
     showDialogOnNewToken = panel.getCheckBox("showDialogOnNewToken");
     visionTypeCombo = panel.getComboBox("defaultVisionType");
     mapSortType = panel.getComboBox("mapSortType");
+    uvttLosImportType = panel.getComboBox("uvttLosImportType");
     movementMetricCombo = panel.getComboBox("movementMetric");
     openEditorForNewMacros = panel.getCheckBox("openEditorForNewMacros");
     allowPlayerMacroEditsDefault = panel.getCheckBox("allowPlayerMacroEditsDefault");
@@ -1524,6 +1528,13 @@ public class PreferencesDialog extends JDialog {
         e ->
             AppPreferences.mapSortType.set(
                 (AppPreferences.MapSortType) mapSortType.getSelectedItem()));
+
+    uvttLosImportType.setModel(new DefaultComboBoxModel<>(UvttLosImportType.values()));
+    uvttLosImportType.setSelectedItem(AppPreferences.uvttLosImportType.get());
+    uvttLosImportType.addItemListener(
+        e ->
+            AppPreferences.uvttLosImportType.set(
+                (UvttLosImportType) uvttLosImportType.getSelectedItem()));
 
     macroEditorThemeCombo.setModel(new DefaultComboBoxModel<>());
     try (Stream<Path> paths = Files.list(AppConstants.THEMES_DIR.toPath())) {

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -360,7 +360,7 @@
                 <properties/>
                 <border type="none"/>
                 <children>
-                  <grid id="77f3" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="77f3" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="0" right="0"/>
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -534,6 +534,24 @@
                         <properties>
                           <actionCommand value="comboBoxChanged"/>
                           <name value="mapSortType"/>
+                        </properties>
+                      </component>
+                      <component id="efe38" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.maps.uvttLosImport"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.maps.uvttLosImport.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="f217e" class="javax.swing.JComboBox">
+                        <constraints>
+                          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="comboBoxChanged"/>
+                          <name value="uvttLosImportType"/>
                         </properties>
                       </component>
                     </children>

--- a/src/main/java/net/rptools/maptool/client/ui/uvtt/UvttLineOfSightPromptDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/uvtt/UvttLineOfSightPromptDialog.java
@@ -1,0 +1,119 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.uvtt;
+
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.util.Optional;
+import javax.swing.AbstractAction;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.KeyStroke;
+import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.AppPreferences.UvttLosImportType;
+import net.rptools.maptool.client.swing.SwingUtil;
+import net.rptools.maptool.language.I18N;
+
+public class UvttLineOfSightPromptDialog extends JDialog {
+  private final UvttLineOfSightPromptView view;
+  private Choices result = null;
+
+  public UvttLineOfSightPromptDialog(JFrame owner) {
+    super(owner, I18N.getString("uvttLosPromptDialog.title"), true);
+    view = new UvttLineOfSightPromptView();
+
+    setLayout(new GridLayout());
+
+    var root = view.getRootComponent();
+
+    // Escape key
+    root.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "cancel");
+    root.getActionMap()
+        .put(
+            "cancel",
+            new AbstractAction() {
+              public void actionPerformed(ActionEvent e) {
+                cancel();
+              }
+            });
+    add(root);
+
+    final var uvttLosImportType = view.getSelectionComboBox();
+    uvttLosImportType.setModel(new DefaultComboBoxModel<>(Choices.values()));
+    uvttLosImportType.setSelectedItem(UvttLosImportType.Walls);
+
+    final var okButton = view.getOkButton();
+    okButton.addActionListener(e -> accept());
+    getRootPane().setDefaultButton(okButton);
+
+    final var cancelButton = view.getCancelButton();
+    cancelButton.addActionListener(e -> cancel());
+
+    pack();
+  }
+
+  @Override
+  public void setVisible(boolean b) {
+    if (b) {
+      result = null;
+      SwingUtil.centerOver(this, getOwner());
+    }
+    super.setVisible(b);
+  }
+
+  public Optional<UvttLosImportType> getResult() {
+    return result == null ? Optional.empty() : Optional.of(result.getWrappedType());
+  }
+
+  private void cancel() {
+    setVisible(false);
+    result = null;
+  }
+
+  private void accept() {
+    setVisible(false);
+    result = view.getSelectionComboBox().getItemAt(view.getSelectionComboBox().getSelectedIndex());
+    if (view.getRememberChoice().isSelected()) {
+      AppPreferences.uvttLosImportType.set(result.getWrappedType());
+    }
+  }
+
+  /** Wrapper around {@link UvttLosImportType} for better text and only two options. */
+  public enum Choices {
+    Walls(UvttLosImportType.Walls, "uvttLosPromptDialog.choice.walls"),
+    Masks(UvttLosImportType.Masks, "uvttLosPromptDialog.choice.masks");
+
+    private final UvttLosImportType wrappedType;
+    private final String description;
+
+    Choices(UvttLosImportType wrappedType, String key) {
+      this.wrappedType = wrappedType;
+      this.description = I18N.getString(key);
+    }
+
+    public UvttLosImportType getWrappedType() {
+      return wrappedType;
+    }
+
+    @Override
+    public String toString() {
+      return description;
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/uvtt/UvttLineOfSightPromptView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/uvtt/UvttLineOfSightPromptView.form
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.rptools.maptool.client.ui.uvtt.UvttLineOfSightPromptView">
+  <grid id="775b6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="5" left="5" bottom="5" right="5"/>
+    <constraints>
+      <xy x="10" y="10" width="488" height="227"/>
+    </constraints>
+    <properties>
+      <name value="root"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <grid id="218f9" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="554b5" class="javax.swing.JButton" binding="okButton">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="OK"/>
+              <name value=""/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="Button.ok"/>
+            </properties>
+          </component>
+          <component id="1f0aa" class="javax.swing.JButton" binding="cancelButton">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="OK"/>
+              <name value=""/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="Button.cancel"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="83a03" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="6a6fb" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="uvttLosPromptDialog.prompt"/>
+            </properties>
+          </component>
+          <component id="d6d2" class="javax.swing.JComboBox" binding="selectionComboBox">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="eed44" class="javax.swing.JSeparator">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="bf432" class="javax.swing.JCheckBox" binding="rememberChoice">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <label value="Remember my choice?"/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="uvttLosPromptDialog.rememberChoice"/>
+            </properties>
+          </component>
+          <component id="49598" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <font style="2"/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="uvttLosPromptDialog.rememberChoiceHelpText"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+  <buttonGroups>
+    <group name="buttonGroup1">
+      <member id="b7462"/>
+      <member id="1ad78"/>
+      <member id="5782f"/>
+      <member id="a9960"/>
+      <member id="ef506"/>
+    </group>
+  </buttonGroups>
+</form>

--- a/src/main/java/net/rptools/maptool/client/ui/uvtt/UvttLineOfSightPromptView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/uvtt/UvttLineOfSightPromptView.java
@@ -1,0 +1,48 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.uvtt;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+
+public class UvttLineOfSightPromptView {
+  private JComboBox<UvttLineOfSightPromptDialog.Choices> selectionComboBox;
+  private JPanel mainPanel;
+  private JButton okButton;
+  private JCheckBox rememberChoice;
+  private JButton cancelButton;
+
+  public JPanel getRootComponent() {
+    return mainPanel;
+  }
+
+  public JComboBox<UvttLineOfSightPromptDialog.Choices> getSelectionComboBox() {
+    return selectionComboBox;
+  }
+
+  public JButton getOkButton() {
+    return okButton;
+  }
+
+  public JButton getCancelButton() {
+    return cancelButton;
+  }
+
+  public JCheckBox getRememberChoice() {
+    return rememberChoice;
+  }
+}

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -588,6 +588,8 @@ Preferences.label.maps.metric                    = Movement metric
 Preferences.label.maps.metric.tooltip            = Determines how MapTool handles movement on the selected grid type.
 Preferences.label.maps.sortType                  = Sorting Method
 Preferences.label.maps.sortType.tooltip          = Determines if the maps are sorted by Name or Display Name
+Preferences.label.maps.uvttLosImport             = Import UVTT line of sight as\:
+Preferences.label.maps.uvttLosImport.tooltip     = Whether to use the newer walls for Universal VTT line of sight data, or use the older VBL and MBL.
 Preferences.label.objects.snap                   = Start Snap to Grid
 Preferences.label.objects.snap.tooltip           = Whether images dropped on the Object layer have snap-to-grid turned on by default.
 Preferences.label.objects.free                   = Start Freesize
@@ -2988,6 +2990,9 @@ lightingStyle.OVERTOP       = Overtop
 mapSortType.GMNAME = True Name
 mapSortType.DISPLAYNAME = Display Name
 
+uvttLosImportType.masks = VBL+MBL
+uvttLosImportType.walls = Walls
+uvttLosImportType.prompt = Ask during import
 
 whisper.command          = Whisper
 whisper.description      = Send a message to a specific player.

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2994,6 +2994,13 @@ uvttLosImportType.masks = VBL+MBL
 uvttLosImportType.walls = Walls
 uvttLosImportType.prompt = Ask during import
 
+uvttLosPromptDialog.title = Universla VTT Line of Sight
+uvttLosPromptDialog.prompt = What should line of sight data to be imported as?
+uvttLosPromptDialog.choice.walls = Walls - new since 1.18
+uvttLosPromptDialog.choice.masks = VBL+MBL - as in 1.17 and earlier
+uvttLosPromptDialog.rememberChoice = Remember my choice
+uvttLosPromptDialog.rememberChoiceHelpText = You can change your choice in the Interactions tab of the Preferences dialog.
+
 whisper.command          = Whisper
 whisper.description      = Send a message to a specific player.
 whisper.enterText        = enter text here


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5182

### Description of the Change

When importing a UVTT file, the user now has a choice of whether to generate VBL+MBL as always, or to use the newer walls. By default, the user is prompted for a choice each time, but this choice can optionally be remembered for future imports. Alternatively, the choice can be set in the Preferences dialog.

When generating walls, open portals are represented as walls, albeit walls the don't block movement, sights, lights, or auras. This differs from the VBL+MBL import where open portals result in nothing, but is consistent in terms of not blocking anything. Since a wall is created, the user can easily modify the blocking properties of any portals to their liking after the import is completed, in case this default behaviour does not suffice.

### Possible Drawbacks

Users may be confused at first with the extra prompt.

### Documentation Notes

Either walls or *BL can be used to represent the line of sight data from a Universal VTT file. When importing a UVTT file, you will be asked which one you want to use:
![image](https://github.com/user-attachments/assets/e2afe82e-8236-48e4-adf5-d3369fff5172)

If you don't want to be asked every time, select the "Remember my choice" option:
![image](https://github.com/user-attachments/assets/f41aa693-ab57-462b-b8af-bd574d4362ca)

Alternatively, you can set your preferred option via Preferences:
![image](https://github.com/user-attachments/assets/ea800002-f492-4787-86b4-dd823b6bcda0)


### Release Notes

- Added the option for walls to be generated during UVTT import instead of VBL+MBL

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5406)
<!-- Reviewable:end -->
