### PR TITLE
Fix preferences dialog width depending on confg file path

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -904,9 +904,7 @@ public class PreferencesDialog extends JDialog {
     // jpackage config files can't be written to. Show a warning to the user describing the
     // situation.
     if (appCfgFile != null) {
-      var warning = I18N.getText("startup.preferences.info.manualCopy");
-      configFileWarningLabel.setText(
-          String.format("<html>%s</html>", warning.replace("\n", "<br>")));
+      configFileWarningLabel.setText(I18N.getText("startup.preferences.info.manualCopy"));
       configFileWarningLabel.setVisible(true);
     } else {
       configFileWarningLabel.setText(null);

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -400,6 +400,8 @@ public class PreferencesDialog extends JDialog {
   /** Label for displaying startup information. */
   private final JTextField cfgFilePath;
 
+  private final AbstractButton copyCfgFilePathButton;
+
   private final JLabel configFileWarningLabel;
 
   private final JLabel startupInfoLabel;
@@ -733,6 +735,13 @@ public class PreferencesDialog extends JDialog {
 
     startupInfoLabel = panel.getLabel("startupInfoLabel");
     cfgFilePath = panel.getTextField("cfgFilePath");
+    copyCfgFilePathButton = panel.getButton("copyCfgPath");
+    copyCfgFilePathButton.addActionListener(
+        e -> {
+          Toolkit.getDefaultToolkit()
+              .getSystemClipboard()
+              .setContents(new StringSelection(cfgFilePath.getText()), null);
+        });
 
     pcTokenLabelFG = (ColorWell) panel.getComponent("pcTokenLabelFG");
     pcTokenLabelFG.setColor(AppPreferences.pcMapLabelForeground.get());

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -896,6 +896,7 @@ public class PreferencesDialog extends JDialog {
     File appCfgFile = AppUtil.getAppCfgFile();
     if (appCfgFile != null) {
       cfgFilePath.setText(appCfgFile.toString());
+      cfgFilePath.setCaretPosition(0);
     } else {
       cfgFilePath.setText("");
     }

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui.preferencesdialog;
 import static net.rptools.maptool.util.UserJvmOptions.getLanguages;
 import static net.rptools.maptool.util.UserJvmOptions.setJvmOption;
 
+import com.formdev.flatlaf.extras.FlatSVGIcon;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.Toolkit;
@@ -399,6 +400,8 @@ public class PreferencesDialog extends JDialog {
   /** Label for displaying startup information. */
   private final JTextField cfgFilePath;
 
+  private final JLabel configFileWarningLabel;
+
   private final JLabel startupInfoLabel;
 
   /** Flag indicating if JVM values have been changed. */
@@ -724,6 +727,10 @@ public class PreferencesDialog extends JDialog {
     jamLanguageOverrideComboBox = panel.getComboBox("jvmLanguageOverideComboBox");
     jamLanguageOverrideComboBox.setToolTipText(I18N.getText("prefs.language.override.tooltip"));
 
+    configFileWarningLabel = panel.getLabel("configFileWarningLabel");
+    configFileWarningLabel.setIcon(
+        new FlatSVGIcon("net/rptools/maptool/client/image/warning.svg", 16, 16));
+
     startupInfoLabel = panel.getLabel("startupInfoLabel");
     cfgFilePath = panel.getTextField("cfgFilePath");
 
@@ -884,11 +891,19 @@ public class PreferencesDialog extends JDialog {
       cfgFilePath.setText("");
     }
 
-    String copyInfo = "";
-    if (appCfgFile != null) { // Don't try to display message if running from dev.
-      copyInfo = I18N.getText("startup.preferences.info.manualCopy");
+    // jpackage config files can't be written to. Show a warning to the user describing the
+    // situation.
+    if (appCfgFile != null) {
+      var warning = I18N.getText("startup.preferences.info.manualCopy");
+      configFileWarningLabel.setText(
+          String.format("<html>%s</html>", warning.replace("\n", "<br>")));
+      configFileWarningLabel.setVisible(true);
+    } else {
+      configFileWarningLabel.setText(null);
+      configFileWarningLabel.setVisible(false);
     }
-    String startupInfoMsg = I18N.getText("startup.preferences.info", copyInfo);
+
+    String startupInfoMsg = I18N.getText("startup.preferences.info");
     startupInfoLabel.setText(startupInfoMsg);
 
     DefaultComboBoxModel<String> languageModel = new DefaultComboBoxModel<String>();

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -397,6 +397,8 @@ public class PreferencesDialog extends JDialog {
   private final JComboBox<String> jamLanguageOverrideComboBox;
 
   /** Label for displaying startup information. */
+  private final JTextField cfgFilePath;
+
   private final JLabel startupInfoLabel;
 
   /** Flag indicating if JVM values have been changed. */
@@ -723,6 +725,7 @@ public class PreferencesDialog extends JDialog {
     jamLanguageOverrideComboBox.setToolTipText(I18N.getText("prefs.language.override.tooltip"));
 
     startupInfoLabel = panel.getLabel("startupInfoLabel");
+    cfgFilePath = panel.getTextField("cfgFilePath");
 
     pcTokenLabelFG = (ColorWell) panel.getComponent("pcTokenLabelFG");
     pcTokenLabelFG.setColor(AppPreferences.pcMapLabelForeground.get());
@@ -875,9 +878,15 @@ public class PreferencesDialog extends JDialog {
     }
 
     File appCfgFile = AppUtil.getAppCfgFile();
+    if (appCfgFile != null) {
+      cfgFilePath.setText(appCfgFile.toString());
+    } else {
+      cfgFilePath.setText("");
+    }
+
     String copyInfo = "";
     if (appCfgFile != null) { // Don't try to display message if running from dev.
-      copyInfo = I18N.getText("startup.preferences.info.manualCopy", appCfgFile.toString());
+      copyInfo = I18N.getText("startup.preferences.info.manualCopy");
     }
     String startupInfoMsg = I18N.getText("startup.preferences.info", copyInfo);
     startupInfoLabel.setText(startupInfoMsg);

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -3,7 +3,7 @@
   <grid id="3f87d" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1063" height="841"/>
+      <xy x="10" y="10" width="1746" height="841"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -2471,7 +2471,7 @@
               </hspacer>
             </children>
           </grid>
-          <grid id="d083" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d083" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.startup"/>
@@ -2707,7 +2707,7 @@
                   </component>
                 </children>
               </grid>
-              <grid id="261e4" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="261e4" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -2719,15 +2719,6 @@
                   <color color="-6710887"/>
                 </border>
                 <children>
-                  <component id="bde4e" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <name value="startupInfoLabel"/>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info"/>
-                    </properties>
-                  </component>
                   <component id="5bcba" class="javax.swing.JLabel">
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -2748,6 +2739,38 @@
                       <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
                     </properties>
                   </component>
+                  <scrollpane id="4c948">
+                    <constraints>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <horizontalScrollBarPolicy value="31"/>
+                    </properties>
+                    <border type="none"/>
+                    <children>
+                      <component id="bde4e" class="javax.swing.JLabel">
+                        <constraints/>
+                        <properties>
+                          <name value="startupInfoLabel"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info"/>
+                        </properties>
+                      </component>
+                    </children>
+                  </scrollpane>
+                  <component id="38eef" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <iconTextGap value="8"/>
+                      <name value="configFileWarningLabel"/>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy"/>
+                      <visible value="true"/>
+                    </properties>
+                    <clientProperties>
+                      <html.disable class="java.lang.Boolean" value="false"/>
+                    </clientProperties>
+                  </component>
                 </children>
               </grid>
               <vspacer id="23f1f">
@@ -2757,12 +2780,12 @@
               </vspacer>
               <vspacer id="9203f">
                 <constraints>
-                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
-              <hspacer id="22367">
+              <hspacer id="8e63a">
                 <constraints>
-                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
             </children>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -3,7 +3,7 @@
   <grid id="3f87d" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1027" height="841"/>
+      <xy x="10" y="10" width="1063" height="841"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -27,7 +27,7 @@
         </properties>
         <border type="none"/>
         <children>
-          <grid id="aa829" layout-manager="GridLayoutManager" row-count="1" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="aa829" layout-manager="GridLayoutManager" row-count="1" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.tab.interactions"/>
@@ -916,6 +916,11 @@
                   </grid>
                 </children>
               </grid>
+              <hspacer id="fbf6">
+                <constraints>
+                  <grid row="0" column="6" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
             </children>
           </grid>
           <grid id="f8e61" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -1343,7 +1348,7 @@
               </hspacer>
             </children>
           </grid>
-          <grid id="70c12" layout-manager="GridLayoutManager" row-count="1" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="70c12" layout-manager="GridLayoutManager" row-count="1" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.application"/>
@@ -2144,6 +2149,11 @@
                   </grid>
                 </children>
               </grid>
+              <hspacer id="1a503">
+                <constraints>
+                  <grid row="0" column="6" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
             </children>
           </grid>
           <grid id="70384" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -2395,7 +2405,7 @@
               </component>
             </children>
           </grid>
-          <grid id="20d25" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="20d25" layout-manager="GridLayoutManager" row-count="3" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.auth"/>
@@ -2454,9 +2464,14 @@
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.auth.regenKey"/>
                 </properties>
               </component>
+              <hspacer id="a7deb">
+                <constraints>
+                  <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
             </children>
           </grid>
-          <grid id="d083" layout-manager="GridLayoutManager" row-count="6" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d083" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.startup"/>
@@ -2725,6 +2740,11 @@
                   <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
+              <hspacer id="22367">
+                <constraints>
+                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
             </children>
           </grid>
           <grid id="2e306" binding="developerTab" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -3,7 +3,7 @@
   <grid id="3f87d" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1746" height="841"/>
+      <xy x="10" y="10" width="1438" height="739"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -2707,91 +2707,6 @@
                   </component>
                 </children>
               </grid>
-              <grid id="261e4" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
-                <constraints>
-                  <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.startup.label.info">
-                  <font name="Dialog" size="12" style="1"/>
-                  <title-color color="-13538620"/>
-                  <color color="-6710887"/>
-                </border>
-                <children>
-                  <component id="ee436" class="javax.swing.JTextField" binding="configFile">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                        <preferred-size width="150" height="-1"/>
-                      </grid>
-                    </constraints>
-                    <properties>
-                      <columns value="30"/>
-                      <enabled value="false"/>
-                      <name value="cfgFilePath"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
-                    </properties>
-                  </component>
-                  <scrollpane id="4c948">
-                    <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <horizontalScrollBarPolicy value="31"/>
-                    </properties>
-                    <border type="none"/>
-                    <children>
-                      <component id="bde4e" class="javax.swing.JLabel">
-                        <constraints/>
-                        <properties>
-                          <name value="startupInfoLabel"/>
-                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info"/>
-                        </properties>
-                      </component>
-                    </children>
-                  </scrollpane>
-                  <component id="38eef" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <iconTextGap value="8"/>
-                      <name value="configFileWarningLabel"/>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy"/>
-                      <visible value="true"/>
-                    </properties>
-                    <clientProperties>
-                      <html.disable class="java.lang.Boolean" value="false"/>
-                    </clientProperties>
-                  </component>
-                  <component id="5bcba" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <labelFor value="ee436"/>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="b5c78" class="javax.swing.JButton" default-binding="true">
-                    <constraints>
-                      <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <icon value="net/rptools/maptool/client/image/page_copy.png"/>
-                      <margin top="5" left="5" bottom="5" right="5"/>
-                      <name value="copyCfgPath"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.button.copyCfgPath.tooltip"/>
-                    </properties>
-                  </component>
-                  <hspacer id="91d89">
-                    <constraints>
-                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                  </hspacer>
-                </children>
-              </grid>
               <vspacer id="23f1f">
                 <constraints>
                   <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
@@ -2807,6 +2722,105 @@
                   <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
+              <grid id="41085" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <grid id="6f864" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.cfgFilePath">
+                      <font name="Dialog" size="12" style="1"/>
+                      <title-color color="-13538620"/>
+                      <color color="-6710887"/>
+                    </border>
+                    <children>
+                      <component id="10368" class="javax.swing.JTextField">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                            <minimum-size width="1" height="-1"/>
+                            <preferred-size width="1" height="-1"/>
+                          </grid>
+                        </constraints>
+                        <properties>
+                          <editable value="false"/>
+                          <name value="cfgFilePath"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="37220" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <iconTextGap value="8"/>
+                          <name value="configFileWarningLabel"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy"/>
+                          <visible value="true"/>
+                        </properties>
+                        <clientProperties>
+                          <html.disable class="java.lang.Boolean" value="false"/>
+                        </clientProperties>
+                      </component>
+                      <component id="b1a1f" class="javax.swing.JButton" default-binding="true">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <icon value="net/rptools/maptool/client/image/page_copy.png"/>
+                          <margin top="5" left="5" bottom="5" right="5"/>
+                          <name value="copyCfgPath"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.button.copyCfgPath.tooltip"/>
+                        </properties>
+                      </component>
+                      <hspacer id="92892">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                      </hspacer>
+                    </children>
+                  </grid>
+                  <grid id="261e4" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.startup.label.info">
+                      <font name="Dialog" size="12" style="1"/>
+                      <title-color color="-13538620"/>
+                      <color color="-6710887"/>
+                    </border>
+                    <children>
+                      <scrollpane id="4c948">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <horizontalScrollBarPolicy value="31"/>
+                        </properties>
+                        <border type="none"/>
+                        <children>
+                          <component id="bde4e" class="javax.swing.JLabel">
+                            <constraints/>
+                            <properties>
+                              <name value="startupInfoLabel"/>
+                              <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info"/>
+                            </properties>
+                          </component>
+                        </children>
+                      </scrollpane>
+                    </children>
+                  </grid>
+                </children>
+              </grid>
             </children>
           </grid>
           <grid id="2e306" binding="developerTab" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -2707,7 +2707,7 @@
                   </component>
                 </children>
               </grid>
-              <grid id="261e4" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="261e4" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -2721,11 +2721,31 @@
                 <children>
                   <component id="bde4e" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <name value="startupInfoLabel"/>
                       <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info"/>
+                    </properties>
+                  </component>
+                  <component id="5bcba" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
+                    </properties>
+                  </component>
+                  <component id="ee436" class="javax.swing.JTextField" default-binding="true">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <name value="cfgFilePath"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -2707,7 +2707,7 @@
                   </component>
                 </children>
               </grid>
-              <grid id="261e4" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="261e4" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -2719,29 +2719,22 @@
                   <color color="-6710887"/>
                 </border>
                 <children>
-                  <component id="5bcba" class="javax.swing.JLabel">
+                  <component id="ee436" class="javax.swing.JTextField" binding="configFile">
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="ee436" class="javax.swing.JTextField" default-binding="true">
-                    <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
                     <properties>
+                      <columns value="30"/>
+                      <enabled value="false"/>
                       <name value="cfgFilePath"/>
                       <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
                     </properties>
                   </component>
                   <scrollpane id="4c948">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <horizontalScrollBarPolicy value="31"/>
@@ -2759,7 +2752,7 @@
                   </scrollpane>
                   <component id="38eef" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <iconTextGap value="8"/>
@@ -2771,6 +2764,32 @@
                       <html.disable class="java.lang.Boolean" value="false"/>
                     </clientProperties>
                   </component>
+                  <component id="5bcba" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <labelFor value="ee436"/>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
+                    </properties>
+                  </component>
+                  <component id="b5c78" class="javax.swing.JButton" default-binding="true">
+                    <constraints>
+                      <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <icon value="net/rptools/maptool/client/image/page_copy.png"/>
+                      <margin top="5" left="5" bottom="5" right="5"/>
+                      <name value="copyCfgPath"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.button.copyCfgPath.tooltip"/>
+                    </properties>
+                  </component>
+                  <hspacer id="91d89">
+                    <constraints>
+                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
                 </children>
               </grid>
               <vspacer id="23f1f">

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -2765,9 +2765,6 @@
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy"/>
                           <visible value="true"/>
                         </properties>
-                        <clientProperties>
-                          <html.disable class="java.lang.Boolean" value="false"/>
-                        </clientProperties>
                       </component>
                       <component id="b1a1f" class="javax.swing.JButton" default-binding="true">
                         <constraints>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -2471,7 +2471,7 @@
               </hspacer>
             </children>
           </grid>
-          <grid id="d083" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d083" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.startup"/>
@@ -2714,14 +2714,9 @@
               </vspacer>
               <vspacer id="9203f">
                 <constraints>
-                  <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
-              <hspacer id="8e63a">
-                <constraints>
-                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </hspacer>
               <grid id="41085" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
@@ -2818,6 +2813,11 @@
                   </grid>
                 </children>
               </grid>
+              <hspacer id="2984">
+                <constraints>
+                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
             </children>
           </grid>
           <grid id="2e306" binding="developerTab" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.java
@@ -34,8 +34,6 @@ public class PreferencesDialogView {
    */
   private JPanel mainPanel;
 
-  private JTextField configFile;
-
   /**
    * Returns the root component of the preferences dialog view.
    *

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.java
@@ -34,6 +34,8 @@ public class PreferencesDialogView {
    */
   private JPanel mainPanel;
 
+  private JTextField configFile;
+
   /**
    * Returns the root component of the preferences dialog view.
    *

--- a/src/main/java/net/rptools/maptool/client/ui/theme/ThemeSupport.java
+++ b/src/main/java/net/rptools/maptool/client/ui/theme/ThemeSupport.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import javax.swing.*;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.ui.themes.*;
 import net.rptools.maptool.events.MapToolEventBus;
 import org.apache.logging.log4j.LogManager;
@@ -640,10 +641,13 @@ public class ThemeSupport {
       }
       var imageIcon = new ImageIcon(imageURL, themeDetails.name);
       if (dimension != null && dimension.width > 0 && dimension.height > 0) {
+        var imageSize = new Dimension(imageIcon.getIconWidth(), imageIcon.getIconHeight());
+        SwingUtil.constrainTo(imageSize, dimension.width, dimension.height);
+
         imageIcon.setImage(
             imageIcon
                 .getImage()
-                .getScaledInstance(dimension.width, dimension.height, Image.SCALE_AREA_AVERAGING));
+                .getScaledInstance(imageSize.width, imageSize.height, Image.SCALE_AREA_AVERAGING));
       }
       return imageIcon;
     }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2974,6 +2974,7 @@ startup.preferences.info.manualCopy = MapTool is unable to write the startup set
   In order for them to take effect you will need to edit the configuration file and restart MapTool \
   after saving your changes.
 
+startup.preferences.button.copyCfgPath.tooltip = Copy the configuration file path to the clipboard.
 
 userTerm.GM     = GM
 userTerm.Player = Player

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -721,7 +721,7 @@ Preferences.label.advanced.javafx                 = Intialize AWT before JavaFX
 Preferences.label.jvm                             = JVM Memory Settings
 Preferences.label.jvm.heap                        = Maximum heap size (-Xmx)
 Preferences.label.jvm.heap.tooltip                = -Xmx size in bytes Sets the maximum size to which the Java heap can grow.
-Preferences.label.jvm.min                         = Initial & minimum heap size (-Xms)
+Preferences.label.jvm.min                         = Initial && minimum heap size (-Xms)
 Preferences.label.jvm.min.tooltip                 = Oracle recommends setting the minimum heap size (-Xms) equal to the maximum heap size (-Xmx) to minimize garbage collections.
 Preferences.label.jvm.stack                       = Thread stack size (-Xss)
 Preferences.label.jvm.stack.tooltip               = Thread stacks are memory areas allocated for each Java thread for their internal use. This is where the thread stores its local execution state.
@@ -2931,7 +2931,6 @@ undefinedmacro.unknownCommand = Unknown command: "{0}".  Try <b>/help</b> for a 
 startup.config.unableToWrite = Unable to write to configuration file.
 Preferences.startup.label.info = Startup Preferences Information
 startup.preferences.info = <html>\
-  {0} <!-- Copy Information will be inserted here if needed. -->\
   <u><b>JVM Memory Settings</b></u>\
   <ul>\
     <li>\
@@ -2971,10 +2970,9 @@ startup.preferences.info = <html>\
   </ul>\
 </html>
 
-startup.preferences.info.manualCopy =  <h1><b>Activating Startup Preferences<b></h1>\
-  MapTool is unable to copy the configuration file to the startup directory.<br>\
+startup.preferences.info.manualCopy = MapTool is unable to write the startup settings to the configuration file.\n\
   In order for them to take effect you will need to edit the configuration file and restart MapTool \
-  after saving your changes. <br>
+  after saving your changes.
 
 
 userTerm.GM     = GM

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2970,9 +2970,9 @@ startup.preferences.info = <html>\
   </ul>\
 </html>
 
-startup.preferences.info.manualCopy = MapTool is unable to write the startup settings to the configuration file.\n\
+startup.preferences.info.manualCopy = <html>MapTool is unable to write the startup settings to the configuration file.<br>\
   In order for them to take effect you will need to edit the configuration file and restart MapTool \
-  after saving your changes.
+  after saving your changes.</html>
 
 startup.preferences.button.copyCfgPath.tooltip = Copy the configuration file path to the clipboard.
 

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -711,6 +711,8 @@ Preferences.label.language.override               = Language Override
 Preferences.label.options                         = Additional Options
 Preferences.label.options.directory               = Data Directory
 Preferences.label.options.directory.tooltip       = Override default data directory. Default is .maptool under user directory.
+Preferences.label.cfgFilePath                     = Configuration file
+Preferences.label.cfgFilePath.tooltip             = Path of the .cfg file containing startup settings.
 Preferences.label.advanced                        = Advanced Options
 Preferences.label.advanced.assert                 = Enable assertions
 Preferences.label.advanced.direct3d               = Disable Direct3d Pipeline
@@ -2971,7 +2973,7 @@ startup.preferences.info = <html>\
 
 startup.preferences.info.manualCopy =  <h1><b>Activating Startup Preferences<b></h1>\
   MapTool is unable to copy the configuration file to the startup directory.<br>\
-  In order for them to take effect you will need to edit the {0} and restart MapTool \
+  In order for them to take effect you will need to edit the configuration file and restart MapTool \
   after saving your changes. <br>
 
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5350

### Description of the Change

This PR factors out the path information in the _Startup_ tab of the **Preferences Dialog**. Now the config file is displayed separately from the "manual copy" text, which also means it is always displayed whether or not that text is shown. When the "manual copy" text is needed, it is now also separate from the ***Startup Preference Information***, and uses a warning icon instead of a heading to get the user's attention.

In the _Themes_ tab, the theme example image is now scaled to fit instead of stretched.

For comparison, the _Startup_ tab in the old **Preferences** dialog looked like this:
![image](https://github.com/user-attachments/assets/dbc64f3c-8603-4b38-893a-b14d42e1409d)
But now it looks like this:
![image](https://github.com/user-attachments/assets/f1fac66c-9e34-4deb-8276-3dd3d747aef0)

### Possible Drawbacks

This changes how the `startup.preferences.info` and `startup.preferences.info.manualCopy` i18n keys are used. It should not be difficult for translators to update, but without an update they will both look a little odd.

### Documentation Notes

N/A

### Release Notes

- Fixed the preferences dialog to not get large when the config file path is long.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5435)
<!-- Reviewable:end -->
