### PR TITLE
Fix Zip Slip vulnerability in file extraction utility

### DIFF
--- a/src/main/java/net/rptools/lib/FileUtil.java
+++ b/src/main/java/net/rptools/lib/FileUtil.java
@@ -386,7 +386,7 @@ public class FileUtil {
         
         // Prevent zip slip - check if file path is within destination directory
         if (!canonicalFile.toPath().startsWith(canonicalDestDir.toPath())) {
-            throw new IOException("Entry is outside of the target directory: " + entry.getName());
+          throw new IOException("Entry is outside of the target directory: " + entry.getName());
         }
 
         // Create parent directories

--- a/src/main/java/net/rptools/lib/FileUtil.java
+++ b/src/main/java/net/rptools/lib/FileUtil.java
@@ -383,7 +383,7 @@ public class FileUtil {
         // Create file object and validate path
         File file = new File(canonicalDestDir, entry.getName());
         File canonicalFile = file.getCanonicalFile();
-        
+
         // Prevent zip slip - check if file path is within destination directory
         if (!canonicalFile.toPath().startsWith(canonicalDestDir.toPath())) {
           throw new IOException("Entry is outside of the target directory: " + entry.getName());

--- a/src/main/java/net/rptools/lib/FileUtil.java
+++ b/src/main/java/net/rptools/lib/FileUtil.java
@@ -370,6 +370,9 @@ public class FileUtil {
   public static void unzipFile(File sourceFile, File destDir) throws IOException {
     if (!sourceFile.exists()) throw new IOException("source file does not exist: " + sourceFile);
 
+    // Canonicalize destination directory path
+    File canonicalDestDir = destDir.getCanonicalFile();
+
     try (ZipFile zipFile = new ZipFile(sourceFile)) {
       Enumeration<? extends ZipEntry> entries = zipFile.entries();
 
@@ -377,12 +380,21 @@ public class FileUtil {
         ZipEntry entry = entries.nextElement();
         if (entry.isDirectory()) continue;
 
-        File file = new File(destDir, entry.getName());
-        String path = file.getAbsolutePath();
+        // Create file object and validate path
+        File file = new File(canonicalDestDir, entry.getName());
+        File canonicalFile = file.getCanonicalFile();
+        
+        // Prevent zip slip - check if file path is within destination directory
+        if (!canonicalFile.toPath().startsWith(canonicalDestDir.toPath())) {
+            throw new IOException("Entry is outside of the target directory: " + entry.getName());
+        }
+
+        // Create parent directories
         file.getParentFile().mkdirs();
 
+        // Extract file content
         try (InputStream is = zipFile.getInputStream(entry);
-            OutputStream os = new BufferedOutputStream(new FileOutputStream(path))) {
+            OutputStream os = new BufferedOutputStream(new FileOutputStream(canonicalFile))) {
           IOUtils.copy(is, os);
         }
       }


### PR DESCRIPTION
### Identify the Bug or Feature request
Fix Zip Slip vulnerability in file extraction utility

Fixes #5421

### Description of the Change
Provide path validation, ensuring files can only be extracted within the intended path directory/ Path canonicalisation to prevent bypass techniques. Added try-with-resources to ensure proper stream colsure, preventing resource leaks. The code extracts content only after verifying that the path is safe. 

This vulnerability was also found in YANG-DB/yang-db@4c32a32 and fixed henceforth,

### Documentation Notes
1. https://nvd.nist.gov/vuln/detail/cve-2018-1002200
2. YANG-DB/yang-db@4c32a32

### Release Notes

Fix Zip Slip vulnerability in file extraction utility

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5422)
<!-- Reviewable:end -->
