### PR TITLE
Add some erase icons for drawings, and get DrawPanel to use new icons

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
+++ b/src/main/java/net/rptools/maptool/client/ui/theme/RessourceManager.java
@@ -329,6 +329,28 @@ public class RessourceManager {
           put(Icons.COLORPICKER_SNAP_OFF, ROD_ICONS + "freehand.svg");
           put(Icons.COLORPICKER_SNAP_ON, ROD_ICONS + "shape_handles.svg");
           put(Icons.EDIT_TOKEN_COLOR_PICKER, ROD_ICONS + "misc/Colour Selection (eye dropper).svg");
+          put(Icons.DRAWPANEL_AREA_DRAW, ROD_ICONS + "ribbon/Draw Poly Line.svg");
+          put(Icons.DRAWPANEL_AREA_ERASE, ROD_ICONS + "ribbon/Draw Poly Line Erase.svg");
+          put(Icons.DRAWPANEL_ELLIPSE_DRAW, ROD_ICONS + "ribbon/Draw Oval.svg");
+          put(Icons.DRAWPANEL_ELLIPSE_ERASE, ROD_ICONS + "ribbon/Draw Oval Erase.svg");
+          put(Icons.DRAWPANEL_LINE_DRAW, ROD_ICONS + "ribbon/Draw Straight Lines.svg");
+          put(Icons.DRAWPANEL_LINE_ERASE, ROD_ICONS + "ribbon/Draw Straight Lines Erase.svg");
+          put(Icons.DRAWPANEL_POLYGON_DRAW, ROD_ICONS + "ribbon/Draw Polygon.svg");
+          put(Icons.DRAWPANEL_POLYGON_ERASE, ROD_ICONS + "ribbon/Draw Polygon Erase.svg");
+          put(Icons.DRAWPANEL_RECTANGLE_DRAW, ROD_ICONS + "ribbon/Draw Rectangle.svg");
+          put(Icons.DRAWPANEL_RECTANGLE_ERASE, ROD_ICONS + "ribbon/Draw Rectangle Erase.svg");
+          put(Icons.DRAWPANEL_TEMPLATE_BLAST, ROD_ICONS + "ribbon/Blast Template.svg");
+          put(Icons.DRAWPANEL_TEMPLATE_BURST, ROD_ICONS + "ribbon/Burst Template.svg");
+          put(Icons.DRAWPANEL_TEMPLATE_CONE, ROD_ICONS + "ribbon/Cone Template.svg");
+          put(Icons.DRAWPANEL_TEMPLATE_LINE, ROD_ICONS + "ribbon/Line Template.svg");
+          put(
+              Icons.DRAWPANEL_TEMPLATE_LINECELL,
+              ROD_ICONS + "ribbon/Line Template Centered on Grid.svg");
+          put(Icons.DRAWPANEL_TEMPLATE_RADIUS, ROD_ICONS + "ribbon/Radius Template.svg");
+          put(
+              Icons.DRAWPANEL_TEMPLATE_RADIUSCELL,
+              ROD_ICONS + "ribbon/Radius Template Centered on Grid.svg");
+          put(Icons.DRAWPANEL_TEMPLATE_WALL, ROD_ICONS + "ribbon/Wall Line Template.svg");
           put(Icons.EDIT_TOKEN_HEROLAB, ROD_ICONS + "hero-lab-icon.svg");
           put(Icons.EDIT_TOKEN_REFRESH_OFF, ROD_ICONS + "refresh_arrows.svg");
           put(Icons.EDIT_TOKEN_REFRESH_ON, ROD_ICONS + "refresh_arrows.svg");
@@ -371,7 +393,7 @@ public class RessourceManager {
           put(Icons.TOOLBAR_DRAW_DELETE, ROD_ICONS + "ribbon/Delete Drawing.svg");
           put(Icons.TOOLBAR_DRAW_DIAMOND, ROD_ICONS + "ribbon/Draw Diamond_2.svg");
           put(Icons.TOOLBAR_DRAW_FREEHAND, ROD_ICONS + "ribbon/Draw Freehand Lines.svg");
-          put(Icons.TOOLBAR_DRAW_LINE, ROD_ICONS + "ribbon/Draw Straight Lines.svg");
+          put(Icons.TOOLBAR_DRAW_LINE, ROD_ICONS + "ribbon/Draw Straight Lines_2.svg");
           put(Icons.TOOLBAR_DRAW_OFF, ROD_ICONS + "ribbon/Drawing Tools.svg");
           put(Icons.TOOLBAR_DRAW_ON, ROD_ICONS + "ribbon/Drawing Tools.svg");
           put(Icons.TOOLBAR_DRAW_OVAL, ROD_ICONS + "ribbon/Draw Oval_2.svg");

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Oval Erase.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Oval Erase.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-19,-133)">
+        <g id="Draw-Oval" serif:id="Draw Oval" transform="matrix(1,0,0,1,-71,133)">
+            <rect x="90" y="0" width="16" height="16" style="fill:none;"/>
+            <g transform="matrix(1,0,0,1,33,-171)">
+                <circle cx="65" cy="179" r="6" style="fill:rgb(219, 88, 96);"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Poly Line Erase.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Poly Line Erase.svg
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:3;">
-    <g transform="matrix(1,0,0,1,-38,-57)">
-        <g id="Draw-Straight-Lines" serif:id="Draw Straight Lines" transform="matrix(1,0,0,1,-52,57)">
+    <g transform="matrix(1,0,0,1,-133,-133)">
+        <g id="Draw-Poly-Line" serif:id="Draw Poly Line" transform="matrix(1,0,0,1,43,133)">
             <rect x="90" y="0" width="16" height="16" style="fill:none;"/>
             <clipPath id="_clip1">
                 <rect x="90" y="0" width="16" height="16"/>
             </clipPath>
             <g clip-path="url(#_clip1)">
-                <g transform="matrix(1,0,0,1,72,-55.8686)">
-                    <path d="M20.541,66.869L25,69.643L26.71,64.775L32.266,66.195L31.663,58.869" style="fill:none;stroke:rgb(110,110,110);stroke-width:1.33px;"/>
+                <g transform="matrix(0.851024,0,0,0.851024,29.9609,-141.486)">
+                    <path d="M74.074,173.304L78.775,168.604L85.825,170.954L82.3,174.479L87,179.179L83.475,182.704L78.775,181.529" style="fill:none;stroke:rgb(219, 88, 96);stroke-width:2.35px;"/>
                 </g>
             </g>
         </g>

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Polygon Erase.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Polygon Erase.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-38,-133)">
+        <g id="Draw-Polygon" serif:id="Draw Polygon" transform="matrix(1,0,0,1,-52,133)">
+            <rect x="90" y="0" width="16" height="16" style="fill:none;"/>
+            <g transform="matrix(0.851024,0,0,0.851024,29.9609,-141.486)">
+                <path d="M74.074,173.304L78.775,168.604L85.825,170.954L82.3,174.479L87,179.179L83.475,182.704L72.899,181.529L77.6,176.829" style="fill:rgb(219, 88, 96);"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Rectangle Erase.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Rectangle Erase.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,0,-133)">
+        <g id="Draw-Rectangle" serif:id="Draw Rectangle" transform="matrix(1,0,0,1,-90,133)">
+            <rect x="90" y="0" width="16" height="16" style="fill:none;"/>
+            <g transform="matrix(1,0,0,1,71,-171)">
+                <rect x="21" y="173" width="12" height="12" style="fill:rgb(219, 88, 96);"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Straight Lines Erase.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Straight Lines Erase.svg
@@ -9,7 +9,7 @@
             </clipPath>
             <g clip-path="url(#_clip1)">
                 <g transform="matrix(1,0,0,1,72,-55.8686)">
