### PR TITLE
Force anchor position to the cell center for snap-to-grid movement

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -436,7 +436,15 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
               var lastPoint = tokenPath.getWayPointList().getLast();
               var endPoint =
                   switch (lastPoint) {
-                    case CellPoint cp -> token.getDragAnchorAsIfLocatedInCell(zone, cp);
+                    case CellPoint cp -> {
+                      // Anchor at the cell center.
+                      var grid = zone.getGrid();
+                      var zp = grid.convert(cp);
+                      var centerOffset = grid.getCenterOffset();
+                      zp.x += (int) centerOffset.x;
+                      zp.y += (int) centerOffset.y;
+                      yield zp;
+                    }
                     case ZonePoint zp -> zp;
                   };
               token.moveDragAnchorTo(zone, endPoint);

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1634,23 +1634,6 @@ public class Token implements Cloneable {
   }
 
   /**
-   * Like {@link #getDragAnchor(Zone)}, but assume the token is in cell {@code cellPoint}.
-   *
-   * @param zone The zone that the token lives in.
-   * @param cellPoint The cell in which the token should pretend to be located.
-   * @return The drag anchor the token would have if located at {@code cellPoint}.
-   */
-  public ZonePoint getDragAnchorAsIfLocatedInCell(Zone zone, CellPoint cellPoint) {
-    ZonePoint anchor = getDragAnchor(zone);
-    ZonePoint nearestGridCellVertex = zone.getGrid().convert(zone.getGrid().convert(anchor));
-    ZonePoint targetCellVertex = zone.getGrid().convert(cellPoint);
-
-    return new ZonePoint(
-        targetCellVertex.x + (anchor.x - nearestGridCellVertex.x),
-        targetCellVertex.y + (anchor.y - nearestGridCellVertex.y));
-  }
-
-  /**
    * Gets the point where the token should go, if it were to be snapped to the grid.
    *
    * @param zone the zone where the token is


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5603 (at least makes it no worse the previous MT versions)

### Description of the Change

When dropping a token, the token's anchor is now forced to lie at the grid center for snap-to-grid tokens. This works around a widespread ambiguity in token positioning that leads to a lot of subtleties in how different components should reposition tokens.

This only mostly fixes the issue by restoring behaviour similar to older MT versions. When a token first ends up in the state described in #5603, the next drag of that token will still show as offset (hence not completely fixed). But once the token is dropped, it will be given a sane position that agrees with its apparent position, rather than maintaining this offset.

### Possible Drawbacks

Breaking some other code's assumptions on token positions.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where snap-to-grid tokens given an offset position would show that position during subsequent drags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5605)
<!-- Reviewable:end -->
