### PR TITLE
1.18 - fix for untransformed token VBL

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/Topology_Functions.java
@@ -595,7 +595,7 @@ public class Topology_Functions extends AbstractFunction {
 
     Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
     if (topologyFromToken) {
-      var newMapTopology = token.getTransformedMaskTopology(topologyType);
+      var newMapTopology = token.getTransformedMaskTopology(zone, topologyType);
       if (newMapTopology != null) {
         MapTool.serverCommand().updateMaskTopology(zone, newMapTopology, false, topologyType);
       }

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -1438,7 +1438,11 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                     MapTool.serverCommand()
                         .updateMaskTopology(
                             MapTool.getFrame().getCurrentZoneRenderer().getZone(),
-                            getTokenTopologyPanel().getToken().getTransformedMaskTopology(topology),
+                            getTokenTopologyPanel()
+                                .getToken()
+                                .getTransformedMaskTopology(
+                                    MapTool.getFrame().getCurrentZoneRenderer().getZone(),
+                                    topology),
                             false,
                             type);
                   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/TokenRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/TokenRenderer.java
@@ -30,6 +30,7 @@ import net.rptools.maptool.client.ui.zone.ZoneViewModel.TokenPosition;
 import net.rptools.maptool.client.ui.zone.renderer.RenderHelper;
 import net.rptools.maptool.model.*;
 import net.rptools.maptool.util.ImageManager;
+import net.rptools.maptool.util.TokenUtil;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -95,68 +96,12 @@ public class TokenRenderer {
       return;
     }
 
-    var isoFigure =
-        zone.getGrid().isIsometric()
-            && !token.getIsFlippedIso()
-            && token.getShape() == Token.TokenShape.FIGURE;
-
-    // centre image
-    double imageCx = -renderImage.getWidth() / 2d;
-    double imageCy =
-        isoFigure
-            ? -renderImage.getHeight() + renderImage.getWidth() / 4d
-            : -renderImage.getHeight() / 2d;
-
-    // Compose a transformation to draw the token image at the correct place.
-    // Because the last transform applies first, read these steps backwards for a better
-    // understanding.
-    AffineTransform imageTransform = new AffineTransform();
-    {
-      // Now move the image back to its actual location.
-      imageTransform.translate(
-          position.footprintBounds().getCenterX(), position.footprintBounds().getCenterY());
-
-      // Rotate around the anchor.
-      if (token.hasFacing() && token.getShape() == Token.TokenShape.TOP_DOWN) {
-        imageTransform.rotate(Math.toRadians(token.getFacingInDegrees()));
-      }
-
-      // Rotation applies around the anchor, so nudge the token first.
-      imageTransform.translate(token.getAnchorX(), token.getAnchorY());
-
-      // Size image to footprint.
-      // For snap-to-scale, fit to footprint, then scale according to layout.
-      // For others, the X/Y scale is already incorporated into the footprint, so just fill the
-      // footprint.
-      if (token.isSnapToScale()) {
-        var scale =
-            isoFigure
-                // Fit width
-                ? position.footprintBounds().getWidth() / renderImage.getWidth()
-                // Scale to fit
-                : Math.min(
-                    position.footprintBounds().getWidth() / renderImage.getWidth(),
-                    position.footprintBounds().getHeight() / renderImage.getHeight());
-        scale *= token.getSizeScale();
-        imageTransform.scale(scale, scale);
-      } else {
-        var scaleX = position.footprintBounds().getWidth() / renderImage.getWidth();
-        var scaleY = position.footprintBounds().getHeight() / renderImage.getHeight();
-        imageTransform.scale(scaleX, scaleY);
-      }
-
-      // Iso flip
-      if (token.getIsFlippedIso() && zone.getGrid().isIsometric()) {
-        imageTransform.scale(Math.sqrt(2), 1 / Math.sqrt(2));
-        imageTransform.rotate(Math.toRadians(45));
-      }
-
-      // Cartesian flip.
-      imageTransform.scale(token.isFlippedX() ? -1 : 1, token.isFlippedY() ? -1 : 1);
-
-      // Move the image center to (0, 0) so rotations and scales can be easily applied.
-      imageTransform.translate(imageCx, imageCy);
-    }
+    var imageTransform =
+        TokenUtil.getRenderTransform(
+            zone,
+            token,
+            new Dimension(renderImage.getWidth(), renderImage.getHeight()),
+            position.footprintBounds());
 
     if (opacity < 1.0f) {
       g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -28,7 +28,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Transparency;
-import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
@@ -50,7 +49,6 @@ import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
-import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
@@ -1421,68 +1419,13 @@ public class Token implements Cloneable {
       return null;
     }
 
-    Rectangle footprintBounds = getBounds(MapTool.getFrame().getCurrentZoneRenderer().getZone());
+    var zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
+    Rectangle footprintBounds = getBounds(zone);
     Dimension imgSize = new Dimension(getWidth(), getHeight());
-    SwingUtil.constrainTo(imgSize, footprintBounds.width, footprintBounds.height);
 
-    // Lets account for ISO images
-    double iso_ho = 0;
-    if (getShape() == TokenShape.FIGURE) {
-      double th = getHeight() * (double) footprintBounds.width / getWidth();
-      iso_ho = footprintBounds.height - th;
-      footprintBounds =
-          new Rectangle(
-              footprintBounds.x, footprintBounds.y - (int) iso_ho, footprintBounds.width, (int) th);
-    }
+    var imageTransform = TokenUtil.getRenderTransform(zone, this, imgSize, footprintBounds);
 
-    // Lets figure in offset if image is not free size/native size aka snapToScale
-    int offsetx = 0;
-    int offsety = 0;
-    if (isSnapToScale()) {
-      offsetx =
-          imgSize.width < footprintBounds.width ? (footprintBounds.width - imgSize.width) / 2 : 0;
-      offsety =
-          imgSize.height < footprintBounds.height
-              ? (footprintBounds.height - imgSize.height) / 2
-              : 0;
-    }
-    double tx = footprintBounds.x + offsetx;
-    double ty = footprintBounds.y + offsety + iso_ho;
-
-    // Apply the coordinate translation
-    AffineTransform atArea = AffineTransform.getTranslateInstance(tx, ty);
-
-    double scalerX = isSnapToScale() ? ((double) imgSize.width) / getWidth() : scaleX;
-    double scalerY = isSnapToScale() ? ((double) imgSize.height) / getHeight() : scaleY;
-
-    // Apply the rotation transformation...
-    if (getShape() == Token.TokenShape.TOP_DOWN && hasFacing()) {
-      // Find the center x,y coords of the rectangle
-      double rx = getWidth() / 2.0 * scalerX - getAnchor().getX();
-      double ry = getHeight() / 2.0 * scalerY - getAnchor().getY();
-
-      atArea.concatenate(
-          AffineTransform.getRotateInstance(Math.toRadians(getFacingInDegrees()), rx, ry));
-    }
-    // Apply the scale transformation
-    atArea.concatenate(AffineTransform.getScaleInstance(scalerX, scalerY));
-
-    // Lets account for flipped images...
-    if (isFlippedX) {
-      atArea.concatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
-      atArea.concatenate(AffineTransform.getTranslateInstance(-getWidth(), 0));
-    }
-
-    if (isFlippedY) {
-      atArea.concatenate(AffineTransform.getScaleInstance(1.0, -1.0));
-      atArea.concatenate(AffineTransform.getTranslateInstance(0, -getHeight()));
-    }
-
-    if (getIsFlippedIso()) {
-      return new Area(atArea.createTransformedShape(IsometricGrid.isoArea(areaToTransform)));
-    }
-
-    return new Area(atArea.createTransformedShape(areaToTransform));
+    return new Area(imageTransform.createTransformedShape(areaToTransform));
   }
 
   public void setIsAlwaysVisible(boolean isAlwaysVisible) {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1355,8 +1355,8 @@ public class Token implements Cloneable {
    * @param topologyType The type of topology to transform.
    * @return the transformed topology for the token
    */
-  public Area getTransformedMaskTopology(Zone.TopologyType topologyType) {
-    return getTransformedMaskTopology(getMaskTopology(topologyType));
+  public Area getTransformedMaskTopology(Zone zone, Zone.TopologyType topologyType) {
+    return getTransformedMaskTopology(zone, getMaskTopology(topologyType));
   }
 
   /**
@@ -1414,12 +1414,11 @@ public class Token implements Cloneable {
    * @author Jamz
    * @since 1.4.1.5
    */
-  public Area getTransformedMaskTopology(Area areaToTransform) {
+  public Area getTransformedMaskTopology(Zone zone, Area areaToTransform) {
     if (areaToTransform == null) {
       return null;
     }
 
-    var zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
     Rectangle footprintBounds = getBounds(zone);
     Dimension imgSize = new Dimension(getWidth(), getHeight());
 

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1061,7 +1061,7 @@ public class Zone {
           continue;
         }
 
-        var tokenArea = token.getTransformedMaskTopology(type);
+        var tokenArea = token.getTransformedMaskTopology(this, type);
         if (tokenArea != null) {
           topologies.add(tokenArea);
         }

--- a/src/main/java/net/rptools/maptool/util/TokenUtil.java
+++ b/src/main/java/net/rptools/maptool/util/TokenUtil.java
@@ -15,16 +15,97 @@
 package net.rptools.maptool.util;
 
 import java.awt.Dimension;
+import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.awt.image.PixelGrabber;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.Zone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class TokenUtil {
   private static final Logger log = LogManager.getLogger(TokenUtil.class);
+
+  /**
+   * Builds the transformation required to render a token image at the correct size and location.
+   *
+   * @param zone The zone in which the token is being rendered.
+   * @param token The token being rendered.
+   * @param imageSize The size of the token image to render.
+   * @param footprintBounds The token's footprint.
+   * @return The {@link AffineTransform} that can be applied to a {@link Graphics2D} object to
+   *     render the token image.
+   */
+  public static AffineTransform getRenderTransform(
+      Zone zone, Token token, Dimension imageSize, Rectangle2D footprintBounds) {
+    var isoFigure =
+        zone.getGrid().isIsometric()
+            && !token.getIsFlippedIso()
+            && token.getShape() == Token.TokenShape.FIGURE;
+
+    // centre image
+    double imageCx = -imageSize.getWidth() / 2d;
+    double imageCy =
+        isoFigure
+            ? -imageSize.getHeight() + imageSize.getWidth() / 4d
+            : -imageSize.getHeight() / 2d;
+
+    // Compose a transformation to draw the token image at the correct place.
+    // Because the last transform applies first, read these steps backwards for a better
+    // understanding.
+    AffineTransform imageTransform = new AffineTransform();
+    {
+      // Now move the image back to its actual location.
+      imageTransform.translate(footprintBounds.getCenterX(), footprintBounds.getCenterY());
+
+      // Rotate around the anchor.
+      if (token.hasFacing() && token.getShape() == Token.TokenShape.TOP_DOWN) {
+        imageTransform.rotate(Math.toRadians(token.getFacingInDegrees()));
+      }
+
+      // Rotation applies around the anchor, so nudge the token first.
+      imageTransform.translate(token.getAnchorX(), token.getAnchorY());
+
+      // Size image to footprint.
+      // For snap-to-scale, fit to footprint, then scale according to layout.
+      // For others, the X/Y scale is already incorporated into the footprint, so just fill the
+      // footprint.
+      if (token.isSnapToScale()) {
+        var scale =
+            isoFigure
+                // Fit width
+                ? footprintBounds.getWidth() / imageSize.getWidth()
+                // Scale to fit
+                : Math.min(
+                    footprintBounds.getWidth() / imageSize.getWidth(),
+                    footprintBounds.getHeight() / imageSize.getHeight());
+        scale *= token.getSizeScale();
+        imageTransform.scale(scale, scale);
+      } else {
+        var scaleX = footprintBounds.getWidth() / imageSize.getWidth();
+        var scaleY = footprintBounds.getHeight() / imageSize.getHeight();
+        imageTransform.scale(scaleX, scaleY);
+      }
+
+      // Iso flip
+      if (token.getIsFlippedIso() && zone.getGrid().isIsometric()) {
+        imageTransform.scale(Math.sqrt(2), 1 / Math.sqrt(2));
+        imageTransform.rotate(Math.toRadians(45));
+      }
+
+      // Cartesian flip.
+      imageTransform.scale(token.isFlippedX() ? -1 : 1, token.isFlippedY() ? -1 : 1);
+
+      // Move the image center to (0, 0) so rotations and scales can be easily applied.
+      imageTransform.translate(imageCx, imageCy);
+    }
+
+    return imageTransform;
+  }
 
   public static Token.TokenShape guessTokenType(Image image) {
     if (image instanceof BufferedImage) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5709

### Description of the Change

This factors out the `AffineTransform` used to render a token image, and uses that to build the transformed token topologies. This ensures the two should always agree when the token has a modified layout.

A minor refactoring is included to inject the `Zone` into the `Token#getTransformedMaskTopology()` rather than querying for the current `ZoneRenderer`.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Fixed token VBL/MBL to respect the token layout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5710)
<!-- Reviewable:end -->
