### PR TITLE
Return drawn templates' template type and size

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -27,6 +27,7 @@ import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.Zone.Layer;
 import net.rptools.maptool.model.drawing.AbstractDrawing;
+import net.rptools.maptool.model.drawing.AbstractTemplate;
 import net.rptools.maptool.model.drawing.Drawable;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
@@ -251,7 +252,7 @@ public class DrawingFunctions extends AbstractFunction {
     dinfo.addProperty("id", el.getDrawable().getId().toString());
     dinfo.addProperty("name", d.getName());
     dinfo.addProperty("layer", el.getDrawable().getLayer().name());
-    dinfo.addProperty("type", getDrawbleType(d));
+    dinfo.addProperty("type", getDrawableType(el));
     dinfo.add("bounds", boundsToJSON(map, d));
     dinfo.addProperty("penColor", paintToString(el.getPen().getPaint()));
     dinfo.addProperty("fillColor", paintToString(el.getPen().getBackgroundPaint()));
@@ -259,6 +260,9 @@ public class DrawingFunctions extends AbstractFunction {
     dinfo.addProperty("isEraser", el.getPen().isEraser() ? BigDecimal.ONE : BigDecimal.ZERO);
     dinfo.addProperty("penWidth", el.getPen().getThickness());
     dinfo.add("path", pathToJSON(d));
+    if (el.getDrawable() instanceof AbstractTemplate t) {
+      dinfo.addProperty("templateSize", t.getRadius());
+    }
 
     return dinfo;
   }
@@ -272,13 +276,15 @@ public class DrawingFunctions extends AbstractFunction {
     return binfo;
   }
 
-  private String getDrawbleType(AbstractDrawing d) {
-    if (d instanceof LineSegment) {
+  private String getDrawableType(DrawnElement el) {
+    if (el.getDrawable() instanceof LineSegment) {
       return "Line";
-    } else if (d instanceof ShapeDrawable sd) {
+    } else if (el.getDrawable() instanceof ShapeDrawable sd) {
       return sd.getShapeTypeName();
-    } else if (d instanceof DrawablesGroup) {
+    } else if (el.getDrawable() instanceof DrawablesGroup) {
       return "Group";
+    } else if (el.getDrawable() instanceof AbstractTemplate t) {
+      return t.getClass().getSimpleName();
     } else {
       return "unknown";
     }


### PR DESCRIPTION
### Identify the Bug or Feature request
[Bug]: getDrawingInfo() for templates returns type = 'unknown'

fixes #5330

### Description of the Change
* modified getDrawingJSONInfo and getDrawbleType (corrected name to getDrawableType) to now get template type and size for drawn templates
* took inspiration from `DrawPanelTreeCellRenderer.java` on how to get these.

### Possible Drawbacks
`getDrawingInfo()` will no longer return 'type' as 'unknown' for known templates.

### Documentation Notes
https://wiki.rptools.info/index.php/getDrawingInfo should perhaps be expanded to mention templates as well as drawings.

* `type` for templates now returns either:
RadiusTemplate, RadiusCellTemplate, ConeTemplate, LineTemplate, LineCellTemplate, BurstTemplate, BlastTemplate, WallTemplate

* `templateSize` is now also returned in the drawing information for templates, representing either the cell radius/length as appropriate to the template.

### Release Notes
- Fixed an issue where `getDrawingInfo()` for templates returns type = 'unknown' and was excluding template size

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5450)
<!-- Reviewable:end -->
