### PR TITLE
1.18 - Remove LibGDX renderer and other minor fixes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/DeveloperOptions.java
+++ b/src/main/java/net/rptools/maptool/client/DeveloperOptions.java
@@ -55,12 +55,6 @@ public class DeveloperOptions {
             "Preferences.developer.debugTokenDragging.label",
             "Preferences.developer.debugTokenDragging.tooltip",
             false);
-    public static final Preference<Boolean> EnableLibGdxRendererToggleButton =
-        store.defineBoolean(
-            "enableLibGDXRendererToggleButton",
-            "Preferences.developer.enableLibGDXRendererToggleButton.label",
-            "Preferences.developer.enableLibGDXRendererToggleButton.tooltip",
-            false);
 
     public static List<Preference<Boolean>> getOptions() {
       return store.getDefinedPreferences().stream()

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -14,13 +14,10 @@
  */
 package net.rptools.maptool.client.ui;
 
-import com.badlogic.gdx.backends.jogamp.JoglAwtApplicationConfiguration;
-import com.badlogic.gdx.backends.jogamp.JoglSwingCanvas;
 import com.google.common.eventbus.Subscribe;
 import com.jidesoft.docking.DefaultDockableHolder;
 import com.jidesoft.docking.DockableFrame;
 import com.jidesoft.docking.DockingManager;
-import com.jogamp.opengl.awt.GLJPanel;
 import java.awt.*;
 import java.awt.event.*;
 import java.awt.image.BufferedImage;
@@ -96,7 +93,6 @@ import net.rptools.maptool.client.ui.tokenpanel.TokenPanelTreeModel;
 import net.rptools.maptool.client.ui.zone.PointerOverlay;
 import net.rptools.maptool.client.ui.zone.PointerToolOverlay;
 import net.rptools.maptool.client.ui.zone.ZoneMiniMapPanel;
-import net.rptools.maptool.client.ui.zone.gdx.GdxRenderer;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
@@ -158,8 +154,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
   /** Contains the zoneRenderer, as well as all overlays. */
   private final JPanel zoneRendererPanel;
-
-  private GLJPanel gdxPanel;
 
   private JPanel currentRenderPanel;
 
@@ -416,11 +410,9 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     zoneRendererPanel = new JPanel(new PositionalLayout(5));
     zoneRendererPanel.setBackground(Color.black);
     currentRenderPanel = zoneRendererPanel;
-    initGdx();
 
     zoneRendererPanel.add(getChatTypingPanel(), PositionalLayout.Position.NW);
     zoneRendererPanel.add(getChatActionLabel(), PositionalLayout.Position.SW);
-    zoneRendererPanel.add(gdxPanel, PositionalLayout.Position.CENTER);
 
     commandPanel = new CommandPanel();
 
@@ -470,37 +462,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     chatTyperTimers = new ChatNotificationTimers();
     chatTimer = getChatTimer();
     setChatTypingLabelColor(AppPreferences.chatNotificationColor.get());
-  }
-
-  private void initGdx() {
-    var config = new JoglAwtApplicationConfiguration();
-    // config.foregroundFPS = 300;
-    // config.backgroundFPS = 10;
-    // config.title = "maptool";
-    // config.width = 640;
-    // config.height = 480;
-    // config.samples = 1;
-    // var config = new LwjglApplicationConfiguration();
-    config.foregroundFPS = 10000;
-    config.vSyncEnabled = false;
-
-    var joglSwingCanvas = new JoglSwingCanvas(GdxRenderer.getInstance(), config);
-    // var joglSwingCanvas = new LwjglAWTCanvas(GdxRenderer.getInstance(), config);
-
-    gdxPanel = joglSwingCanvas.getGLCanvas();
-    gdxPanel.setVisible(false);
-    gdxPanel.setOpaque(false);
-    // gdxPanel.setLayout(new PositionalLayout(5));
-  }
-
-  public void switchRenderers() {
-    var isVisible = gdxPanel.isVisible();
-    gdxPanel.setVisible(!isVisible);
-    // currentRenderer.setVisible(isVisible);
-  }
-
-  public GLJPanel getGdxPanel() {
-    return gdxPanel;
   }
 
   public ChatNotificationTimers getChatNotificationTimers() {

--- a/src/main/java/net/rptools/maptool/client/ui/ToolbarPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ToolbarPanel.java
@@ -18,7 +18,6 @@ import java.awt.*;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import javax.swing.*;
-import net.rptools.maptool.client.DeveloperOptions;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.MediaPlayerAdapter;
 import net.rptools.maptool.client.swing.SwingUtil;
@@ -166,8 +165,6 @@ public class ToolbarPanel extends JToolBar {
 
     tokenSelectionButtonAll.setSelected(true);
     // Jamz: End panel
-
-    add(createGdxButton(Icons.TOOLBAR_LIBGDX));
 
     // the "Select Map" button
     mapselect = createZoneSelectionButton();
@@ -537,20 +534,6 @@ public class ToolbarPanel extends JToolBar {
     if (MediaPlayerAdapter.getGlobalMute()) {
       button.doClick();
     }
-
-    return button;
-  }
-
-  private JToggleButton createGdxButton(final Icons icon) {
-    final JToggleButton button = new JToggleButton();
-    button.addActionListener(
-        e -> {
-          MapTool.getFrame().switchRenderers();
-        });
-
-    button.setIcon(RessourceManager.getBigIcon(icon));
-    button.setVisible(DeveloperOptions.Toggle.EnableLibGdxRendererToggleButton.get());
-    DeveloperOptions.Toggle.EnableLibGdxRendererToggleButton.onChange(button::setVisible);
 
     return button;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -270,7 +270,7 @@ public class ZoneViewModel {
 
   /** Updates {@link #isUsingGdxRenderer}. */
   private void updateIsUsingGdxRenderer() {
-    isUsingGdxRenderer = MapTool.getFrame().getGdxPanel().isVisible();
+    isUsingGdxRenderer = false;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
@@ -95,7 +95,7 @@ public class FogRenderer {
     worldG.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC, view.isGMView() ? .6f : 1f));
     var bounds = originalClip.getBounds();
     worldG.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
-    timer.start("renderFog-hardFow");
+    timer.stop("renderFog-hardFow");
 
     timer.start("renderFog-softFow");
     if (!softFogArea.isEmpty()) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -714,7 +714,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         timer -> {
           timer.setThreshold(10);
 
-          if (!MapTool.getFrame().getGdxPanel().isVisible()) {
+          if (!viewModel.isUsingGdxRenderer()) {
             timer.start("paintComponent");
             Graphics2D g2d = (Graphics2D) g;
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
@@ -68,19 +68,22 @@ public class FacingArrowRenderer {
     var tokenShape = token.getShape();
 
     timer.start("FacingArrowRenderer-preCheck");
-    if (!token.hasFacing()) {
-      return;
-    }
-    final var forceFacing = AppPreferences.forceFacingArrow.get();
-    if (!forceFacing) {
-      if (TokenShape.TOP_DOWN.equals(tokenShape)) {
+    try {
+      if (!token.hasFacing()) {
         return;
       }
-      if (TokenShape.FIGURE.equals(tokenShape) && token.getHasImageTable()) {
-        return;
+      final var forceFacing = AppPreferences.forceFacingArrow.get();
+      if (!forceFacing) {
+        if (TokenShape.TOP_DOWN.equals(tokenShape)) {
+          return;
+        }
+        if (TokenShape.FIGURE.equals(tokenShape) && token.getHasImageTable()) {
+          return;
+        }
       }
+    } finally {
+      timer.stop("FacingArrowRenderer-preCheck");
     }
-    timer.stop("FacingArrowRenderer-preCheck");
 
     timer.start("FacingArrowRenderer-render");
     renderHelper.render(


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5780

### Description of the Change

This removes the LibGDX renderer, which contributes a couple of apparent problems:
1. Continual rerendering.
2. Continual memory allocations (occurs even if LibGDX renderer is not added to the frame).

On the minor side:
- Fixes a couple of timers
- Fixes the check in `ZoneRenderer` for whether the LibGDX renderer is in use.

### Possible Drawbacks

No more LibGDX renderer for 1.18 :disappointed: 

### Documentation Notes

N/A

### Release Notes

- Fixed some issues with continual rerendering and increasing memory usage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5781)
<!-- Reviewable:end -->
