### PR TITLE
Refresh map when assets are loaded

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -19,6 +19,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.ImageObserver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -274,6 +276,12 @@ public class ZoneViewModel {
       // We're done, until the cache is cleared
       return;
     }
+
+    ImageObserver observer =
+        Objects.requireNonNullElseGet(
+            MapTool.getFrame().getZoneRenderer(this.zone),
+            () -> (ImageObserver) (img, infoflags, x, y, width, height) -> false);
+
     // Get a list of all the assets in the zone
     Set<MD5Key> assetSet = zone.getAllAssetIds();
     assetSet.remove(null); // remove bad data
@@ -293,7 +301,7 @@ public class ZoneViewModel {
       downloadCount++;
 
       // Have we loaded the image into memory yet ?
-      Image image = ImageManager.getImage(asset.getMD5Key());
+      Image image = ImageManager.getImage(asset.getMD5Key(), observer);
       if (image == null || image == ImageManager.TRANSFERING_IMAGE) {
         loaded = false;
         continue;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -833,6 +833,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       g2d.fillRect(0, 0, viewRect.width, viewRect.height);
       GraphicsUtil.drawBoxedString(
           g2d, loadingProgress.get(), viewRect.width / 2, viewRect.height / 2);
+      // Make sure we keep checking for completion.
+      repaintDebouncer.dispatch();
       return;
     }
     if (MapTool.getCampaign().isBeingSerialized()) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5620

### Description of the Change

Makes sure the map will repaint once assets are loaded by:
1. Registering an `ImageObserver` in `ZoneViewModel` when checking the asset status.
2. Requesting repaints until the `ZoneRenderer` is loaded.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where maps would not automatically display once assets become loaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5621)
<!-- Reviewable:end -->
