### PR TITLE
DrawPanelTree information improvements for templates

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
@@ -57,6 +57,8 @@ public class DrawPanelTreeCellRenderer extends DefaultTreeCellRenderer {
         var key = String.format("panel.DrawExplorer.Template.%s", at.getClass().getSimpleName());
         text = I18N.getText(key, at.getRadius());
         setLeafIcon(setDrawPanelIcon(key, de.getPen().isEraser()));
+        String keyTooltip = String.format("%s.tooltip", key);
+        setToolTipText(I18N.getText(keyTooltip, at.getRadius()));
       }
       text = addText(de.getPen(), text, de.getDrawable());
     } else if (value instanceof DrawPanelTreeModel.View) {

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeModel.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.JTree;
+import javax.swing.ToolTipManager;
 import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeModelListener;
 import javax.swing.tree.TreeModel;
@@ -70,6 +71,7 @@ public class DrawPanelTreeModel implements TreeModel {
     this.tree = tree;
     update();
     new MapToolEventBus().getMainEventBus().register(this);
+    ToolTipManager.sharedInstance().registerComponent(this.tree);
   }
 
   @Subscribe

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2376,14 +2376,38 @@ panel.DrawExplorer.ShapeDrawable.QuadCurve    = Quadratic Curve - width({0}) hei
 panel.DrawExplorer.ShapeDrawable.RoundRectangle= Rounded Rectangle - width({0}) height({1})
 panel.DrawExplorer.ShapeDrawable.Rectangle    = Rectangle - width({0}) height({1})
 panel.DrawExplorer.ShapeDrawable.Unknown      = Unknown - width({0}) height({1})
+# Entry in the Draw Explorer tree. A blast template. Parameter: template size
 panel.DrawExplorer.Template.BlastTemplate     = Blast ({0})
+# Describes a blast template drawing and its size
+panel.DrawExplorer.Template.BlastTemplate.tooltip= Blast Template - Size: {0}
+# Entry in the Draw Explorer tree. A burst template. Parameter: template size
 panel.DrawExplorer.Template.BurstTemplate     = Burst ({0})
+# Describes a burst template drawing and its size
+panel.DrawExplorer.Template.BurstTemplate.tooltip= Burst Template - Size: {0}
+# Entry in the Draw Explorer tree. A cone template. Parameter: template size
 panel.DrawExplorer.Template.ConeTemplate      = Cone ({0})
-panel.DrawExplorer.Template.LineTemplate      = Line ({0})
-panel.DrawExplorer.Template.LineCellTemplate  = Line ({0})
-panel.DrawExplorer.Template.RadiusTemplate    = Radius ({0})
-panel.DrawExplorer.Template.RadiusCellTemplate = Radius ({0})
+# Describes a cone template drawing and its size
+panel.DrawExplorer.Template.ConeTemplate.tooltip= ConeTemplate - Size: {0}
+# Entry in the Draw Explorer tree. A line template starting from the corner of a grid cell. Parameter: template size
+panel.DrawExplorer.Template.LineTemplate      = Line (Corner) ({0})
+# Describes a line template drawing with a cell corner as its origin and its size
+panel.DrawExplorer.Template.LineTemplate.tooltip= Line (Corner) Template - Size: {0}
+# Entry in the Draw Explorer tree. A line template starting from the middle of a grid cell. Parameter: template size
+panel.DrawExplorer.Template.LineCellTemplate  = Line (Cell) ({0})
+# Describes a line template drawing with the middle of a cell as its origin and its size
+panel.DrawExplorer.Template.LineCellTemplate.tooltip= Line (Cell) Template - Size: {0}
+# Entry in the Draw Explorer tree. A radius template starting from the corner of a grid cell. Parameter: template size
+panel.DrawExplorer.Template.RadiusTemplate    = Radius (Corner) ({0})
+# Describes a radius template drawing with the corner of a cell as its origin and its size
+panel.DrawExplorer.Template.RadiusTemplate.tooltip= Radius (Corner) Template - Size: {0}
+# Entry in the Draw Explorer tree. A radius template starting from the middle of a grid cell. Parameter: template size
+panel.DrawExplorer.Template.RadiusCellTemplate= Radius (Cell) ({0})
+# Describes a radius template drawing with the middle of a cell as its origin and its size
+panel.DrawExplorer.Template.RadiusCellTemplate.tooltip= Radius (Cell) Template - Size: {0}
+# Entry in the Draw Explorer tree. A wall template. Parameter: template size
 panel.DrawExplorer.Template.WallTemplate      = Wall ({0})
+# Describes a wall template drawing and its size
+panel.DrawExplorer.Template.WallTemplate.tooltip= Wall Template - Size: {0}
 # "Group" is a noun
 panel.DrawExplorer.group                      = Group
 panel.DrawExplorer.opacity                    = opacity({0}%)


### PR DESCRIPTION
resolves #5331
closes #5331

### Description of the Change
1. Added ToolTipManager to the DrawPanelTree along with new tooltips for Templates
2. Improved UI text for Templates, differentiating between Corner and Cell types for Line and Radius templates.

### Possible Drawbacks
UI text improvements will appear as and when translation files are updated.

### Documentation Notes
Pre-change the draw explorer showed this for templates:
![image](https://github.com/user-attachments/assets/3a22fb0f-a24d-4e00-96d2-fbb53bd20798)
Post-change it will now list `Radius` as `Radius (Cell)` or `Radius (Corner)` and `Line` as `Line (Cell)` or `Line (Corner)`.

### Release Notes
-- Improved text and tooltips for templates in Draw Explorer Panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5509)
<!-- Reviewable:end -->
