### PR TITLE
Fix for remote client image corruption

### DIFF
--- a/src/main/java/net/rptools/maptool/model/AssetManager.java
+++ b/src/main/java/net/rptools/maptool/model/AssetManager.java
@@ -143,18 +143,6 @@ public class AssetManager {
   }
 
   /**
-   * Determine if the asset is currently being requested. While an asset is being loaded it will be
-   * marked as requested and this function will return true. Once the asset is done loading this
-   * function will return false and the asset will be available from the cache.
-   *
-   * @param key MD5Key of asset being requested
-   * @return True if asset is currently being requested, false otherwise
-   */
-  public static boolean isAssetRequested(MD5Key key) {
-    return assetLoader.isIdRequested(key);
-  }
-
-  /**
    * Register a listener with the asset manager. The listener will be notified when the asset is
    * done loading.
    *
@@ -302,9 +290,7 @@ public class AssetManager {
 
           // Let's get it from the server
           // As a last resort we request the asset from the server
-          if (!isAssetRequested(id)) {
-            requestAssetFromServer(id, listeners);
-          }
+          requestAssetFromServer(id, listeners);
         });
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

fixes https://github.com/RPTools/maptool/issues/5403

### Description of the Change

This moves the check for whether there is already a request for the asset inside the requestAsset method to remove a race condition where AssetManager would synchronize checking whether there was a request and then request it, which fails when multiple threads are checking whether the asset is cached in parallel, all get the result that there are no pending requests, and then submit multiple requests when there should be only one.

### Possible Drawbacks

This is potentially not a complete solution.

It'll stop the parallel requests which result in corrupt asset requests, but it's possible sequential requests for the same assets might still happen if there's so many tokens it's still enumerating them by the time the asset has been loaded.
The locking might be better further up the call stack, but this fixed it for me.

### Release Notes

* Fixed "Received an invalid image" errors when there are multiple tokens on a map sharing an image larger than 5 Kilobytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5451)
<!-- Reviewable:end -->
