### PR TITLE
Reset tooltips for non-template DrawnElements

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelTreeCellRenderer.java
@@ -45,14 +45,17 @@ public class DrawPanelTreeCellRenderer extends DefaultTreeCellRenderer {
       text = de.getDrawable().toString();
       if (de.getDrawable() instanceof DrawablesGroup) {
         text = I18N.getString("panel.DrawExplorer.group");
+        setToolTipText(null);
       } else if (de.getDrawable() instanceof ShapeDrawable sd) {
         var key = String.format("panel.DrawExplorer.ShapeDrawable.%s", sd.getShapeTypeName());
         text = I18N.getText(key, sd.getBounds().width, sd.getBounds().height);
         setLeafIcon(setDrawPanelIcon(key, de.getPen().isEraser()));
+        setToolTipText(null);
       } else if (de.getDrawable() instanceof LineSegment ls) {
         var key = "panel.DrawExplorer.LineSegment.Line";
         text = I18N.getText(key, ls.getPoints().size(), de.getPen().getThickness());
         setLeafIcon(setDrawPanelIcon(key, de.getPen().isEraser()));
+        setToolTipText(null);
       } else if (de.getDrawable() instanceof AbstractTemplate at) {
         var key = String.format("panel.DrawExplorer.Template.%s", at.getClass().getSimpleName());
         text = I18N.getText(key, at.getRadius());


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5663

### Description of the Change
Reset tooltips for non-template `DrawnElements` in the Draw Explorer Panel

### Possible Drawbacks
None

### Documentation Notes
N/A

### Release Notes
- Fixed a Draw Explorer Panel issue where template tooltips were shown for non-template

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5664)
<!-- Reviewable:end -->