-                    <path d="M20.541,66.869L25,69.643L26.71,64.775L32.266,66.195L31.663,58.869" style="fill:none;stroke:rgb(110,110,110);stroke-width:1.33px;"/>
+                    <path d="M20.541,66.869L25,69.643L26.71,64.775L32.266,66.195L31.663,58.869" style="fill:none;stroke:rgb(219, 88, 96);stroke-width:1.33px;"/>
                 </g>
             </g>
         </g>

--- a/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Straight Lines_2.svg
+++ b/src/main/resources/net/rptools/maptool/client/icons/rod_takehara/ribbon/Draw Straight Lines_2.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:3;">
+    <g transform="matrix(1,0,0,1,-38,-57)">
+        <g id="Draw-Straight-Lines" serif:id="Draw Straight Lines" transform="matrix(1,0,0,1,-52,57)">
+            <rect x="90" y="0" width="16" height="16" style="fill:none;"/>
+            <clipPath id="_clip1">
+                <rect x="90" y="0" width="16" height="16"/>
+            </clipPath>
+            <g clip-path="url(#_clip1)">
+                <g transform="matrix(-0.820672,-0.820672,0.506671,-0.506671,77.0643,36.7672)">
+                    <path d="M7.25,41.246L8.5,43.246L6,43.246L7.25,41.246Z" style="fill:rgb(56,159,214);"/>
+                </g>
+                <g transform="matrix(1,0,0,1,71,-57)">
+                    <path d="M21.541,64.34L23.592,66.391L27.842,62.142L25.79,60.09L21.541,64.34ZM26,62C26.276,62.276 26.052,62.948 25.5,63.5C24.948,64.052 24.276,64.276 24,64C23.724,63.724 23.948,63.052 24.5,62.5C25.052,61.948 25.724,61.724 26,62Z" style="fill:rgb(110,110,110);"/>
+                </g>
+                <g transform="matrix(-0.683893,-0.683893,0.0907447,-0.0907447,99.6187,12.5715)">
+                    <rect x="6" y="44.246" width="3" height="8" style="fill:rgb(56,159,214);"/>
+                </g>
+                <g transform="matrix(1,0,0,1,72,-55.8686)">
+                    <path d="M20.541,66.869L25,69.643L26.71,64.775L32.266,66.195L31.663,58.869" style="fill:none;stroke:rgb(56,159,214);stroke-width:1.33px;"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
### Identify the Bug or Feature request
towards #4638

### Description of the Change

- Created new Erase svg icons (i.e. same as draw shape icons but colored red)
- Created new Draw Straight Lines shape svg icon (i.e. without crayon symbol)
- Renamed existing Draw Straight Lines icon with "_2" suffix to match others where a Draw *Shape* (without crayon symbol) is also present.
- Added references to `RessourceManager` for the Draw Panel, reusing existing Draw Tool ribbon icons (both templates and draw shapes) and new/updated icons listed above.

### Possible Drawbacks
None foreseen

### Documentation Notes
N/A

### Release Notes
- Added Rod's style icons to the Draw Panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5675)
<!-- Reviewable:end -->
