### PR TITLE
Warn when resetting the initiative round counter

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -390,6 +390,9 @@ public class AppPreferences {
   public static final Preference<Boolean> showInitiativeGainedMessage =
       store.defineBoolean("showInitGainMessage", true);
 
+  public static final Preference<Boolean> initiativePanelWarnWhenResettingRoundCounter =
+      store.defineBoolean("initWarnWhenResettingRoundCounter", false);
+
   public static final Preference<Boolean> pathfindingEnabled =
       store.defineBoolean("useAstarPathfinding", true);
 

--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -391,7 +391,7 @@ public class AppPreferences {
       store.defineBoolean("showInitGainMessage", true);
 
   public static final Preference<Boolean> initiativePanelWarnWhenResettingRoundCounter =
-      store.defineBoolean("initWarnWhenResettingRoundCounter", false);
+      store.defineBoolean("initWarnWhenResettingRoundCounter", true);
 
   public static final Preference<Boolean> pathfindingEnabled =
       store.defineBoolean("useAstarPathfinding", true);

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -882,16 +882,19 @@ public class InitiativePanel extends JPanel
             return;
           }
 
-          int reset = JOptionPane.YES_OPTION;
+          boolean reset;
           if (AppPreferences.initiativePanelWarnWhenResettingRoundCounter.get()) {
             reset =
-                JOptionPane.showConfirmDialog(
-                    null,
-                    I18N.getText("initPanel.warnWhenResettingRoundCounter.confirm"),
-                    I18N.getText("msg.title.messageDialogConfirm"),
-                    JOptionPane.YES_NO_OPTION);
+                (JOptionPane.showConfirmDialog(
+                        null,
+                        I18N.getText("initPanel.warnWhenResettingRoundCounter.confirm"),
+                        I18N.getText("msg.title.messageDialogConfirm"),
+                        JOptionPane.YES_NO_OPTION)
+                    == JOptionPane.YES_OPTION);
+          } else {
+            reset = true;
           }
-          if (reset == JOptionPane.YES_OPTION) {
+          if (reset) {
             list.startUnitOfWork();
             list.setRound(-1);
             list.setCurrent(-1);

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -92,10 +92,6 @@ public class InitiativePanel extends JPanel
    */
   private boolean initStateSecondLine = AppPreferences.initiativePanelShowsInitiativeOnLine2.get();
 
-  /** Flag indicating whether to display a confirmation dialog when resetting the round counter. */
-  private boolean warnWhenResettingRoundCounter =
-      AppPreferences.initiativePanelWarnWhenResettingRoundCounter.get();
-
   /** The zone data being displayed. */
   private Zone zone;
 
@@ -306,7 +302,7 @@ public class InitiativePanel extends JPanel
       warnWhenResettingRoundCounterMenuItem =
           new JCheckBoxMenuItem(TOGGLE_WARN_WHEN_RESETTING_COUNTER_ACTION);
       warnWhenResettingRoundCounterMenuItem.setSelected(
-          list != null && warnWhenResettingRoundCounter);
+          list != null && AppPreferences.initiativePanelWarnWhenResettingRoundCounter.get());
       popupMenu.add(warnWhenResettingRoundCounterMenuItem);
       popupMenu.addSeparator();
       popupMenu.add(new JMenuItem(ADD_PCS_ACTION));
@@ -872,9 +868,8 @@ public class InitiativePanel extends JPanel
       new AbstractAction() {
         @Override
         public void actionPerformed(ActionEvent e) {
-          warnWhenResettingRoundCounter = ((JCheckBoxMenuItem) e.getSource()).isSelected();
           AppPreferences.initiativePanelWarnWhenResettingRoundCounter.set(
-              warnWhenResettingRoundCounter);
+              ((JCheckBoxMenuItem) e.getSource()).isSelected());
         }
       };
 
@@ -887,18 +882,15 @@ public class InitiativePanel extends JPanel
             return;
           }
 
