### PR TITLE
Fix token topology transfers and other issues with token bounds

### DIFF
--- a/src/main/java/net/rptools/lib/image/ImageUtil.java
+++ b/src/main/java/net/rptools/lib/image/ImageUtil.java
@@ -148,7 +148,7 @@ public class ImageUtil {
         }
       }
     } else {
-      Rectangle b = token.getBounds(grid.getZone());
+      Rectangle b = token.getFootprintBounds(grid.getZone());
       try {
         return ImageUtil.scaleBufferedImage(
             img, (int) Math.ceil(b.width * zoom), (int) Math.ceil(b.height * zoom));

--- a/src/main/java/net/rptools/lib/image/ImageUtil.java
+++ b/src/main/java/net/rptools/lib/image/ImageUtil.java
@@ -148,7 +148,7 @@ public class ImageUtil {
         }
       }
     } else {
-      Rectangle b = token.getFootprintBounds(grid.getZone());
+      Rectangle b = token.getImageBounds(grid.getZone());
       try {
         return ImageUtil.scaleBufferedImage(
             img, (int) Math.ceil(b.width * zoom), (int) Math.ceil(b.height * zoom));

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -241,7 +241,7 @@ public class TokenLocationFunctions extends AbstractFunction {
   private TokenLocation getTokenLocation(boolean useDistancePerCell, Token token) {
     TokenLocation loc = new TokenLocation();
     if (useDistancePerCell) {
-      Rectangle tokenBounds = token.getBounds(token.getZoneRenderer().getZone());
+      Rectangle tokenBounds = token.getFootprintBounds(token.getZoneRenderer().getZone());
       loc.x = tokenBounds.x;
       loc.y = tokenBounds.y;
     } else {
@@ -337,10 +337,10 @@ public class TokenLocationFunctions extends AbstractFunction {
       }
     } else {
       // take distance between center of the two tokens
-      Rectangle sourceBounds = source.getBounds(zone);
+      Rectangle sourceBounds = source.getFootprintBounds(zone);
       double sourceCenterX = sourceBounds.x + sourceBounds.width / 2.0;
       double sourceCenterY = sourceBounds.y + sourceBounds.height / 2.0;
-      Rectangle targetBounds = target.getBounds(zone);
+      Rectangle targetBounds = target.getFootprintBounds(zone);
       double targetCenterX = targetBounds.x + targetBounds.width / 2.0;
       double targetCenterY = targetBounds.y + targetBounds.height / 2.0;
 
@@ -418,7 +418,7 @@ public class TokenLocationFunctions extends AbstractFunction {
       }
 
       // get the pixel coords for the center of the token
-      Rectangle sourceBounds = source.getBounds(zone);
+      Rectangle sourceBounds = source.getFootprintBounds(zone);
       double sourceCenterX = sourceBounds.x + sourceBounds.width / 2.0;
       double sourceCenterY = sourceBounds.y + sourceBounds.height / 2.0;
       double a = (int) (sourceCenterX - targetX);
@@ -452,7 +452,7 @@ public class TokenLocationFunctions extends AbstractFunction {
         }
       }
     } else {
-      Rectangle bounds = token.getBounds(zone);
+      Rectangle bounds = token.getFootprintBounds(zone);
       for (Point point : points) {
         if (bounds.contains(point)) return true;
       }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -241,7 +241,7 @@ public class TokenLocationFunctions extends AbstractFunction {
   private TokenLocation getTokenLocation(boolean useDistancePerCell, Token token) {
     TokenLocation loc = new TokenLocation();
     if (useDistancePerCell) {
-      Rectangle tokenBounds = token.getFootprintBounds(token.getZoneRenderer().getZone());
+      Rectangle tokenBounds = token.getImageBounds(token.getZoneRenderer().getZone());
       loc.x = tokenBounds.x;
       loc.y = tokenBounds.y;
     } else {
@@ -337,10 +337,10 @@ public class TokenLocationFunctions extends AbstractFunction {
       }
     } else {
       // take distance between center of the two tokens
-      Rectangle sourceBounds = source.getFootprintBounds(zone);
+      Rectangle sourceBounds = source.getImageBounds(zone);
       double sourceCenterX = sourceBounds.x + sourceBounds.width / 2.0;
       double sourceCenterY = sourceBounds.y + sourceBounds.height / 2.0;
-      Rectangle targetBounds = target.getFootprintBounds(zone);
+      Rectangle targetBounds = target.getImageBounds(zone);
       double targetCenterX = targetBounds.x + targetBounds.width / 2.0;
       double targetCenterY = targetBounds.y + targetBounds.height / 2.0;
 
@@ -418,7 +418,7 @@ public class TokenLocationFunctions extends AbstractFunction {
       }
 
       // get the pixel coords for the center of the token
-      Rectangle sourceBounds = source.getFootprintBounds(zone);
+      Rectangle sourceBounds = source.getImageBounds(zone);
       double sourceCenterX = sourceBounds.x + sourceBounds.width / 2.0;
       double sourceCenterY = sourceBounds.y + sourceBounds.height / 2.0;
       double a = (int) (sourceCenterX - targetX);
@@ -452,7 +452,7 @@ public class TokenLocationFunctions extends AbstractFunction {
         }
       }
     } else {
-      Rectangle bounds = token.getFootprintBounds(zone);
+      Rectangle bounds = token.getImageBounds(zone);
       for (Point point : points) {
         if (bounds.contains(point)) return true;
       }

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -267,7 +267,7 @@ public class TokenMoveFunctions extends AbstractFunction {
                 .getFootprint(grid)
                 .getBounds(grid, grid.convert(new ZonePoint(entry.get("x"), entry.get("y"))));
       } else {
-        originalArea = tokenInContext.getBounds(zone);
+        originalArea = tokenInContext.getFootprintBounds(zone);
       }
       Rectangle2D oa = originalArea.getBounds2D();
       if (targetArea.contains(oa) || targetArea.intersects(oa)) {
@@ -300,7 +300,7 @@ public class TokenMoveFunctions extends AbstractFunction {
      * if-else sequence...
      */
     Grid grid = zone.getGrid();
-    Rectangle targetArea = target.getBounds(zone);
+    Rectangle targetArea = target.getFootprintBounds(zone);
 
     if (pathPoints == null) {
       return returnPoints;
@@ -326,7 +326,7 @@ public class TokenMoveFunctions extends AbstractFunction {
       Map<String, Integer> firstPoint = new HashMap<String, Integer>(),
           secondPoint = new HashMap<String, Integer>();
       for (Map<String, Integer> entry : pathPoints) {
-        Rectangle tokenArea = tokenInContext.getBounds(zone);
+        Rectangle tokenArea = tokenInContext.getFootprintBounds(zone);
         Point currentPoint = new Point(entry.get("x"), entry.get("y"));
         if (ctr > 0) {
           if (targetArea.intersectsLine(new Line2D.Double(previousPoint, currentPoint))

--- a/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenMoveFunctions.java
@@ -267,7 +267,7 @@ public class TokenMoveFunctions extends AbstractFunction {
                 .getFootprint(grid)
                 .getBounds(grid, grid.convert(new ZonePoint(entry.get("x"), entry.get("y"))));
       } else {
-        originalArea = tokenInContext.getFootprintBounds(zone);
+        originalArea = tokenInContext.getImageBounds(zone);
       }
       Rectangle2D oa = originalArea.getBounds2D();
       if (targetArea.contains(oa) || targetArea.intersects(oa)) {
@@ -300,7 +300,7 @@ public class TokenMoveFunctions extends AbstractFunction {
      * if-else sequence...
      */
     Grid grid = zone.getGrid();
-    Rectangle targetArea = target.getFootprintBounds(zone);
+    Rectangle targetArea = target.getImageBounds(zone);
 
     if (pathPoints == null) {
       return returnPoints;
@@ -326,7 +326,7 @@ public class TokenMoveFunctions extends AbstractFunction {
       Map<String, Integer> firstPoint = new HashMap<String, Integer>(),
           secondPoint = new HashMap<String, Integer>();
       for (Map<String, Integer> entry : pathPoints) {
-        Rectangle tokenArea = tokenInContext.getFootprintBounds(zone);
+        Rectangle tokenArea = tokenInContext.getImageBounds(zone);
         Point currentPoint = new Point(entry.get("x"), entry.get("y"));
         if (ctr > 0) {
           if (targetArea.intersectsLine(new Line2D.Double(previousPoint, currentPoint))

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -779,7 +779,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       // Get the pixel width or height of a given token
-      Rectangle tokenBounds = token.getBounds(zone);
+      Rectangle tokenBounds = token.getFootprintBounds(zone);
 
       if (functionName.equalsIgnoreCase("getTokenWidth")) {
         return BigDecimal.valueOf(tokenBounds.width);
@@ -803,7 +803,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       double magnitude = getBigDecimalFromParam(functionName, parameters, 0).doubleValue();
-      Rectangle tokenBounds = token.getBounds(zone);
+      Rectangle tokenBounds = token.getFootprintBounds(zone);
 
       double oldWidth = tokenBounds.width;
       double oldHeight = tokenBounds.height;

--- a/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenPropertyFunctions.java
@@ -779,7 +779,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       // Get the pixel width or height of a given token
-      Rectangle tokenBounds = token.getFootprintBounds(zone);
+      Rectangle tokenBounds = token.getImageBounds(zone);
 
       if (functionName.equalsIgnoreCase("getTokenWidth")) {
         return BigDecimal.valueOf(tokenBounds.width);
@@ -803,7 +803,7 @@ public class TokenPropertyFunctions extends AbstractFunction {
       Zone zone = zoneR.getZone();
 
       double magnitude = getBigDecimalFromParam(functionName, parameters, 0).doubleValue();
-      Rectangle tokenBounds = token.getFootprintBounds(zone);
+      Rectangle tokenBounds = token.getImageBounds(zone);
 
       double oldWidth = tokenBounds.width;
       double oldHeight = tokenBounds.height;

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
@@ -110,7 +110,7 @@ public class TokenSightFunctions extends AbstractFunction {
           target
               .getFootprint(grid)
               .getBounds(grid, grid.convert(new ZonePoint(target.getX(), target.getY())));
-      if (!target.isSnapToGrid()) bounds = target.getBounds(zone);
+      if (!target.isSnapToGrid()) bounds = target.getFootprintBounds(zone);
 
       int x = (int) bounds.getX();
       int y = (int) bounds.getY();

--- a/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenSightFunctions.java
@@ -110,7 +110,7 @@ public class TokenSightFunctions extends AbstractFunction {
           target
               .getFootprint(grid)
               .getBounds(grid, grid.convert(new ZonePoint(target.getX(), target.getY())));
-      if (!target.isSnapToGrid()) bounds = target.getFootprintBounds(zone);
+      if (!target.isSnapToGrid()) bounds = target.getImageBounds(zone);
 
       int x = (int) bounds.getX();
       int y = (int) bounds.getY();

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1955,7 +1955,7 @@ public class PointerTool extends DefaultTool {
             }
           }
 
-          Rectangle tokenSize = token.getBounds(zone);
+          Rectangle tokenSize = token.getFootprintBounds(zone);
           Rectangle destination =
               new Rectangle(
                   tokenSize.x + deltaX, tokenSize.y + deltaY, tokenSize.width, tokenSize.height);
@@ -1990,7 +1990,7 @@ public class PointerTool extends DefaultTool {
           int x = token.getX() + deltaX;
           int y = token.getY() + deltaY;
 
-          Rectangle tokenSize = token.getBounds(zone);
+          Rectangle tokenSize = token.getFootprintBounds(zone);
           /*
            * Perhaps create a counter and count the number of times that the contains() check returns true? There are currently 9 rectangular areas checked by this code (note the "/3" in the two
            * 'interval' variables) so checking for 5 or more would mean more than 55%+ of the destination was visible...

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -999,7 +999,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         // Resize
         if (!token.isSnapToScale()) {
           double scale = renderer.getScale();
-          Rectangle footprintBounds = token.getBounds(renderer.getZone());
+          Rectangle footprintBounds = token.getFootprintBounds(renderer.getZone());
 
           double scaledWidth = (footprintBounds.width * scale);
           double scaledHeight = (footprintBounds.height * scale);
@@ -1194,7 +1194,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         zp.x += snapOffsetX;
         zp.y += snapOffsetY;
       } else {
-        Rectangle tokenSize = tokenBeingDragged.getBounds(renderer.getZone());
+        Rectangle tokenSize = tokenBeingDragged.getFootprintBounds(renderer.getZone());
         int x = tokenDragCurrent.x + (micro ? dx : (tokenSize.width * dx));
         int y = tokenDragCurrent.y + (micro ? dy : (tokenSize.height * dy));
         zp = new ZonePoint(x, y);

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -923,7 +923,7 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     // Note: order doesn't matter, so don't need to go back-to-front.
     for (Token element :
         zone.getTokensForLayers(layer -> view.isGMView() || layer.isVisibleToPlayers())) {
-      Rectangle drawnBounds = element.getFootprintBounds(zone);
+      Rectangle drawnBounds = element.getImageBounds(zone);
       if (element.hasFacing()) {
         // Get the facing and do a quick fix to make the math easier: -90 is 'unrotated' for some
         // reason

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -923,7 +923,7 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     // Note: order doesn't matter, so don't need to go back-to-front.
     for (Token element :
         zone.getTokensForLayers(layer -> view.isGMView() || layer.isVisibleToPlayers())) {
-      Rectangle drawnBounds = element.getBounds(zone);
+      Rectangle drawnBounds = element.getFootprintBounds(zone);
       if (element.hasFacing()) {
         // Get the facing and do a quick fix to make the math easier: -90 is 'unrotated' for some
         // reason

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenTopologyPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenTopologyPanel.java
@@ -223,7 +223,7 @@ public class TokenTopologyPanel extends JPanel {
 
     // Gather info
     BufferedImage image = ImageManager.getImage(token.getImageAssetId());
-    java.awt.Rectangle tokenSize = token.getBounds(zone);
+    java.awt.Rectangle tokenSize = token.getFootprintBounds(zone);
     Dimension originalImgSize = new Dimension(image.getWidth(), image.getHeight());
     Dimension imgSize = new Dimension(image.getWidth(), image.getHeight());
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/FogUtil.java
@@ -467,7 +467,7 @@ public class FogUtil {
               .getFootprint(grid)
               .getBounds(grid, grid.convert(new ZonePoint(token.getX(), token.getY())));
     } else {
-      bounds = token.getBounds(zone);
+      bounds = token.getFootprintBounds(zone);
     }
 
     x = bounds.x + bounds.width / 2;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -68,7 +68,7 @@ public class ZoneViewModel {
    */
   public record TokenPosition(Token token, Rectangle2D footprintBounds, Area transformedBounds) {
     public static TokenPosition fromToken(Token token, Zone zone) {
-      Rectangle2D footprintBounds = token.getBounds(zone);
+      Rectangle2D footprintBounds = token.getFootprintBounds(zone);
 
       final Area transformedBounds = new Area(footprintBounds);
       if (token.hasFacing() && token.getShape() == Token.TokenShape.TOP_DOWN) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -1012,7 +1012,7 @@ public class GdxRenderer extends ApplicationAdapter {
         }
 
         // OPTIMIZE: combine this with the code in renderTokens()
-        java.awt.Rectangle footprintBounds = token.getBounds(zoneCache.getZone());
+        java.awt.Rectangle footprintBounds = token.getFootprintBounds(zoneCache.getZone());
 
         // get token image, using image table if present
         Sprite image = zoneCache.getSprite(token.getImageAssetId(), stateTime);
@@ -1098,7 +1098,7 @@ public class GdxRenderer extends ApplicationAdapter {
               if (lastPoint instanceof CellPoint) {
                 tokenRectangle = token.getFootprint(grid).getBounds(grid, (CellPoint) lastPoint);
               } else {
-                java.awt.Rectangle tokBounds = token.getBounds(zoneCache.getZone());
+                java.awt.Rectangle tokBounds = token.getFootprintBounds(zoneCache.getZone());
                 tokenRectangle = new java.awt.Rectangle();
                 tokenRectangle.setBounds(
                     lastPoint.x,
@@ -1420,7 +1420,7 @@ public class GdxRenderer extends ApplicationAdapter {
         timer.stop("tokenlist-1");
       }
 
-      java.awt.Rectangle footprintBounds = token.getBounds(zoneCache.getZone());
+      java.awt.Rectangle footprintBounds = token.getFootprintBounds(zoneCache.getZone());
       java.awt.Rectangle origBounds = (java.awt.Rectangle) footprintBounds.clone();
       Area tokenBounds = new Area(footprintBounds);
 
@@ -1694,7 +1694,7 @@ public class GdxRenderer extends ApplicationAdapter {
 
       // Selection and labels
 
-      var tokenRectangle = token.getBounds(zoneCache.getZone());
+      var tokenRectangle = token.getFootprintBounds(zoneCache.getZone());
       var gdxTokenRectangle =
           new Rectangle(
               tokenRectangle.x,
@@ -1785,7 +1785,7 @@ public class GdxRenderer extends ApplicationAdapter {
       if (tokenStackMap != null
           && !hideTSI) { // FIXME Needed to prevent NPE but how can it be null?
         for (Token token : tokenStackMap.keySet()) {
-          var tokenRectangle = token.getBounds(zoneCache.getZone());
+          var tokenRectangle = token.getFootprintBounds(zoneCache.getZone());
           var stackImage = zoneCache.fetch("stack");
           batch.draw(
               stackImage,
@@ -1817,7 +1817,7 @@ public class GdxRenderer extends ApplicationAdapter {
       image = zoneCache.getIsoSprite(token.getImageAssetId());
       token.setHeight((int) image.getHeight());
       token.setWidth((int) image.getWidth());
-      footprintBounds = token.getBounds(zoneCache.getZone());
+      footprintBounds = token.getFootprintBounds(zoneCache.getZone());
     }
     timer.stop("tokenlist-5a");
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/TokenOverlayRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/TokenOverlayRenderer.java
@@ -81,7 +81,7 @@ public class TokenOverlayRenderer {
       float stateTime, MultipleImageBarTokenOverlay overlay, Token token, double barValue) {
     int increment = overlay.findIncrement(barValue);
 
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
 
@@ -111,7 +111,7 @@ public class TokenOverlayRenderer {
 
   private void renderTokenOverlay(
       float stateTime, SingleImageBarTokenOverlay overlay, Token token, double barValue) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
 
@@ -167,7 +167,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(DrawnBarTokenOverlay overlay, Token token, double barValue) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -208,7 +208,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(TwoToneBarTokenOverlay overlay, Token token, double barValue) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -263,7 +263,7 @@ public class TokenOverlayRenderer {
 
   private void renderTokenOverlay(
       float stateTime, TwoImageBarTokenOverlay overlay, Token token, double barValue) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
 
@@ -358,7 +358,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(ShadedTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -371,7 +371,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(float stateTime, ImageTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y;
 
@@ -402,7 +402,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(XTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -422,7 +422,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(FlowColorDotTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
 
     var color = overlay.getColor();
     Color.argb8888ToColor(tmpColor, color.getRGB());
@@ -436,7 +436,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(YieldTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -462,7 +462,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(OTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -495,7 +495,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(ColorDotTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -532,7 +532,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(DiamondTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -559,7 +559,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(TriangleTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;
@@ -586,7 +586,7 @@ public class TokenOverlayRenderer {
   }
 
   private void renderTokenOverlay(CrossTokenOverlay overlay, Token token) {
-    var bounds = token.getBounds(zoneCache.getZone());
+    var bounds = token.getFootprintBounds(zoneCache.getZone());
     var x = bounds.x;
     var y = -bounds.y - bounds.height;
     var w = bounds.width;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/label/TokenLabelRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/label/TokenLabelRenderer.java
@@ -65,7 +65,7 @@ public class TokenLabelRenderer implements ItemRenderer {
 
     float labelHeight = textRenderer.getFont().getLineHeight() + GraphicsUtil.BOX_PADDINGY * 2;
 
-    java.awt.Rectangle r = token.getBounds(zone);
+    java.awt.Rectangle r = token.getFootprintBounds(zone);
     tmpWorldCoord.x = r.x + r.width / 2;
     tmpWorldCoord.y = (r.y + r.height + offset + labelHeight * zoom / 2) * -1;
     tmpWorldCoord.z = 0;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1313,7 +1313,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         return false;
       }
       final var lastPoint = path.getCellPath().getLast();
-      Rectangle tokBounds = token.getBounds(zone);
+      Rectangle tokBounds = token.getFootprintBounds(zone);
       tokenRectangle = new Rectangle();
       tokenRectangle.setBounds(
           lastPoint.x, lastPoint.y, (int) tokBounds.getWidth(), (int) tokBounds.getHeight());
@@ -2387,7 +2387,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       }
 
       // Token type
-      Rectangle size = token.getBounds(zone);
+      Rectangle size = token.getFootprintBounds(zone);
       switch (getActiveLayer()) {
         case TOKEN:
           // Players can't drop invisible tokens

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/TokenVBL.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/TokenVBL.java
@@ -20,17 +20,18 @@ import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.NoninvertibleTransformException;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.util.ImageManager;
+import net.rptools.maptool.util.TokenUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.awt.ShapeReader;
@@ -178,7 +179,7 @@ public class TokenVBL {
   public static Area getTopology_underToken(
       Zone zone, Token token, Zone.TopologyType topologyType) {
     Area topologyOnMap = zone.getMaskTopology(topologyType);
-    Rectangle footprintBounds = token.getBounds(zone);
+    Rectangle footprintBounds = token.getImageBounds(zone);
 
     final AffineTransform captureArea = new AffineTransform();
     final Area topologyUnderToken;
@@ -203,40 +204,18 @@ public class TokenVBL {
     Rectangle footprintBounds = token.getFootprintBounds(zone);
 
     // Reverse all token transformations so we can store a raw untransformed version on the Token.
-    AffineTransform atArea = new AffineTransform();
-    // Let's account for flipped images...
-    if (token.isFlippedX()) {
-      atArea.scale(-1, 1);
-      atArea.translate(-token.getWidth(), 0);
-    }
-    if (token.isFlippedY()) {
-      atArea.scale(1, -1);
-      atArea.translate(0, -token.getHeight());
-    }
-    // Translate the capture to zero out the x,y to store on the Token
-    if (token.isSnapToScale()) {
-      Dimension imgSize = new Dimension(token.getWidth(), token.getHeight());
-      SwingUtil.constrainTo(imgSize, footprintBounds.width, footprintBounds.height);
-      atArea.scale(token.getWidth() / imgSize.getWidth(), token.getHeight() / imgSize.getHeight());
-      atArea.translate(
-          -footprintBounds.getX() - (int) ((footprintBounds.getWidth() - imgSize.getWidth()) / 2),
-          -footprintBounds.getY()
-              - (int) ((footprintBounds.getHeight() - imgSize.getHeight()) / 2));
-    } else {
-      atArea.scale(1 / token.getScaleX(), 1 / token.getScaleY());
-      atArea.translate(-footprintBounds.getX(), -footprintBounds.getY());
+    var transform =
+        TokenUtil.getRenderTransform(
+            zone, token, new Dimension(token.getWidth(), token.getHeight()), footprintBounds);
+    try {
+      transform.invert();
+    } catch (NoninvertibleTransformException e) {
+      // This shouldn't be possible unless something else is broken with the token.
+      log.error("Failed to invert token transform", e);
+      return new Area();
     }
 
-    if (token.getShape() == Token.TokenShape.TOP_DOWN && token.getFacingInDegrees() != 0) {
-      // Get the center of the token bounds
-      double rx = footprintBounds.getCenterX() - token.getAnchor().x;
-      double ry = footprintBounds.getCenterY() - token.getAnchor().y;
-
-      // Rotate the area to match the token facing
-      atArea.rotate(-Math.toRadians(token.getFacingInDegrees()), rx, ry);
-    }
-
-    return new Area(atArea.createTransformedShape(topologyUnderToken));
+    return new Area(transform.createTransformedShape(topologyUnderToken));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/TokenVBL.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/TokenVBL.java
@@ -200,7 +200,7 @@ public class TokenVBL {
   }
 
   public static Area transformTopology_toToken(Zone zone, Token token, Area topologyUnderToken) {
-    Rectangle footprintBounds = token.getBounds(zone);
+    Rectangle footprintBounds = token.getFootprintBounds(zone);
 
     // Reverse all token transformations so we can store a raw untransformed version on the Token.
     AffineTransform atArea = new AffineTransform();

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -630,7 +630,7 @@ public abstract class Grid implements Cloneable {
       // Test for gridless maps
       var cellShape = getCellShape();
       if (cellShape == null) {
-        double tokenBoundsWidth = token.getBounds(zone).getWidth() / 2;
+        double tokenBoundsWidth = token.getFootprintBounds(zone).getWidth() / 2;
         visionRange += (footprintWidth > tokenBoundsWidth) ? tokenBoundsWidth : tokenBoundsWidth;
       } else {
         // For grids, this will be the same, but for Hex's we'll use the smaller side depending on

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -899,7 +899,7 @@ public class Zone {
     }
 
     // Token is visible, and there is fog
-    Rectangle tokenSize = token.getBounds(this);
+    Rectangle tokenSize = token.getFootprintBounds(this);
     Area combined = new Area(exposedArea);
     PlayerView view = MapTool.getFrame().getZoneRenderer(this).getPlayerView();
     if (MapTool.getServerPolicy().isUseIndividualFOW() && getVisionType() != VisionType.OFF) {
@@ -934,7 +934,7 @@ public class Zone {
       return false;
     }
     // Token is visible, and there is fog
-    Rectangle tokenSize = token.getBounds(this);
+    Rectangle tokenSize = token.getFootprintBounds(this);
     Area tokenFootprint = getGrid().getTokenCellArea(tokenSize);
     Area combined = new Area(exposedArea);
     PlayerView view = MapTool.getFrame().getZoneRenderer(this).getPlayerView();
@@ -1967,7 +1967,9 @@ public class Zone {
   private int getFigureZOrder(Token t) {
 
     Rectangle b1 =
-        t.isSnapToScale() ? t.getFootprint(getGrid()).getBounds(getGrid()) : t.getBounds(getZone());
+        t.isSnapToScale()
+            ? t.getFootprint(getGrid()).getBounds(getGrid())
+            : t.getFootprintBounds(getZone());
     /*
      * This is an awful approximation of centre of token footprint. The bounding box (b1 & b2) are
      * usually centred on token x & y So token y + bounding y give you the bottom of the box Then


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5709

### Description of the Change

We now distinguish between a token's _footprint bounds_ and its _image bounds_. Pre-1.18, functionality was largely based on the _image bounds_, but in 1.18 several things now use the _footprint bounds_ that are less dependent on token layout. To make this difference apparent, `Token#getBounds(Zone)` is now `Token#getFootprintBounds(Zone)`, and the new `Token#getImageBounds(Zone)` gets the bounding box of the image. These two methods have a lot of shared logic, but I'm not prepared right now to try refactor them.

Although a lot of things now use the footprint bounds, there are a few things that need to continue using the image bounds as they did in 1.17 and earlier:
- Macro functions, so that macros written in 1.17 continue to work in 1.18. E.g., `movedOverPoints()` and `movedOverTokens()` won't detect the same cases without this fix.
- When transfering topology from the map to a token, the image bounds are needed to decide what topology is covered by the token. Also applies to `transferVBL()` and related macro functions.
- When exporting screenshot, to decide the bounding box of the map content to render.

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Fixed scaling and coverage for when transfering topology from the map to a token.
- Fixed `movedOverPoints()` and `movedOverTokens()` to use the full token bounds again instead of just the footprint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5714)
<!-- Reviewable:end -->
