### PR TITLE
Removes two unused methods from JSONMacroFunctions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/json/JSONMacroFunctions.java
@@ -624,24 +624,6 @@ public class JSONMacroFunctions extends AbstractFunction {
   }
 
   /**
-   * Returns the parameter list as a list of {@link JsonArray}s.
-   *
-   * @param functionName The name of the MT Script function that was called.
-   * @param params The parameters to extract as {@link JsonArray}s.
-   * @return The list of {@link JsonArray}s.
-   * @throws ParserException if the parameters can not be converted to {@link JsonArray}s.
-   */
-  private List<JsonArray> paramsAsJsonArrays(String functionName, List<Object> params)
-      throws ParserException {
-    List<JsonArray> arrays = new ArrayList<>();
-    for (int i = 0; i < params.size(); i++) {
-      arrays.add(FunctionUtil.paramAsJsonArray(functionName, params, i));
-    }
-
-    return arrays;
-  }
-
-  /**
    * Returns the parameter list as a list of {@link JsonArray}s. If the parameter is not a json
    * object/array and is an empty string it will result in a 0 sized JsonArray, otherwise the value
    * will result in a JsonArray containing that value.
@@ -677,24 +659,6 @@ public class JSONMacroFunctions extends AbstractFunction {
     }
 
     return objects;
-  }
-
-  /**
-   * Returns the parameter list as a list of {@link JsonElement}s.
-   *
-   * @param functionName The name of the MT Script function that was called.
-   * @param params The parameters to extract as {@link JsonElement}s.
-   * @return The list of {@link JsonElement}s.
-   * @throws ParserException if the parameters can not be converted to {@link JsonElement}s.
-   */
-  private List<JsonElement> paramsAsJsonElements(String functionName, List<Object> params)
-      throws ParserException {
-    List<JsonElement> elements = new ArrayList<>();
-    for (int i = 0; i < params.size(); i++) {
-      elements.add(FunctionUtil.paramAsJson(functionName, params, i));
-    }
-
-    return elements;
   }
 
   /**


### PR DESCRIPTION
Fixes #5777

### Requirements for Contributing a Bug Fix or Enhancement
* Fill out the template below. Any pull request that does not include enough information to be reviewed in timely manner will result in a request for you to update the pull request 
  and possibly closure of the pull request if it is not provided after this request.
* After you create the pull request, all status checks must pass before a maintainer will review your contribution. 


### Identify the Bug or Feature request

fixes #5777 


### Description of the Change

Removed the two unused methods.


### Possible Drawbacks

None that I can think of.

### Documentation Notes

N/A

### Release Notes

- Removed the two unused methods `paramsAsJsonElements` and `paramsAsJsonArrays` from 
`JSONMacroFunctions` class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5778)
<!-- Reviewable:end -->
