### PR TITLE
Fix light blending with LibGDX renderer

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/BlendFunction.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/BlendFunction.java
@@ -1,0 +1,40 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone.gdx;
+
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.Batch;
+
+public record BlendFunction(
+    int srcFuncColor, int dstFuncColor, int srcFuncAlpha, int dstFuncAlpha) {
+  public static final BlendFunction PREMULTIPLIED_ALPHA_SRC_OVER =
+      new BlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
+  public static BlendFunction readFromBatch(Batch batch) {
+    return new BlendFunction(
+        batch.getBlendSrcFunc(),
+        batch.getBlendDstFunc(),
+        batch.getBlendSrcFuncAlpha(),
+        batch.getBlendDstFuncAlpha());
+  }
+
+  public BlendFunction(int srcFunc, int dstFunc) {
+    this(srcFunc, dstFunc, srcFunc, dstFunc);
+  }
+
+  public void applyToBatch(Batch batch) {
+    batch.setBlendFunctionSeparate(srcFuncColor, dstFuncColor, srcFuncAlpha, dstFuncAlpha);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/BlendFunction.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/BlendFunction.java
@@ -29,6 +29,8 @@ public record BlendFunction(
   public static final BlendFunction SCREEN =
       new BlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_COLOR, GL20.GL_ONE, GL20.GL_NONE);
 
+  public static final BlendFunction SRC_ONLY = new BlendFunction(GL20.GL_ONE, GL20.GL_NONE);
+
   public static BlendFunction readFromBatch(Batch batch) {
     return new BlendFunction(
         batch.getBlendSrcFunc(),

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/BlendFunction.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/BlendFunction.java
@@ -22,6 +22,13 @@ public record BlendFunction(
   public static final BlendFunction PREMULTIPLIED_ALPHA_SRC_OVER =
       new BlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
+  public static final BlendFunction ALPHA_SRC_OVER =
+      new BlendFunction(
+          GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
+  public static final BlendFunction SCREEN =
+      new BlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_COLOR, GL20.GL_ONE, GL20.GL_NONE);
+
   public static BlendFunction readFromBatch(Batch batch) {
     return new BlendFunction(
         batch.getBlendSrcFunc(),

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -67,7 +67,6 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.Label;
 import net.rptools.maptool.model.Path;
-import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawnElement;
 import net.rptools.maptool.util.GraphicsUtil;
 import org.apache.logging.log4j.LogManager;
@@ -1321,13 +1320,10 @@ public class GdxRenderer extends ApplicationAdapter {
     for (var light : lights) {
       var paint = light.getPaint().getPaint();
 
-      if (paint instanceof DrawableColorPaint) {
-        var colorPaint = (DrawableColorPaint) paint;
-        Color.argb8888ToColor(tmpColor, colorPaint.getColor());
-      } else if (paint instanceof java.awt.Color) {
-        Color.argb8888ToColor(tmpColor, ((java.awt.Color) paint).getRGB());
+      if (paint instanceof java.awt.Color color) {
+        Color.argb8888ToColor(tmpColor, color.getRGB());
       } else {
-        System.out.println("unexpected color type");
+        log.warn("Unexpected color type: {}", paint.getClass());
         continue;
       }
       tmpColor.set(tmpColor.r, tmpColor.g, tmpColor.b, alpha);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -329,7 +329,7 @@ public class GdxRenderer extends ApplicationAdapter {
     batch.enableBlending();
     // Framebuffer is premultiplied. Assume source textures are as well (can be changed for
     // operations that require something else).
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+    BlendFunction.PREMULTIPLIED_ALPHA_SRC_OVER.applyToBatch(batch);
 
     // this happens sometimes when starting with ide (non-debug)
     if (batch.isDrawing()) batch.end();
@@ -829,7 +829,7 @@ public class GdxRenderer extends ApplicationAdapter {
     backBuffer.begin();
     ScreenUtils.clear(Color.CLEAR);
 
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_NONE);
+    BlendFunction.SRC_ONLY.applyToBatch(batch);
     setProjectionMatrix(cam.combined);
 
     timer.start("renderFog-allocateBufferedImage");
@@ -878,7 +878,7 @@ public class GdxRenderer extends ApplicationAdapter {
     // createScreenshot("fog");
     backBuffer.end();
 
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+    BlendFunction.PREMULTIPLIED_ALPHA_SRC_OVER.applyToBatch(batch);
     setProjectionMatrix(hudCam.combined);
     batch.setColor(Color.WHITE);
     batch.draw(backBuffer.getColorBufferTexture(), 0, 0, width, height, 0, 0, 1, 1);
@@ -1218,7 +1218,7 @@ public class GdxRenderer extends ApplicationAdapter {
     backBuffer.begin();
     timer.stop("renderLumensOverlay:allocateBuffer");
 
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_NONE);
+    BlendFunction.SRC_ONLY.applyToBatch(batch);
     // At night, show any uncovered areas as dark. In daylight, show them as light (clear).
     if (zoneCache.getZone().getVisionType() == Zone.VisionType.NIGHT) {
       ScreenUtils.clear(0, 0, 0, overlayAlpha);
@@ -1226,8 +1226,6 @@ public class GdxRenderer extends ApplicationAdapter {
       ScreenUtils.clear(Color.CLEAR);
     }
 
-    // Premultiplied alpha compositing.
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_NONE);
     timer.start("renderLumensOverlay:drawLumens");
     for (final var lumensLevel : disjointLumensLevels) {
       final var lumensStrength = lumensLevel.lumensStrength();
@@ -1264,7 +1262,7 @@ public class GdxRenderer extends ApplicationAdapter {
 
     timer.stop("renderLumensOverlay:drawLumens");
 
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+    BlendFunction.PREMULTIPLIED_ALPHA_SRC_OVER.applyToBatch(batch);
     // Now draw borders around each region if configured.
     batch.setColor(Color.WHITE);
     final var borderThickness = AppPreferences.lumensOverlayBorderThickness.get();
@@ -1287,8 +1285,7 @@ public class GdxRenderer extends ApplicationAdapter {
     backBuffer.end();
 
     timer.start("renderLumensOverlay:drawBuffer");
-    // batch.setColor(1,1,1,overlayAlpha);
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+    BlendFunction.PREMULTIPLIED_ALPHA_SRC_OVER.applyToBatch(batch);
     setProjectionMatrix(hudCam.combined);
     batch.draw(backBuffer.getColorBufferTexture(), 0, 0, width, height, 0, 0, 1, 1);
     setProjectionMatrix(cam.combined);
@@ -1351,7 +1348,7 @@ public class GdxRenderer extends ApplicationAdapter {
     setProjectionMatrix(cam.combined);
     timer.stop("renderLightOverlay:drawBuffer");
 
-    batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+    BlendFunction.PREMULTIPLIED_ALPHA_SRC_OVER.applyToBatch(batch);
   }
 
   private void createScreenshot(String name) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5500

### Description of the Change

This updates the light blending to use the proper calculation for screen mode.

Also included is a fix around premultiplied colours for `DrawableLight`. Auras require premultiplied alpha in order to blend properly with each other and the map. Lights cannot use premultiplied alpha otherwise it doesn't match the Swing renderer - although it looks much better IMO with premultiplied alpha, I'm aiming for parity right now.

A convenience type - `BlendFunction` - is added so we don't have to write the same set of blending parameters everywhere for common blending functions. It's also more convenient for passing to methods like `renderLightOverlay()` vs passing individual `int` parameters.

With these changes, the LibGDX renderer draws lights (with Overtop lighting) and auras render near identically to the Swing renderer. Environmental lights is still not supported.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed how lights blend together under LibGDX renderer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5503)
<!-- Reviewable:end -->
