### PR TITLE
Drawing/Template Pointer Tool fixes for 1.19

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
@@ -1324,7 +1324,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
 
             // Server drawing update
             MapTool.serverCommand().updateDrawing(zone.getId(), deOriginal.getPen(), deOriginal);
-            renderer.getZone().addDrawable(deOriginal.getPen(), deOriginal.getDrawable());
+            renderer.getZone().updateDrawable(deOriginal, deOriginal.getPen());
           }
         }
       } // end for

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1416,6 +1416,7 @@ public class Zone {
     final var elementList = drawablesByLayer.get(drawnElement.getDrawable().getLayer());
     for (DrawnElement de : elementList) {
       if (de.getDrawable().getId().equals(drawnElement.getDrawable().getId())) {
+        de.setDrawable(drawnElement.getDrawable());
         de.setPen(new Pen(pen));
         break;
       }

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1678,7 +1678,7 @@ public class Zone {
 
   private DrawnElement findDrawnElement(List<DrawnElement> list, GUID id) {
     for (DrawnElement de : list) {
-      if (de.getDrawable().getId() == id) {
+      if (de.getDrawable().getId().equals(id)) {
         return de;
       }
       if (de.getDrawable() instanceof DrawablesGroup) {

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawnElement.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawnElement.java
@@ -35,6 +35,10 @@ public class DrawnElement {
     return drawable;
   }
 
+  public void setDrawable(Drawable drawable) {
+    this.drawable = drawable;
+  }
+
   public Pen getPen() {
     return pen;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5766

### Description of the Change
1. updateDrawable() now updates the drawable as well as the pen.
2. change to id compare approach in findDrawables() from using == to equals as the above change meant sometimes templates selected using a mouse click were not 'found' using the == approach.

### Possible Drawbacks
None foreseen

### Documentation Notes
None 

### Release Notes
Fix for 1.19 Drawing/Template Pointer Tool

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5767)
<!-- Reviewable:end -->
