### PR TITLE
Revert "Bump com.github.weisj:jsvg from 1.4.0 to 2.0.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ flatlaf-intellij-themes = { group = "com.formdev", name = "flatlaf-intellij-them
 flatlaf-extras = { group = "com.formdev", name = "flatlaf-extras", version.ref = "flatlaf" }
 flatlaf-jide-oss = { group = "com.formdev", name = "flatlaf-jide-oss", version.ref = "flatlaf" }
 tinylaf-nocp = { group = "de.muntjak.tinylookandfeel", name = "tinylaf-nocp", version = "1.4.0" }
-jsvg = { group = "com.github.weisj", name = "jsvg", version = "2.0.0" }
+jsvg = { group = "com.github.weisj", name = "jsvg", version = "1.4.0" }
 
 handlebars = { group = "com.github.jknack", name = "handlebars", version.ref = "handlebars" }
 handlebars-helpers = { group = "com.github.jknack", name = "handlebars-helpers", version.ref = "handlebars" }


### PR DESCRIPTION
### Description of the Change

Reverts PR #5384 as it is causing trouble with FlatLaf

Per JFormDesigner/FlatLaf#997, FlatLaf 3.7 should become compatible JSVG 2.0. When that is released we can update both.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5634)
<!-- Reviewable:end -->
