### PR TITLE
Fix up the "Refactoring" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: File a bug report
 title: "[Bug]: "
 type: Bug
-labels: bug
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/code_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/code_improvement.yml
@@ -1,8 +1,8 @@
 name: Refactoring
 description: Suggest a refactoring to improve the codebase
-title: "[Refactoring]: "
-type: code-maintenance
-labels: ["code maintenance"]
+title: "[Maintenance]: "
+type: "Code Maintenance"
+labels: ["code-maintenance"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Suggest an idea for this project
 title: "[Feature]: "
 type: Feature
-labels: feature
+labels: ["feature"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/submit-a-question.yml
+++ b/.github/ISSUE_TEMPLATE/submit-a-question.yml
@@ -1,7 +1,7 @@
 name: Submit a Question
 description: Technical Questions
 title: '[Question]: '
-labels: question
+labels: ["question"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/zenhub_epic-md.yml
+++ b/.github/ISSUE_TEMPLATE/zenhub_epic-md.yml
@@ -1,7 +1,7 @@
 name: ZenHub Epic
 description: This template is for creating ZenHub Epics
 title: '[Epic]: '
-labels: 'epic'
+labels: ["epic"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5570

### Description of the Change

Changes the title from "[Refactoring]: " to "[Maintenance]: ", and tweaks the `type` and `label` fields to match the type and label on Github.

Also updates the other templates to make the `label` fields into lists as they ought to be.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5571)
<!-- Reviewable:end -->
