### PR TITLE
Add "no statsheet" option

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -475,9 +475,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     var combo = getStatSheetComboBox();
     combo.removeAllItems();
     var ssManager = new StatSheetManager();
-    ssManager.getStatSheets(propertyType).stream()
-        .sorted(Comparator.comparing(StatSheet::description))
-        .forEach(ss -> combo.addItem(ss));
+    ssManager.getOrderedStatSheets(propertyType).forEach(ss -> combo.addItem(ss));
     var statSheetProperty = tokenTypeStatSheetMap.get(propertyType);
     String id;
     if (statSheetProperty == null) {

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -446,7 +446,6 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
                 getTypeDuplicateButton().setEnabled(false);
                 getTokenTypeName().setEditable(false);
                 getStatSheetComboBox().setEnabled(false);
-                getStatSheetLocationComboBox().setEnabled(false);
                 getTypeSetAsDefault().setEnabled(false);
               } else {
                 bind((String) getTokenTypeList().getSelectedValue());
@@ -460,7 +459,6 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
                   getTypeDeleteButton().setEnabled(true);
                 }
                 getStatSheetComboBox().setEnabled(true);
-                getStatSheetLocationComboBox().setEnabled(true);
                 populateStatSheetComboBoxes(propertyType);
                 if (!propertyType.equals(defaultPropertyType)) {
                   getTypeSetAsDefault().setEnabled(true);
@@ -485,16 +483,11 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     if (statSheetProperty == null) {
       id = ssManager.getDefaultStatSheetId();
       tokenTypeStatSheetMap.put(
-          propertyType,
-          new StatSheetProperties(
-              ssManager.getDefaultStatSheetId(), StatSheetLocation.BOTTOM_LEFT));
+          propertyType, new StatSheetProperties(ssManager.getDefaultStatSheetId(), null));
     } else {
       id = statSheetProperty.id();
     }
     combo.setSelectedItem(ssManager.getStatSheet(id));
