### PR TITLE
Stop walls from coming back from the dead

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -445,6 +445,16 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     @Override
     public void delete() {}
 
+    protected void deleteSelectedWall() {
+      tool.getSelectedWall()
+          .ifPresent(
+              wall -> {
+                tool.setSelectedWall(null);
+                wall.delete();
+                MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
+              });
+    }
+
     @Override
     public void mouseMoved(Point2D point, Snap snapMode, MouseEvent event) {}
 
@@ -696,7 +706,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
     @Override
     public void delete() {
-      tool.getSelectedWall().ifPresent(selected -> selected.delete());
+      deleteSelectedWall();
     }
 
     @Override
@@ -735,8 +745,6 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
           case null -> {
             // Hit blank space. Start a new wall.
             var newWall = rig.addDegenerateWall(snapMode.snap(point));
-            tool.setWallPropertiesFromConfigPanel(newWall.getSource());
-            tool.setSelectedWall(newWall);
             tool.changeToolMode(new DrawingWallToolMode(tool, rig, newWall));
           }
           case WallTopologyRig.MovableVertex movableVertex -> {
@@ -777,8 +785,6 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
             .ifPresent(
                 mergeCandidate -> {
                   var newWall = rig.addConnectedWall(mergeCandidate);
-                  tool.setWallPropertiesFromConfigPanel(newWall.getSource());
-                  tool.setSelectedWall(newWall);
                   tool.changeToolMode(new DrawingWallToolMode(tool, rig, newWall));
                 });
       }
@@ -841,6 +847,12 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
         WallTopologyTool tool, WallTopologyRig rig, WallTopologyRig.MovableWall wall) {
       super(tool, rig);
       this.wall = wall;
+    }
+
+    @Override
+    public void activate() {
+      tool.setWallPropertiesFromConfigPanel(wall.getSource());
+      tool.setSelectedWall(wall);
     }
 
     private void findConnectToHandle(InputEvent event) {

--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -76,7 +76,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
               if (selectedWall != null) {
                 selectedWall.getSource().setData(newData);
-                MapTool.serverCommand().updateWall(getZone(), selectedWall.getSource());
+                mode.onWallChanged(selectedWall);
               }
             });
   }
@@ -332,6 +332,13 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     void delete();
 
     /**
+     * Called when a wall is changed from outside this tool mode.
+     *
+     * @param wall The modified wall.
+     */
+    void onWallChanged(WallTopologyRig.MovableWall wall);
+
+    /**
      * Handles a mouse move.
      *
      * <p><strong>Note:</strong> if the mouse is dragged, {@link #mouseDragged(Point2D, Snap,
@@ -409,6 +416,9 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     public void delete() {}
 
     @Override
+    public void onWallChanged(WallTopologyRig.MovableWall wall) {}
+
+    @Override
     public void mouseMoved(Point2D point, Snap snapMode, MouseEvent event) {}
 
     @Override
@@ -465,6 +475,16 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
                 wall.delete();
                 MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
               });
+    }
+
+    /**
+     * Applies the default behaviour of syncing the changed wall.
+     *
+     * @param wall The modified wall.
+     */
+    @Override
+    public void onWallChanged(WallTopologyRig.MovableWall wall) {
+      MapTool.serverCommand().updateWall(tool.getZone(), wall.getSource());
     }
 
     @Override
@@ -883,6 +903,14 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
       tool.setSelectedWall(null);
       tool.changeToolMode(new BasicToolMode(tool, rig));
       return true;
+    }
+
+    @Override
+    public void onWallChanged(WallTopologyRig.MovableWall changedWall) {
+      // The wall we're drawing is temporary, so don't try to sync such changes.
+      if (!changedWall.isForSameElement(wall)) {
+        super.onWallChanged(changedWall);
+      }
     }
 
     @Override

--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -211,11 +211,6 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     return getWallHalfWidth() * 1.5;
   }
 
-  private void setWallPropertiesFromConfigPanel(Wall wall) {
-    var current = controlPanel.getModel();
-    wall.setData(current);
-  }
-
   private void setSelectedWall(@Nullable WallTopologyRig.MovableWall wall) {
     selectedWall = wall;
     if (selectedWall != null) {
@@ -883,7 +878,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
     @Override
     public void activate() {
-      tool.setWallPropertiesFromConfigPanel(wall.getSource());
+      wall.getSource().setData(tool.controlPanel.getModel());
       tool.setSelectedWall(wall);
     }
 
@@ -943,7 +938,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
         }
         wall = newWall;
 
-        tool.setWallPropertiesFromConfigPanel(newWall.getSource());
+        newWall.getSource().setData(tool.controlPanel.getModel());
         tool.setSelectedWall(newWall);
       }
       if (SwingUtilities.isLeftMouseButton(event)) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/MovementBlockingTopology.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/MovementBlockingTopology.java
