### PR TITLE
Make the Connect to Server dialog modal

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/connecttoserverdialog/ConnectToServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/connecttoserverdialog/ConnectToServerDialog.java
@@ -35,6 +35,7 @@ import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
+import javax.swing.WindowConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
@@ -58,7 +59,9 @@ public class ConnectToServerDialog extends AbeillePanel<ConnectToServerDialogPre
       GenericDialog.getFactory()
           .setDialogTitle(I18N.getText("ConnectToServerDialog.msg.title"))
           .createOkCancelButtons()
-          .setDefaultButton(ButtonKind.OK);
+          .setDefaultButton(ButtonKind.OK)
+          .makeModal(true)
+          .setCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
   private RemoteServerConfig connectionDetails = null;
 
   /** This is the default constructor */


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes issue with PR #5623

### Description of the Change

The **Connect to Server** dialog was made no longer closable or effective due to not being modal. This PR fixes that issue.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5682)
<!-- Reviewable:end -->
