### PR TITLE
Remove io.grpc:grpc-protobuf dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,7 +361,6 @@ dependencies {
     implementation(libs.servicediscovery)
     implementation(libs.upnplib)
     implementation(libs.okhttp)
-    implementation(libs.protobuf.grpc)
     implementation(libs.protobuf.java)
 
     implementation(libs.bundles.imageio)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ webrtc = { group = "dev.onvoid.webrtc", name = "webrtc-java", version = "0.9.0" 
 apache-commons-compress = { group = "org.apache.commons", name = "commons-compress", version = "1.27.1" }
 zstd = { group = "com.github.luben", name = "zstd-jni", version = "1.5.7-3" }
 # Protobuf
-protobuf-grpc = { group = "io.grpc", name = "grpc-protobuf", version = "1.61.1" }
 protobuf-java = { group = "com.google.protobuf", name = "protobuf-java-util", version.ref = "protoc" }
 protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protoc" }
 # find running instances in LAN


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5550

### Description of the Change

Removes the unused `io.grpc:grpc-protobuf` dependency from the version catalogue and the gradle build script.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5551)
<!-- Reviewable:end -->
