### PR TITLE
Enable skip_untranslated_strings option for Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,3 +2,4 @@ files:
   - source: /src/main/resources/net/rptools/maptool/language/i18n.properties
     translation: /%original_path%/%file_name%_%locale_with_underscore%.%file_extension%
     escape_quotes: 3
+    skip_untranslated_strings: true


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5448

### Description of the Change

Enables `skip_unstranslated_strings` option in the Crowdin config.

### Possible Drawbacks

Who knows? It was hard enough to find the option let alone understanding any tradeoffs. Shouldn't be any harm that can't be undone, though.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5449)
<!-- Reviewable:end -->
