### PR TITLE
Improve scrolling for states and bars

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -173,6 +173,13 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         });
   }
 
+  public void initStatesAndBarsPanel() {
+    var test = (JScrollPane) getComponent("statesAndBarsScrollPane");
+    // This number is a bit arbitrary, but importantly it is much bigger than the default of 1 pixel
+    // but still likely to be smaller than a single bar's height.
+    test.getVerticalScrollBar().setUnitIncrement(20);
+  }
+
   public void initTerrainModifierOperationComboBox() {
     getTerrainModifierOperationComboBox()
         .setModel(new DefaultComboBoxModel<>(TerrainModifierOperation.values()));

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -1067,11 +1067,9 @@ public class EditTokenDialog extends AbeillePanel<Token> {
       for (BarTokenOverlay bar : MapTool.getCampaign().getTokenBarsMap().values()) {
         JSlider slider = new JSlider(0, 100);
         JCheckBox hide = new JCheckBox(I18N.getString("EditTokenDialog.checkbox.state.hide"));
-        hide.putClientProperty("JSlider", slider);
         hide.addChangeListener(
             e -> {
-              JSlider js = (JSlider) ((JCheckBox) e.getSource()).getClientProperty("JSlider");
-              js.setEnabled(!((JCheckBox) e.getSource()).isSelected());
+              slider.setEnabled(!((JCheckBox) e.getSource()).isSelected());
             });
         slider.setName(bar.getName());
         slider.setPaintLabels(true);
@@ -1992,7 +1990,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         log.error("Error while loading multiline property editor theme", e);
       }
       JScrollPane localJScrollPane = new RTextScrollPane(j);
-      localJScrollPane.setVerticalScrollBarPolicy(22);
+      localJScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
       localJScrollPane.setAutoscrolls(true);
       localJScrollPane.setPreferredSize(new Dimension(300, 200));
       setBorder(BorderFactory.createEmptyBorder(10, 5, 5, 5));

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -1065,7 +1065,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
 
     /* Add sliders to the bar panel */
     var barsPanel = getBarsPanel();
-    barsPanel.setLayout(new MigLayout("wrap 1", "[fill,grow]"));
+    barsPanel.setLayout(new MigLayout("wrap 2,gapx 5%", "[fill,grow][fill,grow]"));
     barsPanel.removeAll();
     if (MapTool.getCampaign().getTokenBarsMap().isEmpty()) {
       barsPanel.setVisible(false);
@@ -1081,11 +1081,15 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         slider.setName(bar.getName());
         slider.setPaintLabels(true);
         slider.setPaintTicks(true);
-        slider.setMajorTickSpacing(20);
-        slider.createStandardLabels(20);
-        slider.setMajorTickSpacing(10);
+        slider.setMajorTickSpacing(25);
+        slider.setLabelTable(slider.createStandardLabels(50));
+        slider.setMinorTickSpacing(5);
 
-        JPanel tokenbarPanel = new JPanel(new MigLayout("wrap 2", "[fill,grow][fill,grow]"));
+        // Sliders by default have a fixed preferred size. Overriding it to zero will instead let
+        // MigLayout grow the slider to fill the space.
+        slider.setPreferredSize(new Dimension(0, 0));
+
+        JPanel tokenbarPanel = new JPanel(new MigLayout("wrap 2", "[fill][fill,grow]"));
         tokenbarPanel.add(new JLabel(bar.getName() + ":"));
         tokenbarPanel.add(slider, "span 1 2 align right");
         tokenbarPanel.add(hide);

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -552,7 +552,6 @@
                         <constraints>
                           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                         </constraints>
-                        <properties/>
                       </component>
                     </children>
                   </grid>
@@ -1113,6 +1112,7 @@
                 </constraints>
                 <properties>
                   <horizontalScrollBarPolicy value="31"/>
+                  <name value="statesAndBarsScrollPane"/>
                 </properties>
                 <border type="empty"/>
                 <children>


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5725

### Description of the Change

Increases the scroll speed of the States & Bars tab in the Edit Token dialog.

Also displays bars in two columns - as was done in 1.17 and earlier - in order to reduce the need for scrolling.

### Possible Drawbacks

The States & Bars tab could feel more cramped now that bars are presented more densely.

### Documentation Notes

N/A

### Release Notes

- Fix the scroll speed of the Edit Token dialog's States & Bars tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5726)
<!-- Reviewable:end -->
