### PR TITLE
1.18 - Fix getSelected() stale results

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -108,7 +108,6 @@ public class ZoneViewModel {
   private final Rectangle2D viewport = new Rectangle2D.Double();
   private Area visibleArea = new Area();
 
-  private final List<Token> selectedTokenList = new ArrayList<>();
   private final Set<GUID> movingTokens = new HashSet<>();
 
   private final Map<GUID, TokenPosition> tokenPositions = new HashMap<>();
@@ -222,7 +221,14 @@ public class ZoneViewModel {
   }
 
   public List<Token> getSelectedTokenList() {
-    return Collections.unmodifiableList(selectedTokenList);
+    var tokens = new ArrayList<Token>();
+    for (GUID g : selectionModel.getSelectedTokenIds()) {
+      final var token = zone.getToken(g);
+      if (token != null) {
+        tokens.add(token);
+      }
+    }
+    return tokens;
   }
 
   public Set<GUID> getVisibleTokens(Zone.Layer layer) {
@@ -252,7 +258,6 @@ public class ZoneViewModel {
     updateViewport();
     updatePlayerView();
     updateVisibleArea();
-    updateSelectedTokensList();
     updateMovingTokens();
     updateTokenPositions();
     updateMarkerPositions();
@@ -343,18 +348,6 @@ public class ZoneViewModel {
   /** Updates {@link #visibleArea} based on {@link #playerView}. */
   private void updateVisibleArea() {
     visibleArea = zoneView.getVisibleArea(playerView);
-  }
-
-  /** Updates {@link #selectedTokenList}. */
-  private void updateSelectedTokensList() {
-    selectedTokenList.clear();
-
-    for (GUID g : selectionModel.getSelectedTokenIds()) {
-      final var token = zone.getToken(g);
-      if (token != null) {
-        selectedTokenList.add(token);
-      }
-    }
   }
 
   /** Updates {@link #playerView}. */


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5745

### Description of the Change

Changes `ZoneViewModel#getSelectedTokenList()` to behave like 1.17's `ZoneRenderer#getSelectedTokensList()`, which resolves the `Token` objects on demand rather than caching it somewhere.

This fixes the issue since a render is not required for `getSelected()` to be updated.

### Possible Drawbacks

Slight reduction in `getSelected()` performance and similar, and corresponding increase in memory allocation.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where `getSelected()` would have out-of-date results when called from `onChangeSelection`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5757)
<!-- Reviewable:end -->
