### PR TITLE
Update cipher algorithms

### DIFF
--- a/src/main/java/net/rptools/maptool/util/cipher/CipherUtil.java
+++ b/src/main/java/net/rptools/maptool/util/cipher/CipherUtil.java
@@ -31,7 +31,7 @@ import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import net.rptools.lib.MD5Key;
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.Logger;
 public class CipherUtil {
 
   /** The algorithm to use for encoding / decoding. */
-  private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+  private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
 
   /** The size of the block cipher's block size in bytes. */
   public static final int CIPHER_BLOCK_SIZE = 16;

--- a/src/main/java/net/rptools/maptool/util/cipher/CipherUtil.java
+++ b/src/main/java/net/rptools/maptool/util/cipher/CipherUtil.java
@@ -72,7 +72,7 @@ public class CipherUtil {
   /** Asynchronous Key Algorithm */
   private static final String ASYMMETRIC_KEY_ALGORITHM = "RSA";
 
-  private static final String ASYMMETRIC_CIPHER_ALGORITHM = "RSA";
+  private static final String ASYMMETRIC_CIPHER_ALGORITHM = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
 
   private static final String PUBLIC_KEY_FIRST_LINE = "====== Begin Public Key ======";
   private static final String PUBLIC_KEY_LAST_LINE = "====== End Public Key ======";


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves the first (and minor part) of #5352

Also updates the symmetric cipher algorithm.

### Description of the Change

Changes the symmetric (password) cipher from `AES/CBC/PKCS5Padding` to `AES/GCM/NoPadding`

Changes the asymmetric cipher from vague `RSA` to specific `RSA/ECB/OAEPWithSHA-1AndMGF1Padding`. rather than leaving it up to the implementation to pick.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Updated the cipher algorithms for password-based and public key connections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5588)
<!-- Reviewable:end -->
