### PR TITLE
Load content into WebViews through URLs

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -26,6 +26,7 @@ import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.LinkedList;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -318,8 +319,7 @@ public class HTMLWebViewManager {
     isFlushed = true;
   }
 
-  public void updateContents(final String html, boolean scrollReset) {
-    log.debug("setting text in WebView: {}", html);
+  public void updateContents(String html, boolean scrollReset) {
     this.scrollReset = scrollReset;
     // If the WebView has been flushed, the scrolling has already been stored
     if (!scrollReset && !isFlushed) {
@@ -327,7 +327,11 @@ public class HTMLWebViewManager {
       scrollY = getVScrollValue();
     }
     isFlushed = false;
-    webEngine.loadContent(SCRIPT_BLOCK_EXT + SCRIPT_BRIDGE + HTMLPanelInterface.fixHTML(html));
+
+    String fixedHtml = SCRIPT_BLOCK_EXT + SCRIPT_BRIDGE + HTMLPanelInterface.fixHTML(html);
+    String encodedHtml =
+        Base64.getEncoder().encodeToString(fixedHtml.getBytes(StandardCharsets.UTF_8));
+    webEngine.load("data:text/html;base64," + encodedHtml);
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4832

### Description of the Change

`WebEngine.loadContent()` seems unable to correctly handle unicode characters above 0xFFFF. However, `WebEngine.load()` is able to handle content with such characters in the resolved document. So this PR changes the way frame5, dialog5, and overlay content is loaded so that `WebEngine.load()` is called with a base64-encoded URL.

Note: for chat, frame, and dialog, the same sort of problem was resolved by using the new unicode-aware parser. frame5, dialog5, and overlays also depends on the new parser, but require this additional work to really fix the unicode issues with them. Also, the built-in font does not support every unicode character, but such support can be added by the document author by including suitable fonts (e.g., Noto Emoji).

### Possible Drawbacks

Extra computation will be required to load an HTML5 document.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where many unicode characters could not be represented properly in frame5, dialog5, and overlays.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5442)
<!-- Reviewable:end -->
