### PR TITLE
Catch and log all errors during startup

### DIFF
--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -16,9 +16,13 @@ package net.rptools.maptool.client;
 
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 
 public class LaunchInstructions {
+  private static final Logger log = LogManager.getLogger(LaunchInstructions.class);
+
   private static final String USAGE =
       "<html><body width=\"400\">You are running MapTool with insufficient memory allocated (%dMB).<br><br>"
           + "You may experience odd behavior, especially when connecting to or hosting a server.<br><br>  "
@@ -55,7 +59,8 @@ public class LaunchInstructions {
       MapTool.main(args);
 
       AppUpdate.gitHubReleases();
-    } catch (Exception e) {
+    } catch (Throwable e) {
+      log.error("Unhandled error during startup", e);
       // Shows a proper error message if MapTool can't initialize. Fix #1678.
       JOptionPane.showMessageDialog(new JFrame(), e.getMessage());
       System.exit(1);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5568

### Description of the Change

Upgrades the catch-all in `LaunchInstructions` to catch all `Throwable` and not just `Exception`. It also logs the error with its stack track for good measure, instead of just displaying the message to the user.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Catch more errors during startup, avoiding a hanging splash screen in some cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5569)
<!-- Reviewable:end -->