@@ -62,7 +62,7 @@ public class MovementBlockingTopology {
             .getWalls()
             .filter(
                 wall ->
-                    switch (wall.movementModifier()) {
+                    switch (wall.data().movementModifier()) {
                       case ForceBoth -> true;
                       case Disabled -> false;
                     })

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -995,7 +995,7 @@ public class Zone {
 
     existingWall.ifPresentOrElse(
         existing -> {
-          existing.copyDataFrom(wall);
+          existing.setData(wall.data());
 
           new MapToolEventBus().getMainEventBus().post(new WallTopologyChanged(this));
         },

--- a/src/main/java/net/rptools/maptool/model/converters/WallTopologyConverter.java
+++ b/src/main/java/net/rptools/maptool/model/converters/WallTopologyConverter.java
@@ -187,11 +187,11 @@ public class WallTopologyConverter extends AbstractCollectionConverter {
     public WallRepresentation(Wall wall) {
       this.from = wall.from().toString();
       this.to = wall.to().toString();
-      this.direction = wall.direction();
-      this.movementDirection = wall.movementModifier();
-      this.sightDirection = wall.directionModifier(VisibilityType.Sight);
-      this.lightDirection = wall.directionModifier(VisibilityType.Light);
-      this.auraDirection = wall.directionModifier(VisibilityType.Aura);
+      this.direction = wall.data().direction();
+      this.movementDirection = wall.data().movementModifier();
+      this.sightDirection = wall.data().directionModifier(VisibilityType.Sight);
+      this.lightDirection = wall.data().directionModifier(VisibilityType.Light);
+      this.auraDirection = wall.data().directionModifier(VisibilityType.Aura);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/topology/Wall.java
+++ b/src/main/java/net/rptools/maptool/model/topology/Wall.java
@@ -95,47 +95,12 @@ public final class Wall {
    * @return An equivalent but reversed wall.
    */
   public Wall reversed() {
-    return new Wall(to, from, direction().reversed(), data.movementModifier(), data.modifiers());
-  }
-
-  public Direction direction() {
-    return data.direction();
-  }
-
-  public void direction(Direction direction) {
-    data = new Data(direction, data.movementModifier(), data.modifiers());
-  }
-
-  public MovementDirectionModifier movementModifier() {
-    return data.movementModifier();
-  }
-
-  public void movementModifier(MovementDirectionModifier modifier) {
-    data = new Data(data.direction(), modifier, data.modifiers());
-  }
-
-  public DirectionModifier directionModifier(VisibilityType visibilityType) {
-    return data.directionModifier(visibilityType);
-  }
-
-  public void directionModifier(VisibilityType visibilityType, DirectionModifier modifier) {
-    var newModifiers = new EnumMap<VisibilityType, DirectionModifier>(VisibilityType.class);
-    newModifiers.putAll(data.modifiers());
-    newModifiers.put(visibilityType, modifier);
-    data = new Data(data.direction(), data.movementModifier(), newModifiers);
+    return new Wall(
+        to, from, data.direction().reversed(), data.movementModifier(), data.modifiers());
   }
 
   public void setData(Data otherData) {
     this.data = otherData;
-  }
-
-  public void copyDataFrom(Wall other) {
-    setData(other.data);
-  }
-
-  public void mergeDataFrom(Wall other) {
-    var newData = data.merge(other.data);
-    setData(newData);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/topology/WallTopology.java
+++ b/src/main/java/net/rptools/maptool/model/topology/WallTopology.java
@@ -340,8 +340,8 @@ public final class WallTopology implements Topology {
     var newVertex = addNewVertex();
     var newWall1 = new Wall(removed.from(), newVertex.id());
     var newWall2 = new Wall(newVertex.id(), removed.to());
-    newWall1.copyDataFrom(wall);
-    newWall2.copyDataFrom(wall);
+    newWall1.setData(wall.data());
+    newWall2.setData(wall.data());
 
     try {
       addWallImpl(newWall1);
@@ -410,7 +410,7 @@ public final class WallTopology implements Topology {
         var newWall =
             new Wall(
                 firstIsSource ? second.id() : neighbour, firstIsSource ? neighbour : second.id());
-        newWall.copyDataFrom(oldWall);
+        newWall.setData(oldWall.data());
         try {
           addWallImpl(newWall);
         } catch (GraphException e) {
@@ -424,7 +424,7 @@ public final class WallTopology implements Topology {
         // If the walls point in opposite directions, flip the one being merged so that they agree
         // on things like direction.
         var wallToMerge = (firstIsSource == secondIsSource) ? oldWall : oldWall.reversed();
-        existingWall.mergeDataFrom(wallToMerge);
+        existingWall.setData(existingWall.data().merge(wallToMerge.data()));
       }
     }
 
@@ -482,9 +482,9 @@ public final class WallTopology implements Topology {
 
               // For directional walls, ensure the origin is on the correct side.
               var direction =
-                  switch (wall.directionModifier(visibilityType)) {
-                    case SameDirection -> wall.direction();
-                    case ReverseDirection -> wall.direction().reversed();
+                  switch (wall.data().directionModifier(visibilityType)) {
+                    case SameDirection -> wall.data().direction();
+                    case ReverseDirection -> wall.data().direction().reversed();
                     case ForceBoth -> Wall.Direction.Both;
                     case Disabled -> null;
                   };


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes [issue](https://github.com/RPTools/maptool/issues/5271#issuecomment-2852645582) with #5271

### Description of the Change

When using the Wall tool, the selected wall is now handled more consistently. There a few facets to this:
1. The control panel is no longer responsible for syncing changes to other clients. It used to have a bad habit of telling other clients to update their walls when the current wall may have been deleted or is a new wall that hasn't been completed yet. Now, it fires an event that the tool itself can handle and decide whether updates need to be synced. This also means the control panel only need to use the immutable `Wall.Data` as its model, rather than a complete and mutable `Wall`.
2. In the tool itself, when a wall is modified, it is up to the specific tool mode to decide whether to sync the changes. For most modes, the sync is always done. But for `DrawingWallToolMode`, the selected wall is only temporary, so changes to it are not synced.
3. Another change to the tool itself is that when the selected wall is deleted, it is also consistently nulled out and deleted on all other clients.

Beyond that, I've cleaned up a bunch of helper methods that hardly saved anything, and I found they actually obscured what was happening.

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5453)
<!-- Reviewable:end -->
