### PR TITLE
Token anchor offset correction on paste

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1071,8 +1071,8 @@ public class AppActions {
     Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
     Grid grid = zone.getGrid();
     double sizeRatio = 1;
-    if(gridCopiedFrom.getSize() != 0 && grid.getSize() != 0){
-        sizeRatio = (double) grid.getSize() / gridCopiedFrom.getSize();
+    if (gridCopiedFrom.getSize() != 0 && grid.getSize() != 0) {
+      sizeRatio = (double) grid.getSize() / gridCopiedFrom.getSize();
     }
     boolean snapToGrid = false;
     Token topLeft = null;
@@ -1108,15 +1108,13 @@ public class AppActions {
     tokenList.sort(Token.COMPARE_BY_ZORDER);
     List<String> failedPaste = new ArrayList<String>(tokenList.size());
 
-    Point unchanged = new Point(0,0);
+    Point unchanged = new Point(0, 0);
     for (Token origToken : tokenList) {
       Token token = new Token(origToken, keepIdsOnPaste); // keep id if first paste since cut
-        if(!unchanged.equals(token.getAnchor())){
-            token.setAnchor(
-                    (int) (token.getAnchorX() * sizeRatio),
-                    (int) (token.getAnchorY() * sizeRatio)
-            );
-        }
+      if (!unchanged.equals(token.getAnchor())) {
+        token.setAnchor(
+            (int) (token.getAnchorX() * sizeRatio), (int) (token.getAnchorY() * sizeRatio));
+      }
       // need this here to get around times when a token is copied and pasted into the
       // same zone, such as a framework "template"
       if (allTokensSet != null && allTokensSet.contains(token.getExposedAreaGUID())) {

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -989,7 +989,7 @@ public class AppActions {
         tokenCopySet.clear(); // Just to help out the garbage collector a little bit
       }
 
-      Token topLeft = tokenList.get(0);
+      Token topLeft = tokenList.getFirst();
       tokenCopySet = new HashSet<Token>();
       for (Token originalToken : tokenList) {
         if (originalToken.getY() < topLeft.getY() || originalToken.getX() < topLeft.getX()) {
@@ -1070,7 +1070,10 @@ public class AppActions {
   private static void pasteTokens(ZonePoint destination, Layer layer) {
     Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
     Grid grid = zone.getGrid();
-
+    double sizeRatio = 1;
+    if(gridCopiedFrom.getSize() != 0 && grid.getSize() != 0){
+        sizeRatio = (double) grid.getSize() / gridCopiedFrom.getSize();
+    }
     boolean snapToGrid = false;
     Token topLeft = null;
 
@@ -1105,9 +1108,15 @@ public class AppActions {
     tokenList.sort(Token.COMPARE_BY_ZORDER);
     List<String> failedPaste = new ArrayList<String>(tokenList.size());
 
+    Point unchanged = new Point(0,0);
     for (Token origToken : tokenList) {
       Token token = new Token(origToken, keepIdsOnPaste); // keep id if first paste since cut
-
+        if(!unchanged.equals(token.getAnchor())){
+            token.setAnchor(
+                    (int) (token.getAnchorX() * sizeRatio),
+                    (int) (token.getAnchorY() * sizeRatio)
+            );
+        }
       // need this here to get around times when a token is copied and pasted into the
       // same zone, such as a framework "template"
       if (allTokensSet != null && allTokensSet.contains(token.getExposedAreaGUID())) {


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #997

### Description of the Change
Tokens with offset anchor positions now get the anchor position scaled when pasted to a zone with a different grid size

### Possible Drawbacks
unknown

### Documentation Notes
More consistent token positioning on paste

### Release Notes
More consistent token positioning on paste

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5428)
<!-- Reviewable:end -->
