### PR TITLE
Fix for get macro location

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MacroFunctions.java
@@ -186,8 +186,8 @@ public class MacroFunctions extends AbstractFunction {
       return MapTool.getParser().getMacroName();
 
     } else if (functionName.equalsIgnoreCase("getMacroLocation")) {
-      return MapTool.getParser().getMacroSource().getLocation();
-
+      var source = MapTool.getParser().getMacroSource();
+      return source.getCallableLocation();
     } else if (functionName.equalsIgnoreCase("setMacroCommand")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 4);
       FunctionUtil.blockUntrustedMacro(functionName);

--- a/src/main/java/net/rptools/maptool/client/macro/MacroLocation.java
+++ b/src/main/java/net/rptools/maptool/client/macro/MacroLocation.java
@@ -68,7 +68,7 @@ public class MacroLocation {
    * @param source the source of the macro.
    * @param location the location of the macro.
    * @param uri the URI of the macro, if applicable.
-   * @param Token the associated token, if applicable.
+   * @param token the associated token, if applicable.
    */
   MacroLocation(
       @Nonnull String name,
@@ -81,6 +81,17 @@ public class MacroLocation {
     this.location = location;
     this.uri = uri;
     this.token = token;
+  }
+
+  /**
+   * Creates a new MacroLocation with the given name and source.
+   *
+   * @param name the name of the macro.
+   * @param source the source of the macro.
+   * @param location the location of the macro.
+   */
+  MacroLocation(@Nonnull String name, @Nonnull MacroSource source, @Nonnull String location) {
+    this(name, source, location, null, null);
   }
 
   /** Enumeration to represent the source of the macro. */
@@ -158,34 +169,28 @@ public class MacroLocation {
    * @return a MacroLocation object representing the parsed macro name.
    */
   public static MacroLocation parseMacroName(
-      @Nonnull String qMacroName, MacroLocation calledFrom, @Nullable Token token) {
+      @Nonnull String qMacroName, @Nullable MacroLocation calledFrom, @Nullable Token token) {
     String qMacroNameLower = qMacroName.toLowerCase();
 
     if (qMacroNameLower.contains("@campaign")) {
       return new MacroLocation(
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.campaign,
-          MacroSource.campaign.getSourceName(),
-          null,
-          null);
+          MacroSource.campaign.getSourceName());
     }
 
     if (qMacroNameLower.contains("@gm")) {
       return new MacroLocation(
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.gm,
-          MacroSource.gm.getSourceName(),
-          null,
-          null);
+          MacroSource.gm.getSourceName());
     }
 
     if (qMacroNameLower.contains("@global")) {
       return new MacroLocation(
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.global,
-          MacroSource.global.getSourceName(),
-          null,
-          null);
+          MacroSource.global.getSourceName());
     }
 
     if (qMacroNameLower.contains("@token")) {

--- a/src/main/java/net/rptools/maptool/client/macro/MacroLocation.java
+++ b/src/main/java/net/rptools/maptool/client/macro/MacroLocation.java
@@ -55,6 +55,9 @@ public class MacroLocation {
   /** The URI of the macro, if applicable. */
   @Nullable private final URI uri;
 
+  /** The token associated with this macro, if applicable. */
+  @Nullable private final Token token;
+
   /** MacroLocationFactory used to create locations during parsing. */
   private static final MacroLocationFactory factory = MacroLocationFactory.getInstance();
 
@@ -65,16 +68,19 @@ public class MacroLocation {
    * @param source the source of the macro.
    * @param location the location of the macro.
    * @param uri the URI of the macro, if applicable.
+   * @param Token the associated token, if applicable.
    */
   MacroLocation(
       @Nonnull String name,
       @Nonnull MacroSource source,
       @Nonnull String location,
-      @Nullable URI uri) {
+      @Nullable URI uri,
+      @Nullable Token token) {
     this.name = name;
     this.source = source;
     this.location = location;
     this.uri = uri;
+    this.token = token;
   }
 
   /** Enumeration to represent the source of the macro. */
@@ -148,11 +154,11 @@ public class MacroLocation {
    *
    * @param qMacroName the qualified macro name to parse.
    * @param calledFrom the location that called this macro, if applicable.
-   * @param token the token that called this macro, if applicable.
+   * @param token the token for this macro, if applicable.
    * @return a MacroLocation object representing the parsed macro name.
    */
   public static MacroLocation parseMacroName(
-      @Nonnull String qMacroName, @Nullable MacroLocation calledFrom, @Nullable Token token) {
+      @Nonnull String qMacroName, MacroLocation calledFrom, @Nullable Token token) {
     String qMacroNameLower = qMacroName.toLowerCase();
 
     if (qMacroNameLower.contains("@campaign")) {
@@ -160,6 +166,7 @@ public class MacroLocation {
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.campaign,
           MacroSource.campaign.getSourceName(),
+          null,
           null);
     }
 
@@ -168,6 +175,7 @@ public class MacroLocation {
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.gm,
           MacroSource.gm.getSourceName(),
+          null,
           null);
     }
 
@@ -176,6 +184,7 @@ public class MacroLocation {
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.global,
           MacroSource.global.getSourceName(),
+          null,
           null);
     }
 
@@ -187,13 +196,14 @@ public class MacroLocation {
           qMacroName.substring(0, qMacroName.indexOf("@")),
           MacroSource.token,
           token.getName(),
-          null);
+          null,
+          token);
     }
 
     if (qMacroNameLower.contains("@lib:")) {
-      String libName = qMacroName.substring(qMacroName.indexOf("@") + 1);
-      return new MacroLocation(
-          qMacroName.substring(0, qMacroName.indexOf("@")), MacroSource.library, libName, null);
+      String macroName = qMacroName.substring(0, qMacroName.indexOf("@"));
+      String namespace = qMacroName.replaceFirst("^[^@]*@(?i)lib:", "");
+      return new MacroLocation(macroName, MacroSource.library, namespace, null, token);
     }
 
     if (qMacroNameLower.contains("@this")) {
@@ -207,7 +217,7 @@ public class MacroLocation {
           return factory.createUnknownLocation(qMacroName);
         }
       }
-      return new MacroLocation(name, cfrom.getSource(), cfrom.getLocation(), null);
+      return new MacroLocation(name, cfrom.getSource(), cfrom.getLocation(), null, token);
     }
 
     // If none of the above then assume it is a URI
@@ -230,7 +240,7 @@ public class MacroLocation {
       return factory.createUnknownLocation(qMacroName);
     }
 
-    return new MacroLocation(uri.getPath().substring(1), MacroSource.uri, uri.getHost(), uri);
+    return new MacroLocation(uri.getPath().substring(1), MacroSource.uri, uri.getHost(), uri, null);
   }
 
   /**
@@ -269,6 +279,31 @@ public class MacroLocation {
     return uri;
   }
 
+  /**
+   * Returns the token associated with this macro, if applicable.
+   *
+   * @return the token associated with this macro, or null if not applicable.
+   */
+  public Token getToken() {
+    return token;
+  }
+
+  /**
+   * Returns the location of the macro that can be called from macro code using the '@' syntax.
+   *
+   * @return the location of the macro that can be called from other macros.
+   */
+  @Nonnull
+  public String getCallableLocation() {
+    if (source == MacroSource.token) {
+      return "Token:" + location;
+    } else if (source == MacroSource.library) {
+      return token != null ? token.getName() : location;
+    } else {
+      return location;
+    }
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -281,6 +316,10 @@ public class MacroLocation {
     if (uri != null) {
       sb.append(", uri='");
       sb.append(uri);
+    }
+    if (token != null) {
+      sb.append(", token='");
+      sb.append(token.getName());
     }
     sb.append("'}");
 

--- a/src/main/java/net/rptools/maptool/client/macro/MacroLocationFactory.java
+++ b/src/main/java/net/rptools/maptool/client/macro/MacroLocationFactory.java
@@ -49,7 +49,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for an unknown location.
    */
   public MacroLocation createUnknownLocation(@Nonnull String name) {
-    return new MacroLocation(name, MacroSource.unknown, "", null);
+    return new MacroLocation(name, MacroSource.unknown, "", null, null);
   }
 
   /**
@@ -59,7 +59,8 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a global Panel.
    */
   public MacroLocation createGlobalLocation(@Nonnull String name) {
-    return new MacroLocation(name, MacroSource.global, MacroSource.global.getSourceName(), null);
+    return new MacroLocation(
+        name, MacroSource.global, MacroSource.global.getSourceName(), null, null);
   }
 
   /**
@@ -70,7 +71,7 @@ public class MacroLocationFactory {
    */
   public MacroLocation createCampaignLocation(@Nonnull String name) {
     return new MacroLocation(
-        name, MacroSource.campaign, MacroSource.campaign.getSourceName(), null);
+        name, MacroSource.campaign, MacroSource.campaign.getSourceName(), null, null);
   }
 
   /**
@@ -81,18 +82,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a token.
    */
   public MacroLocation createTokenLocation(@Nonnull String name, @Nonnull Token token) {
-    return createTokenLocation(name, token.getName());
-  }
-
-  /**
-   * Creates a new {@link MacroLocation} object for a token.
-   *
-   * @param name the name of the macro.
-   * @param tokenName the name of the token associated with the macro.
-   * @return a new {@link MacroLocation} object for a token.
-   */
-  public MacroLocation createTokenLocation(@Nonnull String name, @Nonnull String tokenName) {
-    return new MacroLocation(name, MacroSource.token, tokenName, null);
+    return new MacroLocation(name, MacroSource.token, token.getName(), null, token);
   }
 
   /**
@@ -103,18 +93,8 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a library token.
    */
   public MacroLocation createLibTokenLocation(@Nonnull String name, @Nonnull Token libToken) {
-    return createLibTokenLocation(name, libToken.getName());
-  }
-
-  /**
-   * Creates a new {@link MacroLocation} object for a library token.
-   *
-   * @param name the name of the macro.
-   * @param libTokenName the name of the library token associated with the macro.
-   * @return a new {@link MacroLocation} object for a library token.
-   */
-  public MacroLocation createLibTokenLocation(@Nonnull String name, @Nonnull String libTokenName) {
-    return new MacroLocation(name, MacroSource.library, libTokenName.substring(4), null);
+    return new MacroLocation(
+        name, MacroSource.library, libToken.getName().substring(4), null, libToken);
   }
 
   /**
@@ -124,7 +104,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a GM Panel.
    */
   public MacroLocation createGmLocation(@Nonnull String name) {
-    return new MacroLocation(name, MacroSource.gm, MacroSource.gm.getSourceName(), null);
+    return new MacroLocation(name, MacroSource.gm, MacroSource.gm.getSourceName(), null, null);
   }
 
   /**
@@ -135,7 +115,11 @@ public class MacroLocationFactory {
    */
   public MacroLocation createExecFunctionLocation(@Nonnull String functionName) {
     return new MacroLocation(
-        MacroSource.execFunction.getSourceName(), MacroSource.execFunction, functionName, null);
+        MacroSource.execFunction.getSourceName(),
+        MacroSource.execFunction,
+        functionName,
+        null,
+        null);
   }
 
   /**
@@ -149,6 +133,7 @@ public class MacroLocationFactory {
         MacroSource.macroLink.getSourceName(),
         MacroSource.macroLink,
         MacroSource.macroLink.getSourceName(),
+        null,
         null);
   }
 
@@ -159,7 +144,8 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for an event.
    */
   public MacroLocation createEventLocation(@Nonnull String name) {
-    return new MacroLocation(MacroSource.event.getSourceName(), MacroSource.event, name, null);
+    return new MacroLocation(
+        MacroSource.event.getSourceName(), MacroSource.event, name, null, null);
   }
 
   public MacroLocation createSentryIoLoggingLocation() {
@@ -167,6 +153,7 @@ public class MacroLocationFactory {
         MacroSource.sentryIoLogging.getSourceName(),
         MacroSource.sentryIoLogging,
         MacroSource.sentryIoLogging.getSourceName(),
+        null,
         null);
   }
 
