### PR TITLE
1.18 - fix for lib: prefix handling

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1232,28 +1232,24 @@ public class MapToolLineParser {
     switch (mloc.getSource()) {
       case library, uri -> {
         try {
-          String namespace;
-          String macro;
-          switch (mloc.getSource()) {
-            case uri -> {
-              namespace = mloc.getUri().getHost();
-              macro = mloc.getUri().toString();
-            }
-            case library -> {
-              namespace = mloc.getLocation();
-              macro = mloc.getName();
-            }
-            case null, default -> {
-              throw new IllegalStateException("Unexpected value: " + mloc.getSource());
-            }
-          }
+          var namespace = mloc.getLocation();
           var lib = new LibraryManager().getLibrary(namespace);
           if (lib.isEmpty()) {
             throw new ParserException(
                 I18N.getText("lineParser.unknownLibToken", mloc.getLocation()));
           }
           var library = lib.get();
-          var macroInfo = library.getMTScriptMacroInfo(macro).get();
+
+          var macroInfoFuture =
+              switch (mloc.getSource()) {
+                case uri -> library.getMTScriptMacroInfoForUriPath(mloc.getName());
+                case library -> library.getMTScriptMacroInfo(mloc.getName());
+                case null, default -> {
+                  throw new IllegalStateException("Unexpected value: " + mloc.getSource());
+                }
+              };
+
+          var macroInfo = macroInfoFuture.get();
           if (macroInfo.isEmpty()) {
             // if the macro source is the same as the location then check private macros.
             if (!contextStackEmpty()) {

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1240,7 +1240,7 @@ public class MapToolLineParser {
               macro = mloc.getUri().toString();
             }
             case library -> {
-              namespace = mloc.getLocation().replaceFirst("^(?i)lib:", "");
+              namespace = mloc.getLocation();
               macro = mloc.getName();
             }
             case null, default -> {

--- a/src/main/java/net/rptools/maptool/client/functions/DefineMacroFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DefineMacroFunction.java
@@ -60,7 +60,7 @@ public class DefineMacroFunction extends AbstractFunction {
       if (macro.toLowerCase().endsWith("@this")) {
         macro =
             macro.substring(0, macro.length() - 4)
-                + MapTool.getParser().getMacroSource().getLocation();
+                + MapTool.getParser().getMacroSource().getCallableLocation();
       }
 
       boolean ignoreOutput = false;

--- a/src/main/java/net/rptools/maptool/client/functions/ParserPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ParserPropertyFunctions.java
@@ -87,7 +87,7 @@ public class ParserPropertyFunctions extends AbstractFunction {
       MapToolMacroContext mc = mtlParser.getContext();
       mco.addProperty("stackSize", mtlParser.getContextStackSize());
       mco.addProperty("name", mc.getName());
-      mco.addProperty("source", mc.getSource().getLocation());
+      mco.addProperty("source", mc.getSource().getCallableLocation());
       mco.addProperty("trusted", mc.isTrusted());
       if (mc.getMacroButtonIndex() >= 0) {
         mco.addProperty("buttonIndex", mc.getMacroButtonIndex());

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -508,19 +508,8 @@ public class TokenPropertyFunctions extends AbstractFunction {
     if (functionName.equalsIgnoreCase("getLibProperty")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 2);
       String propertyName = parameters.get(0).toString();
-      String location;
-      if (parameters.size() > 1) {
-        location = parameters.get(1).toString();
-      } else {
-        location = MapTool.getParser().getMacroSource().getLocation();
-      }
 
-      String libName;
-      if (location.toLowerCase().startsWith("lib:")) {
-        libName = location.substring(4);
-      } else {
-        libName = location;
-      }
+      String libName = findLibNamespaceFromParams(parameters, 1, false);
 
       try {
         var library =
@@ -550,20 +539,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       FunctionUtil.checkNumberParam(functionName, parameters, 2, 3);
       String property = parameters.get(0).toString();
       Object value = parameters.get(1);
-
-      String location;
-      if (parameters.size() > 2) {
-        location = parameters.get(2).toString();
-      } else {
-        location = MapTool.getParser().getMacroSource().getLocation();
-      }
-
-      String libName;
-      if (location.toLowerCase().startsWith("lib:")) {
-        libName = location.substring(4);
-      } else {
-        libName = location;
-      }
+      String libName = findLibNamespaceFromParams(parameters, 2, false);
 
       var library =
           new LibraryManager()
@@ -589,22 +565,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
      */
     if (functionName.equalsIgnoreCase("getLibPropertyNames")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
-      String location;
-      if (parameters.size() > 0) {
-        location = parameters.get(0).toString();
-        if (location.equals("*") || location.equalsIgnoreCase("this")) {
-          location = MapTool.getParser().getMacroSource().getLocation();
-        }
-      } else {
-        location = MapTool.getParser().getMacroSource().getLocation();
-      }
-
-      String libName;
-      if (location.toLowerCase().startsWith("lib:")) {
-        libName = location.substring(4);
-      } else {
-        libName = location;
-      }
+      String libName = findLibNamespaceFromParams(parameters, 0, true);
       String delim = parameters.size() > 1 ? parameters.get(1).toString() : ",";
       return getMatchingLibProperties(libName, delim, ".*", functionName);
     }
@@ -614,23 +575,8 @@ public class TokenPropertyFunctions extends AbstractFunction {
      */
     if (functionName.equalsIgnoreCase("getMatchingLibProperties")) {
       FunctionUtil.checkNumberParam(functionName, parameters, 1, 3);
-      String location;
       String pattern = parameters.get(0).toString();
-      if (parameters.size() > 1) {
-        location = parameters.get(1).toString();
-        if (location.equals("*") || location.equalsIgnoreCase("this")) {
-          location = MapTool.getParser().getMacroSource().getLocation();
-        }
-      } else {
-        location = MapTool.getParser().getMacroSource().getLocation();
-      }
-
-      String libName;
-      if (location.toLowerCase().startsWith("lib:")) {
-        libName = location.substring(4);
-      } else {
-        libName = location;
-      }
+      String libName = findLibNamespaceFromParams(parameters, 1, true);
 
       String delim = parameters.size() > 2 ? parameters.get(2).toString() : ",";
       return getMatchingLibProperties(libName, delim, pattern, functionName);
@@ -1337,5 +1283,19 @@ public class TokenPropertyFunctions extends AbstractFunction {
           I18N.getText(
               "macro.function.general.argumentTypeN", functionName, index, param.toString()));
     }
+  }
+
+  private String findLibNamespaceFromParams(
+      List<Object> parameters, int libIndex, boolean allowWildcards) {
+    if (parameters.size() <= libIndex) {
+      return MapTool.getParser().getMacroSource().getLocation();
+    }
+
+    var location = parameters.get(libIndex).toString();
+    if (allowWildcards && (location.equals("*") || location.equalsIgnoreCase("this"))) {
+      return MapTool.getParser().getMacroSource().getLocation();
+    }
+
+    return location.toLowerCase().startsWith("lib:") ? location.substring(4) : location;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/macro/impl/SayMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/SayMacro.java
@@ -37,7 +37,7 @@ public class SayMacro extends AbstractMacro {
               null,
               MapTool.getParser().isMacroPathTrusted(),
               executionContext.getName(),
-              executionContext.getSource().getLocation());
+              executionContext.getSource().getCallableLocation());
     } else {
       msg = MessageUtil.getFormattedSay(macro, null, false, null, null);
     }

--- a/src/main/java/net/rptools/maptool/client/macro/impl/ToGMMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/ToGMMacro.java
@@ -36,7 +36,7 @@ public class ToGMMacro extends AbstractRollMacro {
               MapTool.getPlayer().getName(),
               MapTool.getParser().isMacroPathTrusted(),
               executionContext.getName(),
-              executionContext.getSource().getLocation());
+              executionContext.getSource().getCallableLocation());
     } else {
       toGmMsg =
           MessageUtil.getFormattedToGmRecipient(

--- a/src/main/java/net/rptools/maptool/model/library/Library.java
+++ b/src/main/java/net/rptools/maptool/model/library/Library.java
@@ -157,6 +157,14 @@ public interface Library {
   /**
    * Returns the information about MapTool Macro Script on this library.
    *
+   * @param macroPath The path to the macro, as used in lib: URIs.
+   * @return the information about the MapTool Macro Script.
+   */
+  CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfoForUriPath(String macroPath);
+
+  /**
+   * Returns the information about MapTool Macro Script on this library.
+   *
    * @param macroName The name of the macro.
    * @return the information about the MapTool Macro Script.
    */

--- a/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/addon/AddOnLibrary.java
@@ -360,6 +360,13 @@ public class AddOnLibrary implements Library {
   }
 
   @Override
+  public CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfoForUriPath(
+      String macroPath) {
+    // For add-ons, the path and the macro name are the same.
+    return getMTScriptMacroInfo(macroPath);
+  }
+
+  @Override
   public CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfo(String macroName) {
     var macro = mtsFunctionAssetMap.get(MTSCRIPT_PUBLIC_DIR + macroName);
     if (macro == null) {

--- a/src/main/java/net/rptools/maptool/model/library/builtin/ClassPathAddOnLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/ClassPathAddOnLibrary.java
@@ -132,6 +132,12 @@ public class ClassPathAddOnLibrary implements BuiltInLibrary {
   }
 
   @Override
+  public CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfoForUriPath(
+      String macroPath) {
+    return addOnLibrary.getMTScriptMacroInfoForUriPath(macroPath);
+  }
+
+  @Override
   public CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfo(String macroName) {
     return addOnLibrary.getMTScriptMacroInfo(macroName);
   }

--- a/src/main/java/net/rptools/maptool/model/library/builtin/MapToolBuiltInLibrary.java
+++ b/src/main/java/net/rptools/maptool/model/library/builtin/MapToolBuiltInLibrary.java
@@ -224,6 +224,12 @@ public class MapToolBuiltInLibrary implements BuiltInLibrary {
   }
 
   @Override
+  public CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfoForUriPath(
+      String macroPath) {
+    return CompletableFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
   public CompletableFuture<Optional<MTScriptMacroInfo>> getMTScriptMacroInfo(String macroName) {
     return CompletableFuture.completedFuture(Optional.empty());
   }

--- a/src/main/java/net/rptools/maptool/model/library/token/LibraryTokenManager.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/LibraryTokenManager.java
@@ -229,9 +229,7 @@ public class LibraryTokenManager {
     return new ThreadExecutionHelper<Library>()
         .runOnSwingThread(
             () -> {
-              var libNamespace =
-                  namespace.toLowerCase().startsWith("lib:") ? namespace : "lib:" + namespace;
-              var tokenList = getTokensWithName(libNamespace);
+              var tokenList = getTokensWithName("lib:" + namespace);
               if (tokenList.isEmpty()) {
                 return null;
               } else {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5706

### Description of the Change

A few places have been updated to use the callable location instead of the plain location from the `MacroLocation`:
- When resolving `@this` in `defineFunction()`
- In the tooltips for `/say` and `/gm`.
- In the `"source"` value returned by `getMacroContext()`

A few other places directly handle `lib:` prefixes but weren't correct, particularly for tokens with strange but valid names like `Lib:Lib:Hero`:
- `LibraryTokenManager#getLibrary()` once again always adds the `lib:` prefix rather than doing so conditionally. All callers were checked to make sure they pass the namespace, thereby removing the need for the check in the first place.
- `MapToolLineParser#runMacro()` does not remove the `lib:` prefix since it is guaranteed to have the namespace already from `MacroLocation#getLocation()`.
- Similarly, functions like `getLibProperty()` do not try to remove the `lib:` prefix from the result of `MacroLocation#getLocation()`, but they do still need to be able to remove it from a user-supplied lib:token name.

Similar to the `Lib:Lib:Hero` naming issue, macros named like `macro/example` on lib:tokens had the same sort of problem when trying to reference them via URIs with the `macro()` roll option, e.g., `[r, macro(lib://Dragon/macro/macro/example): ""]`. Add-on macros, on the other hand, simply could not be referenced via `macro()` since a full URI could not be resolved by add-ons. Both of these have been fixed. As part of this fix, URI `MacroLocation` and library `MacroLocation` need to be resolved differently, so there is a new method `Library#getMTScriptMacroInfoForUriPath(String)` that supports the URI case, while `Library#getMTScriptMacroInfo(String)` continues to support the library case (among other things).

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Fix various places to correctly handle the `lib:` prefix on lib:tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5708)
<!-- Reviewable:end -->
