### PR TITLE
Further adjustments to Startup tab of Preferences dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -903,16 +903,16 @@ public class PreferencesDialog extends JDialog {
 
     // jpackage config files can't be written to. Show a warning to the user describing the
     // situation.
+    var manualCopyPrimary = I18N.getText("startup.preferences.info.manualCopy.primary");
+    var manualCopySecondary = I18N.getText("startup.preferences.info.manualCopy.secondary");
+    configFileWarningLabel.setText(
+        String.format("<html>%s<br>%s</html>", manualCopyPrimary, manualCopySecondary));
+
     if (appCfgFile != null) {
-      configFileWarningLabel.setText(I18N.getText("startup.preferences.info.manualCopy"));
       configFileWarningLabel.setVisible(true);
     } else {
-      configFileWarningLabel.setText(null);
       configFileWarningLabel.setVisible(false);
     }
-
-    String startupInfoMsg = I18N.getText("startup.preferences.info");
-    startupInfoLabel.setText(startupInfoMsg);
 
     DefaultComboBoxModel<String> languageModel = new DefaultComboBoxModel<String>();
     languageModel.addAll(getLanguages());

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -404,8 +404,6 @@ public class PreferencesDialog extends JDialog {
 
   private final JLabel configFileWarningLabel;
 
-  private final JLabel startupInfoLabel;
-
   /** Flag indicating if JVM values have been changed. */
   private boolean jvmValuesChanged = false;
 
@@ -709,31 +707,21 @@ public class PreferencesDialog extends JDialog {
     themeFilterCombo = panel.getComboBox("themeFilterCombo");
 
     jvmXmxTextField = panel.getTextField("jvmXmxTextField");
-    jvmXmxTextField.setToolTipText(I18N.getText("prefs.jvm.xmx.tooltip"));
     jvmXmsTextField = panel.getTextField("jvmXmsTextField");
-    jvmXmsTextField.setToolTipText(I18N.getText("prefs.jvm.xms.tooltip"));
     jvmXssTextField = panel.getTextField("jvmXssTextField");
-    jvmXssTextField.setToolTipText(I18N.getText("prefs.jvm.xss.tooltip"));
 
     dataDirTextField = panel.getTextField("dataDirTextField");
 
     jvmDirect3dCheckbox = panel.getCheckBox("jvmDirect3dCheckbox");
-    jvmDirect3dCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.direct3d.tooltip"));
-
     jvmOpenGLCheckbox = panel.getCheckBox("jvmOpenGLCheckbox");
-    jvmOpenGLCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.opengl.tooltip"));
-
     jvmInitAwtCheckbox = panel.getCheckBox("jvmInitAwtCheckbox");
-    jvmInitAwtCheckbox.setToolTipText(I18N.getText("prefs.jvm.advanced.initAWTbeforeJFX.tooltip"));
 
     jamLanguageOverrideComboBox = panel.getComboBox("jvmLanguageOverideComboBox");
-    jamLanguageOverrideComboBox.setToolTipText(I18N.getText("prefs.language.override.tooltip"));
 
     configFileWarningLabel = panel.getLabel("configFileWarningLabel");
     configFileWarningLabel.setIcon(
         new FlatSVGIcon("net/rptools/maptool/client/image/warning.svg", 16, 16));
 
-    startupInfoLabel = panel.getLabel("startupInfoLabel");
     cfgFilePath = panel.getTextField("cfgFilePath");
     copyCfgFilePathButton = panel.getButton("copyCfgPath");
     copyCfgFilePathButton.addActionListener(

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -402,7 +402,7 @@ public class PreferencesDialog extends JDialog {
 
   private final AbstractButton copyCfgFilePathButton;
 
-  private final JLabel configFileWarningLabel;
+  private final JPanel configFileWarningPanel;
 
   /** Flag indicating if JVM values have been changed. */
   private boolean jvmValuesChanged = false;
@@ -718,8 +718,9 @@ public class PreferencesDialog extends JDialog {
 
     jamLanguageOverrideComboBox = panel.getComboBox("jvmLanguageOverideComboBox");
 
-    configFileWarningLabel = panel.getLabel("configFileWarningLabel");
-    configFileWarningLabel.setIcon(
+    configFileWarningPanel = (JPanel) panel.getComponent("configFileWarningPanel");
+    JLabel configFileWarningIcon = panel.getLabel("configFileWarningIcon");
+    configFileWarningIcon.setIcon(
         new FlatSVGIcon("net/rptools/maptool/client/image/warning.svg", 16, 16));
 
     cfgFilePath = panel.getTextField("cfgFilePath");
@@ -891,15 +892,11 @@ public class PreferencesDialog extends JDialog {
 
     // jpackage config files can't be written to. Show a warning to the user describing the
     // situation.
-    var manualCopyPrimary = I18N.getText("startup.preferences.info.manualCopy.primary");
-    var manualCopySecondary = I18N.getText("startup.preferences.info.manualCopy.secondary");
-    configFileWarningLabel.setText(
-        String.format("<html>%s<br>%s</html>", manualCopyPrimary, manualCopySecondary));
 
     if (appCfgFile != null) {
-      configFileWarningLabel.setVisible(true);
+      configFileWarningPanel.setVisible(true);
     } else {
-      configFileWarningLabel.setVisible(false);
+      configFileWarningPanel.setVisible(false);
     }
 
     DefaultComboBoxModel<String> languageModel = new DefaultComboBoxModel<String>();

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -2506,20 +2506,6 @@
                       <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
                     </properties>
                   </component>
-                  <component id="37220" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
-                        <minimum-size width="1" height="-1"/>
-                        <preferred-size width="1" height="-1"/>
-                      </grid>
-                    </constraints>
-                    <properties>
-                      <iconTextGap value="8"/>
-                      <name value="configFileWarningLabel"/>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy.primary"/>
-                      <visible value="true"/>
-                    </properties>
-                  </component>
                   <component id="b1a1f" class="javax.swing.JButton" default-binding="true">
                     <constraints>
                       <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -2531,9 +2517,60 @@
                       <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.button.copyCfgPath.tooltip"/>
                     </properties>
                   </component>
+                  <grid id="3cf6a" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <name value="configFileWarningPanel"/>
+                    </properties>
+                    <border type="none"/>
+                    <children>
+                      <component id="37220" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                            <minimum-size width="1" height="-1"/>
+                            <preferred-size width="1" height="-1"/>
+                          </grid>
+                        </constraints>
+                        <properties>
+                          <iconTextGap value="8"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy.primary"/>
+                          <visible value="true"/>
+                        </properties>
+                      </component>
+                      <component id="99257" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                            <minimum-size width="1" height="-1"/>
+                            <preferred-size width="1" height="-1"/>
+                          </grid>
+                        </constraints>
+                        <properties>
+                          <iconTextGap value="8"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy.secondary"/>
+                          <visible value="true"/>
+                        </properties>
+                      </component>
+                      <component id="e008c" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="0" row-span="2" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <name value="configFileWarningIcon"/>
+                        </properties>
+                      </component>
+                      <hspacer id="8a02">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                      </hspacer>
+                    </children>
+                  </grid>
                   <hspacer id="92892">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </hspacer>
                 </children>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -3,7 +3,7 @@
   <grid id="3f87d" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1438" height="739"/>
+      <xy x="10" y="10" width="1438" height="815"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -2712,12 +2712,7 @@
                   <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
-              <vspacer id="9203f">
-                <constraints>
-                  <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </vspacer>
-              <grid id="41085" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="41085" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -2752,12 +2747,15 @@
                       </component>
                       <component id="37220" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                            <minimum-size width="1" height="-1"/>
+                            <preferred-size width="1" height="-1"/>
+                          </grid>
                         </constraints>
                         <properties>
                           <iconTextGap value="8"/>
                           <name value="configFileWarningLabel"/>
-                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy.primary"/>
                           <visible value="true"/>
                         </properties>
                       </component>
@@ -2796,7 +2794,7 @@
                           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <horizontalScrollBarPolicy value="31"/>
+                          <horizontalScrollBarPolicy value="30"/>
                         </properties>
                         <border type="none"/>
                         <children>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -3,7 +3,7 @@
   <grid id="3f87d" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1438" height="815"/>
+      <xy x="10" y="10" width="1469" height="1079"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -2471,7 +2471,7 @@
               </hspacer>
             </children>
           </grid>
-          <grid id="d083" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d083" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="5" left="5" bottom="5" right="5"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.startup"/>
@@ -2481,341 +2481,361 @@
             </properties>
             <border type="none"/>
             <children>
-              <grid id="1dbec" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="6f864" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="0">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                 </constraints>
                 <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.jvm">
+                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.cfgFilePath">
                   <font name="Dialog" size="12" style="1"/>
                   <title-color color="-13538620"/>
                   <color color="-6710887"/>
                 </border>
                 <children>
-                  <component id="a0e2a" class="javax.swing.JLabel">
+                  <component id="10368" class="javax.swing.JTextField">
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.jvm.heap"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.jvm.heap.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="81e0d" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.jvm.min"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.jvm.min.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="c563f" class="javax.swing.JTextField">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <minimum-size width="1" height="-1"/>
+                        <preferred-size width="1" height="-1"/>
+                      </grid>
                     </constraints>
                     <properties>
                       <editable value="false"/>
-                      <horizontalAlignment value="4"/>
-                      <name value="jvmXmxTextField"/>
-                      <scrollOffset value="1"/>
-                      <selectionEnd value="2"/>
-                      <selectionStart value="2"/>
-                      <text value="4G"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.language.tooltip"/>
+                      <name value="cfgFilePath"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
                     </properties>
                   </component>
-                  <component id="ccdf2" class="javax.swing.JTextField">
+                  <component id="37220" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                      <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                        <minimum-size width="1" height="-1"/>
+                        <preferred-size width="1" height="-1"/>
+                      </grid>
                     </constraints>
                     <properties>
-                      <editable value="false"/>
-                      <horizontalAlignment value="4"/>
-                      <name value="jvmXmsTextField"/>
-                      <scrollOffset value="1"/>
-                      <selectionEnd value="2"/>
-                      <selectionStart value="2"/>
-                      <text value="4G"/>
-                      <toolTipText value="Oracle recommends setting the minimum heap size (-Xms) equal to the maximum heap size (-Xmx) to minimize garbage collections."/>
+                      <iconTextGap value="8"/>
+                      <name value="configFileWarningLabel"/>
+                      <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy.primary"/>
+                      <visible value="true"/>
                     </properties>
                   </component>
-                  <component id="d0d82" class="javax.swing.JLabel">
+                  <component id="b1a1f" class="javax.swing.JButton" default-binding="true">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.jvm.stack"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.jvm.stack.tooltip"/>
+                      <icon value="net/rptools/maptool/client/image/page_copy.png"/>
+                      <margin top="5" left="5" bottom="5" right="5"/>
+                      <name value="copyCfgPath"/>
+                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.button.copyCfgPath.tooltip"/>
                     </properties>
                   </component>
-                  <component id="8bb5a" class="javax.swing.JTextField">
+                  <hspacer id="92892">
                     <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                     </constraints>
-                    <properties>
-                      <editable value="false"/>
-                      <horizontalAlignment value="4"/>
-                      <name value="jvmXssTextField"/>
-                      <scrollOffset value="1"/>
-                      <selectionEnd value="2"/>
-                      <selectionStart value="2"/>
-                      <text value="4M"/>
-                      <toolTipText value="Thread stacks are memory areas allocated for each Java thread for their internal use. This is where the thread stores its local execution state."/>
-                    </properties>
-                  </component>
+                  </hspacer>
                 </children>
               </grid>
-              <grid id="7d6e1" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
+              <vspacer id="f97f4">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.advanced">
-                  <font name="Dialog" size="12" style="1"/>
-                  <title-color color="-13538620"/>
-                  <color color="-6710887"/>
-                </border>
-                <children>
-                  <component id="402df" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <enabled value="false"/>
-                      <name value="jvmDirect3dCheckbox"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="1601e" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <enabled value="false"/>
-                      <name value="jvmOpenGLCheckbox"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="87f36" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.advanced.direct3d"/>
-                    </properties>
-                  </component>
-                  <component id="f844f" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.advanced.opengl"/>
-                    </properties>
-                  </component>
-                  <component id="28540" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.advanced.javafx"/>
-                    </properties>
-                  </component>
-                  <component id="87c34" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <enabled value="false"/>
-                      <name value="jvmInitAwtCheckbox"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                </children>
-              </grid>
-              <grid id="64613" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
-                <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.language.override">
-                  <font name="Dialog" size="12" style="1"/>
-                  <title-color color="-13538620"/>
-                  <color color="-6710887"/>
-                </border>
-                <children>
-                  <component id="43739" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text value="Language"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.language.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="a78f" class="javax.swing.JComboBox">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="comboBoxChanged"/>
-                      <enabled value="false"/>
-                      <model>
-                        <item value="English"/>
-                      </model>
-                      <name value="jvmLanguageOverideComboBox"/>
-                    </properties>
-                  </component>
-                </children>
-              </grid>
-              <grid id="91892" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
-                <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.options">
-                  <font name="Dialog" size="12" style="1"/>
-                  <title-color color="-13538620"/>
-                  <color color="-6710887"/>
-                </border>
-                <children>
-                  <component id="e2a2e" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.options.directory"/>
-                    </properties>
-                  </component>
-                  <component id="93ded" class="javax.swing.JTextField">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <editable value="false"/>
-                      <horizontalAlignment value="2"/>
-                      <name value="dataDirTextField"/>
-                      <selectionEnd value="14"/>
-                      <selectionStart value="14"/>
-                      <text value=".maptool-nerps"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.options.directory.tooltip"/>
-                    </properties>
-                  </component>
-                </children>
-              </grid>
-              <vspacer id="23f1f">
-                <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
-              <grid id="41085" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
+              <grid id="ca66e" layout-manager="GridLayoutManager" row-count="8" column-count="4" same-size-horizontally="false" same-size-vertically="true" hgap="15" vgap="5">
+                <margin top="20" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="0" column="2" row-span="5" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
-                <properties/>
+                <properties>
+                  <name value=""/>
+                </properties>
                 <border type="none"/>
                 <children>
-                  <grid id="6f864" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                    <margin top="0" left="0" bottom="0" right="0"/>
+                  <grid id="1dbec" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="5" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="0" row-span="3" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                     </constraints>
                     <properties/>
-                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.cfgFilePath">
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.jvm">
                       <font name="Dialog" size="12" style="1"/>
                       <title-color color="-13538620"/>
                       <color color="-6710887"/>
                     </border>
                     <children>
-                      <component id="10368" class="javax.swing.JTextField">
+                      <component id="a0e2a" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                            <minimum-size width="1" height="-1"/>
-                            <preferred-size width="1" height="-1"/>
-                          </grid>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xmx.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xmx.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="81e0d" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xms.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xms.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="c563f" class="javax.swing.JTextField">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <editable value="false"/>
-                          <name value="cfgFilePath"/>
-                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.cfgFilePath.tooltip"/>
+                          <horizontalAlignment value="4"/>
+                          <name value="jvmXmxTextField"/>
+                          <scrollOffset value="1"/>
+                          <selectionEnd value="2"/>
+                          <selectionStart value="2"/>
+                          <text value="4G"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xmx.tooltip"/>
                         </properties>
                       </component>
-                      <component id="37220" class="javax.swing.JLabel">
+                      <component id="ccdf2" class="javax.swing.JTextField">
                         <constraints>
-                          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
-                            <minimum-size width="1" height="-1"/>
-                            <preferred-size width="1" height="-1"/>
-                          </grid>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <iconTextGap value="8"/>
-                          <name value="configFileWarningLabel"/>
-                          <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info.manualCopy.primary"/>
-                          <visible value="true"/>
+                          <editable value="false"/>
+                          <horizontalAlignment value="4"/>
+                          <name value="jvmXmsTextField"/>
+                          <scrollOffset value="1"/>
+                          <selectionEnd value="2"/>
+                          <selectionStart value="2"/>
+                          <text value="4G"/>
+                          <toolTipText value="Oracle recommends setting the minimum heap size (-Xms) equal to the maximum heap size (-Xmx) to minimize garbage collections."/>
                         </properties>
                       </component>
-                      <component id="b1a1f" class="javax.swing.JButton" default-binding="true">
+                      <component id="d0d82" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <icon value="net/rptools/maptool/client/image/page_copy.png"/>
-                          <margin top="5" left="5" bottom="5" right="5"/>
-                          <name value="copyCfgPath"/>
-                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.button.copyCfgPath.tooltip"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xss.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xss.tooltip"/>
                         </properties>
                       </component>
-                      <hspacer id="92892">
+                      <component id="8bb5a" class="javax.swing.JTextField">
                         <constraints>
-                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
-                      </hspacer>
+                        <properties>
+                          <editable value="false"/>
+                          <horizontalAlignment value="4"/>
+                          <name value="jvmXssTextField"/>
+                          <scrollOffset value="1"/>
+                          <selectionEnd value="2"/>
+                          <selectionStart value="2"/>
+                          <text value="4M"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xss.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="2a021" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xmx.help"/>
+                        </properties>
+                      </component>
+                      <component id="9b348" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xms.help"/>
+                        </properties>
+                      </component>
+                      <component id="42cb5" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xss.help"/>
+                        </properties>
+                      </component>
                     </children>
                   </grid>
-                  <grid id="261e4" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                    <margin top="0" left="0" bottom="0" right="0"/>
+                  <grid id="91892" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="5" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="2" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                     </constraints>
                     <properties/>
-                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.startup.label.info">
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.options">
                       <font name="Dialog" size="12" style="1"/>
                       <title-color color="-13538620"/>
                       <color color="-6710887"/>
                     </border>
                     <children>
-                      <scrollpane id="4c948">
+                      <component id="e2a2e" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <horizontalScrollBarPolicy value="30"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.dataDirectory.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.dataDirectory.tooltip"/>
                         </properties>
-                        <border type="none"/>
-                        <children>
-                          <component id="bde4e" class="javax.swing.JLabel">
-                            <constraints/>
-                            <properties>
-                              <name value="startupInfoLabel"/>
-                              <text resource-bundle="net/rptools/maptool/language/i18n" key="startup.preferences.info"/>
-                            </properties>
-                          </component>
-                        </children>
-                      </scrollpane>
+                      </component>
+                      <component id="93ded" class="javax.swing.JTextField">
+                        <constraints>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <editable value="false"/>
+                          <horizontalAlignment value="2"/>
+                          <name value="dataDirTextField"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.dataDirectory.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="43739" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.language.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.language.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="a78f" class="javax.swing.JComboBox">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="comboBoxChanged"/>
+                          <enabled value="false"/>
+                          <model>
+                            <item value="English"/>
+                          </model>
+                          <name value="jvmLanguageOverideComboBox"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.language.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="f1872" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.language.help"/>
+                        </properties>
+                      </component>
+                      <component id="54d41" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.dataDirectory.help"/>
+                        </properties>
+                      </component>
+                    </children>
+                  </grid>
+                  <grid id="7d6e1" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="5" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="5" column="0" row-span="3" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.advanced">
+                      <font name="Dialog" size="12" style="1"/>
+                      <title-color color="-13538620"/>
+                      <color color="-6710887"/>
+                    </border>
+                    <children>
+                      <component id="402df" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <enabled value="false"/>
+                          <name value="jvmDirect3dCheckbox"/>
+                          <text value=""/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.disableDirect3D.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="1601e" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <enabled value="false"/>
+                          <name value="jvmOpenGLCheckbox"/>
+                          <text value=""/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.enableOpenGL.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="87f36" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.disableDirect3D.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.disableDirect3D.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="f844f" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.enableOpenGL.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.enableOpenGL.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="28540" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.javafx.macOsEmbedded.label"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.javafx.macOsEmbedded.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="87c34" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <enabled value="false"/>
+                          <name value="jvmInitAwtCheckbox"/>
+                          <text value=""/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.javafx.macOsEmbedded.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="b03a4" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.disableDirect3D.help"/>
+                        </properties>
+                      </component>
+                      <component id="97d9" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.enableOpenGL.help"/>
+                        </properties>
+                      </component>
+                      <component id="8406b" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.javafx.macOsEmbedded.help"/>
+                        </properties>
+                      </component>
                     </children>
                   </grid>
                 </children>
               </grid>
-              <hspacer id="2984">
-                <constraints>
-                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </hspacer>
             </children>
           </grid>
           <grid id="2e306" binding="developerTab" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -3,7 +3,7 @@
   <grid id="3f87d" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="1469" height="1079"/>
+      <xy x="10" y="10" width="1017" height="815"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -35,323 +35,6 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="b641a" layout-manager="GridLayoutManager" row-count="17" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
-                <constraints>
-                  <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.tokens">
-                  <font name="Dialog" size="12" style="1"/>
-                  <title-color color="-13538620"/>
-                  <color color="-6710887"/>
-                </border>
-                <children>
-                  <component id="4208b" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.objects.snap"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.snap.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="bbd3f" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Tokens start with snap to grid"/>
-                      <name value="tokensStartSnapToGridCheckBox"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="acebf" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.visible"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.visible.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="d37fc" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="New tokens are visible to players"/>
-                      <name value="newTokensVisibleCheckBox"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="5d7b" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.duplicate"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.duplicate.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="c824" class="javax.swing.JComboBox">
-                    <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="comboBoxChanged"/>
-                      <name value="duplicateTokenCombo"/>
-                    </properties>
-                  </component>
-                  <component id="509ab" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.numbering"/>
-                    </properties>
-                  </component>
-                  <component id="ba60d" class="javax.swing.JComboBox">
-                    <constraints>
-                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="comboBoxChanged"/>
-                      <name value="showNumberingCombo"/>
-                    </properties>
-                  </component>
-                  <component id="a961b" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.naming"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.naming.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="85202" class="javax.swing.JComboBox">
-                    <constraints>
-                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="comboBoxChanged"/>
-                      <name value="tokenNamingCombo"/>
-                    </properties>
-                  </component>
-                  <component id="b1212" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.objects.free"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.free.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="3d924" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Start tokens in freesize"/>
-                      <name value="tokensStartFreeSize"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="ea27c" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.dialog"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.dialog.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="26576" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Show token creation dialog"/>
-                      <name value="showDialogOnNewToken"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="2972" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="a2589" class="javax.swing.JTextField">
-                    <constraints>
-                      <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <columns value="5"/>
-                      <name value="statsheetPortraitSize"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="17252" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.delete"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.delete.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="e8333" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Warn when tokens are deleted"/>
-                      <name value="tokensPopupWarningWhenDeletedCheckBox"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="8152c" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Show statsheet on mouseover"/>
-                      <name value="showStatSheet"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="5b821" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.mouse"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.mouse.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="e774c" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Show statsheet on mouseover"/>
-                      <name value="forceFacingArrow"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="6966d" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.portrait.mouse"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.portrait.mouse.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="c4bab" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Show statsheet on mouseover"/>
-                      <name value="showPortrait"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="69755" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.shift"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.shift.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="22191" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <actionCommand value="Show statsheet on mouseover"/>
-                      <name value="showStatSheetModifier"/>
-                      <text value=""/>
-                    </properties>
-                  </component>
-                  <component id="bf608" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.snap"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.snap.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="88d43" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="13" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <name value="tokensSnapWhileDragging"/>
-                      <text value="&#9;"/>
-                    </properties>
-                  </component>
-                  <component id="c0cdd" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.arrow"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.arrow.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="82a88" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.hide"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.hide.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="2dbc6" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="14" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <name value="hideMousePointerWhileDragging"/>
-                      <selected value="false"/>
-                      <text value="&#9;"/>
-                    </properties>
-                  </component>
-                  <vspacer id="a9eb4">
-                    <constraints>
-                      <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                  </vspacer>
-                  <component id="60bed" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide"/>
-                      <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide.tooltip"/>
-                    </properties>
-                  </component>
-                  <component id="93234" class="javax.swing.JCheckBox">
-                    <constraints>
-                      <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <name value="hideTokenStackIndicator"/>
-                      <text value="&#9;"/>
-                    </properties>
-                  </component>
-                </children>
-              </grid>
               <grid id="f38d9" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
@@ -921,6 +604,333 @@
                   <grid row="0" column="6" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
+              <grid id="aa603" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <grid id="b641a" layout-manager="GridLayoutManager" row-count="17" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Label.tokens">
+                      <font name="Dialog" size="12" style="1"/>
+                      <title-color color="-13538620"/>
+                      <color color="-6710887"/>
+                    </border>
+                    <children>
+                      <component id="4208b" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.objects.snap"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.snap.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="bbd3f" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Tokens start with snap to grid"/>
+                          <name value="tokensStartSnapToGridCheckBox"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="acebf" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.visible"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.visible.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="d37fc" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="New tokens are visible to players"/>
+                          <name value="newTokensVisibleCheckBox"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="5d7b" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.duplicate"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.duplicate.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="c824" class="javax.swing.JComboBox">
+                        <constraints>
+                          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="comboBoxChanged"/>
+                          <name value="duplicateTokenCombo"/>
+                        </properties>
+                      </component>
+                      <component id="509ab" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.numbering"/>
+                        </properties>
+                      </component>
+                      <component id="ba60d" class="javax.swing.JComboBox">
+                        <constraints>
+                          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="comboBoxChanged"/>
+                          <name value="showNumberingCombo"/>
+                        </properties>
+                      </component>
+                      <component id="a961b" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.naming"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.naming.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="85202" class="javax.swing.JComboBox">
+                        <constraints>
+                          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="comboBoxChanged"/>
+                          <name value="tokenNamingCombo"/>
+                        </properties>
+                      </component>
+                      <component id="b1212" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.objects.free"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.free.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="3d924" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Start tokens in freesize"/>
+                          <name value="tokensStartFreeSize"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="ea27c" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.dialog"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.dialog.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="26576" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Show token creation dialog"/>
+                          <name value="showDialogOnNewToken"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="2972" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="a2589" class="javax.swing.JTextField">
+                        <constraints>
+                          <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <columns value="5"/>
+                          <name value="statsheetPortraitSize"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="17252" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.delete"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.delete.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="e8333" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Warn when tokens are deleted"/>
+                          <name value="tokensPopupWarningWhenDeletedCheckBox"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="8152c" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Show statsheet on mouseover"/>
+                          <name value="showStatSheet"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="5b821" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.mouse"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.mouse.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="e774c" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Show statsheet on mouseover"/>
+                          <name value="forceFacingArrow"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="6966d" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.portrait.mouse"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.portrait.mouse.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="c4bab" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Show statsheet on mouseover"/>
+                          <name value="showPortrait"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="69755" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.shift"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.statsheet.shift.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="22191" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Show statsheet on mouseover"/>
+                          <name value="showStatSheetModifier"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="bf608" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.snap"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.snap.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="88d43" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="13" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <name value="tokensSnapWhileDragging"/>
+                          <text value="&#9;"/>
+                        </properties>
+                      </component>
+                      <component id="c0cdd" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.arrow"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.arrow.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="82a88" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.hide"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.drag.hide.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="2dbc6" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="14" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <name value="hideMousePointerWhileDragging"/>
+                          <selected value="false"/>
+                          <text value="&#9;"/>
+                        </properties>
+                      </component>
+                      <component id="60bed" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.tokens.stack.hide.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="93234" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <name value="hideTokenStackIndicator"/>
+                          <text value="&#9;"/>
+                        </properties>
+                      </component>
+                    </children>
+                  </grid>
+                  <vspacer id="a9eb4">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </vspacer>
+                </children>
+              </grid>
             </children>
           </grid>
           <grid id="f8e61" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -2099,7 +2109,7 @@
                           <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.lumens.borderThickness.tooltip"/>
                         </properties>
                       </component>
-                      <component id="61dcd" class="javax.swing.JSpinner" binding="spinner1" default-binding="true">
+                      <component id="61dcd" class="javax.swing.JSpinner" default-binding="true">
                         <constraints>
                           <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
@@ -2116,7 +2126,7 @@
                           <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.lumens.startEnabled.tooltip"/>
                         </properties>
                       </component>
-                      <component id="8d9c8" class="javax.swing.JCheckBox" binding="checkBox1" default-binding="true">
+                      <component id="8d9c8" class="javax.swing.JCheckBox" default-binding="true">
                         <constraints>
                           <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
@@ -2135,7 +2145,7 @@
                           <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.lights.startEnabled.tooltip"/>
                         </properties>
                       </component>
-                      <component id="c4943" class="javax.swing.JCheckBox" binding="checkBox2" default-binding="true">
+                      <component id="c4943" class="javax.swing.JCheckBox" default-binding="true">
                         <constraints>
                           <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
@@ -2875,7 +2885,7 @@
               </grid>
             </children>
           </grid>
-          <grid id="2e306" binding="developerTab" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="2e306" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <tabbedpane title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.tab.developer"/>
@@ -2888,7 +2898,7 @@
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
-              <grid id="a5b3c" binding="developerOptionToggles" layout-manager="GridBagLayout">
+              <grid id="a5b3c" layout-manager="GridBagLayout">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                 </constraints>
@@ -2902,7 +2912,7 @@
                   <color color="-6710887"/>
                 </border>
                 <children>
-                  <component id="bc6ed" class="javax.swing.JLabel" binding="developerTabWarning">
+                  <component id="bc6ed" class="javax.swing.JLabel">
                     <constraints>
                       <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                       <gridbag top="6" left="0" bottom="6" right="0" weightx="0.0" weighty="0.0"/>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -2590,7 +2590,7 @@
                   <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
               </vspacer>
-              <grid id="ca66e" layout-manager="GridLayoutManager" row-count="8" column-count="4" same-size-horizontally="false" same-size-vertically="true" hgap="15" vgap="5">
+              <grid id="ca66e" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="15" vgap="5">
                 <margin top="20" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -2603,7 +2603,7 @@
                   <grid id="1dbec" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="5" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="0" column="0" row-span="3" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                      <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                     </constraints>
                     <properties/>
                     <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.jvm">
@@ -2632,7 +2632,7 @@
                       </component>
                       <component id="c563f" class="javax.swing.JTextField">
                         <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <editable value="false"/>
@@ -2647,7 +2647,7 @@
                       </component>
                       <component id="ccdf2" class="javax.swing.JTextField">
                         <constraints>
-                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <editable value="false"/>
@@ -2671,7 +2671,7 @@
                       </component>
                       <component id="8bb5a" class="javax.swing.JTextField">
                         <constraints>
-                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <editable value="false"/>
@@ -2686,7 +2686,7 @@
                       </component>
                       <component id="2a021" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xmx.help"/>
@@ -2694,7 +2694,7 @@
                       </component>
                       <component id="9b348" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xms.help"/>
@@ -2702,7 +2702,7 @@
                       </component>
                       <component id="42cb5" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.xss.help"/>
@@ -2710,10 +2710,10 @@
                       </component>
                     </children>
                   </grid>
-                  <grid id="91892" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="91892" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="true" hgap="-1" vgap="-1">
                     <margin top="0" left="5" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="3" column="0" row-span="2" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                      <grid row="1" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                     </constraints>
                     <properties/>
                     <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.options">
@@ -2733,7 +2733,7 @@
                       </component>
                       <component id="93ded" class="javax.swing.JTextField">
                         <constraints>
-                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <editable value="false"/>
@@ -2753,7 +2753,7 @@
                       </component>
                       <component id="a78f" class="javax.swing.JComboBox">
                         <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <actionCommand value="comboBoxChanged"/>
@@ -2767,7 +2767,7 @@
                       </component>
                       <component id="f1872" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.language.help"/>
@@ -2775,7 +2775,7 @@
                       </component>
                       <component id="54d41" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.dataDirectory.help"/>
@@ -2786,7 +2786,7 @@
                   <grid id="7d6e1" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="5" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="5" column="0" row-span="3" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                      <grid row="2" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
                     </constraints>
                     <properties/>
                     <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Preferences.label.advanced">
@@ -2797,7 +2797,7 @@
                     <children>
                       <component id="402df" class="javax.swing.JCheckBox">
                         <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <enabled value="false"/>
@@ -2808,7 +2808,7 @@
                       </component>
                       <component id="1601e" class="javax.swing.JCheckBox">
                         <constraints>
-                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <enabled value="false"/>
@@ -2846,7 +2846,7 @@
                       </component>
                       <component id="87c34" class="javax.swing.JCheckBox">
                         <constraints>
-                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <enabled value="false"/>
@@ -2857,7 +2857,7 @@
                       </component>
                       <component id="b03a4" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.disableDirect3D.help"/>
@@ -2865,7 +2865,7 @@
                       </component>
                       <component id="97d9" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.jvm.enableOpenGL.help"/>
@@ -2873,7 +2873,7 @@
                       </component>
                       <component id="8406b" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
                           <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.javafx.macOsEmbedded.help"/>

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.java
@@ -21,12 +21,6 @@ import javax.swing.*;
  * for accessing the root component of the dialog.
  */
 public class PreferencesDialogView {
-  private JSpinner spinner1;
-  private JCheckBox checkBox1;
-  private JCheckBox checkBox2;
-  private JPanel developerOptionToggles;
-  private JPanel developerTab;
-  private JLabel developerTabWarning;
 
   /**
    * The mainPanel variable represents the root component of the preferences dialog view. It is an

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2458,7 +2458,7 @@ Preferences.jvm.xms.help = This should include G for gigabyte, e.g. 4G.
 
 Preferences.jvm.xss.label = Thread stack size
 Preferences.jvm.xss.tooltip = -Xss: the amount of memory MapTool will use for its thread stacks. Increase this if you get stack errors when running macros.
-Preferences.jvm.xss.help = This should include M for Meg, e.g. 8M. Warning: setting this higher than 16M may cause issues.
+Preferences.jvm.xss.help = This should include M for megabyte, e.g. 8M. Warning: setting this higher than 16M may cause issues.
 
 Preferences.language.label = Language
 Preferences.language.tooltip = The language to use for MapTool.

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -706,25 +706,12 @@ Preferences.label.auth.publicKey                  = Client Public Key
 Preferences.label.auth.publicKey.tooltip          = Key used for authentication with servers using public/private key authentication.
 Preferences.label.auth.copyKey                    = Copy Public Key
 Preferences.label.auth.regenKey                   = Regenerate Key
-Preferences.label.language.tooltip                = Select Language for User Interface.
-Preferences.label.language.override               = Language Override
 Preferences.label.options                         = Additional Options
-Preferences.label.options.directory               = Data Directory
-Preferences.label.options.directory.tooltip       = Override default data directory. Default is .maptool under user directory.
 Preferences.label.cfgFilePath                     = Configuration file
 Preferences.label.cfgFilePath.tooltip             = Path of the .cfg file containing startup settings.
 Preferences.label.advanced                        = Advanced Options
 Preferences.label.advanced.assert                 = Enable assertions
-Preferences.label.advanced.direct3d               = Disable Direct3d Pipeline
-Preferences.label.advanced.opengl                 = Enable OpenGL Pipeline
-Preferences.label.advanced.javafx                 = Intialize AWT before JavaFX
 Preferences.label.jvm                             = JVM Memory Settings
-Preferences.label.jvm.heap                        = Maximum heap size (-Xmx)
-Preferences.label.jvm.heap.tooltip                = -Xmx size in bytes Sets the maximum size to which the Java heap can grow.
-Preferences.label.jvm.min                         = Initial && minimum heap size (-Xms)
-Preferences.label.jvm.min.tooltip                 = Oracle recommends setting the minimum heap size (-Xms) equal to the maximum heap size (-Xmx) to minimize garbage collections.
-Preferences.label.jvm.stack                       = Thread stack size (-Xss)
-Preferences.label.jvm.stack.tooltip               = Thread stacks are memory areas allocated for each Java thread for their internal use. This is where the thread stores its local execution state.
 Preferences.label.autosave                        = Campaign autosave every
 Preferences.label.autosave.tooltip                = <html>Autosaved campaigns are in <b>${appHome}/autosave</b>. Autosaving a campaign is memory-intensive. Be sure to take that into account. Set to 0 to disable.
 Preferences.label.save.reminder                   = Save reminder on close
@@ -2455,16 +2442,43 @@ dialog.NewToken.tokenPropertyType        = Token Property
 dialog.NewToken.statSheet                = Stat Sheet
 dialog.NewToken.statSheetLocation        = Stat Sheet Location
 
-prefs.language.override.tooltip = Select a language for the MapTool interface.
-
 prefs.jvm.advanced.enableAssertions.tooltip = Enables Java language assertions in the MapTool code.
-prefs.jvm.advanced.direct3d.tooltip         = Disable the use of Direct3D pipeline for problem video cards/drivers.
-prefs.jvm.advanced.opengl.tooltip           = Enable the OpenGL pipeline.
-prefs.jvm.advanced.initAWTbeforeJFX.tooltip = Initialize AWT before JavaFx. This is for issues specific to the MacOS.
 
-prefs.jvm.xmx.tooltip     = <html>Set the maximum memory (heap size) that MapTool is allowed to use. Input a number followed by either a single letter <b>M</b> or <b>G</b>.<br>Examples: 4G is 4 Gigabytes, 4096M is 4096 Megabytes and is the same as 4G.</html>
-prefs.jvm.xms.tooltip     = <html>Set the initial and minimum memory setting for MapTool. Must be less than or equal to max heap size.<br>Input a number followed by either a single letter <b>M</b> or <b>G</b>.</html>
-prefs.jvm.xss.tooltip     = <html>Set the stack size for MapTool program threads.  Values between 4M and 12M are recommended.<br>Values too large will cause problems.</html>
+# Principles for the JVM wording:
+# 1. Labels are descriptive for a broad audience (no JVM flags displayed there).
+# 2. Tooltips describe the nuts and bolts (JVM flags are present here).
+# 3. The help text shows only what is immediately necessary to guard against errors, and does not repeat the tooltip.
+Preferences.jvm.xmx.label = Maximum heap size
+Preferences.jvm.xmx.tooltip = -Xmx: the maximum memory (heap size) that MapTool is allowed to use.
+Preferences.jvm.xmx.help = This should include G for gigabyte, e.g. 8G.
+
+Preferences.jvm.xms.label = Minimum heap size
+Preferences.jvm.xms.tooltip = -Xms: the initial and minimum memory (heap size) that MapTool is will use.
+Preferences.jvm.xms.help = This should include G for gigabyte, e.g. 4G.
+
+Preferences.jvm.xss.label = Thread stack size
+Preferences.jvm.xss.tooltip = -Xss: the amount of memory MapTool will use for its thread stacks. Increase this if you get stack errors when running macros.
+Preferences.jvm.xss.help = This should include M for Meg, e.g. 8M. Warning: setting this higher than 16M may cause issues.
+
+Preferences.language.label = Language
+Preferences.language.tooltip = The language to use for MapTool.
+Preferences.language.help =
+
+Preferences.dataDirectory.label = Data Directory
+Preferences.dataDirectory.tooltip = The directory where MapTool data will be stored. Default is .maptool under user directory.
+Preferences.dataDirectory.help =
+
+Preferences.jvm.disableDirect3D.label = Disable Direct3d Pipeline
+Preferences.jvm.disableDirect3D.tooltip = Disables the use of Direct3D for Java2D rendering.
+Preferences.jvm.disableDirect3D.help = Try disabling this if you are experiencing graphical glitches on Windows systems.
+
+Preferences.jvm.enableOpenGL.label = Enable OpenGL Pipeline
+Preferences.jvm.enableOpenGL.tooltip = Enables the use of OpenGL for Java2D rendering.
+Preferences.jvm.enableOpenGL.help = Try disabling this if you are experiencing graphical glitches on non-Windows systems.
+
+Preferences.javafx.macOsEmbedded.label = Intialize AWT before JavaFX
+Preferences.javafx.macOsEmbedded.tooltip = On MacOS, forces JavaFX to initialize AWT before initializing itself.
+Preferences.javafx.macOsEmbedded.help = Only check this if you are experiencing problems with windows and dialogs not appearing on MacOS.
 
 roll.description         = Roll and broadcast the result to all connected players.
 roll.general.unknown     = <html>Unknown roll: "{0}".  Use #<b>d</b>#<b>+</b>#.
@@ -2714,46 +2728,6 @@ undefinedmacro.unknownCommand = Unknown command: "{0}".  Try <b>/help</b> for a 
 
 
 startup.config.unableToWrite = Unable to write to configuration file.
-Preferences.startup.label.info = Startup Preferences Information
-startup.preferences.info = <html>\
-  <u><b>JVM Memory Settings</b></u>\
-  <ul>\
-    <li>\
-        <b>Maximum Heap Size: </b>The maximum amount of memory MapTool can use\
-        <ul>\
-            <li>This should include G for gig, e.g. 8G</li>\
-        </ul>\
-    </li>\
-    <li>\
-        <b>Minimum Heap Size: </b>The minimum amount of memory MapTool will use\
-        <ul>\
-            <li>This should include G for gig, e.g. 4G</li>\
-        </ul>\
-    </li>\
-    <li>\
-        <b>Thread Stack Size: </b>The amount of memory MapTool will for its stack, increase this if you get stack errors when running \
-  macros.\
-        <ul>\
-            <li>This should include M for Meg, e.g. 8M</li>\
-            <li><i>warning setting this higher than 16M may cause issues</i></li>\
-        </ul>\
-  </li>\
-  </ul>\
-  <u><b>Language Override</b></u>\
-  <ul>\
-    <li><b>Language: </b>The language to use for MapTool<p></li>\
-  </ul>\
-  <u><b>Additional Options</b></u>\
-  <ul>\
-    <li><b>Data Directory: </b>The directory where MapTool data will be stored</li>\
-  </ul>\
-  <u><b>Advanced Options</b></u>\
-  <ul>\
-      <li><b>Disable Direct3d pipeline: </b>Try disabling this if you are experiencing graphical glitches on Windows Systems</li>\
-      <li><b>Disable OpenGL pipeline: </b>Try disabling this if you are experiencing graphical glitches on non Windows Systems</li>\
-      <li><b>Initialize AWT before JavaFx: </b>Only check this if you are experiencing problems with windows and dialogs not appearing</li>\
-  </ul>\
-</html>
 
 startup.preferences.info.manualCopy.primary = MapTool is unable to write the startup settings to the configuration file.
 startup.preferences.info.manualCopy.secondary = In order for them to take effect you will need to edit the configuration file and restart MapTool after saving your changes.

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2755,9 +2755,8 @@ startup.preferences.info = <html>\
   </ul>\
 </html>
 
-startup.preferences.info.manualCopy = <html>MapTool is unable to write the startup settings to the configuration file.<br>\
-  In order for them to take effect you will need to edit the configuration file and restart MapTool \
-  after saving your changes.</html>
+startup.preferences.info.manualCopy.primary = MapTool is unable to write the startup settings to the configuration file.
+startup.preferences.info.manualCopy.secondary = In order for them to take effect you will need to edit the configuration file and restart MapTool after saving your changes.
 
 startup.preferences.button.copyCfgPath.tooltip = Copy the configuration file path to the clipboard.
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5350

### Description of the Change

This changes the "manual copy" warning text to be two separate translatable strings in two separate labels so that no HTML formatting is required in the translations. These new labels can also shrink, so long text will not force the dialog to go extra dialog. They also uses new translation keys so no legacy text will be used.

The remainder of the tab has a different layout as well. Instead of monolithic help text, we now have one-line help for each field. This makes translation easier, and makes it easier to control the size and layout of the panel.

Each field now uses the following all-new keys:
- `Preferences.${name}.label`: the main label for the field. Text is descriptive for regular humans (no JVM command line options).
- `Preferences.${name}.tooltip`: the tooltip for the field. Text is more nuts-and-bolts (so command line options are okay).
- `Preferences.${name}.help`: the short, one-line help text for the field. Only there to steer the user away from obvious mistakes, but does not try to educate them on the meaning of the field, nor does it repeat tooltip information.

### Possible Drawbacks

Should be none.

### Documentation Notes

The Startup tab now looks like this:
![image](https://github.com/user-attachments/assets/73ca61ec-8be8-4df7-a760-e7b56c2f2601)

### Release Notes

- Modified the Startup panel to support better layout and translations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5521)
<!-- Reviewable:end -->
