### PR TITLE
Fix token halo color to not be set by default

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenHaloFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenHaloFunction.java
@@ -64,8 +64,9 @@ public class TokenHaloFunction extends AbstractFunction {
    * @return the halo.
    */
   public static Object getHalo(Token token) {
-    if (token.getHaloColor() != null) {
-      return "#" + Integer.toHexString(token.getHaloColor().getRGB()).substring(2);
+    var haloColor = token.getHaloColor();
+    if (haloColor != null) {
+      return "#" + Integer.toHexString(haloColor.getRGB()).substring(2);
     } else {
       return "None";
     }

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
@@ -345,12 +345,13 @@ public class InitiativeListCellRenderer extends JPanel
 
       // Paint the halo if needed
       Token token = tokenInitiative.getToken();
-      if (panel.isShowTokenStates() && token.hasHalo()) {
+      Color haloColor = token.getHaloColor();
+      if (panel.isShowTokenStates() && haloColor != null) {
         Graphics2D g2d = (Graphics2D) g;
         Stroke oldStroke = g2d.getStroke();
         Color oldColor = g.getColor();
         g2d.setStroke(new BasicStroke(AppPreferences.haloLineWidth.get()));
-        g.setColor(token.getHaloColor());
+        g.setColor(haloColor);
         g2d.draw(new Rectangle2D.Double(x, y, ICON_SIZE, ICON_SIZE));
         g2d.setStroke(oldStroke);
         g.setColor(oldColor);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -1468,8 +1468,9 @@ public class GdxRenderer extends ApplicationAdapter {
       prepareTokenSprite(image, token, footprintBounds);
 
       // Render Halo
-      if (token.hasHalo()) {
-        Color.argb8888ToColor(tmpColor, token.getHaloColor().getRGB());
+      var haloColor = token.getHaloColor();
+      if (haloColor != null) {
+        Color.argb8888ToColor(tmpColor, haloColor.getRGB());
         tmpColor.premultiplyAlpha();
         areaRenderer.setColor(tmpColor);
         areaRenderer.drawArea(

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -28,7 +28,8 @@ public class HaloRenderer {
 
   // Render Halos
   public void renderHalo(Graphics2D g2d, Token token, ZoneViewModel.TokenPosition position) {
-    if (!token.hasHalo()) {
+    Color haloColor = token.getHaloColor();
+    if (haloColor == null) {
       return;
     }
 
@@ -38,7 +39,7 @@ public class HaloRenderer {
           worldG.setStroke(
               new BasicStroke(
                   AppPreferences.haloLineWidth.get() / (float) worldG.getTransform().getScaleX()));
-          worldG.setColor(token.getHaloColor());
+          worldG.setColor(haloColor);
           worldG.draw(position.transformedBounds());
         });
   }

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -671,10 +671,16 @@ public class Token implements Cloneable {
     haloColor = color;
   }
 
-  public Color getHaloColor() {
-    if (haloColor == null && haloColorValue != null) {
+  public @Nullable Color getHaloColor() {
+    if (haloColorValue == null) {
+      return null;
+    }
+
+    // Cache the Color from the int.
+    if (haloColor == null) {
       haloColor = new Color(haloColorValue);
     }
+
     return haloColor;
   }
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -46,7 +46,6 @@ import net.rptools.CaseInsensitiveHashMap;
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.lib.transferable.TokenTransferData;
-import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
@@ -285,8 +284,7 @@ public class Token implements Cloneable {
       MapTool.getCampaign().getCampaignProperties().getDefaultTokenPropertyType();
 
   private Integer haloColorValue;
-  private transient Color haloColor =
-      new Color(ImageUtil.negativeColourInt(AppPreferences.defaultGridColor.getDefault().getRGB()));
+  private transient Color haloColor;
 
   private Integer visionOverlayColorValue;
   private transient Color visionOverlayColor;

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -650,10 +650,6 @@ public class Token implements Cloneable {
     gmName = name;
   }
 
-  public boolean hasHalo() {
-    return haloColorValue != null;
-  }
-
   public String getLabel() {
     return label;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5516

### Description of the Change

In 1.17 and before, `Token#haloColor` was null by default. Recently, it has been set to the negative of the grid colour, which causes some code to think new tokens have a halo when they in fact do not. This PR restores the original behaviour so that there is no confusion over whether a halo is active.

It also corrects `Token#getHaloColor()` to return `null` whenever `haloColorValue` is null, not when `haloColor` is null. To make code analysis a little easier, the few uses of `Token#hasHalo()` have been removed in favour of checking `Token#getHaloColor()` for a null value before using it.

### Possible Drawbacks

None

### Documentation Notes

None

### Release Notes

- Fixed a bug

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5519)
<!-- Reviewable:end -->
