### PR TITLE
Update json-smart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,7 +393,14 @@ dependencies {
     implementation(libs.apache.tika)
 
     implementation(libs.gson)
-    implementation(libs.jsonpath)
+
+    // region json-smart <2.5.2 is subject to DoS, but json-path has not updated yet. Force it to.
+    implementation(libs.jsonpath) {
+        exclude group: 'net.minidev', module: 'json-smart'
+    }
+    implementation("net.minidev:json-smart:2.5.2")
+    // endregion
+
     implementation(libs.jsoup)
     implementation(libs.jcabi.xml)
     implementation(libs.xstream)

--- a/build.gradle
+++ b/build.gradle
@@ -435,8 +435,6 @@ dependencies {
     implementation 'com.badlogicgames.gdx:gdx-freetype-platform:1.13.1:natives-desktop'
     implementation "com.badlogicgames.gdx-video:gdx-video:1.3.2-SNAPSHOT"
     implementation "com.badlogicgames.gdx-video:gdx-video-lwjgl3:1.3.2-SNAPSHOT"
-    // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-jul
-    implementation("org.apache.logging.log4j:log4j-jul:2.24.3")
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -426,15 +426,9 @@ dependencies {
     implementation(libs.noiselib)
 
     // libgdx
-    implementation 'com.github.thelsing:libgdx-jogl-backend:becdde406e'
-    implementation 'com.badlogicgames.gdx:gdx-backend-lwjgl:1.13.1'
-    implementation 'com.badlogicgames.gdx:gdx:1.13.1'
-    implementation 'com.badlogicgames.gdx:gdx-platform:1.13.1:natives-desktop'
-    implementation "space.earlygrey:shapedrawer:2.6.0"
-    implementation 'com.badlogicgames.gdx:gdx-freetype:1.13.1'
-    implementation 'com.badlogicgames.gdx:gdx-freetype-platform:1.13.1:natives-desktop'
-    implementation "com.badlogicgames.gdx-video:gdx-video:1.3.2-SNAPSHOT"
-    implementation "com.badlogicgames.gdx-video:gdx-video-lwjgl3:1.3.2-SNAPSHOT"
+    implementation(libs.bundles.gdx)
+    implementation(variantOf(libs.gdx.platform) { classifier('natives-desktop')})
+    implementation(variantOf(libs.gdx.freetype.platform) { classifier('natives-desktop')})
 }
 
 processResources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ findbugs-jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version
 # Logging
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
+log4j-jul = { group = "org.apache.logging.log4j", name = "log4j-jul", version.ref = "log4j" }
 # Bridges v1 to v2 for other code in other libs
 log4j-1_2-api = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version = "2.0.16" }
@@ -169,7 +170,7 @@ mockito-core = { group = "org.mockito", name = "mockito-core", version = "5.18.0
 
 
 [bundles]
-log4j = ["log4j-core", "log4j-api", "log4j-1_2-api"]
+log4j = ["log4j-core", "log4j-api", "log4j-jul", "log4j-1_2-api"]
 sentry = ["sentry", "sentry-log4j"]
 imageio = [
   "imageio-core",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jai-imageio = "1.4.0"
 graalvm-js = "21.2.0"
 pdfbox = "3.0.0"
 protoc = "4.29.3"
+gdx = "1.13.1"
 
 [libraries]
 findbugs-jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version = "3.0.2" }
@@ -150,6 +151,16 @@ intellij-forms-runtime = { group = "com.jetbrains.intellij.java", name = "java-g
 # layout for forms created in code
 miglayout-swing = { group = "com.miglayout", name = "miglayout-swing", version = "11.3" }
 
+gdx = { group = "com.badlogicgames.gdx", name = "gdx", version.ref = "gdx" }
+gdx-backend-lwjgl = { group = "com.badlogicgames.gdx", name = "gdx-backend-lwjgl", version.ref = "gdx" }
+gdx-platform = { group = "com.badlogicgames.gdx", name = "gdx-platform", version.ref = "gdx" }
+gdx-freetype = { group = "com.badlogicgames.gdx", name = "gdx-freetype", version.ref = "gdx" }
+gdx-freetype-platform = { group = "com.badlogicgames.gdx", name = "gdx-freetype-platform", version.ref = "gdx" }
+gdx-video = { group = "com.badlogicgames.gdx-video", name = "gdx-video", version = "1.3.2-SNAPSHOT" }
+gdx-video-lwjgl3 = { group = "com.badlogicgames.gdx-video", name = "gdx-video-lwjgl3", version = "1.3.2-SNAPSHOT" }
+libgdx-jogl-backend = { group = "com.github.thelsing", name = "libgdx-jogl-backend", version = "becdde406e" }
+earlygrey-shapedrawer = { group = "space.earlygrey", name = "shapedrawer", version = "2.6.0" }
+
 # RPTools libs
 # default resources (token, textures etc.)
 rptools-maptool-resources = { group = "com.github.RPTools", name = "maptool-resources", version = "1.6.0" }
@@ -202,6 +213,8 @@ handlebars = ["handlebars", "handlebars-helpers"]
 junit = ["junit-api", "junit-engine", "junit-params"]
 jai-imageio = ["jai-imageio-core", "jai-imageio-jpeg"]
 graalvm-js = ["graalvm-js", "graalvm-js-scriptengine"]
+gdx = ["gdx", "gdx-backend-lwjgl", "gdx-platform", "gdx-freetype", "gdx-freetype-platform",
+       "gdx-video", "gdx-video-lwjgl3", "libgdx-jogl-backend", "earlygrey-shapedrawer"]
 
 [plugins]
 git-version = { id = "com.palantir.git-version", version = "3.2.0" }


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5548

### Description of the Change

Forces the `json-smart` dependency of `json-path` to 2.5.2 (previously would sit at 2.5.0).

Also moves some stray dependencies out of `build.gradle` and into the version catalogue (`lib.versions.toml`):
- `log4j-jul` is now part of the `log4j` bundle.
- The various GDX dependencies have all been moved under the `gdx` bundle.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5549)
<!-- Reviewable:end -->
