### PR TITLE
1.18 - Fix "Visible over FoW" setting for stamps

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1782,10 +1782,12 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       if (isTokenInNeedOfClipping(token, position.transformedBounds(), isGMView)) {
         tokenG = (Graphics2D) clippedG.create();
         if (token.getShape() == Token.TokenShape.FIGURE || token.isAlwaysVisible()) {
+          Area cellVisibleArea = new Area(visibleScreenArea);
           Area cb =
               zone.getGrid()
                   .getTokenCellArea(zoneScale.toScreenSpace(position.transformedBounds()));
-          tokenG.clip(cb);
+          cellVisibleArea.intersect(cb);
+          tokenG.clip(cellVisibleArea);
         }
       } else {
         tokenG = (Graphics2D) g.create();


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5762

### Description of the Change

For Object or Background stamps that have "Visible over FoW" set, the token has to be clipped to the visible area. On the token layer, this happens naturally because of the clip set on `clippedG`, but for other layers that clipping is not set. This PR adjusts the clipping logic for "Visible over FoW" stamps (and figures, too) to follow the logic in 1.17 which explicitly intsersects the new clipping region with the visible area.

> [!NOTE]
> I _believe_ a better change would be to adjust `clippedG` so it is clipped regardless of layer. That would be cleaner and more performant with complex fog of war. But I don't want to introduce potential knock-on effects into 1.18, so I'll instead look into making such a change for 1.19 or later.

For comparison, this is 1.18.3 behaviour for a bunch of "Visible over FoW" Objects:
<img width="535" height="381" alt="image" src="https://github.com/user-attachments/assets/45059eab-e709-40f0-be66-f1e55290be30" />

After this fix:
<img width="545" height="396" alt="image" src="https://github.com/user-attachments/assets/cffca7c9-aef3-492b-a2ad-2c4736d141a9" />

And on 1.17:
<img width="544" height="391" alt="image" src="https://github.com/user-attachments/assets/62a92040-2d3e-4f21-990b-da1371129de1" />


### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where "Visible over FoW" stamps would be shown to players even when covered by hard FoW.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5776)
<!-- Reviewable:end -->
