### PR TITLE
Fix regex ranges

### DIFF
--- a/src/main/java/net/rptools/dicelib/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/dicelib/expression/ExpressionParser.java
@@ -241,8 +241,9 @@ public class ExpressionParser {
 
   private final List<Pair<Pattern, String>> preprocessPatterns =
       List.of(
-          new Pair<>(Pattern.compile("^([A-z]+)!\"([^\"]*)\"$"), "advancedRoll('$1', " + "'$2')"),
-          new Pair<>(Pattern.compile("^([A-z]+)!'([^']*)'$"), "advancedRoll('$1', " + "'$2')"));
+          new Pair<>(
+              Pattern.compile("^([A-Za-z]+)!\"([^\"]*)\"$"), "advancedRoll('$1', " + "'$2')"),
+          new Pair<>(Pattern.compile("^([A-Za-z]+)!'([^']*)'$"), "advancedRoll('$1', " + "'$2')"));
 
   public ExpressionParser() {
     this(DICE_PATTERNS);

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanelInterface.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLPanelInterface.java
@@ -74,7 +74,7 @@ interface HTMLPanelInterface {
             "\036(\001\002)?([^\036]*)\036",
             "&#171;<span class='roll' style='color:blue'>&nbsp;$2&nbsp;</span>&#187;");
     // Auto inline expansion
-    html = html.replaceAll("(^|\\s)(https?://[\\w.%-/~?&+#=]+)", "$1<a href='$2'>$2</a>");
+    html = html.replaceAll("(^|\\s)(https?://[\\w.%\\-/~?&+#=]+)", "$1<a href='$2'>$2</a>");
 
     // Web view doesn't have any way to turn off caching for a link so we have to resort to a bit
     // of a hack


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5587

### Description of the Change

For advanced roll support, the regex now matches `A-Za-z` instead of `A-z` (which included `[`, `\`, `]`, `^`, `_`, and `,` in addition to alphabetic characters).

For `HTMLPanelInterface#fixHTML()`, escapes the `-` to avoid an accidental character range.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5589)
<!-- Reviewable:end -->
