### PR TITLE
For linear drawing tools, force the foreground mode to be solid

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -203,6 +203,9 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
           pen.setPaint(new DrawableColorPaint(Color.white));
           pen.setBackgroundPaint(new DrawableColorPaint(Color.white));
         }
+        if (isLinearTool()) {
+          pen.setForegroundMode(Pen.MODE_SOLID);
+        }
 
         drawable.draw(renderer.getZone(), g2, pen);
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5674

### Description of the Change

Restores 1.15.2 drawing behaviour by rendering transparent borders as opaque black while the user is drawing a freehand or straight line drawing. This is done by forcing the foreground mode to solid, as used to be done by the `AbstractLineTool`.

There's probably a better way to give user feedback while drawing, e.g., that includes the background colour for these tools. But for this PR I just want to focus on the bugfix and restoring 1.15.2-era drawing behaviour.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where freehand and straight line drawings with transparent outlines would not render while drawing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5687)
<!-- Reviewable:end -->
