### PR TITLE
Fix bounds issues with screenshots

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/BufferedImagePool.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/BufferedImagePool.java
@@ -76,11 +76,19 @@ public class BufferedImagePool {
     this.checkedOut.clear();
   }
 
+  public int getWidth() {
+    return this.width;
+  }
+
   public void setWidth(int width) {
     if (width != this.width) {
       this.width = width;
       this.clear();
     }
+  }
+
+  public int getHeight() {
+    return this.height;
   }
 
   public void setHeight(int height) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/GridRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/GridRenderer.java
@@ -20,24 +20,15 @@ import net.rptools.maptool.client.ui.zone.PlayerView;
 import net.rptools.maptool.model.Zone;
 
 public class GridRenderer {
-  private Zone zone;
-  private ZoneRenderer renderer;
+  private final Zone zone;
+  private final ZoneRenderer renderer;
 
-  private boolean initialised = false;
-
-  public boolean isInitialised() {
-    return initialised;
+  public GridRenderer(ZoneRenderer renderer) {
+    this.renderer = renderer;
+    this.zone = renderer.getZone();
   }
 
-  GridRenderer() {}
-
-  public void setRenderer(ZoneRenderer zoneRenderer) {
-    renderer = zoneRenderer;
-    zone = renderer.getZone();
-    initialised = true;
-  }
-
-  protected void renderGrid(Graphics2D g, PlayerView view) {
+  public void renderGrid(Graphics2D g, PlayerView view) {
     int gridSize = (int) (zone.getGrid().getSize() * renderer.getScale());
     if (!AppState.isShowGrid() || gridSize < ZoneRendererConstants.MIN_GRID_SIZE) {
       return;
@@ -45,7 +36,7 @@ public class GridRenderer {
     zone.getGrid().draw(renderer, g, g.getClipBounds());
   }
 
-  protected void renderCoordinates(Graphics2D g, PlayerView view) {
+  public void renderCoordinates(Graphics2D g, PlayerView view) {
     if (AppState.isShowCoordinates()) {
       zone.getGrid().drawCoordinatesOverlay(g, renderer);
     }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -132,7 +132,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   private ZonePoint previousZonePoint;
 
   private final EnumSet<Layer> disabledLayers = EnumSet.noneOf(Layer.class);
-  private final ZoneCompositor compositor;
   private final GridRenderer gridRenderer;
   private final HaloRenderer haloRenderer;
   private final TokenRenderer tokenRenderer;
@@ -169,8 +168,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
             Zone.Layer.class, layer -> new PartitionedDrawableRenderer(zone));
 
     var renderHelper = new RenderHelper(this, tempBufferPool);
-    this.compositor = new ZoneCompositor();
-    this.gridRenderer = new GridRenderer();
+    this.gridRenderer = new GridRenderer(this);
     this.haloRenderer = new HaloRenderer(renderHelper);
     this.tokenRenderer = new TokenRenderer(renderHelper, zone);
     this.facingArrowRenderer = new FacingArrowRenderer(renderHelper, zone);
@@ -717,13 +715,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
             // Clear internal state
             itemRenderList.clear();
 
-            if (!compositor.isInitialised()) {
-              compositor.setRenderer(this);
-            }
-            if (!gridRenderer.isInitialised()) {
-              gridRenderer.setRenderer(this);
-            }
-
             timer.start("paintComponent");
             Graphics2D g2d = (Graphics2D) g;
 
@@ -858,8 +849,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       invalidateCurrentViewCache();
     }
     lastView = view;
-
-    Map<Token, Set<Token>> drawThese = compositor.drawWhat(viewRect);
 
     timer.stop("setup");
 
@@ -1038,9 +1027,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     timer.stop("overlays");
 
     timer.start("renderCoordinates");
-    if (!gridRenderer.isInitialised()) {
-      gridRenderer.setRenderer(this);
-    }
     gridRenderer.renderCoordinates(g2d, view);
     timer.stop("renderCoordinates");
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5488

### Description of the Change

Fixes two issues that have a similar apparent effect of making screen bounds be incorrect during screenshotting.

For #5488, the issue was that we use temporary buffers to render fog (and other layers), which typically matches the size of the `ZoneRenderer`'s render surface. But they do not necessarily match when taking a screenshot, since part of the screenshot logic is to resize the renderer in order to generate a properly sized image. The logic has been changed in `RenderHelper` to only use the pool if the configuration matches, otherwise fallback to allocating a new image.

Before:
![maptool](https://github.com/user-attachments/assets/dd38f64d-98d2-47f6-a48d-11db9d39a005)
After:
![maptool2](https://github.com/user-attachments/assets/9a36c55d-00bf-4cb7-b616-7f3c3ebe11ae)

The second issue is that tokens outside of the current viewport do not show up in a screenshot that has a different viewport that should include the tokens. This happens because the `ZoneViewModel` is not updated prior to calling `renderZone()`, but it must be updated in order for the renderer to know which tokens are on screen. This is fixed by pushing the update log from `paintComponent()` down into `renderZone()`. Some of the update logic - for initializing `compositor` and `gridRenderer` - is not really needed, so it has been removed.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where screenshots would not use the correct bounds when deciding what to render

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5529)
<!-- Reviewable:end -->
