### PR TITLE
New MTScript get table entries functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -311,7 +311,7 @@ public class LookupTableFunction extends AbstractFunction {
       if (rollInt < entry.getMin() || rollInt > entry.getMax()) {
         return ""; // entry was found but doesn't match
       }
-      return convertLookUpEntrytoJson(entry);
+      return convertLookUpEntryToJson(entry);
 
     } else if ("getTableEntryAtIndex".equalsIgnoreCase(function)) {
       /*
@@ -321,12 +321,12 @@ public class LookupTableFunction extends AbstractFunction {
        */
       FunctionUtil.checkNumberParam(function, params, 2, 2);
       String name = params.get(0).toString();
-      int index = ((BigDecimal) params.get(1)).intValue();
+      int index = FunctionUtil.paramAsInteger(function, params, 1, false);
       LookupTable lookupTable = getMaptoolTable(name, function);
       List<LookupEntry> entriesList = lookupTable.getEntryList();
       if (index >= 0 && index < entriesList.size()) {
         LookupEntry entry = entriesList.get(index);
-        return convertLookUpEntrytoJson(entry);
+        return convertLookUpEntryToJson(entry);
       } else {
         return "";
       }
@@ -342,8 +342,9 @@ public class LookupTableFunction extends AbstractFunction {
       FunctionUtil.checkNumberParam(function, params, 1, 4);
       String name = params.get(0).toString();
       String pattern = (params.size() > 1) ? params.get(1).toString() : "";
-      int limit = (params.size() > 2) ? ((BigDecimal) params.get(2)).intValue() : 0;
-      int offset = (params.size() > 3) ? ((BigDecimal) params.get(3)).intValue() : 0;
+      int limit = (params.size() > 2) ? FunctionUtil.paramAsInteger(function, params, 2, false) : 0;
+      int offset =
+          (params.size() > 3) ? FunctionUtil.paramAsInteger(function, params, 3, false) : 0;
 
       LookupTable lookupTable = getMaptoolTable(name, function);
       List<LookupEntry> entriesList = lookupTable.getEntryList();
@@ -351,7 +352,13 @@ public class LookupTableFunction extends AbstractFunction {
       // Filter by regex pattern, then apply offset, then apply limit
       if (!pattern.isEmpty()) {
         entriesList =
-            entriesList.stream().filter(entry -> entry.getValue().matches(pattern)).toList();
+            entriesList.stream()
+                .filter(
+                    entry -> {
+                      assert entry.getValue() != null;
+                      return entry.getValue().matches(pattern);
+                    })
+                .toList();
       }
       if (offset > 0) {
         entriesList = entriesList.stream().skip(offset).toList();
@@ -361,7 +368,7 @@ public class LookupTableFunction extends AbstractFunction {
       }
       JsonArray jarrEntries = new JsonArray();
       for (LookupEntry entry : entriesList) {
-        jarrEntries.add(convertLookUpEntrytoJson(entry));
+        jarrEntries.add(convertLookUpEntryToJson(entry));
       }
       return jarrEntries;
 
@@ -378,7 +385,13 @@ public class LookupTableFunction extends AbstractFunction {
       List<LookupEntry> entriesList = lookupTable.getEntryList();
       if (!pattern.isEmpty()) {
         entriesList =
-            entriesList.stream().filter(entry -> entry.getValue().matches(pattern)).toList();
+            entriesList.stream()
+                .filter(
+                    entry -> {
+                      assert entry.getValue() != null;
+                      return entry.getValue().matches(pattern);
+                    })
+                .toList();
       }
       return entriesList.size();
 
@@ -580,7 +593,7 @@ public class LookupTableFunction extends AbstractFunction {
    * @return entryDetails A Json Object representation of the LookupEntry details
    * @throws ParserException if there were more or less parameters than allowed
    */
-  private JsonObject convertLookUpEntrytoJson(LookupEntry entry) {
+  private JsonObject convertLookUpEntryToJson(LookupEntry entry) throws ParserException {
     JsonObject entryDetails = new JsonObject();
     entryDetails.addProperty("min", entry.getMin());
     entryDetails.addProperty("max", entry.getMax());

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -15,7 +15,6 @@
 package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +58,9 @@ public class LookupTableFunction extends AbstractFunction {
         "setTableImage",
         "copyTable",
         "getTableEntry",
+        "getTableEntryAtIndex",
+        "getTableEntries",
+        "getTableEntriesCount",
         "setTableEntry",
         "resetTablePicks",
         "getTablePickOnce",
@@ -292,6 +294,7 @@ public class LookupTableFunction extends AbstractFunction {
         }
       MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
       return 1;
+
     } else if ("getTableEntry".equalsIgnoreCase(function)) {
 
       FunctionUtil.checkNumberParam(function, params, 2, 2);
@@ -299,25 +302,85 @@ public class LookupTableFunction extends AbstractFunction {
       LookupTable lookupTable = getMaptoolTable(name, function);
       String roll = params.get(1).toString();
       LookupEntry entry = lookupTable.getLookupDirect(roll);
-      if (entry == null) return ""; // no entry was found
 
-      int rollInt = Integer.parseInt(roll);
-      if (rollInt < entry.getMin() || rollInt > entry.getMax())
-        return ""; // entry was found but doesn't match
-
-      JsonObject entryDetails = new JsonObject();
-      entryDetails.addProperty("min", entry.getMin());
-      entryDetails.addProperty("max", entry.getMax());
-      entryDetails.addProperty("value", entry.getValue());
-      entryDetails.addProperty("picked", entry.getPicked());
-
-      MD5Key imageId = entry.getImageId();
-      if (imageId != null) {
-        entryDetails.addProperty("assetid", "asset://" + imageId.toString());
-      } else {
-        entryDetails.addProperty("assetid", "");
+      if (entry == null) {
+        return ""; // no entry was found
       }
-      return entryDetails;
+      int rollInt = Integer.parseInt(roll);
+      if (rollInt < entry.getMin() || rollInt > entry.getMax()) {
+        return ""; // entry was found but doesn't match
+      }
+      return entry.toJson();
+
+    } else if ("getTableEntryAtIndex".equalsIgnoreCase(function)) {
+      /*
+       * Parameters:
+       * name - the name of the table to get a table entry from
+       * index - the index of the entry value to return
+       */
+      FunctionUtil.checkNumberParam(function, params, 2, 2);
+      String name = params.get(0).toString();
+      int index = ((BigDecimal) params.get(1)).intValue();
+      LookupTable lookupTable = getMaptoolTable(name, function);
+      List<LookupEntry> entries = lookupTable.getEntryList();
+      if (index >= 0 && index < entries.size()) {
+        LookupEntry entry = entries.get(index);
+        return entry.toJson();
+      } else {
+        return "";
+      }
+
+    } else if ("getTableEntries".equalsIgnoreCase(function)) {
+      /*
+       * Parameters:
+       * name - the name of the table to get entries from
+       * pattern - (optional) filter table entries where their value match the regex pattern
+       * limit - (optional) the maximum number of filtered entries to be returned
+       * offset - (optional) skip a certain number of filtered entries to be returned
+       */
+      FunctionUtil.checkNumberParam(function, params, 1, 4);
+      String name = params.get(0).toString();
+      String pattern = (params.size() > 1) ? params.get(1).toString() : "";
+      int limit = (params.size() > 2) ? ((BigDecimal) params.get(2)).intValue() : 0;
+      int offset = (params.size() > 3) ? ((BigDecimal) params.get(3)).intValue() : 0;
+
+      LookupTable lookupTable = getMaptoolTable(name, function);
+      List<LookupEntry> entriesList = lookupTable.getEntryList();
+
+      // Filter by regex pattern, then apply offset, then apply limit
+      if (!pattern.isEmpty()) {
+        entriesList =
+            entriesList.stream().filter(entry -> entry.getValue().matches(pattern)).toList();
+      }
+      if (offset > 0) {
+        entriesList = entriesList.stream().skip(offset).toList();
+      }
+      if (limit > 0) {
+        entriesList = entriesList.stream().limit(limit).toList();
+      }
+      JsonArray jarrEntries = new JsonArray();
+      for (LookupEntry entry : entriesList) {
+        jarrEntries.add(entry.toJson());
+      }
+      return jarrEntries;
+
+    } else if ("getTableEntriesCount".equalsIgnoreCase(function)) {
+      /*
+       * Parameters:
+       * name - the name of the table to analyse
+       * pattern - (optional) filter table entries where their value match the regex pattern
+       */
+      FunctionUtil.checkNumberParam(function, params, 1, 2);
+      String name = params.get(0).toString();
+      String pattern = (params.size() > 1) ? params.get(1).toString() : "";
+      LookupTable lookupTable = getMaptoolTable(name, function);
+      List<LookupEntry> entriesList = lookupTable.getEntryList();
+      if (!pattern.isEmpty()) {
+        entriesList =
+            entriesList.stream().filter(entry -> entry.getValue().matches(pattern)).toList();
+      }
+      return entriesList.size();
+
     } else if ("resetTablePicks".equalsIgnoreCase(function)) {
       /*
        * resetTablePicks(tblName) - reset all entries on a table

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -310,7 +311,7 @@ public class LookupTableFunction extends AbstractFunction {
       if (rollInt < entry.getMin() || rollInt > entry.getMax()) {
         return ""; // entry was found but doesn't match
       }
-      return entry.toJson();
+      return convertLookUpEntrytoJson(entry);
 
     } else if ("getTableEntryAtIndex".equalsIgnoreCase(function)) {
       /*
@@ -322,10 +323,10 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       int index = ((BigDecimal) params.get(1)).intValue();
       LookupTable lookupTable = getMaptoolTable(name, function);
-      List<LookupEntry> entries = lookupTable.getEntryList();
-      if (index >= 0 && index < entries.size()) {
-        LookupEntry entry = entries.get(index);
-        return entry.toJson();
+      List<LookupEntry> entriesList = lookupTable.getEntryList();
+      if (index >= 0 && index < entriesList.size()) {
+        LookupEntry entry = entriesList.get(index);
+        return convertLookUpEntrytoJson(entry);
       } else {
         return "";
       }
@@ -360,7 +361,7 @@ public class LookupTableFunction extends AbstractFunction {
       }
       JsonArray jarrEntries = new JsonArray();
       for (LookupEntry entry : entriesList) {
-        jarrEntries.add(entry.toJson());
+        jarrEntries.add(convertLookUpEntrytoJson(entry));
       }
       return jarrEntries;
 
@@ -570,5 +571,28 @@ public class LookupTableFunction extends AbstractFunction {
               "macro.function.LookupTableFunctions.unknownTable", functionName, tableName));
     }
     return lookupTable;
+  }
+
+  /**
+   * Function to convert a LookupEntry into a Json Object
+   *
+   * @param entry The LookupEntry to be converted
+   * @return entryDetails A Json Object representation of the LookupEntry details
+   * @throws ParserException if there were more or less parameters than allowed
+   */
+  private JsonObject convertLookUpEntrytoJson(LookupEntry entry) {
+    JsonObject entryDetails = new JsonObject();
+    entryDetails.addProperty("min", entry.getMin());
+    entryDetails.addProperty("max", entry.getMax());
+    entryDetails.addProperty("value", entry.getValue());
+    entryDetails.addProperty("picked", entry.getPicked());
+
+    MD5Key imageId = entry.getImageId();
+    if (imageId != null) {
+      entryDetails.addProperty("assetid", "asset://" + imageId.toString());
+    } else {
+      entryDetails.addProperty("assetid", "");
+    }
+    return entryDetails;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.model;
 
+import com.google.gson.JsonObject;
 import com.google.protobuf.StringValue;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -446,6 +447,21 @@ public class LookupTable {
         dto.setImageId(StringValue.of(imageId.toString()));
       }
       return dto.build();
+    }
+
+    public JsonObject toJson() {
+      JsonObject entryDetails = new JsonObject();
+      entryDetails.addProperty("min", this.min);
+      entryDetails.addProperty("max", this.max);
+      entryDetails.addProperty("value", this.value);
+      entryDetails.addProperty("picked", this.picked);
+
+      if (this.imageId != null) {
+        entryDetails.addProperty("assetid", "asset://" + this.imageId.toString());
+      } else {
+        entryDetails.addProperty("assetid", "");
+      }
+      return entryDetails;
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.model;
 
-import com.google.gson.JsonObject;
 import com.google.protobuf.StringValue;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -447,21 +446,6 @@ public class LookupTable {
         dto.setImageId(StringValue.of(imageId.toString()));
       }
       return dto.build();
-    }
-
-    public JsonObject toJson() {
-      JsonObject entryDetails = new JsonObject();
-      entryDetails.addProperty("min", this.min);
-      entryDetails.addProperty("max", this.max);
-      entryDetails.addProperty("value", this.value);
-      entryDetails.addProperty("picked", this.picked);
-
-      if (this.imageId != null) {
-        entryDetails.addProperty("assetid", "asset://" + this.imageId.toString());
-      } else {
-        entryDetails.addProperty("assetid", "");
-      }
-      return entryDetails;
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #4859

### Description of the Change
* ~~Added new LookupEntry method `toJson()`~~ (REVERTED)
* Added new three MTScript functions for tables: 
  * getTableEntries
  * getTableEntriesCount
  * getTableEntrybyIndex
* New `convertLookupEntrytoJson()` function 

### Possible Drawbacks
I'm a Java newbie and have not done things in the best way.

### Documentation Notes
Add pages for three new MTScript [table](https://wiki.rptools.info/index.php/Category:Table_Function) get functions which expand the utility of MapTool tables:

**`getTableEntries(name, pattern, limit, offset)`** -> Returns a json array of json objects containing the table entry details filtered by the arguments (where given).
 * `name` - the name of the table to get entries from
 * `pattern` - (optional) filter table entries where their value match the regex pattern, or provide "" to not filter.
 * `limit` - (optional) the maximum number of filtered entries to be returned, or provide 0 to not limit.
 * `offset` - (optional) skip a certain number of filtered entries to be returned, or provide 0 to not offset.

**`getTableEntriesCount(name, pattern)`** -> Returns a count of the number of tables entries
 * `name` - the name of the table to analyse
 * `pattern` - (optional) filter table entries where their value match the regex pattern, or provide "" to not filter.

**`getTableEntrybyIndex(name, index)`** -> Returns a json object containing the table entry details.
 * `name` - the name of the table to get a table entry from
 * `index` - the index of the entry value to return

### Release Notes
-- Added new MTScript functions for getting table entries by pattern match or by index

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5515)
<!-- Reviewable:end -->
