### PR TITLE
1.18 - Fix HTML5 cachelib=false

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLContent.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLContent.java
@@ -141,9 +141,8 @@ public class HTMLContent {
       document.outputSettings().charset(StandardCharsets.US_ASCII);
     }
 
-    public HtmlDocumentContent(
-        String str, boolean isJavaBridgeInjected, boolean isBaseUrlInjected) {
-      this(Jsoup.parse(str), isJavaBridgeInjected, isBaseUrlInjected);
+    public HtmlDocumentContent(String str) {
+      this(Jsoup.parse(str), false, false);
     }
 
     public String str() {
@@ -176,7 +175,7 @@ public class HTMLContent {
    * @return an HTMLContent object
    */
   public static HTMLContent htmlFromString(@Nonnull String html) {
-    return new HTMLContent(new HtmlDocumentContent(html, false, false));
+    return new HTMLContent(new HtmlDocumentContent(html));
   }
 
   /**
@@ -333,7 +332,7 @@ public class HTMLContent {
           var assetType = Asset.Type.fromMediaType(mediaType);
 
           if (assetType == Asset.Type.HTML) {
-            return new HTMLContent(new HtmlDocumentContent(html, false, false));
+            return new HTMLContent(new HtmlDocumentContent(html));
           }
           return new HTMLContent(new StringContent(html));
         }
@@ -343,7 +342,7 @@ public class HTMLContent {
       if (asset != null) {
         if (asset.isStringAsset()) {
           if (asset.getType() == Asset.Type.HTML) {
-            return new HTMLContent(new HtmlDocumentContent(asset.getDataAsString(), false, false));
+            return new HTMLContent(new HtmlDocumentContent(asset.getDataAsString()));
           }
           return new HTMLContent(new StringContent(asset.getDataAsString()));
         } else {

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLContent.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLContent.java
@@ -142,7 +142,7 @@ public class HTMLContent {
     }
 
     public HtmlDocumentContent(String str) {
-      this(Jsoup.parse(str), false, false);
+      this(Jsoup.parse(HTMLPanelInterface.fixHTML(str)), false, false);
     }
 
     public String str() {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5755

### Description of the Change

Modifies `HTMLContent` to apply `HTMLPanelInterface.fixHTML(...)` as was done for HTML5 content in 1.17 and earlier.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where `cachelib=false` would have no effect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5771)
<!-- Reviewable:end -->
