### PR TITLE
Upgrade sentry from 1.7.29 to 7.22.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 log4j = "2.24.3"
 junit = "5.11.4"
 imageio = "3.12.0"
-sentry = "6.34.0"
+sentry = "7.22.5"
 jide = "3.7.9"
 flatlaf = "3.5.4"
 handlebars = "4.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 log4j = "2.24.3"
 junit = "5.11.4"
 imageio = "3.12.0"
-sentry = "5.7.4"
+sentry = "6.34.0"
 jide = "3.7.9"
 flatlaf = "3.5.4"
 handlebars = "4.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 log4j = "2.24.3"
 junit = "5.11.4"
 imageio = "3.12.0"
-sentry = "4.3.0"
+sentry = "5.7.4"
 jide = "3.7.9"
 flatlaf = "3.5.4"
 handlebars = "4.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 log4j = "2.24.3"
 junit = "5.11.4"
 imageio = "3.12.0"
-sentry = "1.7.29"
+sentry = "4.3.0"
 jide = "3.7.9"
 flatlaf = "3.5.4"
 handlebars = "4.4.0"

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1470,43 +1470,6 @@ public class MapTool {
     return StringUtil.parseInteger(cmd.getOptionValue(searchValue), defaultValue);
   }
 
-  /** An example method that throws an exception. */
-  static void unsafeMethod() {
-    throw new UnsupportedOperationException("You shouldn't call this either!");
-  }
-
-  /** Examples using the (recommended) static API. */
-  static void testSentryAPI() {
-    // Note that all fields set on the context are optional. Context data is copied onto
-    // all future events in the current context (until the context is cleared).
-
-    // Record a breadcrumb in the current context. By default the last 100 breadcrumbs are kept.
-    Sentry.getContext()
-        .recordBreadcrumb(new BreadcrumbBuilder().setMessage("User made an action").build());
-
-    // Set the user in the current context.
-    Sentry.getContext().setUser(new UserBuilder().setEmail("hello@sentry.io").build());
-
-    // Add extra data to future events in this context.
-    Sentry.getContext().addExtra("extra", "thing");
-
-    // Add an additional tag to future events in this context.
-    Sentry.getContext().addTag("tagName", "tagValue");
-
-    /*
-     * This sends a simple event to Sentry using the statically stored instance that was created in the ``main`` method.
-     */
-    Sentry.capture("This is another logWithStaticAPI test");
-
-    try {
-      unsafeMethod();
-    } catch (Exception e) {
-      // This sends an exception event to Sentry using the statically stored instance
-      // that was created in the ``main`` method.
-      Sentry.capture(e);
-    }
-  }
-
   public static String getLoggerFileName() {
     org.apache.logging.log4j.core.Logger loggerImpl = (org.apache.logging.log4j.core.Logger) log;
     Appender appender = loggerImpl.getAppenders().get("LogFile");
@@ -1585,7 +1548,6 @@ public class MapTool {
     // Initialize Sentry.io logging
     Sentry.init();
     sentry = SentryClientFactory.sentryClient();
-    // testSentryAPI(); // purely for testing...
 
     // Jamz: Overwrite version for testing if passed as command line argument using -v or
     // -version

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -18,6 +18,7 @@ import com.jidesoft.plaf.LookAndFeelFactory;
 import com.jidesoft.plaf.UIDefaultsLookup;
 import com.jidesoft.plaf.basic.ThemePainter;
 import io.sentry.EventProcessor;
+import io.sentry.Hint;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
 import io.sentry.SentryEvent;
@@ -1551,7 +1552,7 @@ public class MapTool {
           options.addEventProcessor(
               new EventProcessor() {
                 @Override
-                public SentryEvent process(@Nonnull SentryEvent event, @Nullable Object hint) {
+                public SentryEvent process(@Nonnull SentryEvent event, @Nullable Hint hint) {
                   event.setRelease(getVersion());
                   return event;
                 }

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -19,9 +19,6 @@ import com.jidesoft.plaf.UIDefaultsLookup;
 import com.jidesoft.plaf.basic.ThemePainter;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
-import io.sentry.SentryClientFactory;
-import io.sentry.event.BreadcrumbBuilder;
-import io.sentry.event.UserBuilder;
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.EventQueue;
@@ -1546,8 +1543,15 @@ public class MapTool {
     }
 
     // Initialize Sentry.io logging
-    Sentry.init();
-    sentry = SentryClientFactory.sentryClient();
+    Sentry.init(
+        options -> {
+          options.setEnableExternalConfiguration(true);
+          options.addEventProcessor(
+              (event, hint) -> {
+                event.setRelease(getVersion());
+                return event;
+              });
+        });
 
     // Jamz: Overwrite version for testing if passed as command line argument using -v or
     // -version
@@ -1628,11 +1632,10 @@ public class MapTool {
     }
 
     // Set MapTool version
-    sentry.setRelease(getVersion());
-    sentry.addTag("os", System.getProperty("os.name"));
-    sentry.addTag("version", MapTool.getVersion());
-    sentry.addTag("versionImplementation", versionImplementation);
-    sentry.addTag("versionOverride", versionOverride);
+    Sentry.setTag("os", System.getProperty("os.name"));
+    Sentry.setTag("version", MapTool.getVersion());
+    Sentry.setTag("versionImplementation", versionImplementation);
+    Sentry.setTag("versionOverride", versionOverride);
 
     if (listMacros) {
       StringBuilder logOutput = new StringBuilder();

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -17,8 +17,10 @@ package net.rptools.maptool.client;
 import com.jidesoft.plaf.LookAndFeelFactory;
 import com.jidesoft.plaf.UIDefaultsLookup;
 import com.jidesoft.plaf.basic.ThemePainter;
+import io.sentry.EventProcessor;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
+import io.sentry.SentryEvent;
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.EventQueue;
@@ -1547,9 +1549,12 @@ public class MapTool {
         options -> {
           options.setEnableExternalConfiguration(true);
           options.addEventProcessor(
-              (event, hint) -> {
-                event.setRelease(getVersion());
-                return event;
+              new EventProcessor() {
+                @Override
+                public SentryEvent process(@Nonnull SentryEvent event, @Nullable Object hint) {
+                  event.setRelease(getVersion());
+                  return event;
+                }
               });
         });
 

--- a/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
@@ -283,7 +283,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
           if (obj instanceof String) {
             MapTool.showMessage(
                 "dialog.addresource.warn.badresourceid", "Error", JOptionPane.ERROR_MESSAGE, obj);
-            Sentry.capture("Add Resource to Library Error\nResource: " + obj);
+            Sentry.captureMessage("Add Resource to Library Error\nResource: " + obj);
             // Move on to next one...
             continue;
           }


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5560

### Description of the Change

Updates `io.sentry:sentry` and `io.sentry:sentry-log4j2` to 7.22.5. Some of the concepts have changed since 4.x, but have readily available equivalents. The main exception is the ability to set the release number after `Sentry.init()` - this now requires the use of an `EventProcessor` to set it per event. I considered just moving the `Sentry.init()` call a little later, but decided to leave it where it is in an attempt to change behaviour as little as possible.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5561)
<!-- Reviewable:end -->
