### PR TITLE
Apply flat labels to initiative panel

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/label/FlatImageLabel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/label/FlatImageLabel.java
@@ -164,25 +164,50 @@ public class FlatImageLabel {
 
   /**
    * Renders a string with customizable properties such as font, padding, colors, and justification
-   * using the specified graphics context.
+   * using the specified graphics context. Height and width are computed based on the provided
+   * string. Also see {@link #render(Graphics2D, int, int, int, int, String)}.
    *
    * @param graphics2D the graphics context used for rendering
    * @param x the x-coordinate of the top-left corner of the rendered string
    * @param y the y-coordinate of the top-left corner of the rendered string
    * @param string the string to be rendered
    * @return a Rectangle representing the dimensions and position of the rendered string with
-   *     padding
+   *     padding.
    */
   public Rectangle render(Graphics2D graphics2D, int x, int y, String string) {
+
+    var g2d = (Graphics2D) graphics2D.create();
+    g2d.setFont(font);
+
+    var dim = getDimensions(g2d, string);
+    int width = (int) dim.getWidth();
+    int height = (int) dim.getHeight();
+
+    g2d.dispose();
+
+    return render(graphics2D, x, y, width, height, string);
+  }
+
+  /**
+   * Renders a string with customizable properties such as font, padding, colors, and justification
+   * using the specified graphics context.
+   *
+   * @param graphics2D the graphics context used for rendering
+   * @param x the x-coordinate of the top-left corner of the rendered string
+   * @param y the y-coordinate of the top-left corner of the rendered string
+   * @param width the width of the label
+   * @param height the height of the label
+   * @param string the string to be rendered
+   * @return a Rectangle representing the dimensions and position of the rendered string with
+   *     padding
+   */
+  public Rectangle render(
+      Graphics2D graphics2D, int x, int y, int width, int height, String string) {
     var g2d = (Graphics2D) graphics2D.create();
     g2d.setFont(font);
     var fm = g2d.getFontMetrics();
     int strWidth = SwingUtilities.computeStringWidth(fm, string);
     int strHeight = fm.getAscent() - fm.getDescent() - fm.getLeading();
-
-    var dim = getDimensions(g2d, string);
-    int width = (int) dim.getWidth();
-    int height = (int) dim.getHeight();
 
     var bounds = new Rectangle(x, y, width, height);
 
@@ -206,6 +231,7 @@ public class FlatImageLabel {
       g2d.draw(labelRect);
     }
 
+    g2d.dispose();
     return bounds;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
@@ -255,7 +255,7 @@ public class InitiativeListCellRenderer extends JPanel
       int th = textHeight * (initStateSecondLine ? 2 : 1);
       Insets insets = getInsets();
       if (getIcon() != null) th = Math.max(th, getIcon().getIconHeight());
-      s.height = th + insets.top + insets.bottom - 4;
+      s.height = th + insets.top + insets.bottom;
       return s;
     }
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #5632

### Description of the Change

- Brings the new user defined token labels colors into the initiative panel
- Replaces the background `ImageLabel` with `FlatImageLabel`
- Does not use the `FlatImageLabel` text, but retains UI text styling.
- Changes the `FlatImageLabel` render to now also accept width and height.

### Possible Drawbacks
Not in line with best practices or design principles, but I thoughts I'd gives it a go.
Does it needs any caching?  That seems beyond me right now, so any pointer welcome :)

### Documentation Notes
Preferences for map label colors and borders now also apply to tokens shown in the initiative panel.  Text size still managed by the UI.

![image](https://github.com/user-attachments/assets/974cfc4a-a45b-461b-92b8-e6ad210c16f9)


### Release Notes
- Initiative Panel now uses map token label colors defined in user accessibility preferences.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5649)
<!-- Reviewable:end -->
