### PR TITLE
Fix logger initialization

### DIFF
--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -21,8 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 
 public class LaunchInstructions {
-  private static final Logger log = LogManager.getLogger(LaunchInstructions.class);
-
   private static final String USAGE =
       "<html><body width=\"400\">You are running MapTool with insufficient memory allocated (%dMB).<br><br>"
           + "You may experience odd behavior, especially when connecting to or hosting a server.<br><br>  "
@@ -60,6 +58,10 @@ public class LaunchInstructions {
 
       AppUpdate.gitHubReleases();
     } catch (Throwable e) {
+      // IMPORTANT: don't move this logger init to class-level because we need AppUtil.initLogging()
+      // to run before any loggers are initialized. Yes, it's brittle, but c'est la vie.
+      Logger log = LogManager.getLogger(LaunchInstructions.class);
+
       log.error("Unhandled error during startup", e);
       // Shows a proper error message if MapTool can't initialize. Fix #1678.
       JOptionPane.showMessageDialog(new JFrame(), e.getMessage());


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5600

### Description of the Change

We can't initialize the `LaunchInstructions` logger before calling `AppUtil.initLogging()`, or else we would not have set the `MAPTOOL_LOGDIR` system property yet.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where logging would go in the `${sys:MAPTOOL_LOGDIR}` folder instead of under the data directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5601)
<!-- Reviewable:end -->
