### PR TITLE
For linear drawing tools, force the foreground mode to be solid

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -203,6 +203,9 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
           pen.setPaint(new DrawableColorPaint(Color.white));
           pen.setBackgroundPaint(new DrawableColorPaint(Color.white));
         }
+        if (isLinearTool()) {
+          pen.setForegroundMode(Pen.MODE_SOLID);
+        }
 
         drawable.draw(renderer.getZone(), g2, pen);
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Backports #5687 to 1.18

### Description of the Change

I meant to target 1.18 for the bug fix, but forgot to do so.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where freehand and straight line drawings with transparent outlines would not render while drawing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5688)
<!-- Reviewable:end -->
