### PR TITLE
Fix errors when editing Native Size or Free Size tokens

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -50,7 +50,6 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
-import javax.swing.text.JTextComponent;
 import javax.swing.text.Position.Bias;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
@@ -2144,52 +2143,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       label.setHorizontalTextPosition(JLabel.LEFT);
       label.setFont(font);
       return label;
-    }
-  }
-
-  /* HANDLER */
-  public static class MouseHandler extends MouseAdapter {
-
-    HtmlEditorSplit source;
-
-    public MouseHandler(HtmlEditorSplit source) {
-      this.source = source;
-    }
-
-    @Override
-    public void mouseClicked(MouseEvent e) {
-      if (SwingUtilities.isRightMouseButton(e)) {
-        JPopupMenu menu = new JPopupMenu();
-        JMenuItem sendToChatItem =
-            new JMenuItem(I18N.getString("EditTokenDialog.menu.notes.sendChat"));
-        sendToChatItem.addActionListener(
-            e12 -> {
-              String selectedText = source.getSelectedText();
-              if (selectedText == null) {
-                selectedText = source.getText();
-              }
-              JTextComponent commandArea =
-                  MapTool.getFrame().getCommandPanel().getCommandTextArea();
-
-              commandArea.setText(commandArea.getText() + selectedText);
-              commandArea.requestFocusInWindow();
-            });
-        menu.add(sendToChatItem);
-
-        JMenuItem sendAsEmoteItem =
-            new JMenuItem(I18N.getString("EditTokenDialog.menu.notes.sendEmit"));
-        sendAsEmoteItem.addActionListener(
-            e1 -> {
-              String selectedText = source.getSelectedText();
-              if (selectedText == null) {
-                selectedText = source.getText();
-              }
-              MapTool.getFrame().getCommandPanel().commitCommand("/emit " + selectedText);
-              MapTool.getFrame().getCommandPanel().getCommandTextArea().requestFocusInWindow();
-            });
-        menu.add(sendAsEmoteItem);
-        menu.show((JComponent) e.getSource(), e.getX(), e.getY());
-      }
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -342,7 +342,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     }
 
     /* OWNER LIST */
-    EventQueue.invokeLater(() -> getOwnerList().setModel(new OwnerListModel()));
+    EventQueue.invokeLater(() -> getOwnerList().setModel(new OwnerListModel(token)));
 
     /* SPEECH TABLE */
     EventQueue.invokeLater(() -> getSpeechTable().setModel(new SpeechTableModel(token)));
@@ -2244,14 +2244,14 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     }
   }
 
-  private class OwnerListModel extends AbstractListModel {
+  private static final class OwnerListModel extends AbstractListModel<Selectable> {
 
     private static final long serialVersionUID = 2375600545516097234L;
 
     List<Selectable> ownerList = new ArrayList<Selectable>();
 
-    public OwnerListModel() {
-      Set<String> ownerSet = getModel().getOwners();
+    public OwnerListModel(Token model) {
+      Set<String> ownerSet = model.getOwners();
       List<String> list = new ArrayList<String>(ownerSet);
 
       List<Player> playerList = MapTool.getPlayerList();
@@ -2271,7 +2271,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       }
     }
 
-    public Object getElementAt(int index) {
+    public Selectable getElementAt(int index) {
       return ownerList.get(index);
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -472,6 +472,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     String heroLabTitle = I18N.getString("EditTokenDialog.tab.hero");
 
     if (heroLabData != null) {
+      getHeroLabImagesList().setCellRenderer(new HeroLabImageListRenderer(heroLabData));
+
       boolean isDirty = heroLabData.isDirty() && heroLabData.getPortfolioFile().exists();
       JButton refreshDataButton = (JButton) getComponent("refreshDataButton");
 
@@ -516,6 +518,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
       EventQueue.invokeLater(this::loadHeroLabImageList);
     } else {
+      getHeroLabImagesList().setCellRenderer(new DefaultListCellRenderer());
+
       tabbedPane.setEnabledAt(tabbedPane.indexOfTab(heroLabTitle), false);
       if (tabbedPane.getSelectedIndex() == tabbedPane.indexOfTab(heroLabTitle)) {
         tabbedPane.setSelectedIndex(6);
@@ -1571,10 +1575,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
   /*
    * Initialize the Hero Lab Images tab
    */
-  @SuppressWarnings("unchecked")
   public void initHeroLabImageList() {
-    getHeroLabImagesList().setCellRenderer(new HeroLabImageListRenderer());
-
     JButton setTokenImage = (JButton) getComponent("setAsImageButton");
     setTokenImage.addActionListener(
         e -> {
@@ -2130,10 +2131,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     }
   }
 
-  public class HeroLabImageListRenderer extends DefaultListCellRenderer {
+  private static class HeroLabImageListRenderer extends DefaultListCellRenderer {
+    private final Font font = new Font("helvitica", Font.BOLD, 24);
+    private final HeroLabData heroLabData;
 
-    private static final long serialVersionUID = 7113815213979044509L;
-    Font font = new Font("helvitica", Font.BOLD, 24);
+    public HeroLabImageListRenderer(HeroLabData heroLabData) {
+      this.heroLabData = heroLabData;
+    }
 
     @Override
     public Component getListCellRendererComponent(

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -2105,7 +2105,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     }
   }
 
-  class OpacitySliderListener implements ChangeListener {
+  private class OpacitySliderListener implements ChangeListener {
 
     public void stateChanged(ChangeEvent e) {
       JSlider source = (JSlider) e.getSource();


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5419 

### Description of the Change

Two main parts:
1. Model classes in `EditTokenDialog` are all static, with necessary data being passed to constructors instead of being pulled from `getModel()` and elsewhere. This makes the dialog as a whole less prone to errors when there is a problem during binding. _That said, there's still a lot of room for improvement in terms of making the dialog more robust_.
2. The token layout panel now accounts for tokens that don't have a footprint for the current grid, i.e., Native Size or Free Size tokens. For such tokens, the panel uses the token's width/height instead of the footprint's bounds, and assumes a scale of 1 instead of using the footprint's scale.

### Possible Drawbacks

I don't think there's any.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where tokens could not be edited when the size was Native Size or Free Size

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5437)
<!-- Reviewable:end -->
