### PR TITLE
Update upnplib to 1.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref 
 # find running instances in LAN
 servicediscovery = { group = "net.tsc.servicediscovery", name = "servicediscovery", version = "1.0.b5" }
 # UPNP. Maybe replace with jupnp
-upnplib = { group = "com.github.fishface60", name = "upnplib", version = "0351d7502a57f6c5dc8653220bc03ad99af58b21" }
+upnplib = { group = "com.github.RPTools", name = "upnplib", version = "1.2.0" }
 # For RESTful functions
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0" }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5538

### Description of the Change

As the title says. Also targets the upstream `com.github.RPTools` rather than `com.github.fishface60`·

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5539)
<!-- Reviewable:end -->
