### PR TITLE
Preserve user-specified order of sights, lights, and auras

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/FindTokenFunctions.java
@@ -499,10 +499,9 @@ public class FindTokenFunctions extends AbstractFunction {
           type = jobjLight.has("category") ? jobjLight.get("category").getAsString() : "*";
           name = jobjLight.has("name") ? jobjLight.get("name").getAsString() : "*";
 
-          Map<String, Map<GUID, LightSource>> lightSourcesMap =
-              MapTool.getCampaign().getLightSourcesMap();
+          CategorizedLights lightSources = MapTool.getCampaign().getLightSources();
 
-          if (!"*".equals(type) && !lightSourcesMap.containsKey(type)) {
+          if (!"*".equals(type) && lightSources.getCategory(type).isEmpty()) {
             throw new ParserException(
                 I18N.getText("macro.function.tokenLight.unknownLightType", "light", type));
           }

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -38,6 +38,7 @@ import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Campaign;
 import net.rptools.maptool.model.CampaignProperties;
+import net.rptools.maptool.model.CategorizedLights;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.Light;
@@ -381,9 +382,9 @@ public class getInfoFunction extends AbstractFunction {
     cinfo.add("token types", ttinfo);
 
     JsonObject llinfo = new JsonObject();
-    for (String ltype : c.getLightSourcesMap().keySet()) {
+    for (CategorizedLights.Category category : c.getLightSources().getCategories()) {
       JsonArray ltinfo = new JsonArray();
-      for (LightSource ls : c.getLightSourceMap(ltype).values()) {
+      for (LightSource ls : category.lights()) {
         JsonObject linfo = new JsonObject();
         linfo.addProperty("name", ls.getName());
         linfo.addProperty("max range", ls.getMaxRange());
@@ -397,7 +398,7 @@ public class getInfoFunction extends AbstractFunction {
         linfo.add("light segments", lightList);
         ltinfo.add(linfo);
       }
-      llinfo.add(ltype, ltinfo);
+      llinfo.add(category.name(), ltinfo);
     }
     cinfo.add("light sources", llinfo);
 
@@ -444,7 +445,7 @@ public class getInfoFunction extends AbstractFunction {
     cinfo.add("remote repository", remoteRepos);
 
     JsonObject sightInfo = new JsonObject();
-    for (SightType sightType : c.getSightTypeMap().values()) {
+    for (SightType sightType : c.getSightTypes()) {
       JsonObject si = new JsonObject();
       if (sightType.getShape() == ShapeType.BEAM) {
         si.addProperty("width", sightType.getWidth());

--- a/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AbstractTokenPopupMenu.java
@@ -20,9 +20,6 @@ import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -46,10 +43,12 @@ import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.tool.*;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.CategorizedLights;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.Light;
 import net.rptools.maptool.model.LightSource;
+import net.rptools.maptool.model.Lights;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Token.TokenShape;
 import net.rptools.maptool.model.TokenFootprint;
@@ -137,9 +136,9 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       }
     }
 
-    for (Entry<String, Map<GUID, LightSource>> entry :
-        MapTool.getCampaign().getLightSourcesMap().entrySet()) {
-      JMenu subMenu = createLightCategoryMenu(entry.getKey(), entry.getValue().values());
+    for (CategorizedLights.Category category :
+        MapTool.getCampaign().getLightSources().getCategories()) {
+      JMenu subMenu = createLightCategoryMenu(category.name(), category.lights());
       if (subMenu.getItemCount() != 0) {
         menu.add(subMenu);
       }
@@ -147,7 +146,7 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
     return menu;
   }
 
-  protected JMenu createLightCategoryMenu(String categoryName, Collection<LightSource> sources) {
+  protected JMenu createLightCategoryMenu(String categoryName, Lights sources) {
     JMenu subMenu = new JMenu(categoryName);
 
     for (LightSource lightSource : sources) {
@@ -197,9 +196,9 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
       }
     }
 
-    for (Entry<String, Map<GUID, LightSource>> entry :
-        MapTool.getCampaign().getLightSourcesMap().entrySet()) {
-      JMenu subMenu = createAuraCategoryMenu(entry.getKey(), entry.getValue().values());
+    for (CategorizedLights.Category category :
+        MapTool.getCampaign().getLightSources().getCategories()) {
+      JMenu subMenu = createAuraCategoryMenu(category.name(), category.lights());
       if (subMenu.getItemCount() != 0) {
         menu.add(subMenu);
       }
@@ -207,7 +206,7 @@ public abstract class AbstractTokenPopupMenu extends JPopupMenu {
     return menu;
   }
 
-  protected JMenu createAuraCategoryMenu(String categoryName, Collection<LightSource> sources) {
+  protected JMenu createAuraCategoryMenu(String categoryName, Lights sources) {
     JMenu subMenu = new JMenu(categoryName);
 
     for (LightSource lightSource : sources) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.ui.token.dialog.edit;
 
+import com.google.common.collect.Iterables;
 import com.jidesoft.combobox.MultilineStringExComboBox;
 import com.jidesoft.combobox.PopupPanel;
 import com.jidesoft.grid.MultilineStringCellEditor;
@@ -396,15 +397,15 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                 .toArray());
 
     var uniqueLightsSources = token.getUniqueLightSources();
-    var uniqueLights = new ArrayList<LightSource>();
-    var uniqueAuras = new ArrayList<LightSource>();
+    var uniqueLights = new Lights();
+    var uniqueAuras = new Lights();
     for (var lightSource : uniqueLightsSources) {
-      var list =
+      var lights =
           switch (lightSource.getType()) {
             case NORMAL -> uniqueLights;
             case AURA -> uniqueAuras;
           };
-      list.add(lightSource);
+      lights.add(lightSource);
     }
 
     getUniqueLightSourcesTextPane().setText(new LightSyntax().stringifyLights(uniqueLights));
@@ -652,8 +653,10 @@ public class EditTokenDialog extends AbeillePanel<Token> {
   }
 
   private void updateSightTypeCombo() {
-    List<String> typeList = new ArrayList<String>(MapTool.getCampaign().getSightTypes());
-    Collections.sort(typeList);
+    List<String> typeList = new ArrayList<String>();
+    for (var sightType : MapTool.getCampaign().getSightTypes()) {
+      typeList.add(sightType.getName());
+    }
 
     DefaultComboBoxModel model = new DefaultComboBoxModel(typeList.toArray());
     getSightTypeCombo().setModel(model);
@@ -847,17 +850,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         new HashSet<>(getTerrainModifiersIgnoredList().getSelectedValuesList()));
 
     var existingUniqueLightSources = token.getUniqueLightSources();
-    var uniqueLightSources = new ArrayList<LightSource>();
     var uniqueLights =
         new LightSyntax()
             .parseLights(getUniqueLightSourcesTextPane().getText(), existingUniqueLightSources);
     var uniqueAuras =
         new AuraSyntax().parseAuras(getUniqueAurasTextPane().getText(), existingUniqueLightSources);
-    uniqueLightSources.addAll(uniqueLights.values());
-    uniqueLightSources.addAll(uniqueAuras.values());
-
     token.removeAllUniqueLightsources();
-    for (var lightSource : uniqueLightSources) {
+    for (var lightSource : Iterables.concat(uniqueLights, uniqueAuras)) {
       token.addUniqueLightSource(lightSource);
     }
 

--- a/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
+++ b/src/main/java/net/rptools/maptool/model/AttachedLightSource.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.model;
 
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.maptool.server.proto.AttachedLightSourceDto;
@@ -54,9 +53,10 @@ public final class AttachedLightSource {
       return uniqueLightSource;
     }
 
-    for (Map<GUID, LightSource> map : campaign.getLightSourcesMap().values()) {
-      if (map.containsKey(lightSourceId)) {
-        return map.get(lightSourceId);
+    for (CategorizedLights.Category category : campaign.getLightSources().getCategories()) {
+      var source = category.lights().get(lightSourceId);
+      if (source.isPresent()) {
+        return source.get();
       }
     }
 

--- a/src/main/java/net/rptools/maptool/model/CategorizedLights.java
+++ b/src/main/java/net/rptools/maptool/model/CategorizedLights.java
@@ -1,0 +1,93 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import com.google.common.collect.Iterables;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+/** A collection of {@link LightSource} grouped into categories. */
+public class CategorizedLights {
+  public record Category(String name, Lights lights) {}
+
+  public static CategorizedLights copyOf(Map<String, ? extends Map<GUID, LightSource>> sources) {
+    var categorized = new CategorizedLights();
+    for (var entry : sources.entrySet()) {
+      categorized.addAllToCategory(entry.getKey(), entry.getValue().values());
+    }
+    return categorized;
+  }
+
+  private final TreeMap<String, Lights> allLights;
+
+  public CategorizedLights() {
+    allLights = new TreeMap<>();
+  }
+
+  public CategorizedLights(CategorizedLights other) {
+    this();
+    for (var entry : other.allLights.entrySet()) {
+      allLights.put(entry.getKey(), new Lights(entry.getValue()));
+    }
+  }
+
+  public boolean isEmpty() {
+    return allLights.isEmpty();
+  }
+
+  public void clear() {
+    allLights.clear();
+  }
+
+  public Iterable<Category> getCategories() {
+    return Iterables.transform(allLights.entrySet(), e -> new Category(e.getKey(), e.getValue()));
+  }
+
+  /**
+   * Looks up a category, adding it if it doesn't already exist.
+   *
+   * @param name The name of the category to find.
+   * @return The existing category if present, otherwise the new category.
+   */
+  public Optional<Category> getCategory(String name) {
+    var lights = this.allLights.get(name);
+    if (lights == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(new Category(name, lights));
+  }
+
+  public void addToCategory(String categoryName, LightSource light) {
+    addAllToCategory(categoryName, List.of(light));
+  }
+
+  public void addAllToCategory(String categoryName, Collection<LightSource> lights) {
+    if (lights.isEmpty()) {
+      // Don't create a category if we don't have to.
+      return;
+    }
+    allLights.computeIfAbsent(categoryName, c -> new Lights()).addAll(lights);
+  }
+
+  public void addAll(CategorizedLights other) {
+    for (var entry : other.allLights.entrySet()) {
+      addAllToCategory(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/src/main/java/net/rptools/maptool/model/Lights.java
+++ b/src/main/java/net/rptools/maptool/model/Lights.java
@@ -1,0 +1,87 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/**
+ * A collection of {@link LightSource} with unique IDs.
+ *
+ * <p>When adding a {@code LightSource}, if the collection already has one with the same ID it will
+ * be replaced.
+ */
+public class Lights extends AbstractSet<LightSource> {
+  public static Lights copyOf(Iterable<LightSource> sources) {
+    var lights = new Lights();
+    for (var source : sources) {
+      lights.add(source);
+    }
+    return lights;
+  }
+
+  private final LinkedHashMap<GUID, LightSource> sources;
+
+  public Lights() {
+    this.sources = new LinkedHashMap<>();
+  }
+
+  public Lights(Lights other) {
+    this();
+    addAll(other);
+  }
+
+  @Override
+  public int size() {
+    return sources.size();
+  }
+
+  @Override
+  public void clear() {
+    sources.clear();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return o instanceof LightSource lightSource && this.sources.containsKey(lightSource.getId());
+  }
+
+  @Override
+  public boolean add(LightSource lightSource) {
+    sources.put(lightSource.getId(), lightSource);
+    return true;
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    if (o instanceof LightSource lightSource) {
+      var previous = sources.remove(lightSource.getId());
+      return previous != null;
+    }
+    return false;
+  }
+
+  @Override
+  public @Nonnull Iterator<LightSource> iterator() {
+    return sources.values().iterator();
+  }
+
+  public Optional<LightSource> get(GUID lightSourceId) {
+    return Optional.ofNullable(sources.get(lightSourceId));
+  }
+}

--- a/src/main/java/net/rptools/maptool/model/Sights.java
+++ b/src/main/java/net/rptools/maptool/model/Sights.java
@@ -1,0 +1,87 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.model;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/**
+ * A set of {@link SightType} with unique names.
+ *
+ * <p>When adding a {@code SightType}, if the collection already has one with the same name it will
+ * be replaced.
+ */
+public class Sights extends AbstractSet<SightType> {
+  public static Sights copyOf(Iterable<SightType> sightTypes) {
+    var sights = new Sights();
+    for (var sightType : sightTypes) {
+      sights.add(sightType);
+    }
+    return sights;
+  }
+
+  private final LinkedHashMap<String, SightType> sightTypes;
+
+  public Sights() {
+    this.sightTypes = new LinkedHashMap<>();
+  }
+
+  public Sights(Sights other) {
+    this();
+    addAll(other);
+  }
+
+  @Override
+  public int size() {
+    return sightTypes.size();
+  }
+
+  @Override
+  public void clear() {
+    sightTypes.clear();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return o instanceof SightType sightType && this.sightTypes.containsKey(sightType.getName());
+  }
+
+  @Override
+  public boolean add(SightType sightType) {
+    sightTypes.put(sightType.getName(), sightType);
+    return true;
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    if (o instanceof SightType sightType) {
+      var previous = sightTypes.remove(sightType.getName());
+      return previous != null;
+    }
+    return false;
+  }
+
+  @Override
+  public @Nonnull Iterator<SightType> iterator() {
+    return sightTypes.values().iterator();
+  }
+
+  public Optional<SightType> get(String sightTypeName) {
+    return Optional.ofNullable(sightTypes.get(sightTypeName));
+  }
+}

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -552,7 +552,7 @@ public class Token implements Cloneable {
 
     // Try and silently catch any errors if there is an issue with sightType...
     try {
-      if (!MapTool.getCampaign().getCampaignProperties().getSightTypeMap().containsKey(sightType)) {
+      if (MapTool.getCampaign().getCampaignProperties().getSightTypes().get(sightType).isEmpty()) {
         sightType = MapTool.getCampaign().getCampaignProperties().getDefaultSightType();
       }
     } catch (Exception e) {
@@ -849,8 +849,8 @@ public class Token implements Cloneable {
     return imageTableName;
   }
 
-  public @Nonnull Collection<LightSource> getUniqueLightSources() {
-    return uniqueLightSources.values();
+  public @Nonnull Lights getUniqueLightSources() {
+    return Lights.copyOf(uniqueLightSources.values());
   }
 
   public @Nullable LightSource getUniqueLightSource(GUID lightSourceId) {

--- a/src/main/java/net/rptools/maptool/util/SightSyntax.java
+++ b/src/main/java/net/rptools/maptool/util/SightSyntax.java
@@ -23,7 +23,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.language.I18N;
@@ -31,14 +30,15 @@ import net.rptools.maptool.model.Light;
 import net.rptools.maptool.model.LightSource;
 import net.rptools.maptool.model.ShapeType;
 import net.rptools.maptool.model.SightType;
+import net.rptools.maptool.model.Sights;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 
 public class SightSyntax {
 
   private static final int DEFAULT_LUMENS = 100;
 
-  public List<SightType> parse(String text) {
-    final var sightList = new LinkedList<SightType>();
+  public Sights parse(String text) {
+    final var sightList = new Sights();
     final var reader = new LineNumberReader(new BufferedReader(new StringReader(text)));
     String line;
     String toBeParsed = null, errmsg = null;
@@ -193,9 +193,9 @@ public class SightSyntax {
     return sightList;
   }
 
-  public String stringify(Map<String, SightType> sightTypeMap) {
+  public String stringify(Sights sightTypeMap) {
     StringBuilder builder = new StringBuilder();
-    for (SightType sight : sightTypeMap.values()) {
+    for (SightType sight : sightTypeMap) {
       builder.append(sight.getName()).append(": ");
 
       builder.append(sight.getShape().name().toLowerCase()).append(" ");


### PR DESCRIPTION
### Identify the Bug or Feature request

Closes #3786

### Description of the Change

Changes the runtime storage for campaign sights and lights to be ordered. They are encapsulated in `Sights` and `CategorizedLights`, respectively, which enforces the use of `LinkedHashMap<>` to preserve insertion order. When loading a campaign, the existing `sightTypeMap` and `lightSourcesMap`  in `CampaignProperties` are converted to `Sights` and `CategorizedLights` for convenient use and better guarantees. When saving the campaign, these `Sights` and `CategorizedLights` get written back to the `sightTypeMap` and `lightSourcesMap` field. This ensures that the campaign format does not change, while still reaping the benefits of these more specialized types.

`Sights` is a `Set<SightType>` that guarantees unique names. `Lights` is a `Set<LightSource>` that guarantees unique IDs. `CategorizedLights` is not a real collection type, but is conceptually similar to a `Map<String, Lights>`.

We no longer pass around raw `Map<>` instances for sights and lights, but always use the encapsulated `Sights`, `Lights` or `CategorizedLights` as appropriate.

Whatever order for sights, lights, and auras is set in the **Campaign Properties** dialog will be used everywhere else:
- In the **Edit Token** dialog's _Sight Type_ dropdown (no longer sorted alphabetically).
- In the _Light Sources_ and _Auras_ submenus of the token popup menu.

A similar change has been make to `Token` so that it represents unique light sources and auras as `Lights` (at least externally). Its lights and auras already maintained their order, so there is no observable change there.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Respect the order of sights, lights, and auras as set by the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5537)
<!-- Reviewable:end -->
