### PR TITLE
Add texture to GdxPaint for solid colours

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -284,7 +284,7 @@ public class GdxRenderer extends ApplicationAdapter {
     try {
       doRendering();
     } catch (Exception ex) {
-      log.warn(ex);
+      log.warn("Error while rendering", ex);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/ZoneCache.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/ZoneCache.java
@@ -21,7 +21,6 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.*;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.video.VideoPlayer;
-import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -322,7 +321,7 @@ public class ZoneCache implements Disposable {
     if (paint instanceof DrawableColorPaint) {
       var color = new Color();
       Color.argb8888ToColor(color, ((DrawableColorPaint) paint).getColor());
-      return new GdxPaint(color, null);
+      return new GdxPaint(color, whitePixelRegion);
     }
 
     var texturePaint = (DrawableTexturePaint) paint;


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5470

### Description of the Change

Rendering via `PolygonSprite` requires a texture, so use the solid white texture for solid colour paints.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fix LibGDX renderer to render solid colour background and fog of war

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5471)
<!-- Reviewable:end -->
