### PR TITLE
Fix token ownership list in Edit Token dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/AbeillePanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/AbeillePanel.java
@@ -112,9 +112,6 @@ public class AbeillePanel<T> extends JPanel {
       case GridLayoutManager gridLayoutManager -> {
         constraints = gridLayoutManager.getConstraintsForComponent(placeHolder);
       }
-      case ScrollPaneLayout scrollPaneLayout -> {
-        /* Nothing to do. */
-      }
       default -> {
         throw new RuntimeException(
             "Replacement of components not implemented for layout: " + layout.getClass().getName());

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -1246,7 +1246,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
   public void initOwnershipPanel() {
     CheckBoxListWithSelectable list = new CheckBoxListWithSelectable();
     list.setName("ownerList");
-    replaceComponent("ownershipPanel", "ownershipList", list);
+    replaceComponent(
+        "ownershipPanel",
+        "ownershipList",
+        new JScrollPane(
+            list,
+            JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER));
   }
 
   public void initPropertiesPanel() {

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -45,7 +45,9 @@
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
-                    <properties/>
+                    <properties>
+                      <name value="ownershipPanel"/>
+                    </properties>
                     <border type="etched" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="EditTokenDialog.border.title.ownership"/>
                     <children>
                       <component id="f24a5" class="javax.swing.JCheckBox">
@@ -58,25 +60,15 @@
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="EditTokenDialog.label.allplayers"/>
                         </properties>
                       </component>
-                      <scrollpane id="e8ec3">
+                      <component id="39337" class="javax.swing.JLabel">
                         <constraints>
                           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <horizontalScrollBarPolicy value="31"/>
-                          <name value="ownershipPanel"/>
+                          <name value="ownershipList"/>
+                          <text value=""/>
                         </properties>
-                        <border type="none"/>
-                        <children>
-                          <component id="39337" class="javax.swing.JLabel">
-                            <constraints/>
-                            <properties>
-                              <name value="ownershipList"/>
-                              <text value=""/>
-                            </properties>
-                          </component>
-                        </children>
-                      </scrollpane>
+                      </component>
                       <vspacer id="bd32">
                         <constraints>
                           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes an issue with PR #5431

### Description of the Change

In #5431, I add support for replacing components in `JScrollPane`. This required more care than I realized, and resulted in the ownership list of the **Edit Token** dialog not showing up.

This PR fixes that by going back to the old method of injecting an entire `JScrollPane` instead of just the contents.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5436)
<!-- Reviewable:end -->
