### PR TITLE
Fix display of PreferenceDialog

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -507,7 +507,7 @@ public class AppActions {
 
           // Probably don't have to create a new one each time
           PreferencesDialog dialog = new PreferencesDialog();
-          dialog.setVisible(true);
+          dialog.showDialog();
         }
       };
 

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -1557,14 +1557,6 @@ public class PreferencesDialog extends AbeillePanel {
     }
   }
 
-  @Override
-  public void setVisible(boolean b) {
-    if (b) {
-      themeChanged = false;
-    }
-    super.setVisible(b);
-  }
-
   /**
    * Initializes and sets the initial state of various user preferences in the application. This
    * method is called during the initialization process.
@@ -1917,6 +1909,7 @@ public class PreferencesDialog extends AbeillePanel {
   }
 
   public void showDialog() {
+    themeChanged = false;
     dialogFactory.display();
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes issue with PR #5658

### Description of the Change

The Preferences dialog needs to be shown using the new `showDialog()` method, not the old `setVisible(true)` from `JDialog`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5686)
<!-- Reviewable:end -->
