### PR TITLE
Another round of renderer fixes

### DIFF
--- a/src/main/java/net/rptools/lib/CodeTimer.java
+++ b/src/main/java/net/rptools/lib/CodeTimer.java
@@ -62,6 +62,7 @@ public class CodeTimer {
     return stack.isEmpty() ? ROOT_TIMER.get() : stack.getLast();
   }
 
+  private final Map<String, Integer> counterMap = new LinkedHashMap<>();
   private final Map<String, Timer> timeMap = new LinkedHashMap<>();
   private final String name;
   private long threshold = 1;
@@ -82,6 +83,14 @@ public class CodeTimer {
 
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public void increment(String id) {
+    increment(id, 1);
+  }
+
+  public void increment(String id, int amount) {
+    counterMap.merge(id, amount, Integer::sum);
   }
 
   public void start(String id, Object... parameters) {
@@ -113,6 +122,7 @@ public class CodeTimer {
 
   public void clear() {
     timeMap.clear();
+    counterMap.clear();
   }
 
   @Override
@@ -137,6 +147,20 @@ public class CodeTimer {
       }
       builder.append(String.format("  %3d.  %6d ms  %s\n", i, elapsed, id));
     }
+
+    if (!counterMap.isEmpty()) {
+      builder.append("\nCounters\n");
+      i = -1;
+      for (var entry : counterMap.entrySet()) {
+        ++i;
+
+        var id = entry.getKey();
+        var count = entry.getValue();
+
+        builder.append(String.format("  %3d.  %6d     %s\n", i, count, id));
+      }
+    }
+
     return builder.toString();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/Scale.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Scale.java
@@ -15,6 +15,8 @@
 package net.rptools.maptool.client.ui;
 
 import java.awt.Point;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeListener;
@@ -179,6 +181,13 @@ public class Scale implements Serializable {
         screenRect.getHeight() / scale);
   }
 
+  public Area toWorldSpace(Area area) {
+    var transform = new AffineTransform();
+    transform.scale(1 / scale, 1 / scale);
+    transform.translate(-offsetX, -offsetY);
+    return area.createTransformedArea(transform);
+  }
+
   /**
    * Transforms a rectangle from world space to screen space.
    *
@@ -199,6 +208,13 @@ public class Scale implements Serializable {
 
   public ScreenPoint toScreenSpace(double x, double y) {
     return new ScreenPoint(x * scale + offsetX, y * scale + offsetY);
+  }
+
+  public Area toScreenSpace(Area area) {
+    var transform = new AffineTransform();
+    transform.translate(offsetX, offsetY);
+    transform.scale(scale, scale);
+    return area.createTransformedArea(transform);
   }
 
   private PropertyChangeSupport getPropertyChangeSupport() {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/MenuButtonsPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/MenuButtonsPanel.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.client.ui.macrobuttons.panels;
 
-import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
@@ -48,9 +47,7 @@ public class MenuButtonsPanel extends JToolBar {
             ZoneRenderer zr = MapTool.getFrame().getCurrentZoneRenderer();
             // Check if there is a map. Fix #1605
             if (zr != null) {
-              final var tokens =
-                  zr.getTokenIdsInBounds(
-                      new Rectangle(zr.getX(), zr.getY(), zr.getWidth(), zr.getHeight()));
+              final var tokens = zr.getTokenIdsOnScreen();
               zr.getSelectionModel().replaceSelection(tokens);
             }
           }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -153,6 +153,10 @@ public class ZoneViewModel {
         viewport.getMinX(), viewport.getMinY(), viewport.getWidth(), viewport.getHeight());
   }
 
+  public Area getVisibleArea() {
+    return visibleArea;
+  }
+
   public PlayerView getPlayerView() {
     return playerView;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -1528,8 +1528,10 @@ public class GdxRenderer extends ApplicationAdapter {
         }
       } else {
         // fallthrough normal token rendered against visible area
-
-        if (zoneCache.getZoneRenderer().isTokenInNeedOfClipping(token, tokenCellArea, isGMView)) {
+        if (zoneCache
+            .getZoneRenderer()
+            .isTokenInNeedOfClipping(
+                token, viewModel.getZoneScale().toWorldSpace(tokenCellArea), isGMView)) {
           paintClipped(image, tokenCellArea, cellArea);
         } else image.draw(batch);
       }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -2256,9 +2256,22 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   /**
-   * Selects the tokens inside a selection rectangle.
+   * Gets the tokens inside the viewport.
    *
-   * @param screenRect the selection rectangle
+   * <p>This is a convenience method for {@link #getTokenIdsInBounds(Rectangle)} that supplies the
+   * viewport as the rectangle.
+   *
+   * @return A list of token IDs for tokens whose footprint intersects with the current viewport.
+   */
+  public List<GUID> getTokenIdsOnScreen() {
+    return getTokenIdsInBounds(getBounds());
+  }
+
+  /**
+   * Gets the tokens inside a rectangle.
+   *
+   * @param screenRect the bounds in which to look for tokens.
+   * @return A list of token IDs for tokens whose footprint intersects with {@code screenRect}.
    */
   public List<GUID> getTokenIdsInBounds(Rectangle screenRect) {
     var rect = zoneScale.toWorldSpace(screenRect);
@@ -2307,13 +2320,16 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public Area getTokenBounds(Token token) {
-    for (ZoneViewModel.TokenPosition position :
-        viewModel.getTokenPositionsForLayer(token.getLayer())) {
-      if (position.token() == token) {
-        return new Area(position.transformedBounds());
-      }
+    if (!viewModel.getOnScreenTokens().contains(token.getId())) {
+      return null;
     }
-    return null;
+
+    var position = viewModel.getTokenPositions().get(token.getId());
+    if (position == null) {
+      return null;
+    }
+
+    return new Area(position.transformedBounds());
   }
 
   public Area getMarkerBounds(Token token) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/TokenRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/TokenRenderer.java
@@ -48,6 +48,7 @@ public class TokenRenderer {
 
   public void renderToken(Token token, TokenPosition position, Graphics2D g2d, float opacity) {
     var timer = CodeTimer.get();
+    timer.increment("TokenRenderer-renderToken");
     timer.start("TokenRenderer-renderToken");
 
     timer.start("TokenRenderer-loadImageTable");


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes some oversights in PR #5510

Fixes #252

### Description of the Change

Despite what I mentioned in #5510 - and what comments on the old `tokenLocationCache` suggested - `ZoneViewModel` _does_ need to track positions for all tokens on the map, provided their visbility flags allow it. This information is queried in a number of places and is not necessarily restricted to tokens on screen. But there is also a need to check whether a token is on-screen. So `ZoneViewModel` now keeps track of that both. So there are once again these categories of tokens:
- All tokens that pass basic visibility checks (equivalent to the old `ZoneRenderer.tokenLocationCache`).
- On-screen tokens (equivalent to the old `ZoneRenderer.tokenLocationMap`).
- Visible tokens (equivalent to the old `ZoneRenderer.visibleTokenSet`).

I've also added counters to `CodeTimer` so that we can keep track of how many times certain things are called. So far I'm only using it for counting how many times `TokenRender.renderToken()` is called, but I expect this will get used much more in the future.

The remaining changes are just cleanup to remove unused code and redundant logic in `ZoneRenderer`, especially now that `ZoneViewModel` keep track of most things. One consequence of this is that the checks for Visible over FoW and Figure tokens is now done in world space, not screen space. This fixes #252 as there is no longer any dependence of the current zoom.

### Possible Drawbacks

I'll probably find some other bugs with this.

Also `GdxRenderer` is getting more out of sync with `ZoneRenderer`. It could use a lot of the same sort of cleanup, especially to use `ZoneViewModel` more. I'll look into that kind of thing after this PR.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where tokens covered in VBL and marked as **Visible over FoW** would sometimes be covered by FoW and sometimes not, depending on the current zoom level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5518)
<!-- Reviewable:end -->
