### PR TITLE
More separated sentry environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,34 +33,9 @@ apply from: rootProject.file('buildSrc/shared.gradle')
 // Definitions
 defaultTasks 'clean', 'build'
 
-def javaArgs = [
-        "-Xss8M", "-Dsun.java2d.d3d=false", "-Dsentry.environment=Production", "-Dfile.encoding=UTF-8",
-        "-Dpolyglot.engine.WarnInterpreterOnly=false",
-        "-Djava.util.Arrays.useLegacyMergeSort=true",
-        "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
-        "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
-        "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
-        "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",
-        "--add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED","--add-opens=java.base/java.lang=ALL-UNNAMED",
-        "--add-opens=java.desktop/sun.awt=ALL-UNNAMED", "--add-opens=java.desktop/sun.java2d=ALL-UNNAMED",
-        "--add-opens=java.desktop/javax.swing=ALL-UNNAMED","--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED",
-        "--add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED"]
-
-// Used by gradle assemble & run tasks
-application {
-    mainClass = 'net.rptools.maptool.client.LaunchInstructions'
-    applicationDefaultJvmArgs = javaArgs + ["-DRUN_FROM_IDE=true"]
-    if (osdetector.os.is('osx')) {
-        applicationDefaultJvmArgs += [ '-Xdock:name=' + project.name + developerRelease ]
-    }
-}
-def appSemVer = ""
-
-configurations {
-    forms.extendsFrom implementation
-}
 
 // Custom properties
+def appSemVer = ""
 ext {
     // Allow packagers to build from the source code tarball, which doesn't
     // have '.git'
@@ -76,15 +51,25 @@ ext {
 
         revision = details.gitHash
         revisionFull = details.gitHashFull
-        if (details.commitDistance == 0) {
-          tagVersion = details.lastTag
-          environment = "Production"
-            sentryDSN = sentry_production_dsn
-        } else {
+        // Do not count as production if changes (committed or otherwise) have been made to the tree
+        // since the tag. And if the tag is a nightly tag, give it the special "Nightly" environment
+        // instead of counting it the same as a production release.
+        if (!details.isCleanTag) {
             tagVersion = 'SNAPSHOT-' + revision
             project.description = "SNAPSHOT-" + revision
             environment = "Development"
             sentryDSN = sentry_development_dsn
+        }
+        else if (details.lastTag.startsWith('nightly')) {
+            tagVersion = 'NIGHTLY-' + revision
+            project.description = "NIGHTLY-" + revision
+            environment = "Nightly"
+            sentryDSN = sentry_production_dsn
+        }
+        else {
+            tagVersion = details.lastTag
+            environment = "Production"
+            sentryDSN = sentry_production_dsn
         }
     }
 
@@ -108,6 +93,31 @@ ext {
     println "OS Detected: " + osdetector.os
 }
 
+def javaArgs = [
+        "-Xss8M", "-Dsun.java2d.d3d=false", "-Dfile.encoding=UTF-8",
+        "-Dpolyglot.engine.WarnInterpreterOnly=false",
+        "-Djava.util.Arrays.useLegacyMergeSort=true",
+        "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
+        "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",
+        "--add-opens=javafx.web/com.sun.webkit.dom=ALL-UNNAMED","--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt=ALL-UNNAMED", "--add-opens=java.desktop/sun.java2d=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing=ALL-UNNAMED","--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED",
+        "--add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED"]
+
+// Used by gradle assemble & run tasks
+application {
+    mainClass = 'net.rptools.maptool.client.LaunchInstructions'
+    applicationDefaultJvmArgs = javaArgs + ["-DRUN_FROM_IDE=true", "-Dsentry.environment=Development"]
+    if (osdetector.os.is('osx')) {
+        applicationDefaultJvmArgs += [ '-Xdock:name=' + project.name + developerRelease ]
+    }
+}
+
+configurations {
+    forms.extendsFrom implementation
+}
 
 spotless {
     java {

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -58,7 +58,9 @@ public class LaunchInstructions {
 
       MapTool.main(args);
 
-      AppUpdate.gitHubReleases();
+      if (!MapTool.isDevelopment()) {
+        AppUpdate.gitHubReleases();
+      }
     } catch (Throwable e) {
       log.error("Unhandled error during startup", e);
       // Shows a proper error message if MapTool can't initialize. Fix #1678.


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5567

### Description of the Change

This changes the build logic for picking a sentry environment in the manner described in #5567, with these details:
- Git tag details are readied very early in the script so that every task configuration can use them.
- Development builds are detected based on `isCleanTag` rather than `commitDistance`. This catches cases where uncommitted changes have been made to the source tree that could cause deviations from production releases.
- Clean tags prefixed with "nightly" are given the "Nightly" environment and the production DSN.
- Clean tags that are not "nightly" are given the "Production" environment.

That last case is now the only case where the "Production" environment is used. When executing `gradle run`, the "Development" environment is explicitly set on the command line. In all other cases, we do not set `sentry.environment` on the command line, but instead expect to find it in `sentry.properties`.

I've also disabled the auto-update check during development as that prompt can get annoying, and I don't want to hit "Never check for updates again!" during development just to silence it.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5602)
<!-- Reviewable:end -->
