### PR TITLE
Fix for ZoneRenderer.getTokenBounds()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/FacingTool.java
@@ -87,16 +87,23 @@ public class FacingTool extends DefaultTool {
   public void mouseMoved(MouseEvent e) {
     super.mouseMoved(e);
 
-    if (tokenUnderMouse == null || renderer.getTokenBounds(tokenUnderMouse) == null) {
+    if (tokenUnderMouse == null) {
       return;
     }
-    Rectangle bounds = renderer.getTokenBounds(tokenUnderMouse).getBounds();
 
-    int x = bounds.x + bounds.width / 2;
-    int y = bounds.y + bounds.height / 2;
+    var viewModel = renderer.getViewModel();
+    var position = viewModel.getTokenPositions().get(tokenUnderMouse.getId());
+    if (position == null) {
+      return;
+    }
+    if (!viewModel.getOnScreenTokens().contains(tokenUnderMouse.getId())) {
+      return;
+    }
 
-    double angle = Math.atan2(y - e.getY(), e.getX() - x);
+    var bounds = viewModel.getZoneScale().toScreenSpace(position.transformedBounds()).getBounds2D();
 
+    double angle =
+        Math.atan2((int) bounds.getCenterY() - e.getY(), e.getX() - (int) bounds.getCenterX());
     int degrees = (int) Math.toDegrees(angle);
 
     if (!SwingUtil.isControlDown(e)) {

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -80,7 +80,6 @@ public class PointerTool extends DefaultTool {
 
   // Hovers
   private boolean isShowingHover;
-  private Area hoverTokenBounds;
   private String hoverTokenNotes;
 
   // Track token interactions to hide statsheets when doing other stuff
@@ -398,7 +397,6 @@ public class PointerTool extends DefaultTool {
 
     if (isShowingHover) {
       isShowingHover = false;
-      hoverTokenBounds = null;
       hoverTokenNotes = null;
       markerUnderMouse = renderer.getMarkerAt(e.getX(), e.getY());
       repaint();
@@ -514,12 +512,7 @@ public class PointerTool extends DefaultTool {
             && !isShowingHover
             && tokenDragOp == null) {
           isShowingHover = true;
-          hoverTokenBounds = renderer.getMarkerBounds(markerUnderMouse);
           hoverTokenNotes = createHoverNote(markerUnderMouse);
-          if (hoverTokenBounds == null) {
-            // Uhhhh, where's the token ?
-            isShowingHover = false;
-          }
           repaint();
         }
         // SELECTION BOUND BOX
@@ -1623,16 +1616,8 @@ public class PointerTool extends DefaultTool {
               hoverTokenNotes,
               (int) (renderer.getWidth() * .75),
               (int) (renderer.getHeight() * .75));
-      Point location =
-          new Point(
-              hoverTokenBounds.getBounds().x
-                  + hoverTokenBounds.getBounds().width / 2
-                  - size.width / 2,
-              hoverTokenBounds.getBounds().y);
-
       // Anchor in the bottom left corner
-      location.x = 4 + PADDING;
-      location.y = viewSize.height - size.height - 4 - PADDING;
+      Point location = new Point(4 + PADDING, viewSize.height - size.height - 4 - PADDING);
 
       // Keep it on screen
       if (location.x + size.width > viewSize.width) {

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -992,13 +992,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
           return;
         }
         // Show sizing controls
-        // getTokenBounds() pulls the data from the tokenLocationCache in ZoneRenderer. That cache
-        // is populated inside renderer.renderTokens(). As long as the cache is created first, we
-        // should
-        // be good, right? This code relies on the order of operations in another class! Ugh!
-        // Double-ugh! :)
-        Area bounds = renderer.getTokenBounds(token);
-        if (bounds == null || renderer.isTokenMoving(token)) {
+        if (!renderer.getViewModel().getOnScreenTokens().contains(token.getId())
+            || renderer.isTokenMoving(token)) {
           continue;
         }
         // Resize

--- a/src/main/java/net/rptools/maptool/client/ui/Scale.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Scale.java
@@ -202,8 +202,8 @@ public class Scale implements Serializable {
         worldRect.getHeight() * scale);
   }
 
-  public ScreenPoint toScreenSpace(Point2D.Double worldSpace) {
-    return toScreenSpace(worldSpace.x, worldSpace.y);
+  public ScreenPoint toScreenSpace(Point2D worldSpace) {
+    return toScreenSpace(worldSpace.getX(), worldSpace.getY());
   }
 
   public ScreenPoint toScreenSpace(double x, double y) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/LightSourceIconOverlay.java
@@ -15,45 +15,24 @@
 package net.rptools.maptool.client.ui.zone;
 
 import java.awt.Graphics2D;
-import java.awt.geom.Area;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.theme.Images;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
-import net.rptools.maptool.model.AttachedLightSource;
-import net.rptools.maptool.model.LightSource;
-import net.rptools.maptool.model.Token;
 
 public class LightSourceIconOverlay implements ZoneOverlay {
-  private BufferedImage lightSourceIcon = RessourceManager.getImage(Images.LIGHT_SOURCE);
+  private final BufferedImage lightSourceIcon = RessourceManager.getImage(Images.LIGHT_SOURCE);
 
   public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
-
-    for (Token token : renderer.getZone().getAllTokens()) {
-
-      if (token.hasLightSources()) {
-        boolean foundNormalLight = false;
-        for (AttachedLightSource attachedLightSource : token.getLightSources()) {
-          LightSource lightSource = attachedLightSource.resolve(token, MapTool.getCampaign());
-          if (lightSource != null && lightSource.getType() == LightSource.Type.NORMAL) {
-            foundNormalLight = true;
-            break;
-          }
-        }
-        if (!foundNormalLight) {
-          continue;
-        }
-
-        Area area = renderer.getTokenBounds(token);
-        if (area == null) {
-          continue;
-        }
-
-        int x = area.getBounds().x + (area.getBounds().width - lightSourceIcon.getWidth()) / 2;
-        int y = area.getBounds().y + (area.getBounds().height - lightSourceIcon.getHeight()) / 2;
-        g.drawImage(lightSourceIcon, x, y, null);
-      }
+    var viewModel = renderer.getViewModel();
+    for (var point : viewModel.getLightPositions()) {
+      var screenPoint = viewModel.getZoneScale().toScreenSpace(point);
+      var at =
+          AffineTransform.getTranslateInstance(
+              screenPoint.x - lightSourceIcon.getWidth() / 2.,
+              screenPoint.y - lightSourceIcon.getHeight() / 2.);
+      g.drawImage(lightSourceIcon, at, null);
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -661,7 +661,7 @@ public class GdxRenderer extends ApplicationAdapter {
 
     if (zoneCache.getZoneRenderer().shouldRenderLayer(Zone.Layer.TOKEN, view)) {
       timer.start("lightSourceIconOverlay.paintOverlay");
-      paintlightSourceIconOverlay(view);
+      paintLightSourceIconOverlay(view);
       timer.stop("lightSourceIconOverlay.paintOverlay");
     }
 
@@ -762,36 +762,16 @@ public class GdxRenderer extends ApplicationAdapter {
     batch.setProjectionMatrix(cam.combined);
   }
 
-  private void paintlightSourceIconOverlay(PlayerView view) {
+  private void paintLightSourceIconOverlay(PlayerView view) {
     if (!AppState.isShowLightSources() || !view.isGMView()) {
       return;
     }
 
-    var lightbulb = zoneCache.fetch("lightbulb");
-    for (Token token : zoneCache.getZone().getAllTokens()) {
-
-      if (token.hasLightSources()) {
-        boolean foundNormalLight = false;
-        for (AttachedLightSource attachedLightSource : token.getLightSources()) {
-          LightSource lightSource = attachedLightSource.resolve(token, MapTool.getCampaign());
-          if (lightSource != null && lightSource.getType() == LightSource.Type.NORMAL) {
-            foundNormalLight = true;
-            break;
-          }
-        }
-        if (!foundNormalLight) {
-          continue;
-        }
-
-        Area area = zoneCache.getZoneRenderer().getTokenBounds(token);
-        if (area == null) {
-          continue;
-        }
-
-        int x = area.getBounds().x + (area.getBounds().width - lightbulb.getRegionWidth()) / 2;
-        int y = -area.getBounds().y - (area.getBounds().height + lightbulb.getRegionHeight()) / 2;
-        batch.draw(lightbulb, x, y);
-      }
+    TextureRegion lightbulb = zoneCache.fetch("lightbulb");
+    for (var point : viewModel.getLightPositions()) {
+      var x = point.getX() - lightbulb.getRegionWidth() / 2.;
+      var y = -point.getY() - lightbulb.getRegionHeight() / 2.;
+      batch.draw(lightbulb, (float) x, (float) y);
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/ZoneCache.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/ZoneCache.java
@@ -31,6 +31,7 @@ import net.rptools.lib.MD5Key;
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.ZoneView;
+import net.rptools.maptool.client.ui.zone.ZoneViewModel;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.IsometricGrid;
@@ -71,6 +72,10 @@ public class ZoneCache implements Disposable {
 
   public ZoneRenderer getZoneRenderer() {
     return zoneRenderer;
+  }
+
+  public ZoneViewModel getZoneViewModel() {
+    return zoneRenderer.getViewModel();
   }
 
   public ZoneView getZoneView() {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -2161,17 +2161,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         Collections.singletonList(visibleTokens.get(newSelection).getId()));
   }
 
-  public Area getMarkerBounds(Token token) {
-    // Note: this method must iterate only over markers. It cannot be implemented on top of
-    // getTokenBounds().
-    for (ZoneViewModel.TokenPosition position : viewModel.getMarkerPositions()) {
-      if (position.token() == token) {
-        return new Area(position.transformedBounds());
-      }
-    }
-    return null;
-  }
-
   public Rectangle getLabelBounds(Label label) {
     for (LabelLocation location : labelLocationList) {
       if (location.label == label) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1976,16 +1976,23 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       boolean hideTSI = AppPreferences.hideTokenStackIndicator.get();
       if (!hideTSI) {
         for (Token token : viewModel.getTokenStackMap().keySet()) {
-          Area bounds = getTokenBounds(token);
-          if (bounds == null) {
-            // token is off-screen
+          var position = viewModel.getTokenPositions().get(token.getId());
+          if (position == null) {
+            // Shouldn't happen, but should handle the case anyway.
             continue;
           }
+          if (!viewModel.getOnScreenTokens().contains(token.getId())) {
+            // Don't draw indicator for offscreen tokens.
+            continue;
+          }
+
+          var bounds = zoneScale.toScreenSpace(position.transformedBounds().getBounds2D());
+
           BufferedImage stackImage = RessourceManager.getImage(Images.ZONE_RENDERER_STACK_IMAGE);
           clippedG.drawImage(
               stackImage,
-              bounds.getBounds().x + bounds.getBounds().width - stackImage.getWidth() + 2,
-              bounds.getBounds().y - 2,
+              AffineTransform.getTranslateInstance(
+                  bounds.getMaxX() - stackImage.getWidth() + 2, bounds.getMinY() - 2),
               null);
         }
       }
@@ -2152,19 +2159,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     // Make the selection
     selectionModel.replaceSelection(
         Collections.singletonList(visibleTokens.get(newSelection).getId()));
-  }
-
-  public Area getTokenBounds(Token token) {
-    if (!viewModel.getOnScreenTokens().contains(token.getId())) {
-      return null;
-    }
-
-    var position = viewModel.getTokenPositions().get(token.getId());
-    if (position == null) {
-      return null;
-    }
-
-    return new Area(position.transformedBounds());
   }
 
   public Area getMarkerBounds(Token token) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes [this bug](https://github.com/RPTools/maptool/issues/5508#issuecomment-2923370582) introduced by #5490.

### Description of the Change

`ZoneRenderer.getTokenBounds()` was recently accidentally changed from returning bounds in screen space to returning bounds in world space. This caused some functionality, like light icons, stack indicators, and the facing tool to misbehave.

This PR correct this by removing `ZoneRenderer.getTokenBounds()` in favour of callers being more explicit about their needs. If they need screen space, they are responsible for doing the transformation. If they require the bounds to be on screen, they have to explicitly check that.

For light source icons specifically, `ZoneViewModel` is now responsible for deciding their locations. Both `ZoneRenderer` (via `LightSourceIconOverlay`) and `GdxRenderer` use this now instead of duplicating this logic and basing it on `ZoneRenderer.getTokenBounds()`.

The similar method `getMarkerBounds()` was removed as its only use was not itself used for anything.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5524)
<!-- Reviewable:end -->
