### PR TITLE
Do not show token popup menu while dragging map

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -478,6 +478,8 @@ public class PointerTool extends DefaultTool {
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    final boolean isDraggingMap = isDraggingMap();
+
     super.mouseReleased(e);
 
     mouseButtonDown = false;
@@ -563,7 +565,7 @@ public class PointerTool extends DefaultTool {
     }
 
     // POPUP MENU
-    if (SwingUtilities.isRightMouseButton(e) && tokenDragOp == null && !isDraggingMap()) {
+    if (SwingUtilities.isRightMouseButton(e) && tokenDragOp == null && !isDraggingMap) {
       final var selectionModel = renderer.getSelectionModel();
       if (tokenUnderMouse != null && !selectionModel.isSelected(tokenUnderMouse.getId())) {
         if (!SwingUtil.isShiftDown(e)) {
@@ -585,7 +587,6 @@ public class PointerTool extends DefaultTool {
         return;
       }
     }
-    super.mouseReleased(e);
   }
 
   // //

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -377,6 +377,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
 
   @Override
   public void mouseReleased(MouseEvent e) {
+    final boolean isDraggingMap = isDraggingMap();
+
     super.mouseReleased(e);
 
     if (isShowingTokenStackPopup) {
@@ -446,7 +448,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
       return;
     }
     // POPUP MENU
-    if (SwingUtilities.isRightMouseButton(e) && tokenDragOp == null && !isDraggingMap()) {
+    if (SwingUtilities.isRightMouseButton(e) && tokenDragOp == null && !isDraggingMap) {
       final var selectionModel = renderer.getSelectionModel();
       if (tokenUnderMouse != null && !selectionModel.isSelected(tokenUnderMouse.getId())) {
         if (!SwingUtil.isShiftDown(e)) {
@@ -469,7 +471,6 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         return;
       }
     }
-    super.mouseReleased(e);
   }
 
   // //


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5738

### Description of the Change

For `PointerTool` and `StampTool`, when releasing the right mouse button, we now grab the current drag state before it can possibly be cleared by `DefaultTool`. This stops us from "forgetting" that the user was just dragging the map.

Also removed the redundant `super.mouseReleased()` calls at the end of the methods.

_Note: `PointerTool` and `StampTool` really need to be refactored to separate user actions, but that is beyond this humble bugfix PR._

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the token popup menu would show if dragging the map with the cursor over a token.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5749)
<!-- Reviewable:end -->
