### PR TITLE
Always populate token properties table in Edit Token dialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -361,13 +361,11 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     /* Updates the Property Type list. */
     updatePropertyTypeCombo();
 
-    /* Set the selected item in Property Type list. Triggers a itemStateChanged event if index != 0 */
-    getPropertyTypeCombo().setSelectedItem(token.getPropertyType());
-
-    /* If index == 0, the itemStateChanged event wasn't triggered, so we update. Fix #1504 */
-    if (getPropertyTypeCombo().getSelectedIndex() == 0) {
-      updatePropertiesTable(token, (String) getPropertyTypeCombo().getSelectedItem());
-    }
+    /* Set the selected item in Property Type list. */
+    var propertyType = token.getPropertyType();
+    getPropertyTypeCombo().setSelectedItem(propertyType);
+    /* Make sure the right properties are displayed. */
+    updatePropertiesTable(token, propertyType);
 
     getSightTypeCombo()
         .setSelectedItem(


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5607

### Description of the Change

When binding the Edit Token dialog to a token, we now always explicitly update the properties table instead of trying to guess whether an itemStateChanged event would have been triggered during binding. This is not only more obvious, it matters since the dialog has not been completely set up yet and the token has not yet been set as the dialog's model, so the code that sets up the properties table does not have access to the token yet via the event listeners.

_Note: it would probably also be okay to just move the `super.bind(token);` call to the top of the method to make sure the token is set as the dialog's model right away. But there's too much magic in that little method for me to be confident doing it as a bug fix._

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where property types other than the default would not populate when the Edit Token dialog is first opened.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5609)
<!-- Reviewable:end -->
