### PR TITLE
Fix spurious theme change warning on preferences close

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/FontChooser.java
+++ b/src/main/java/net/rptools/maptool/client/swing/FontChooser.java
@@ -152,8 +152,7 @@ public class FontChooser extends JComponent {
     ChangeListener<Object> changeListener =
         (obs, was, now) -> {
           updateFont();
-          firePropertyChange(
-              obs.equals(referenceSize) ? "referenceSize" : "relativeSize", was, now);
+          firePropertyChange("font", was, now);
         };
 
     bold.addListener(changeListener);

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -590,12 +590,12 @@ public class PreferencesDialog extends JDialog {
         e -> {
           boolean close = true;
           if (close) {
-            themeFontPreferences.commit();
+            themeChanged = themeChanged | themeFontPreferences.commit();
             setVisible(false);
             dispose();
           }
           new MapToolEventBus().getMainEventBus().post(new PreferencesChanged());
-          if (ThemeSupport.needsRestartForNewTheme()) {
+          if (themeChanged || ThemeSupport.needsRestartForNewTheme()) {
             MapTool.showMessage(
                 "PreferencesDialog.themeChangeWarning",
                 "PreferencesDialog.themeChangeWarningTitle",

--- a/src/main/java/net/rptools/maptool/client/ui/theme/ThemeFontPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/theme/ThemeFontPreferences.java
@@ -57,7 +57,6 @@ public class ThemeFontPreferences extends AbeillePanel {
               stateChanged
                   | evt.getPropertyName().equals("font")
                   | evt.getPropertyName().equals("enabled");
-          System.out.println(stateChanged);
         }
       };
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5611 (backports #5612 to 1.18)

### Description of the Change

Removed theme restart warning check in ThemeFontPreferences. Now uses commit return value to warning check in PreferencesDialog. Changed FontChooser change event to use property name "font". Added change checks in ThemeFontPreferences to only warn if something changes.

### Possible Drawbacks
none

### Documentation Notes
n/a

### Release Notes

- Fix spurious theme change warning on preferences close

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5614)
<!-- Reviewable:end -->
