### PR TITLE
Fix mangled text after JSoup parsing

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLContent.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLContent.java
@@ -138,6 +138,7 @@ public class HTMLContent {
 
     public HtmlDocumentContent {
       document = document.clone();
+      document.outputSettings().charset(StandardCharsets.US_ASCII);
     }
 
     public HtmlDocumentContent(

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLWebViewManager.java
@@ -317,7 +317,7 @@ public class HTMLWebViewManager {
   }
 
   /**
-   * Upate the contents of the WebView with the HTMLContent.
+   * Update the contents of the WebView with the HTMLContent.
    *
    * @param htmlContent the HTMLContent to display.
    * @param scrollReset true if the scrolling should be reset, false otherwise.
@@ -334,7 +334,7 @@ public class HTMLWebViewManager {
     if (htmlContent.isUrl()) {
       webEngine.load(htmlContent.getUrl().toString());
     } else {
-      webEngine.load(htmlContent.injectJavaBridge().getHtmlStringAsDataUrl());
+      webEngine.loadContent(htmlContent.injectJavaBridge().getHtmlString());
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5640

### Description of the Change

The key change here is that the document output settings are now set to output ASCII text only. Any non-ASCII characters, including characters from resolved references - such as `•` for `&bull;` - will be replaced by entities (not necessarily the same entity, but an equivalent one).

To make sure we don't end up in a situation where some code paths result in ASCII, while others keep the unicode characters, I've modifed `HTMLContent` to always parse HTML documents, and to represent them as `Document` objects instead of raw strings. When the string is needed, `Document#html()` will render it to a string, applying the output settings described above.

As we're now guaranteed to have ASCII HTML documents, the base64 `data:` URL workaround from #5442 is no longer needed and has been removed.

And since I was in the weeds here anyways, I removed the unused bits of `HTMLContent`, encapsulated it more by making some `public` stuff `private`, and changed `Content` from a single record class representing many types to an ADT that represents each type as its own record class.

### Possible Drawbacks

The HTML content of frames and dialogs will not match the code provided by the macro author. This was already true, but now it's extra true. Although the result should be functionally equivalent, it may cause confusion if the loaded HTML source is ever viewed.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where HTML entities for non-ascii characters would not render correctly in `frame5`, `dialog5` or `overlay`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5645)
<!-- Reviewable:end -->
