### PR TITLE
1.17 - Fix ClassCastException when draging snap-to-grid token on gridless map

### DIFF
--- a/src/main/java/net/rptools/maptool/model/Path.java
+++ b/src/main/java/net/rptools/maptool/model/Path.java
@@ -98,24 +98,28 @@ public class Path<T extends AbstractPoint> {
 
   /** Create a related path that can be applied to a follower token. */
   public Path<?> derive(Grid grid, Token keyToken, Token followerToken) {
-    if (keyToken.isSnapToGrid() && followerToken.isSnapToGrid()) {
+    final var gridSupportsStg = grid.getCapabilities().isSnapToGridSupported();
+    final var keyIsStg = keyToken.isSnapToGrid() && gridSupportsStg;
+    final var followerIsStg = followerToken.isSnapToGrid() && gridSupportsStg;
+
+    if (keyIsStg && followerIsStg) {
       // Assume T = CellPoint.
       var originCell = grid.convert(new ZonePoint(keyToken.getX(), keyToken.getY()));
       var tokenCell = grid.convert(new ZonePoint(followerToken.getX(), followerToken.getY()));
       return deriveSameSnapToGrid(this, originCell.x - tokenCell.x, originCell.y - tokenCell.y);
-    } else if (!keyToken.isSnapToGrid() && !followerToken.isSnapToGrid()) {
+    } else if (!keyIsStg && !followerIsStg) {
       // Assume T = ZonePoint.
       var originPoint = new ZonePoint(keyToken.getX(), keyToken.getY());
       var tokenPoint = new ZonePoint(followerToken.getX(), followerToken.getY());
       return deriveSameSnapToGrid(this, originPoint.x - tokenPoint.x, originPoint.y - tokenPoint.y);
-    } else if (keyToken.isSnapToGrid()) {
+    } else if (keyIsStg) { // && !followerIsStg
       // Assume T = CellPoint.
       return deriveFromSnapToGrid(
           (Path<CellPoint>) this,
           grid,
           keyToken.getX() - followerToken.getX(),
           keyToken.getY() - followerToken.getY());
-    } else /* (!keyToken.isSnapToGrid) */ {
+    } else /* (!keyIsStg && followerIsStg) */ {
       // Assume T = ZonePoint.
       return deriveFromNotSnapToGrid(
           (Path<ZonePoint>) this,


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5494

### Description of the Change

When deriving a path for a follower token, we now account for whether the grid supports snap-to-grid when decide what type of path we have.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where an exception is thrown is a non-snap-to-grid token is following a snap-to-grid token.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5504)
<!-- Reviewable:end -->