-          int reset;
-          if (warnWhenResettingRoundCounter) {
+          int reset = JOptionPane.YES_OPTION;
+          if (AppPreferences.initiativePanelWarnWhenResettingRoundCounter.get()) {
             reset =
                 JOptionPane.showConfirmDialog(
                     null,
                     I18N.getText("initPanel.warnWhenResettingRoundCounter.confirm"),
                     I18N.getText("msg.title.messageDialogConfirm"),
                     JOptionPane.YES_NO_OPTION);
-          } else {
-            reset = JOptionPane.YES_OPTION;
           }
-
           if (reset == JOptionPane.YES_OPTION) {
             list.startUnitOfWork();
             list.setRound(-1);

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -92,6 +92,10 @@ public class InitiativePanel extends JPanel
    */
   private boolean initStateSecondLine = AppPreferences.initiativePanelShowsInitiativeOnLine2.get();
 
+  /** Flag indicating whether to display a confirmation dialog when resetting the round counter. */
+  private boolean warnWhenResettingRoundCounter =
+      AppPreferences.initiativePanelWarnWhenResettingRoundCounter.get();
+
   /** The zone data being displayed. */
   private Zone zone;
 
@@ -111,6 +115,11 @@ public class InitiativePanel extends JPanel
    * The menu item that tells the GM if players can only move their tokens when it is their turn.
    */
   private JCheckBoxMenuItem movementLockMenuItem;
+
+  /**
+   * The menu item for whether to display a confirmation dialog when resetting the round counter.
+   */
+  private JCheckBoxMenuItem warnWhenResettingRoundCounterMenuItem;
 
   /**
    * Flag indicating that the owners of tokens have been granted permission to restricted actions
@@ -153,12 +162,13 @@ public class InitiativePanel extends JPanel
     toolBar.add(new TextlessButton(PREV_ACTION));
     toolBar.add(new TextlessButton(TOGGLE_HOLD_ACTION));
     toolBar.add(new TextlessButton(NEXT_ACTION));
-    toolBar.add(new TextlessButton(RESET_COUNTER_ACTION));
 
     round = new JLabel("", SwingConstants.LEFT);
     toolBar.add(Box.createHorizontalGlue());
     toolBar.add(round);
     toolBar.add(Box.createHorizontalStrut(8));
+
+    toolBar.add(new TextlessButton(RESET_COUNTER_ACTION));
 
     // ensure that the preferred width is enough to show the round counter in fullscreen
     round.setText(I18N.getText("initPanel.round") + "WWW");
@@ -218,6 +228,8 @@ public class InitiativePanel extends JPanel
     I18N.setAction("initPanel.toggleOwnerPermissions", TOGGLE_OWNER_PERMISSIONS_ACTION);
     I18N.setAction("initPanel.toggleMovementLock", TOGGLE_MOVEMENT_LOCK_ACTION);
     I18N.setAction("initPanel.round", RESET_COUNTER_ACTION);
+    I18N.setAction(
+        "initPanel.warnWhenResettingRoundCounter", TOGGLE_WARN_WHEN_RESETTING_COUNTER_ACTION);
     I18N.setAction("initPanel.next", NEXT_ACTION);
     I18N.setAction("initPanel.prev", PREV_ACTION);
     updateView();
@@ -291,6 +303,11 @@ public class InitiativePanel extends JPanel
       movementLockMenuItem = new JCheckBoxMenuItem(TOGGLE_MOVEMENT_LOCK_ACTION);
       movementLockMenuItem.setSelected(list != null && movementLock);
       popupMenu.add(movementLockMenuItem);
+      warnWhenResettingRoundCounterMenuItem =
+          new JCheckBoxMenuItem(TOGGLE_WARN_WHEN_RESETTING_COUNTER_ACTION);
+      warnWhenResettingRoundCounterMenuItem.setSelected(
+          list != null && warnWhenResettingRoundCounter);
+      popupMenu.add(warnWhenResettingRoundCounterMenuItem);
       popupMenu.addSeparator();
       popupMenu.add(new JMenuItem(ADD_PCS_ACTION));
       popupMenu.add(new JMenuItem(ADD_ALL_ACTION));
@@ -850,6 +867,17 @@ public class InitiativePanel extends JPanel
         }
       };
 
+  /** Enable/Disable showing a warning dialog when resetting the round counter */
+  public final Action TOGGLE_WARN_WHEN_RESETTING_COUNTER_ACTION =
+      new AbstractAction() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          warnWhenResettingRoundCounter = ((JCheckBoxMenuItem) e.getSource()).isSelected();
+          AppPreferences.initiativePanelWarnWhenResettingRoundCounter.set(
+              warnWhenResettingRoundCounter);
+        }
+      };
+
   /** This action will reset the round counter for the initiative panel. */
   public final Action RESET_COUNTER_ACTION =
       new AbstractAction() {
@@ -859,10 +887,24 @@ public class InitiativePanel extends JPanel
             return;
           }
 
