### PR TITLE
Remove redundant application of token opacity

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1815,11 +1815,9 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       // Render Halo
       haloRenderer.renderHalo(tokenG, token, position);
 
-      // Calculate alpha Transparency from token and use opacity to indicate that token is moving
-      float opacity = token.getTokenOpacity();
-      if (viewModel.isTokenMoving(token.getId())) {
-        opacity = opacity / 2.0f;
-      }
+      // Use opacity to indicate that token is moving
+      float opacity = viewModel.isTokenMoving(token.getId()) ? 0.5f : 1f;
+
       // Finally render the token image
       timer.start("token-list-7");
       // Clipping is handled in the isTokenInNeedOfClipping() call far above.

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/TokenRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/TokenRenderer.java
@@ -47,7 +47,7 @@ public class TokenRenderer {
     this.zone = zone;
   }
 
-  public void renderToken(Token token, TokenPosition position, Graphics2D g2d, float opacity) {
+  public void renderToken(Token token, TokenPosition position, Graphics2D g2d, float extraOpacity) {
     var timer = CodeTimer.get();
     timer.increment("TokenRenderer-renderToken");
     timer.start("TokenRenderer-renderToken");
@@ -60,7 +60,7 @@ public class TokenRenderer {
 
     timer.start("TokenRenderer-paintTokenImage");
     renderHelper.render(
-        g2d, worldG -> paintTokenImage(worldG, position, opacity * token.getTokenOpacity()));
+        g2d, worldG -> paintTokenImage(worldG, position, extraOpacity * token.getTokenOpacity()));
     timer.stop("TokenRenderer-paintTokenImage");
     timer.stop("TokenRenderer-renderToken");
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5761

### Description of the Change

`TokenRenderer` applies the token opacity, so callers do not need to pass it in. They should only pass additional opacity, such as that used to indicate a dragged token.


### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where tokens would be more transparent than they should be.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5765)
<!-- Reviewable:end -->
