### PR TITLE
Fix capitalization for Run Macro button i18n key

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroButtonDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroButtonDialogView.form
@@ -507,7 +507,7 @@
             <properties>
               <actionCommand value="OK"/>
               <name value="runButton"/>
-              <text resource-bundle="net/rptools/maptool/language/i18n" key="Button.runmacro"/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="Button.runMacro"/>
             </properties>
           </component>
           <component id="e9372" class="javax.swing.JButton">


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes missed i18n key in PR #5623

### Description of the Change

Changes the use of `Button.runmacro` to the new capitalization of `Button.runMacro` so that macro editors can be opened once again.

I've also gone through all changed or removed keys from #5623 to make sure they are't used in any `.form` files anymore. Looks like this was the only one.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5652)
<!-- Reviewable:end -->
