### PR TITLE
setPenColor and setFillColor now set respective paints to null

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
@@ -70,18 +70,20 @@ public class DrawingSetterFunctions extends DrawingFunctions {
       return "";
     } else if ("setPenColor".equalsIgnoreCase(functionName)) {
       String paint = parameters.get(2).toString();
-      if ("".equalsIgnoreCase(paint))
+      if ("".equalsIgnoreCase(paint)) {
         getPen(functionName, map, guid).setForegroundMode(Pen.MODE_TRANSPARENT);
-      else {
+        getPen(functionName, map, guid).setPaint(null);
+      } else {
         getPen(functionName, map, guid).setForegroundMode(Pen.MODE_SOLID);
         getPen(functionName, map, guid).setPaint(FunctionUtil.getPaintFromString(paint));
       }
       return "";
     } else if ("setFillColor".equalsIgnoreCase(functionName)) {
       String paint = parameters.get(2).toString();
-      if ("".equalsIgnoreCase(paint))
+      if ("".equalsIgnoreCase(paint)) {
         getPen(functionName, map, guid).setBackgroundMode(Pen.MODE_TRANSPARENT);
-      else {
+        getPen(functionName, map, guid).setBackgroundPaint(null);
+      } else {
         getPen(functionName, map, guid).setBackgroundMode(Pen.MODE_SOLID);
         getPen(functionName, map, guid).setBackgroundPaint(FunctionUtil.getPaintFromString(paint));
       }


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5348

### Description of the Change
Persist color  transparency when provided via mtscript functions, using null (same as the transparency color stored in the drawing/template color picker palette:
* `setPenColor()` mtscript function now sets drawing info to null via `setPaint`  when "" is provided as the color argument.
* `setFillColor()` mtscript function now sets drawing info to null via `setBackgroundPaint` when "" is provided as the color argument.

### Possible Drawbacks
None foreseen.

### Documentation Notes
None.

### Release Notes
Fixed the issue where transparency was not persisted in drawing settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5426)
<!-- Reviewable:end -->