-
-    var locationCombo = getStatSheetLocationComboBox();
-    locationCombo.setSelectedItem(tokenTypeStatSheetMap.get(propertyType).location());
   }
 
   public void initStatSheetDetails() {
@@ -516,10 +509,11 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     var combo = getStatSheetComboBox();
     combo.setEnabled(false);
     combo.setRenderer(new StatSheetComboBoxRenderer());
+    final var ssManager = new StatSheetManager();
     combo.addActionListener(
         l -> {
+          var ss = (StatSheet) combo.getSelectedItem();
           if (getStatSheetComboBox().hasFocus()) { // Only if user has made change
-            var ss = (StatSheet) combo.getSelectedItem();
             var tokenType = (String) getTokenTypeList().getSelectedValue();
             if (ss != null && tokenType != null) {
               var id = new StatSheetManager().getId(ss);
@@ -527,6 +521,12 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
               tokenTypeStatSheetMap.put(tokenType, new StatSheetProperties(id, location));
               getStatSheetLocationComboBox().setSelectedItem(location);
             }
+          }
+          if (ssManager.isLocationUserSettable(ss)) {
+            getStatSheetLocationComboBox().setEnabled(true);
+          } else {
+            getStatSheetLocationComboBox().setEnabled(false);
+            getStatSheetLocationComboBox().setSelectedItem(null);
           }
         });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
+++ b/src/main/java/net/rptools/maptool/client/ui/sheet/stats/StatSheetListener.java
@@ -42,14 +42,17 @@ public class StatSheetListener {
     if (AppPreferences.showStatSheet.get()
         && AppPreferences.showStatSheetRequiresModifierKey.get() == event.shiftDown()) {
       var ssManager = new StatSheetManager();
-      if (statSheet == null && !ssManager.isLegacyStatSheet(event.token().getStatSheet())) {
+      var ssProperties = event.token().getStatSheet();
+      if (ssManager.isNoStatSheet(ssProperties)) {
+        return; // No stat sheet to show
+      }
+      if (statSheet == null && !ssManager.isLegacyStatSheet(ssProperties)) {
         /*
          * We have to hide the control panel as we don't know how big the stat sheet is going
          * to be, and we don't want to obscure it.
          */
         MapTool.getFrame().hideControlPanel();
         statSheet = new StatSheet();
-        var ssProperties = event.token().getStatSheet();
         var ssId = ssProperties.id();
         var ssRecord = ssManager.getStatSheet(ssId);
         var token = event.token();

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
@@ -20,7 +20,6 @@ import java.awt.Toolkit;
 import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Set;
 import javax.swing.*;
 import net.rptools.lib.AwtUtil;
@@ -235,9 +234,7 @@ public class NewTokenDialog extends AbeillePanel<Token> {
       var defaultSS =
           new StatSheet(null, I18N.getText("token.statSheet.useDefault"), null, Set.of(), null);
       combo.addItem(defaultSS);
-      ssManager.getStatSheets(propertyType).stream()
-          .sorted(Comparator.comparing(StatSheet::description))
-          .forEach(ss -> combo.addItem(ss));
+      ssManager.getOrderedStatSheets(propertyType).forEach(ss -> combo.addItem(ss));
       combo.setSelectedItem(defaultSS);
 
       combo.setEnabled(true);
@@ -247,14 +244,12 @@ public class NewTokenDialog extends AbeillePanel<Token> {
     } else {
       var ss =
           MapTool.getCampaign().getCampaignProperties().getTokenTypeDefaultStatSheet(propertyType);
-      boolean isLegacy = ssManager.isLegacyStatSheet(statSheet);
-      boolean isDefault = statSheet.name() == null && statSheet.namespace() == null;
-      if (isLegacy || isDefault) {
-        locationCombo.setEnabled(false);
-        locationCombo.setSelectedItem(null);
-      } else {
+      if (ssManager.isLocationUserSettable(statSheet)) {
         locationCombo.setEnabled(true);
         locationCombo.setSelectedItem(ss.location());
+      } else {
+        locationCombo.setEnabled(false);
+        locationCombo.setSelectedItem(null);
       }
     }
   }
@@ -276,28 +271,6 @@ public class NewTokenDialog extends AbeillePanel<Token> {
     populateStatSheetComboBoxes((String) getPropertyTypeComboBox().getSelectedItem(), null);
   }
 
-  // /**
-  // * Update the token to match the state of the dialog
-  // */
-  // public void updateToken() {
-  //
-  // token.setName(getNameTextField().getText());
-  // token.setGMName(getGMNameTextField().getText());
-  // if (getNPCTypeRadio().isSelected()) {
-  // token.setType(Token.Type.NPC);
-  // }
-  // if (getPCTypeRadio().isSelected()) {
-  // token.setType(Token.Type.PC);
-  // }
-  // if (getMarkerTypeRadio().isSelected()) {
-  // token.setType(Token.Type.NPC);
-  // token.setLayer(Zone.Layer.OBJECT);
-  // token.setGMNote("Marker"); // In order for it to be recognized as a marker, it needs something
-  // in the notes field
-  // token.setVisible(false);
-  // }
-  // }
-  //
   /**
    * Get and icon from the asset manager and scale it properly.
    *

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -156,12 +156,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         l -> {
           var sheet = (StatSheet) sheetCombo.getSelectedItem();
           var ssManager = new StatSheetManager();
-          boolean usingDefault =
-              sheet != null && (sheet.name() == null && sheet.namespace() == null);
-          if (sheet == null || ssManager.isLegacyStatSheet(sheet) || usingDefault) {
-            locationCombo.setEnabled(false);
-            locationCombo.setSelectedItem(null);
-          } else {
+          if (ssManager.isLocationUserSettable(sheet)) {
             locationCombo.setEnabled(true);
             var tokenSheet = getModel().getStatSheet();
             if (tokenSheet != null) {
@@ -171,6 +166,9 @@ public class EditTokenDialog extends AbeillePanel<Token> {
                   MapTool.getCampaign().getTokenTypeDefaultSheetId(getModel().getPropertyType());
               locationCombo.setSelectedItem(sheetProp.location());
             }
+          } else {
+            locationCombo.setEnabled(false);
+            locationCombo.setSelectedItem(null);
           }
         });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -262,9 +262,7 @@ public class EditTokenDialog extends AbeillePanel<Token> {
         new StatSheet(null, I18N.getText("token.statSheet.useDefault"), null, Set.of(), null);
     combo.addItem(defaultSS);
     var ssManager = new StatSheetManager();
-    ssManager.getStatSheets(token.getPropertyType()).stream()
-        .sorted(Comparator.comparing(StatSheet::description))
-        .forEach(ss -> combo.addItem(ss));
+    ssManager.getOrderedStatSheets(token.getPropertyType()).forEach(ss -> combo.addItem(ss));
     if (token.usingDefaultStatSheet()) {
       combo.setSelectedItem(defaultSS);
     } else {

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
@@ -34,6 +34,12 @@ public class StatSheetManager {
   /** The namespace of the legacy stat sheet. */
   private static final String LEGACY_STATSHEET_NAMESPACE = "net.rptools.maptool";
 
+  /** The namespace used for no stat sheet. */
+  private static final String NO_STATSHEET_NAMESPACE = "net.rptools.maptool";
+
+  /** The name used for no stat sheet. */
+  private static final String NO_STATSHEET_NAME = "no-statsheet";
+
   /** The id of the legacy stat sheet. */
   public static final String LEGACY_STATSHEET_ID =
       LEGACY_STATSHEET_NAMESPACE + "." + LEGACY_STATSHEET_NAME;
@@ -47,12 +53,21 @@ public class StatSheetManager {
           Set.of(),
           LEGACY_STATSHEET_NAMESPACE);
 
+  public static final StatSheet NO_STATSHEET =
+      new StatSheet(
+          NO_STATSHEET_NAME,
+          I18N.getText("token.statSheet.noStatSheetDescription"),
+          null,
+          Set.of(),
+          NO_STATSHEET_NAMESPACE);
+
   /** The stat sheets that are available to the system. */
   private static final Map<StatSheet, String> statSheets = new ConcurrentHashMap<>();
 
-  /** adds the legacy stat sheet to the list of stat sheets. */
+  /** Adds the legacy and "no" stat sheet to the list of stat sheets. */
   static {
     statSheets.put(LEGACY_STATSHEET, "");
+    statSheets.put(NO_STATSHEET, "");
   }
 
   /**
@@ -71,6 +86,24 @@ public class StatSheetManager {
    */
   public String getDefaultStatSheetId() {
     return getId(LEGACY_STATSHEET);
+  }
+
+  /**
+   * Returns the "no" stat sheet.
+   *
+   * @return the "no" stat sheet.
+   */
+  public StatSheet getNoStatSheet() {
+    return NO_STATSHEET;
+  }
+
+  /**
+   * Returns the id of the "no" stat sheet.
+   *
+   * @return the id of the "no" stat sheet.
+   */
+  public String getNoStatSheetId() {
+    return getId(NO_STATSHEET);
   }
 
   /**
@@ -103,6 +136,49 @@ public class StatSheetManager {
    */
   public boolean isLegacyStatSheet(StatSheet statSheet) {
     return statSheet == null || LEGACY_STATSHEET.equals(statSheet);
+  }
+
+  /**
+   * Returns true if the stat sheet is the "no" stat sheet.
+   *
+   * @param sheet the stat sheet to check.
+   * @return true if the stat sheet is the "no" stat sheet.
+   */
+  public boolean isNoStatSheet(StatSheetProperties sheet) {
+    return isNoStatSheet(getStatSheet(sheet.id()));
+  }
+
+  /**
+   * Returns true if the stat sheet is the "no" stat sheet.
+   *
+   * @param statSheet the stat sheet to check.
+   * @return true if the stat sheet is the "no" stat sheet.
+   */
+  public boolean isNoStatSheet(StatSheet statSheet) {
+    return NO_STATSHEET.equals(statSheet);
+  }
+
+  /**
+   * Returns true if the location of the stat sheet can be set by the user.
+   *
+   * @param sheet the stat sheet to check.
+   * @return true if the location of the stat sheet can be set by the user.
+   */
+  public boolean isLocationUserSettable(StatSheet sheet) {
+    return sheet != null
+        && !isLegacyStatSheet(sheet)
+        && !isNoStatSheet(sheet)
+        && sheet.namespace() != null;
+  }
+
+  /**
+   * Returns true if the location of the stat sheet can be set by the user.
+   *
+   * @param sheet the stat sheet to check.
+   * @return true if the location of the stat sheet can be set by the user.
+   */
+  public boolean isLocationUserSettable(StatSheetProperties sheet) {
+    return isLocationUserSettable(getStatSheet(sheet.id()));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
@@ -15,8 +15,11 @@
 package net.rptools.maptool.model.sheet.stats;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import net.rptools.maptool.language.I18N;
@@ -60,6 +63,9 @@ public class StatSheetManager {
           null,
           Set.of(),
           NO_STATSHEET_NAMESPACE);
+
+  /** The internal stat sheets that are always available. */
+  private static final Set<StatSheet> internalStatSheets = Set.of(LEGACY_STATSHEET, NO_STATSHEET);
 
   /** The stat sheets that are available to the system. */
   private static final Map<StatSheet, String> statSheets = new ConcurrentHashMap<>();
@@ -219,6 +225,20 @@ public class StatSheetManager {
   }
 
   /**
+   * Returns the stat sheets ordered by internal vs non-internal and then alphabetically by
+   * description.
+   *
+   * @param propertyType the property type of the stat sheet.
+   * @return the id of the stat sheet.
+   */
+  public SortedSet<StatSheet> getOrderedStatSheets(String propertyType) {
+    TreeSet<StatSheet> sheets =
+        new TreeSet<StatSheet>((s1, s2) -> StatSheetManager.compareStatSheets(s1, s2));
+    sheets.addAll(getStatSheets(propertyType));
+    return sheets;
+  }
+
+  /**
    * Returns the id of the stat sheet.
    *
    * @param statSheet the stat sheet.
@@ -290,5 +310,31 @@ public class StatSheetManager {
    */
   public String getId(StatSheet ss) {
     return getId(ss.namespace(), ss.name());
+  }
+
+  /**
+   * Compares two stat sheets. Internal stat sheets (null, legacy, and no stat sheet) come before
+   * non-internal stat sheets. Among internal stat sheets, null (default) comes first, then legacy,
+   * then no stat sheet. Non-internal stat sheets are sorted alphabetically by description.
+   *
+   * @param ss1 the first stat sheet.
+   * @param ss2 the second stat sheet.
+   * @return a negative integer, zero, or a positive integer as the first argument is less than,
+   *     equal to, or greater than the second.
+   */
+  private static int compareStatSheets(StatSheet ss1, StatSheet ss2) {
+    if (internalStatSheets.contains(ss1)) {
+      if (internalStatSheets.contains(ss2)) {
+        return Comparator.comparing((StatSheet ss) -> ss == null)
+            .thenComparing(ss -> ss.description())
+            .compare(ss1, ss2);
+      } else {
+        return -1; // Internal stat sheets come before non-internal stat sheets
+      }
+    } else if (internalStatSheets.contains(ss2)) {
+      return 1; // Non-internal stat sheets come after internal stat sheets
+    } else {
+      return Comparator.comparing((StatSheet ss) -> ss.description()).compare(ss1, ss2);
+    }
   }
 }

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -3104,6 +3104,7 @@ Label.label=Label:
 
 # StatSheet
 token.statSheet.legacyStatSheetDescription = Legacy (pre 1.14) Stat Sheet
+token.statSheet.noStatSheetDescription = No Stat Sheet
 token.statSheet.useDefault                 = Default Stat Sheet for Property Type
 
 # Advanced Dice Rolls


### PR DESCRIPTION


### Identify the Bug or Feature request
#5643

### Description of the Change
Added a No StatSheet option and cleaned up the stat-sheet location combo box on the campaign properties and edit toke dialogs so that it is disabled when the location can't be set.

### Possible Drawbacks

Should be none

### Documentation Notes
Its now possible to set the stat sheet type as "No Stat Sheet"

### Release Notes
Its now possible to set the stat sheet type as "No Stat Sheet"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5788)
<!-- Reviewable:end -->
