### PR TITLE
Reduce the statefulness of HaloRenderer

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -21,74 +21,77 @@ import java.awt.geom.Ellipse2D;
 import java.util.HashMap;
 import java.util.Map;
 import net.rptools.maptool.client.AppPreferences;
-import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.ui.zone.ZoneViewModel;
 import net.rptools.maptool.model.*;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class HaloRenderer {
-  private static final Logger log = LogManager.getLogger(HaloRenderer.class);
   private final RenderHelper renderHelper;
-  private static final Map<Grid, Map<TokenFootprint, Shape>> GRID_SHAPE_MAP = new HashMap<>();
-  private Map<TokenFootprint, Shape> shapeMap;
-  private Grid grid;
-  private Shape haloShape;
-  private Shape paintShape;
-  private final int gridLineWeight = AppState.getGridSize();
+  private final Zone zone;
 
-  public HaloRenderer(RenderHelper renderHelper) {
+  // region These fields need to be recalculated whenever the grid changes.
+
+  private final Map<TokenFootprint, Shape> shapeMap = new HashMap<>();
+  private Shape cachedHaloShape;
+
+  // endregion
+
+  public HaloRenderer(RenderHelper renderHelper, Zone zone) {
     this.renderHelper = renderHelper;
+    this.zone = zone;
+    gridChanged();
   }
 
-  public void setRenderer(ZoneRenderer zoneRenderer) {
-    Zone zone = zoneRenderer.getZone();
-    grid = zone.getGrid();
-    if (grid == null) {
-      return;
-    }
-    shapeMap = GRID_SHAPE_MAP.get(grid);
-    if (shapeMap == null) {
-      shapeMap = new HashMap<>();
-    }
-    if (GridFactory.getGridType(grid).equals(GridFactory.NONE)) {
-      double r = grid.getSize() / 2d;
-      haloShape = new Ellipse2D.Double(-r, -r, 2 * r, 2 * r);
-    } else {
-      haloShape = grid.getCellShape();
-      haloShape =
-          AffineTransform.getTranslateInstance(
-                  -haloShape.getBounds2D().getCenterX(), -haloShape.getBounds2D().getCenterY())
-              .createTransformedShape(haloShape);
+  public void gridChanged() {
+    shapeMap.clear();
+    cachedHaloShape = null;
+  }
+
+  private Shape getHaloShape(Grid grid) {
+    if (cachedHaloShape == null) {
+      if (GridFactory.getGridType(grid).equals(GridFactory.NONE)) {
+        double r = grid.getSize() / 2d;
+        cachedHaloShape = new Ellipse2D.Double(-r, -r, 2 * r, 2 * r);
+      } else {
+        cachedHaloShape = grid.getCellShape();
+        cachedHaloShape =
+            AffineTransform.getTranslateInstance(
+                    -cachedHaloShape.getBounds2D().getCenterX(),
+                    -cachedHaloShape.getBounds2D().getCenterY())
+                .createTransformedShape(cachedHaloShape);
+      }
     }
 
-    log.info("HaloRenderer - ZoneRenderer updated - Grid set.");
+    return cachedHaloShape;
   }
 
   // Render Halos
   public void renderHalo(Graphics2D g2d, Token token, ZoneViewModel.TokenPosition position) {
-    if (token.getHaloColor() == null || grid == null) {
+    if (token.getHaloColor() == null) {
       return;
     }
-    // use cache so we don't have to resize halos every time
-    TokenFootprint fp = token.getFootprint(grid);
-    if (shapeMap.containsKey(fp)) {
-      paintShape = shapeMap.get(fp);
-    } else {
-      double maxD =
-          Math.max(
-              position.footprintBounds().getBounds2D().getWidth()
-                  / haloShape.getBounds2D().getWidth(),
-              position.footprintBounds().getBounds2D().getHeight()
-                  / haloShape.getBounds2D().getHeight());
-      paintShape = AffineTransform.getScaleInstance(maxD, maxD).createTransformedShape(haloShape);
 
-      shapeMap.put(fp, paintShape);
-      GRID_SHAPE_MAP.put(grid, shapeMap);
+    var grid = zone.getGrid();
+    if (grid == null) {
+      return;
     }
 
+    var haloShape = getHaloShape(grid);
+    TokenFootprint fp = token.getFootprint(grid);
+
+    // use cache so we don't have to resize halos every time
+    Shape paintShape =
+        shapeMap.computeIfAbsent(
+            fp,
+            fp2 -> {
+              double maxD =
+                  Math.max(
+                      position.footprintBounds().getWidth() / haloShape.getBounds2D().getWidth(),
+                      position.footprintBounds().getHeight() / haloShape.getBounds2D().getHeight());
+              return AffineTransform.getScaleInstance(maxD, maxD).createTransformedShape(haloShape);
+            });
+
     // position the shape we are painting
-    paintShape =
+    var positionedPaintShape =
         AffineTransform.getTranslateInstance(
                 position.transformedBounds().getBounds2D().getCenterX(),
                 position.transformedBounds().getBounds2D().getCenterY())
@@ -98,11 +101,11 @@ public class HaloRenderer {
     renderHelper.render(
         g2d,
         worldG -> {
-          paintLineHalo(worldG, token);
+          paintLineHalo(worldG, token, grid, positionedPaintShape);
         });
   }
 
-  private void paintLineHalo(Graphics2D g2d, Token token) {
+  private void paintLineHalo(Graphics2D g2d, Token token, Grid grid, Shape paintShape) {
     // double width because we will clip the inside half
     g2d.setStroke(
         new BasicStroke(
@@ -117,9 +120,5 @@ public class HaloRenderer {
     g2d.setClip(a);
     g2d.draw(paintShape);
     g2d.setClip(oldClip);
-  }
-
-  public void gridChanged(ZoneRenderer zoneRenderer) {
-    setRenderer(zoneRenderer);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.ui.zone.renderer;
 
+import com.google.common.eventbus.Subscribe;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
@@ -22,7 +23,9 @@ import java.util.HashMap;
 import java.util.Map;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.ui.zone.ZoneViewModel;
+import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.*;
+import net.rptools.maptool.model.zones.GridChanged;
 
 public class HaloRenderer {
   private final RenderHelper renderHelper;
@@ -38,10 +41,16 @@ public class HaloRenderer {
   public HaloRenderer(RenderHelper renderHelper, Zone zone) {
     this.renderHelper = renderHelper;
     this.zone = zone;
-    gridChanged();
+
+    new MapToolEventBus().getMainEventBus().register(this);
   }
 
-  public void gridChanged() {
+  @Subscribe
+  private void gridChanged(GridChanged event) {
+    if (event.zone() != this.zone) {
+      return;
+    }
+
     shapeMap.clear();
     cachedHaloShape = null;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -169,7 +169,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
     var renderHelper = new RenderHelper(this, tempBufferPool);
     this.gridRenderer = new GridRenderer(this);
-    this.haloRenderer = new HaloRenderer(renderHelper);
+    this.haloRenderer = new HaloRenderer(renderHelper, zone);
     this.tokenRenderer = new TokenRenderer(renderHelper, zone);
     this.facingArrowRenderer = new FacingArrowRenderer(renderHelper, zone);
     this.selectionRenderer = new SelectionRenderer(renderHelper, viewModel, zoneView);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -2655,7 +2655,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   @Subscribe
   private void onGridChanged(GridChanged event) {
     if (event.zone() != this.zone) {
-      haloRenderer.gridChanged(this);
       return;
     }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5597

### Description of the Change

This removes some unnecessary state from `HaloRenderer`, reducing the possibility that the rendering logic does not match user expectations.

There's a few dimensions to this:
- The zone for the `HaloRenderer` is injected in the constructor so it doesn't have to later be looked from a `ZoneRenderer`. This ensures the renderer is always properly initialized with consistent state, and removes the need for a `setRenderer()` method separate from `gridChanged()`.
- The static `GRID_SHAPE_MAP` was a memory leak (never cleared) and was also not needed since `Grid` objects cannot migrate between zones or renderers, and therefore different `HaloRenderer` instances have no need to share this cache. Instead, the non-static `shapeMap` suffices as a cache in its own right that just needs to be cleared whenever the grid changes.
- The halo shape (now in the `cachedHaloShape` field) is calculated on-demand rather than when the grid changes. This ensures that if, for some reason, the zone does not have a grid at a certain point in time, then there is still a chance to calculate it at the next render.
- The `paintState` field was only there to pass data from `renderHalo()` to `paintLineHalo()`. This is now a method parameter instead of a field.
- `HaloRenderer` subscribes itself to `GridChanged` events rather than relying on the `ZoneRenderer` to tell it when the grid changes.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where halos would not render until a grid was changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5598)
<!-- Reviewable:end -->