@@ -186,7 +173,7 @@ public class MacroLocationFactory {
         }
         uri = calledFrom.resolve(uri);
       }
-      return new MacroLocation(uri.getPath(), MacroSource.uri, uri.getHost(), uri);
+      return new MacroLocation(uri.getPath(), MacroSource.uri, uri.getHost(), uri, null);
     } catch (URISyntaxException e) {
       return createUnknownLocation(name);
     }
@@ -195,12 +182,16 @@ public class MacroLocationFactory {
   /**
    * Creates a new {@link MacroLocation} object for the chat box.
    *
-   * @param token the token associated with the the chat box.
+   * @param token the token associated with the chat box.
    * @return a new {@link MacroLocation} object for a the chat box.
    */
   public MacroLocation createChatLocation() {
     return new MacroLocation(
-        MacroSource.chat.getSourceName(), MacroSource.chat, MacroSource.chat.getSourceName(), null);
+        MacroSource.chat.getSourceName(),
+        MacroSource.chat,
+        MacroSource.chat.getSourceName(),
+        null,
+        null);
   }
 
   /**
@@ -214,6 +205,7 @@ public class MacroLocationFactory {
         MacroSource.tooltip.getSourceName(),
         MacroSource.tooltip,
         token != null ? token.getName() : "",
-        null);
+        null,
+        token);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/macro/MacroLocationFactory.java
+++ b/src/main/java/net/rptools/maptool/client/macro/MacroLocationFactory.java
@@ -49,7 +49,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for an unknown location.
    */
   public MacroLocation createUnknownLocation(@Nonnull String name) {
-    return new MacroLocation(name, MacroSource.unknown, "", null, null);
+    return new MacroLocation(name, MacroSource.unknown, "");
   }
 
   /**
@@ -59,8 +59,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a global Panel.
    */
   public MacroLocation createGlobalLocation(@Nonnull String name) {
-    return new MacroLocation(
-        name, MacroSource.global, MacroSource.global.getSourceName(), null, null);
+    return new MacroLocation(name, MacroSource.global, MacroSource.global.getSourceName());
   }
 
   /**
@@ -70,8 +69,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a campaign Panel.
    */
   public MacroLocation createCampaignLocation(@Nonnull String name) {
-    return new MacroLocation(
-        name, MacroSource.campaign, MacroSource.campaign.getSourceName(), null, null);
+    return new MacroLocation(name, MacroSource.campaign, MacroSource.campaign.getSourceName());
   }
 
   /**
@@ -104,7 +102,7 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for a GM Panel.
    */
   public MacroLocation createGmLocation(@Nonnull String name) {
-    return new MacroLocation(name, MacroSource.gm, MacroSource.gm.getSourceName(), null, null);
+    return new MacroLocation(name, MacroSource.gm, MacroSource.gm.getSourceName());
   }
 
   /**
@@ -115,11 +113,7 @@ public class MacroLocationFactory {
    */
   public MacroLocation createExecFunctionLocation(@Nonnull String functionName) {
     return new MacroLocation(
-        MacroSource.execFunction.getSourceName(),
-        MacroSource.execFunction,
-        functionName,
-        null,
-        null);
+        MacroSource.execFunction.getSourceName(), MacroSource.execFunction, functionName);
   }
 
   /**
@@ -132,9 +126,7 @@ public class MacroLocationFactory {
     return new MacroLocation(
         MacroSource.macroLink.getSourceName(),
         MacroSource.macroLink,
-        MacroSource.macroLink.getSourceName(),
-        null,
-        null);
+        MacroSource.macroLink.getSourceName());
   }
 
   /**
@@ -144,17 +136,14 @@ public class MacroLocationFactory {
    * @return a new {@link MacroLocation} object for an event.
    */
   public MacroLocation createEventLocation(@Nonnull String name) {
-    return new MacroLocation(
-        MacroSource.event.getSourceName(), MacroSource.event, name, null, null);
+    return new MacroLocation(MacroSource.event.getSourceName(), MacroSource.event, name);
   }
 
   public MacroLocation createSentryIoLoggingLocation() {
     return new MacroLocation(
         MacroSource.sentryIoLogging.getSourceName(),
         MacroSource.sentryIoLogging,
-        MacroSource.sentryIoLogging.getSourceName(),
-        null,
-        null);
+        MacroSource.sentryIoLogging.getSourceName());
   }
 
   /**
@@ -187,11 +176,7 @@ public class MacroLocationFactory {
    */
   public MacroLocation createChatLocation() {
     return new MacroLocation(
-        MacroSource.chat.getSourceName(),
-        MacroSource.chat,
-        MacroSource.chat.getSourceName(),
-        null,
-        null);
+        MacroSource.chat.getSourceName(), MacroSource.chat, MacroSource.chat.getSourceName());
   }
 
   /**

--- a/src/test/java/net/rptools/maptool/client/macro/MacroLocationFactory.java
+++ b/src/test/java/net/rptools/maptool/client/macro/MacroLocationFactory.java
@@ -67,10 +67,12 @@ class MacroLocationFactoryTest {
 
   @Test
   void testCreateLibTokenLocation() {
-    MacroLocation location = factory.createLibTokenLocation("libMacro", "lib:TokenName");
+    Token mockToken = Mockito.mock(Token.class);
+    Mockito.when(mockToken.getName()).thenReturn("lib:libToken");
+    MacroLocation location = factory.createLibTokenLocation("libMacro", mockToken);
     assertEquals("libMacro", location.getName());
     assertEquals(MacroLocation.MacroSource.library, location.getSource());
-    assertEquals("TokenName", location.getLocation());
+    assertEquals("libToken", location.getLocation());
     assertNull(location.getUri());
   }
 

--- a/src/test/java/net/rptools/maptool/client/macro/MacroLocationTest.java
+++ b/src/test/java/net/rptools/maptool/client/macro/MacroLocationTest.java
@@ -58,7 +58,7 @@ class MacroLocationTest {
     MacroLocation location = MacroLocation.parseMacroName("test@lib:libName", null, null);
     assertEquals("test", location.getName());
     assertEquals(MacroLocation.MacroSource.library, location.getSource());
-    assertEquals("lib:libName", location.getLocation());
+    assertEquals("libName", location.getLocation());
     assertNull(location.getUri());
   }
 
@@ -158,7 +158,7 @@ class MacroLocationTest {
     MacroLocation location = MacroLocation.parseMacroName("test@this", caller, null);
     assertEquals("test", location.getName());
     assertEquals(MacroLocation.MacroSource.library, location.getSource());
-    assertEquals("lib:libName", location.getLocation());
+    assertEquals("libName", location.getLocation());
     assertNull(location.getUri());
   }
 
@@ -182,5 +182,44 @@ class MacroLocationTest {
     assertEquals(MacroLocation.MacroSource.unknown, location.getSource());
     assertEquals("", location.getLocation());
     assertNull(location.getUri());
+  }
+
+  @Test
+  void testTokenGetCallableLocation() {
+    Token mockToken = Mockito.mock(Token.class);
+    Mockito.when(mockToken.getName()).thenReturn("mockToken");
+    MacroLocation location = MacroLocation.parseMacroName("test@token", null, mockToken);
+    assertEquals("Token:mockToken", location.getCallableLocation());
+  }
+
+  @Test
+  void testCampaignGetCallableLocation() {
+    MacroLocation location = MacroLocation.parseMacroName("test@campaign", null, null);
+    assertEquals("campaign", location.getCallableLocation());
+  }
+
+  @Test
+  void testGmGetCallableLocation() {
+    MacroLocation location = MacroLocation.parseMacroName("test@gm", null, null);
+    assertEquals("gm", location.getCallableLocation());
+  }
+
+  @Test
+  void testGlobalGetCallableLocation() {
+    MacroLocation location = MacroLocation.parseMacroName("test@global", null, null);
+    assertEquals("global", location.getCallableLocation());
+  }
+
+  @Test
+  void testLibGetCallableLocation() {
+    Token mockToken = Mockito.mock(Token.class);
+    Mockito.when(mockToken.getName()).thenReturn("Lib:TestToken");
+    MacroLocation location = MacroLocation.parseMacroName("test@Lib:TestToken", null, mockToken);
+    assertEquals("Lib:TestToken", location.getCallableLocation());
+
+    Token mockToken2 = Mockito.mock(Token.class);
+    Mockito.when(mockToken2.getName()).thenReturn("lib:TestToken");
+    MacroLocation location2 = MacroLocation.parseMacroName("test@lib:TestToken", null, mockToken2);
+    assertEquals("lib:TestToken", location2.getCallableLocation());
   }
 }


### PR DESCRIPTION

### Identify the Bug or Feature request
resolves #5638

### Description of the Change
The `getMacroLocation()` method was exposing the internal workings of how the parser tracked context, so when these changed, it caused an error with the return value in some instances. I have added a new `getCallableLocation()` method to the parser macro source location that exposes these values in a way compatible with `getMacroLocation()`, while allowing the context handling in the parser to remain hidden from macros.


### Possible Drawbacks
Before the change in 1.18 `getMacroLocation()` would not produce consistent values for token macros. I have remedied this by returning a consistent value that matches the documented behaviour on the wiki. This may break some macros, but it's unlikely, and probably better than trying to emulate the broken behaviour for an edge case for this macro call.

### Documentation Notes
Fix for bug in `getMacroLocation()` that was introduced with the changes to macro function call routing.

### Release Notes
- N/A Fix for regression

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5651)
<!-- Reviewable:end -->
