### PR TITLE
Set properties of selected drawn elements

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -362,28 +362,35 @@ public class DrawPanelPopupMenu extends JPopupMenu {
 
     public void actionPerformed(ActionEvent e) {
       ColorPicker cp = MapTool.getFrame().getColorPicker();
-      Pen p = elementUnderMouse.getPen();
-      if (cp.getForegroundPaint() != null) {
-        p.setPaint(DrawablePaint.convertPaint(cp.getForegroundPaint()));
-        p.setForegroundMode(0);
-      } else {
-        p.setPaint(null);
-        p.setForegroundMode(1);
+
+      // Set the properties for each selected drawing
+      List<DrawnElement> drawableList = renderer.getZone().getAllDrawnElements();
+      for (DrawnElement de : drawableList) {
+        if (selectedDrawSet.contains(de.getDrawable().getId())) {
+          Pen p = de.getPen();
+          if (cp.getForegroundPaint() != null) {
+            p.setPaint(DrawablePaint.convertPaint(cp.getForegroundPaint()));
+            p.setForegroundMode(0);
+          } else {
+            p.setPaint(null);
+            p.setForegroundMode(1);
+          }
+          if (cp.getBackgroundPaint() != null) {
+            p.setBackgroundPaint(DrawablePaint.convertPaint(cp.getBackgroundPaint()));
+            p.setBackgroundMode(0);
+          } else {
+            p.setBackgroundPaint(null);
+            p.setBackgroundMode(1);
+          }
+          p.setThickness(cp.getStrokeWidth());
+          p.setOpacity(cp.getOpacity());
+          p.setThickness(cp.getStrokeWidth());
+          p.setEraser(cp.isEraseSelected());
+          p.setSquareCap(cp.isSquareCapSelected());
+          MapTool.getFrame().updateDrawTree();
+          MapTool.serverCommand().updateDrawing(renderer.getZone().getId(), p, de);
+        }
       }
-      if (cp.getBackgroundPaint() != null) {
-        p.setBackgroundPaint(DrawablePaint.convertPaint(cp.getBackgroundPaint()));
-        p.setBackgroundMode(0);
-      } else {
-        p.setBackgroundPaint(null);
-        p.setBackgroundMode(1);
-      }
-      p.setThickness(cp.getStrokeWidth());
-      p.setOpacity(cp.getOpacity());
-      p.setThickness(cp.getStrokeWidth());
-      p.setEraser(cp.isEraseSelected());
-      p.setSquareCap(cp.isSquareCapSelected());
-      MapTool.getFrame().updateDrawTree();
-      MapTool.serverCommand().updateDrawing(renderer.getZone().getId(), p, elementUnderMouse);
     }
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #5680

### Description of the Change
Instead of only applying the color picker settings to a single drawing/template, "Set Properties" from the Draw Panel popup menu will now apply these to all selected drawings and templates.

### Possible Drawbacks
Slight change in behavior.

### Documentation Notes

### Release Notes
- Draw Panel Set Properties will now apply color picker properties to all selected drawings and templates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5681)
<!-- Reviewable:end -->
