### PR TITLE
Update protobuf plugin to 0.9.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ protobuf {
 sourceSets {
     main {
         java {
-            srcDirs 'build/generated/source/proto/main/java'
+            srcDirs 'build/generated/sources/proto/main/java'
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -219,6 +219,6 @@ gdx = ["gdx", "gdx-backend-lwjgl", "gdx-platform", "gdx-freetype", "gdx-freetype
 git-version = { id = "com.palantir.git-version", version = "3.2.0" }
 javafx = { id = "org.openjfx.javafxplugin", version = "0.0.14" }
 jpackage-runtime = { id = "org.beryx.runtime", version = "1.13.1" }
-protobuf = { id = "com.google.protobuf", version = "0.9.4" }
+protobuf = { id = "com.google.protobuf", version = "0.9.5" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes dependabot PR #5552

### Description of the Change

Updates the protobuf output directory from `generated/source/proto` to `generated/sources/proto` according to the [release notes](https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.9.5).

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5572)
<!-- Reviewable:end -->
