### PR TITLE
Go back to using the NIGHTLY_BUILD_GH_TOKEN secret

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,5 +1,10 @@
 name: Nightly Release
 
+# Note that we use the NIGHTLY_BUILD_GH_TOKEN PAT in this workflow, and do not define permissions
+# for GITHUB_TOKEN. If we use GITHUB_TOKEN, GitHub will not trigger downstream workflows, in
+# particular, the publish.yml workflow will not run. So we have to use a PAT that has the necessary
+# permissions preconfigured.
+
 on:
   schedule:
     - cron: '13 2 * * *' # Odd time so that it doesn't run afoul of busy periods everyone picks
@@ -7,14 +12,12 @@ on:
 jobs:
   build:
     if: github.repository == 'RPTools/maptool'  # Don't run nightly releases on contributor forks.
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Set Vars
         id: set-vars
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
           echo "LATEST_STABLE_TAG=$(gh release list -R ${{ github.repository}} --exclude-drafts --exclude-pre-releases --order 'desc' --limit 1 --json tagName --jq '.[].tagName')"  >> $GITHUB_ENV
           echo "Latest Stable Tag: $LATEST_STABLE_TAG"
@@ -23,12 +26,12 @@ jobs:
       - name: Create Release
         id: create-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
           gh release create  nightly-${NIGHTLY_DATE} -R ${{github.repository}} --title "MapTool Nightly ${NIGHTLY_DATE}"  --notes "MapTool Nightly Build for ${NIGHTLY_DATE}" --generate-notes -p --target develop
       - name: Delete old Nightly releases
         id: delete-old
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
         run: |
           gh release list -R ${{ github.repository }} --json 'name,tagName' --jq '.[] | select(.tagName | startswith("nightly"))|.tagName' | tail +2 | xargs -r -n 1 gh release delete -R ${{ github.repository}} -y --cleanup-tag


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes nightly build after PR #5591

### Description of the Change

Github has a Creative™ design where jobs will only trigger subsequent jobs if they use Personal Access Tokens (PATs) for permissions, but not if they use `GITHUB_TOKEN`. This is true even if `GITHUB_TOKEN` is defined by the workflow's declared permissions rather than being the general permissions for the repository.

This prevents us from using explicit and constrained permissions in `nightly-publish.yml` as doing so will not allow the `publish.yml` workflow to trigger afterwards.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5595)
<!-- Reviewable:end -->
