### PR TITLE
Various fixes for recent renderer changes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -344,6 +344,18 @@ public class ZoneViewModel {
           transformedBounds.transform(at);
         }
 
+        if (!transformedBounds.intersects(viewport)) {
+          continue;
+        }
+
+        // Then make sure it is in revealed area (for players).
+        if (!playerView.isGMView()
+            && layer.supportsVision()
+            && zoneView.isUsingVision()
+            && !GraphicsUtil.intersects(transformedBounds, visibleArea)) {
+          continue;
+        }
+
         TokenPosition tokenPosition = new TokenPosition(token, footprintBounds, transformedBounds);
         tokenPositions.put(token.getId(), tokenPosition);
         layerList.add(tokenPosition);
@@ -407,23 +419,12 @@ public class ZoneViewModel {
     }
 
     for (var layer : Zone.Layer.values()) {
+      // This list only contains tokens that are on screen.
       var tokenPositions = tokenPositionsByLayer.get(layer);
 
       var visibleTokens = visibleTokensByLayer.get(layer);
       visibleTokens.clear();
       for (var tokenPosition : tokenPositions) {
-        // First make sure it is on screen.
-        if (!tokenPosition.transformedBounds().intersects(viewport)) {
-          continue;
-        }
-        // Then make sure it is in revealed area (for players).
-        if (!playerView.isGMView()
-            && layer.supportsVision()
-            && zoneView.isUsingVision()
-            && !GraphicsUtil.intersects(tokenPosition.transformedBounds(), visibleArea)) {
-          continue;
-        }
-
         var bounds = tokenPosition.transformedBounds().getBounds2D();
         if (bounds.getWidth() * scale < 1 || bounds.getHeight() * scale < 1) {
           continue;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -2096,9 +2096,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
       timer.start("token-list-8");
       // Facing
-      if (token.hasFacing()) {
-        facingArrowRenderer.paintArrow(tokenG, position);
-      }
+      facingArrowRenderer.paintArrow(tokenG, position);
       timer.stop("token-list-8");
 
       timer.start("token-list-9");

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -2573,7 +2573,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
   private void clearZoomDependantCaches() {
     invalidateCurrentViewCache();
-    tokenRenderer.zoomChanged();
   }
 
   public double getScale() {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1401,10 +1401,10 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         // Other details.
         // If the token is visible on the screen it will be in the location cache
         var tokenPosition = viewModel.getTokenPositions().get(token.getId());
-        if (token == keyToken
+        if (tokenPosition != null
+            && token == keyToken
             && (isOwner || shouldShowMovementLabels(token, set, clearArea))
-            && viewModel.getViewport().intersects(tokenPosition.footprintBounds())
-            && zoneView.getVisibleArea(view).intersects(tokenPosition.footprintBounds())) {
+            && viewModel.getViewport().intersects(tokenPosition.footprintBounds())) {
           var labelY = y + 10 + scaledHeight;
           var labelX = x + scaledWidth / 2;
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
@@ -17,13 +17,13 @@ package net.rptools.maptool.client.ui.zone.renderer.tokenRender;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
-import javax.annotation.Nullable;
 import net.rptools.lib.CodeTimer;
 import net.rptools.maptool.client.AppPreferences;
-import net.rptools.maptool.client.ui.zone.ZoneViewModel;
+import net.rptools.maptool.client.ui.zone.ZoneViewModel.TokenPosition;
 import net.rptools.maptool.client.ui.zone.renderer.RenderHelper;
-import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Token.TokenShape;
 import net.rptools.maptool.model.Zone;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -31,112 +31,85 @@ import org.apache.log4j.Logger;
 public class FacingArrowRenderer {
   private static final Logger log = LogManager.getLogger(FacingArrowRenderer.class);
 
+  /** An arrow facing horizontally to the positive x-axis, with its point at (0, 0). */
+  private static final Path2D UNIT_ARROW;
+
+  static {
+    final double tailX = -0.25;
+    final double tailY = .35;
+    UNIT_ARROW = new Path2D.Double();
+    UNIT_ARROW.moveTo(0, 0);
+    UNIT_ARROW.lineTo(tailX, -tailY);
+    UNIT_ARROW.lineTo(tailX, tailY);
+    UNIT_ARROW.closePath();
+  }
+
   private final RenderHelper renderHelper;
   private final Zone zone;
 
-  private ArrayList<Color> fillColours = new ArrayList<>();
-  private Color fillColour = Color.YELLOW;
-  private Color borderColour = Color.DARK_GRAY;
+  private final ArrayList<Color> figureFillColours = new ArrayList<>();
+  private final Color fillColour = Color.YELLOW;
+  private final Color borderColour = Color.DARK_GRAY;
 
   public FacingArrowRenderer(RenderHelper renderHelper, Zone zone) {
     this.renderHelper = renderHelper;
     this.zone = zone;
     for (int i = 0; i <= 90; i++) {
-      fillColours.add(new Color(1 - 0.5f / 90f * i, 1 - 0.5f / 90f * i, 0));
+      figureFillColours.add(new Color(1 - 0.5f / 90f * i, 1 - 0.5f / 90f * i, 0));
     }
     for (int i = 89; i >= 0; i--) {
-      fillColours.add(fillColours.get(i));
+      figureFillColours.add(figureFillColours.get(i));
     }
   }
 
-  public void paintArrow(Graphics2D tokenG, ZoneViewModel.TokenPosition position) {
+  public void paintArrow(Graphics2D tokenG, TokenPosition position) {
     var timer = CodeTimer.get();
     var token = position.token();
-    var tokenType = token.getShape();
+    var tokenShape = token.getShape();
 
     timer.start("FacingArrowRenderer-preCheck");
     if (!token.hasFacing()) {
       return;
     }
-    if (tokenType.equals(Token.TokenShape.TOP_DOWN) && !AppPreferences.forceFacingArrow.get()) {
-      return;
-    }
-    if (tokenType.equals(Token.TokenShape.FIGURE)
-        && token.getHasImageTable()
-        && !AppPreferences.forceFacingArrow.get()) {
-      return;
+    final var forceFacing = AppPreferences.forceFacingArrow.get();
+    if (!forceFacing) {
+      if (TokenShape.TOP_DOWN.equals(tokenShape)) {
+        return;
+      }
+      if (TokenShape.FIGURE.equals(tokenShape) && token.getHasImageTable()) {
+        return;
+      }
     }
     timer.stop("FacingArrowRenderer-preCheck");
 
     timer.start("FacingArrowRenderer-render");
-    renderHelper.render(tokenG, worldG -> paintArrowWorld(worldG, position));
+    renderHelper.render(
+        tokenG,
+        worldG ->
+            paintArrowWorld(worldG, token.getFacing(), tokenShape, position.footprintBounds()));
     timer.stop("FacingArrowRenderer-render");
   }
 
-  private void paintArrowWorld(Graphics2D tokenG, ZoneViewModel.TokenPosition position) {
+  private void paintArrowWorld(
+      Graphics2D tokenG, int facing, TokenShape tokenShape, Rectangle2D footprintBounds) {
     var timer = CodeTimer.get();
     timer.start("FacingArrowRenderer-paintArrow");
     try {
       final var isIsometric = zone.getGrid().isIsometric();
 
-      timer.start("FacingArrowRenderer-getArrow");
-      var arrow = getArrow(position, isIsometric);
-      timer.stop("FacingArrowRenderer-getArrow");
-      if (arrow == null) {
-        return;
-      }
-
-      AffineTransform oldAT = tokenG.getTransform();
-
       timer.start("FacingArrowRenderer-calculateTransform");
-      double facing = position.token().getFacing();
-      facing = isIsometric ? facing + 45 : facing;
-      while (facing < 0) {
-        facing += 360;
-      }
-      if (facing > 360) {
-        facing %= 360;
-      }
-      double radFacing = Math.toRadians(facing);
-      double cx = position.footprintBounds().getX() + position.footprintBounds().getWidth() / 2d;
-      double cy = position.footprintBounds().getY() + position.footprintBounds().getHeight() / 2d;
-
-      AffineTransform transform = AffineTransform.getRotateInstance(-radFacing);
-      if (isIsometric) {
-        transform.preConcatenate(AffineTransform.getScaleInstance(1.0, 0.5));
-      }
+      int angle = Math.floorMod(facing + (isIsometric ? 45 : 0), 360);
+      AffineTransform transform =
+          buildArrowTransform(tokenShape, footprintBounds, angle, isIsometric);
       timer.stop("FacingArrowRenderer-calculateTransform");
 
       timer.start("FacingArrowRenderer-transformArrow");
-      Shape facingArrow = transform.createTransformedShape(arrow);
+      Shape facingArrow = transform.createTransformedShape(UNIT_ARROW);
       timer.stop("FacingArrowRenderer-transformArrow");
 
-      timer.start("FacingArrowRenderer-adjustArrowForSquare");
-      if (position.token().getShape().equals(Token.TokenShape.SQUARE) && !isIsometric) {
-        double xp = position.footprintBounds().getWidth() / 2;
-        double yp = position.footprintBounds().getHeight() / 2;
-        if (facing >= 45 && facing <= 135 || facing >= 225 && facing <= 315) {
-          xp = yp / Math.tan(Math.toRadians(facing));
-          if (facing > 180) {
-            xp = -xp;
-            yp = -yp;
-          }
-        } else {
-          yp = xp * Math.tan(Math.toRadians(facing));
-          if (facing > 90 && facing < 270) {
-            xp = -xp;
-            yp = -yp;
-          }
-        }
-        cx += xp;
-        cy -= yp;
-      }
-      tokenG.translate(cx, cy);
-      timer.stop("FacingArrowRenderer-adjustArrowForSquare");
-
       timer.start("FacingArrowRenderer-fill");
-      if (position.token().getShape().equals(Token.TokenShape.FIGURE) && facing <= 180) {
-        tokenG.setColor(fillColours.get((int) facing));
+      if (TokenShape.FIGURE.equals(tokenShape) && angle <= 180) {
+        tokenG.setColor(figureFillColours.get(angle));
       } else {
         tokenG.setColor(fillColour);
       }
@@ -147,8 +120,6 @@ public class FacingArrowRenderer {
       tokenG.setColor(borderColour);
       tokenG.draw(facingArrow);
       timer.stop("FacingArrowRenderer-draw");
-
-      tokenG.setTransform(oldAT);
     } catch (Exception e) {
       log.error("Failed to paint facing arrow.", e);
     } finally {
@@ -156,68 +127,29 @@ public class FacingArrowRenderer {
     }
   }
 
-  private @Nullable Shape getArrow(ZoneViewModel.TokenPosition position, boolean isIsometric) {
-    var tokenType = position.token().getShape();
-    if ((!AppPreferences.forceFacingArrow.get() && tokenType.equals(Token.TokenShape.TOP_DOWN))
-        || (!AppPreferences.forceFacingArrow.get() && position.token().getHasImageTable())) {
-      return null;
-    }
-    final ArrowType arrowType;
+  private static AffineTransform buildArrowTransform(
+      TokenShape shape, Rectangle2D footprintBounds, int angle, boolean isIsometric) {
+    double radFacing = Math.toRadians(angle);
+
+    AffineTransform transform = new AffineTransform();
+    transform.translate(footprintBounds.getCenterX(), footprintBounds.getCenterY());
     if (isIsometric) {
-      arrowType = ArrowType.ISOMETRIC;
-    } else {
-      switch (tokenType) {
-        case FIGURE, TOP_DOWN, CIRCLE -> arrowType = ArrowType.CIRCLE;
-        case SQUARE -> arrowType = ArrowType.SQUARE;
-        default -> arrowType = ArrowType.NONE;
+      transform.scale(1.0, 0.5);
+    }
+    transform.rotate(-radFacing);
+
+    double distanceToPoint = footprintBounds.getWidth() / 2;
+    if (TokenShape.SQUARE.equals(shape) && !isIsometric) {
+      if (angle >= 45 && angle <= 135 || angle >= 225 && angle <= 315) { // Top or bottom face.
+        distanceToPoint = footprintBounds.getHeight() / 2 / Math.abs(Math.sin(radFacing));
+      } else { // Left or right face
+        distanceToPoint = footprintBounds.getWidth() / 2 / Math.abs(Math.cos(radFacing));
       }
     }
-    double size = position.footprintBounds().getWidth() / 2d;
-    return switch (arrowType) {
-      case CIRCLE -> getCircleFacingArrow(size);
-      case ISOMETRIC -> getFigureFacingArrow(size);
-      case SQUARE -> getSquareFacingArrow(size);
-      case NONE -> null;
-    };
-  }
+    transform.translate(distanceToPoint, 0);
 
-  protected Shape getCircleFacingArrow(double size) {
-    double base = size * .75;
-    double y = size * .35;
-    Path2D facingArrow = new Path2D.Double();
-    facingArrow.moveTo(base, -y);
-    facingArrow.lineTo(size, 0);
-    facingArrow.lineTo(base, y);
-    facingArrow.lineTo(base, -y);
-    return facingArrow;
-  }
-
-  protected Shape getFigureFacingArrow(double size) {
-    double base = size * .75;
-    double y = size * .35;
-    Path2D facingArrow = new Path2D.Double();
-    facingArrow.moveTo(base, -y);
-    facingArrow.lineTo(size, 0);
-    facingArrow.lineTo(base, y);
-    facingArrow.lineTo(base, -y);
-    return facingArrow;
-  }
-
-  protected Shape getSquareFacingArrow(double size) {
-    double base = size * .75;
-    double y = size * .35;
-    Path2D facingArrow = new Path2D.Double();
-    facingArrow.moveTo(0, 0);
-    facingArrow.lineTo(-(size - base), -y);
-    facingArrow.lineTo(-(size - base), y);
-    facingArrow.lineTo(0, 0);
-    return facingArrow;
-  }
-
-  private enum ArrowType {
-    CIRCLE,
-    ISOMETRIC,
-    SQUARE,
-    NONE
+    var size = footprintBounds.getWidth() / 2d;
+    transform.scale(size, size);
+    return transform;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
@@ -31,7 +31,6 @@ import org.apache.log4j.Logger;
 
 public class FacingArrowRenderer {
   private static final Logger log = LogManager.getLogger(FacingArrowRenderer.class);
-  private final CodeTimer timer;
   private final Map<ArrowType, Map<Double, Shape>> quivers = new HashMap<>();
 
   private final RenderHelper renderHelper;
@@ -50,7 +49,6 @@ public class FacingArrowRenderer {
     for (int i = 89; i >= 0; i--) {
       fillColours.add(fillColours.get(i));
     }
-    timer = CodeTimer.get();
   }
 
   public void paintArrow(Graphics2D tokenG, ZoneViewModel.TokenPosition position) {
@@ -58,6 +56,8 @@ public class FacingArrowRenderer {
   }
 
   private void paintArrowWorld(Graphics2D tokenG, ZoneViewModel.TokenPosition position) {
+    var timer = CodeTimer.get();
+    timer.start("ArrowRenderer-paintArrow");
     try {
       var token = position.token();
 
@@ -73,7 +73,6 @@ public class FacingArrowRenderer {
 
       final var isIsometric = zone.getGrid().isIsometric();
 
-      timer.start("ArrowRenderer-paintArrow");
       AffineTransform oldAT = tokenG.getTransform();
       double facing = token.getFacing();
       facing = isIsometric ? facing + 45 : facing;
@@ -127,8 +126,9 @@ public class FacingArrowRenderer {
       tokenG.setTransform(oldAT);
     } catch (Exception e) {
       log.error("Failed to paint facing arrow.");
+    } finally {
+      timer.stop("ArrowRenderer-paintArrow");
     }
-    timer.stop("ArrowRenderer-paintArrow");
   }
 
   private Shape getArrow(ZoneViewModel.TokenPosition position, boolean isIsometric) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
@@ -154,7 +154,7 @@ public class FacingArrowRenderer {
       arrowType = ArrowType.ISOMETRIC;
     } else {
       switch (tokenType) {
-        case FIGURE, CIRCLE -> arrowType = ArrowType.CIRCLE;
+        case FIGURE, TOP_DOWN, CIRCLE -> arrowType = ArrowType.CIRCLE;
         case SQUARE -> arrowType = ArrowType.SQUARE;
         default -> arrowType = ArrowType.NONE;
       }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
@@ -18,8 +18,6 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 import net.rptools.lib.CodeTimer;
 import net.rptools.maptool.client.AppPreferences;
@@ -32,7 +30,6 @@ import org.apache.log4j.Logger;
 
 public class FacingArrowRenderer {
   private static final Logger log = LogManager.getLogger(FacingArrowRenderer.class);
-  private final Map<ArrowType, Map<Double, Shape>> quivers = new HashMap<>();
 
   private final RenderHelper renderHelper;
   private final Zone zone;
@@ -152,7 +149,6 @@ public class FacingArrowRenderer {
         || (!AppPreferences.forceFacingArrow.get() && position.token().getHasImageTable())) {
       return null;
     }
-    Shape arrow = new Path2D.Double();
     final ArrowType arrowType;
     if (isIsometric) {
       arrowType = ArrowType.ISOMETRIC;
@@ -164,24 +160,12 @@ public class FacingArrowRenderer {
       }
     }
     double size = position.footprintBounds().getWidth() / 2d;
-    Map<Double, Shape> quiver;
-    if (quivers.containsKey(arrowType)) {
-      quiver = quivers.get(arrowType);
-    } else {
-      quiver = new HashMap<>();
-    }
-    if (quiver.containsKey(size)) {
-      arrow = quiver.get(size);
-    } else {
-      switch (arrowType) {
-        case CIRCLE -> arrow = getCircleFacingArrow(size);
-        case ISOMETRIC -> arrow = getFigureFacingArrow(size);
-        case SQUARE -> arrow = getSquareFacingArrow(size);
-      }
-      quiver.put(size, arrow);
-      quivers.put(arrowType, quiver);
-    }
-    return arrow;
+    return switch (arrowType) {
+      case CIRCLE -> getCircleFacingArrow(size);
+      case ISOMETRIC -> getFigureFacingArrow(size);
+      case SQUARE -> getSquareFacingArrow(size);
+      case NONE -> null;
+    };
   }
 
   protected Shape getCircleFacingArrow(double size) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1508,8 +1508,8 @@ public class Token implements Cloneable {
 
     // Sizing
     if (!isSnapToScale()) {
-      w = getWidth();
-      h = getHeight();
+      w = getWidth() * scaleX;
+      h = getHeight() * scaleY;
       if (grid.isIsometric() && getShape() == Token.TokenShape.FIGURE) {
         // Native size figure tokens need to follow iso rules
         h = (w / 2);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5508

### Description of the Change

This fixes the three big contributors to recent renderer slowdowns:
1. Excessive setting of clips on `Graphics2D` objects in `RenderHelper`. This is actually only need for buffered renders, so we only do that now.
2. Generating multiple "large" intermediate images to prepare a token for rendering. Now we just draw the image with appropriate transformations applied. This also means we don't need to cache these intermediate images, saving some hassle and overhead.
3. `ZoneViewModel` mistakenly tracking all tokens regardless of visibility on the client. This is plainly a bug and has been fixed.

Other fixes for things encountered along the way:
- Free size tokens did not have their `scaleX` and `scaleY` incorporated into their footprints. This meant they couldn't be resized, and such existing token could only be selected by their unscaled footprint.
- Top Down tokens did not have their facing arrows rendered when enabled.
- `CodeTimer`s were been stashed in `TokenRenderer` and `FacingRenderer`, which makes them non-functional.
- Fixed an NPE in `FacingArrowRenderer` for Top Down and image table tokens when arrows are not forced.

Beyond that, there's just a lot of cleanup in `TokenRenderer` and `FacingRenderer` for things that are no longer needed.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Improved performance when large numbers of tokens are present on a map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5510)
<!-- Reviewable:end -->