-          list.startUnitOfWork();
-          list.setRound(-1);
-          list.setCurrent(-1);
-          list.finishUnitOfWork();
+          int reset;
+          if (warnWhenResettingRoundCounter) {
+            reset =
+                JOptionPane.showConfirmDialog(
+                    null,
+                    I18N.getText("initPanel.warnWhenResettingRoundCounter.confirm"),
+                    I18N.getText("msg.title.messageDialogConfirm"),
+                    JOptionPane.YES_NO_OPTION);
+          } else {
+            reset = JOptionPane.YES_OPTION;
+          }
+
+          if (reset == JOptionPane.YES_OPTION) {
+            list.startUnitOfWork();
+            list.setRound(-1);
+            list.setCurrent(-1);
+            list.finishUnitOfWork();
+          }
         }
       };
 

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1786,6 +1786,9 @@ initPanel.toggleReverseSort.description = Use the Reverse (Ascending) Order when
 initPanel.togglePanelButtonsDisabled = Disable Panel Buttons
 initPanel.togglePanelButtonsDisabled.description = Disable the Next/Previous buttons on the Initiative Panel.  Useful to prevent mistakes when managing initiative through other macros.
 initPanel.buttonsAreDisabled     = Panel buttons have been disabled by GM.
+initPanel.warnWhenResettingRoundCounter = Warn when resetting the round counter
+initPanel.warnWhenResettingRoundCounter.description = When enabled, a confirmation dialog will be displayed to the GM resetting the round counter
+initPanel.warnWhenResettingRoundCounter.confirm = Are you sure you want to reset the initiative round counter?
 
 # Initiative menu on the token popup.
 initiative.menu                 = Initiative


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #5617

### Description of the Change

1. Adds an AppPreference for warning about resetting the round counter (false by default - i.e. current behavior)
2. Adds an initiative panel popup menu item to allow setting the preference (visible to GMs only)
3. If enabled shows a confirmation dialog to a GM when clicking on the reset round counter button on the initiative panel
4. Moves the reset counter mini button to the right of the round counter (i.e. away from the initiative PREV/HOLD/NEXT  buttons)

### Possible Drawbacks
Slight change to the interface layout, but in the interests of reducing risks (i.e. for even when the confirmation is disabled)

### Documentation Notes

Initiative Panel Toolbar Reset Counter mini-button new placement:
![image](https://github.com/user-attachments/assets/b725bbf8-af01-42e2-893e-fd059d595a91)

Initiative Panel Menu Item:
![image](https://github.com/user-attachments/assets/4abb8e28-9156-464a-9a36-80259c219cf2)

Confirmation Dialog:
![image](https://github.com/user-attachments/assets/878bb44a-791e-430f-9f06-9041533cf402)


### Release Notes
- Moved button for resetting the initiative round counter and added optional reset confirmation step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5644)
<!-- Reviewable:end -->
