### PR TITLE
Improve fog rendering performance

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1952,9 +1952,11 @@ public class PointerTool extends DefaultTool {
             ExposedAreaMetaData meta = zone.getExposedAreaMetaData(token.getExposedAreaGUID());
             tokenFog.add(meta.getExposedAreaHistory());
 
-            // Jamz: Allow a token without site to move within the current PlayerView
+            // Jamz: Allow a token without sight to move within the current PlayerView
             if (!token.getHasSight()) {
-              tokenFog.add(renderer.getZoneView().getVisibleArea(new PlayerView(Role.PLAYER)));
+              var view = new PlayerView(Role.PLAYER);
+              var visibleArea = renderer.getZoneView().getVisibility(view).visibleArea();
+              tokenFog.add(visibleArea);
             }
           }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/PlayerView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/PlayerView.java
@@ -31,8 +31,8 @@ public class PlayerView {
   /**
    * Creates a player view that does not use token views.
    *
-   * <p>Calling `isUsingTokenView()` on the new player view will return {@code false} and {@link
-   * #getTokens()} should not be called.
+   * <p>Calling {@link #isUsingTokenView()} on the new player view will return {@code false} and
+   * {@link #getTokens()} should not be called.
    *
    * @param role The player role for the view.
    */
@@ -45,8 +45,8 @@ public class PlayerView {
   /**
    * Creates a player view for a token view.
    *
-   * <p>Calling `isUsingTokenView()` on the new player view will return {@code false} and {@link
-   * #getTokens()} can be called to retrieve the list of tokens.
+   * <p>Calling {@link #isUsingTokenView()} on the new player view will return {@code true} and
+   * {@link #getTokens()} can be called to retrieve the list of tokens.
    *
    * @param role The player role for the view.
    */

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -294,31 +294,6 @@ public class ZoneView {
   }
 
   /**
-   * Gets the exposed area (area without hard FoW0 for the given view.
-   *
-   * <p>The results of this method are only meaningful if the zone has fog enabled.
-   *
-   * @param view The player view
-   * @return The exposed area for {@code view}.
-   */
-  public @Nonnull Area getExposedArea(PlayerView view) {
-    return getVisibility(view).exposedArea();
-  }
-
-  /**
-   * Gets the visible area of the view, cache it in visibleAreaMap, and return it
-   *
-   * <p>The visible area is calculated for each token in the view. The token's visible area is its
-   * vision obstructed by topology and restricted to the illuminated portions of the map.
-   *
-   * @param view the PlayerView
-   * @return the visible area
-   */
-  public @Nonnull Area getVisibleArea(PlayerView view) {
-    return getVisibility(view).visibleArea();
-  }
-
-  /**
    * Get the vision status of the zone.
    *
    * @return true if the vision of the zone is not of type VisionType.OFF

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneView.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import net.rptools.lib.CodeTimer;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.zone.Illumination.LumensLevel;
@@ -139,11 +140,57 @@ public class ZoneView {
    */
   private final Map<PlayerView, Illumination> illuminationsPerView = new HashMap<>();
 
-  /** Map the PlayerView to its exposed area. */
-  private final Map<PlayerView, Area> exposedAreaMap = new HashMap<>();
+  /**
+   * Holds the visibility information for a {@link PlayerView}.
+   *
+   * <p>The {@link #visibleArea()} and {@link #exposedArea()} are the fundamental areas that
+   * describe the view's visibility and fog of war. The {@link #clearArea()} and {@link
+   * #softFogArea()} are derived from these based on the zone's configuration.
+   *
+   * <p>When {@link Zone#hasFog()} returns {@code false}, the {@link #exposedArea()} is meaningless.
+   * In this case, the area will be empty and should not be used. Because {@link #clearArea()} and
+   * {@link #softFogArea()} derive from {@link #exposedArea()}, these are also meaningless and will
+   * be set to the empty area.
+   *
+   * <p>Because of the way Fog of War has to be rendered, {@link #softFogArea()} may not be very
+   * intuitive. Keep this rendering logic in mind when thinking about these areas:
+   *
+   * <ol>
+   *   <li>Start by assuming everything is covered in hard FoW.
+   *   <li>Use {@link #softFogArea()} to carve out part of the hard FoW.
+   *   <li>Use {@link #clearArea()} to carve out part of the soft FoW and hard Fow.
+   * </ol>
+   *
+   * @param visibleArea The combined visible area of all tokens in the view.
+   * @param exposedArea The combined exposed area of all tokens in the view.
+   * @param softFogArea The area that is clear of hard FoW. Typically, the same as {@link
+   *     #exposedArea()}, unless vision is off in which case it is empty.
+   * @param clearArea The area that is clear of soft FoW and hard Fow. Typically, the intersection
+   *     of {@link #visibleArea()} and {@link #exposedArea()}, unless vision if off in which case it
+   *     is just {@link #exposedArea()}.
+   */
+  public record Visibility(
+      @Nonnull Area visibleArea,
+      @Nonnull Area exposedArea,
+      @Nonnull Area softFogArea,
+      @Nonnull Area clearArea) {
 
-  /** Map the PlayerView to its visible area. */
-  private final Map<PlayerView, Area> visibleAreaMap = new HashMap<>();
+    /**
+     * Creates a visibility record for when the zone does not have fog enabled.
+     *
+     * <p>The {@link #exposedArea()}, {@link #softFogArea()}, and {@link #clearArea()} will all be
+     * set to empty areas.
+     *
+     * @param visibleArea The visible area for the view.
+     * @return A visibility record that only contains the visible area.
+     */
+    public static @Nonnull Visibility withoutFog(@Nonnull Area visibleArea) {
+      return new Visibility(visibleArea, new Area(), new Area(), new Area());
+    }
+  }
+
+  /** Map the PlayerView to its visible area and exposed area. */
+  private final Map<PlayerView, Visibility> visibilityMap = new HashMap<>();
 
   // endregion
 
@@ -169,41 +216,97 @@ public class ZoneView {
     new MapToolEventBus().getMainEventBus().register(this);
   }
 
-  public Area getExposedArea(PlayerView view) {
-    Area exposed = exposedAreaMap.get(view);
+  private @Nonnull Area calculateExposedArea(PlayerView view) {
+    boolean combinedView =
+        !isUsingVision()
+            || MapTool.isPersonalServer()
+            || !MapTool.getServerPolicy().isUseIndividualFOW()
+            || view.isGMView();
 
-    if (exposed == null) {
-      boolean combinedView =
-          !isUsingVision()
-              || MapTool.isPersonalServer()
-              || !MapTool.getServerPolicy().isUseIndividualFOW()
-              || view.isGMView();
-
-      if (view.isUsingTokenView() || combinedView) {
-        exposed = zone.getExposedArea(view);
-      } else {
-        // Not a token-specific view, but we are using Individual FoW. So we build up all the owned
-        // tokens' exposed areas to build the soft FoW. Note that not all owned tokens may still
-        // have sight (so weren't included in the PlayerView), but could still have previously
-        // exposed areas.
-        exposed = new Area();
-        for (Token tok : zone.getTokensForLayers(Zone.Layer::supportsVision)) {
-          if (!AppUtil.playerOwns(tok)) {
-            continue;
-          }
-          ExposedAreaMetaData meta = zone.getExposedAreaMetaData(tok.getExposedAreaGUID());
-          Area exposedArea = meta.getExposedAreaHistory();
-          exposed.add(new Area(exposedArea));
+    @Nonnull Area exposed;
+    if (view.isUsingTokenView() || combinedView) {
+      exposed = zone.getExposedArea(view);
+    } else {
+      // Not a token-specific view, but we are using Individual FoW. So we build up all the owned
+      // tokens' exposed areas to build the soft FoW. Note that not all owned tokens may still
+      // have sight (so weren't included in the PlayerView), but could still have previously
+      // exposed areas.
+      exposed = new Area();
+      for (Token tok : zone.getTokensForLayers(Zone.Layer::supportsVision)) {
+        if (!AppUtil.playerOwns(tok)) {
+          continue;
         }
+        ExposedAreaMetaData meta = zone.getExposedAreaMetaData(tok.getExposedAreaGUID());
+        Area exposedArea = meta.getExposedAreaHistory();
+        exposed.add(new Area(exposedArea));
       }
-
-      exposedAreaMap.put(view, exposed);
     }
     return exposed;
   }
 
+  private @Nonnull Area calculateVisibleArea(PlayerView view) {
+    final var visibleArea = new Area();
+    getTokensForView(view).map(token -> this.getVisibleArea(token, view)).forEach(visibleArea::add);
+    return visibleArea;
+  }
+
+  public @Nonnull Visibility getVisibility(PlayerView view) {
+    return visibilityMap.computeIfAbsent(
+        view,
+        view2 -> {
+          var timer = CodeTimer.get();
+          var tokenCount = view.isUsingTokenView() ? view.getTokens().size() : 0;
+
+          timer.start("ZoneView.getVisibility(%d tokens)-getVisibleArea", tokenCount);
+          var visibleArea = calculateVisibleArea(view2);
+          timer.stop("ZoneView.getVisibility(%d tokens)-getVisibleArea", tokenCount);
+
+          if (!zone.hasFog()) {
+            // Exposed and clear areas are meaningless when not using fog of war.
+            return Visibility.withoutFog(visibleArea);
+          }
+
+          timer.start("ZoneView.getVisibility(%d tokens)-getExposedArea", tokenCount);
+          var exposedArea = calculateExposedArea(view2);
+          timer.stop("ZoneView.getVisibility(%d tokens)-getExposedArea", tokenCount);
+
+          /*
+           * Hard FOW is cleared by exposed areas. The exposed area itself has two regions: the
+           * visible area (rendered clear) and the soft FOW area (rendered translucent). But if
+           * vision is off, treat the entire exposed area as clear with no soft FOW.
+           */
+
+          timer.start("ZoneView.getVisibility(%d tokens)-getClearArea", tokenCount);
+          Area softFogArea;
+          Area clearArea;
+          if (isUsingVision()) {
+            softFogArea = exposedArea;
+            clearArea = new Area(visibleArea);
+            clearArea.intersect(softFogArea);
+          } else {
+            softFogArea = new Area();
+            clearArea = exposedArea;
+          }
+          timer.stop("ZoneView.getVisibility(%d tokens)-getClearArea", tokenCount);
+
+          return new Visibility(visibleArea, exposedArea, softFogArea, clearArea);
+        });
+  }
+
   /**
-   * Calculate the visible area of the view, cache it in visibleAreaMap, and return it
+   * Gets the exposed area (area without hard FoW0 for the given view.
+   *
+   * <p>The results of this method are only meaningful if the zone has fog enabled.
+   *
+   * @param view The player view
+   * @return The exposed area for {@code view}.
+   */
+  public @Nonnull Area getExposedArea(PlayerView view) {
+    return getVisibility(view).exposedArea();
+  }
+
+  /**
+   * Gets the visible area of the view, cache it in visibleAreaMap, and return it
    *
    * <p>The visible area is calculated for each token in the view. The token's visible area is its
    * vision obstructed by topology and restricted to the illuminated portions of the map.
@@ -212,15 +315,7 @@ public class ZoneView {
    * @return the visible area
    */
   public @Nonnull Area getVisibleArea(PlayerView view) {
-    return visibleAreaMap.computeIfAbsent(
-        view,
-        view2 -> {
-          final var visibleArea = new Area();
-          getTokensForView(view2)
-              .map(token -> this.getVisibleArea(token, view2))
-              .forEach(visibleArea::add);
-          return visibleArea;
-        });
+    return getVisibility(view).visibleArea();
   }
 
   /**
@@ -722,8 +817,8 @@ public class ZoneView {
   }
 
   /**
-   * Clear the vision caches (@link #tokenVisionCachePerView}, {@link #visibleAreaMap}), fog cache
-   * ({@link #exposedAreaMap}), and illumination caches ({@link #illuminationModels}.
+   * Clear the vision caches (@link #tokenVisionCachePerView}, {@link #visibilityMap}), and
+   * illumination caches ({@link #illuminationModels}.
    *
    * <p>Needs to be called whenever topology changes, fog is edited, or map vision settings are
    * changed. These are all external factors that directly affect vision and illumination. In the
@@ -739,14 +834,13 @@ public class ZoneView {
 
     tokenVisionCachePerView.clear();
     illuminationsPerView.clear();
-    exposedAreaMap.clear();
-    visibleAreaMap.clear();
+    flushFog();
 
     flushLights();
   }
 
   public void flushFog() {
-    exposedAreaMap.clear();
+    visibilityMap.clear();
   }
 
   private void flushLights() {
@@ -756,8 +850,8 @@ public class ZoneView {
 
   /**
    * Flush the ZoneView cache of the token. Remove token from {@link #tokenVisionCachePerView}, and
-   * {@link #illuminationModels}. Can clear {@link #tokenVisionCachePerView}, {@link
-   * #visibleAreaMap}, and {@link #exposedAreaMap} depending on the token.
+   * {@link #illuminationModels}. Can clear {@link #tokenVisionCachePerView}, and {@link
+   * #visibilityMap} depending on the token.
    *
    * @param token the token to flush.
    */
@@ -776,14 +870,12 @@ public class ZoneView {
       contributedPersonalLightsByToken.remove(token.getId());
       tokenVisionCachePerView.clear();
       illuminationsPerView.clear();
-      exposedAreaMap.clear();
-      visibleAreaMap.clear();
+      flushFog();
       drawableLights.clear();
     } else if (token.getHasSight()) {
       contributedPersonalLightsByToken.remove(token.getId());
       illuminationsPerView.clear();
-      exposedAreaMap.clear();
-      visibleAreaMap.clear();
+      flushFog();
       drawableLights.clear();
     }
 
@@ -884,7 +976,7 @@ public class ZoneView {
 
   /**
    * Update {@link #lightSourceMap} with the light sources of the tokens, and clear {@link
-   * #visibleAreaMap} and {@link #exposedAreaMap} if one of the tokens has sight.
+   * #visibilityMap} if one of the tokens has sight.
    *
    * @param tokens the list of tokens
    */
@@ -892,8 +984,7 @@ public class ZoneView {
     updateLightSourcesFromTokens(tokens);
 
     if (tokens.stream().anyMatch(Token::getHasSight)) {
-      exposedAreaMap.clear();
-      visibleAreaMap.clear();
+      flushFog();
     }
 
     if (tokens.stream().anyMatch(Token::hasAnyMaskTopology)) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -347,7 +347,7 @@ public class ZoneViewModel {
 
   /** Updates {@link #visibleArea} based on {@link #playerView}. */
   private void updateVisibleArea() {
-    visibleArea = zoneView.getVisibleArea(playerView);
+    visibleArea = zoneView.getVisibility(playerView).visibleArea();
   }
 
   /** Updates {@link #playerView}. */

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -855,24 +855,9 @@ public class GdxRenderer extends ApplicationAdapter {
 
     var zoneView = zoneCache.getZoneView();
 
-    timer.start("renderFog-visibleArea");
-    Area visibleArea = zoneView.getVisibleArea(view);
-    timer.stop("renderFog-visibleArea");
-
-    timer.start("renderFog-combined(%d)", view.isUsingTokenView() ? view.getTokens().size() : 0);
-    Area exposedArea = zoneView.getExposedArea(view);
-    timer.stop("renderFog-combined(%d)", view.isUsingTokenView() ? view.getTokens().size() : 0);
-
-    Area softFogArea;
-    Area clearArea;
-    if (zoneView.isUsingVision()) {
-      softFogArea = exposedArea;
-      clearArea = new Area(visibleArea);
-      clearArea.intersect(softFogArea);
-    } else {
-      softFogArea = new Area();
-      clearArea = exposedArea;
-    }
+    var visibility = zoneView.getVisibility(view);
+    Area softFogArea = visibility.softFogArea();
+    Area clearArea = visibility.clearArea();
 
     timer.start("renderFog");
     ScreenUtils.clear(Color.CLEAR);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/gdx/GdxRenderer.java
@@ -688,7 +688,8 @@ public class GdxRenderer extends ApplicationAdapter {
     timer.start("calcs-1");
     timer.start("ZoneRenderer-getVisibleArea");
     if (visibleScreenArea == null) {
-      visibleScreenArea = zoneCache.getZoneView().getVisibleArea(viewModel.getPlayerView());
+      visibleScreenArea =
+          zoneCache.getZoneView().getVisibility(viewModel.getPlayerView()).visibleArea();
     }
     timer.stop("ZoneRenderer-getVisibleArea");
 
@@ -1090,7 +1091,8 @@ public class GdxRenderer extends ApplicationAdapter {
                       || zoneCache
                           .getZoneRenderer()
                           .getZoneView()
-                          .getVisibleArea(view)
+                          .getVisibility(view)
+                          .visibleArea()
                           .intersects(tokenRectangle);
             }
           } else {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/FogRenderer.java
@@ -52,33 +52,17 @@ public class FogRenderer {
   }
 
   private void renderWorld(Graphics2D worldG, PlayerView view) {
+    /*
+     * The tricky thing in this method is that the areas we have (exposed, visible) are the areas
+     * where we should _not_ render. So we have to do clipped fills and clears instead of directly
+     * rendering the areas.
+     */
+
     var timer = CodeTimer.get();
 
-    /* The tricky thing in this method is that the areas we have (exposed, visible) are the areas
-     * where we should _not_ render. So we have to do clipped fills and clears instead of directly
-     * rendering the areas. */
-    timer.start("renderFog-getVisibleArea");
-    Area visibleArea = zoneView.getVisibleArea(view);
-    timer.stop("renderFog-getVisibleArea");
-
-    var tokenCount = view.isUsingTokenView() ? view.getTokens().size() : 0;
-    timer.start("renderFog-getExposedArea(%d)", tokenCount);
-    Area exposedArea = zoneView.getExposedArea(view);
-    timer.stop("renderFog-getExposedArea(%d)", tokenCount);
-
-    // Hard FOW is cleared by exposed areas. The exposed area itself has two regions: the visible
-    // area (rendered clear) and the soft FOW area (rendered translucent). But if vision is off,
-    // treat the entire exposed area as visible.
-    Area softFogArea;
-    Area clearArea;
-    if (zoneView.isUsingVision()) {
-      softFogArea = exposedArea;
-      clearArea = new Area(visibleArea);
-      clearArea.intersect(softFogArea);
-    } else {
-      softFogArea = new Area();
-      clearArea = exposedArea;
-    }
+    var visibility = zoneView.getVisibility(view);
+    Area softFogArea = visibility.softFogArea();
+    Area clearArea = visibility.clearArea();
 
     var originalClip = worldG.getClip();
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LightsRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LightsRenderer.java
@@ -111,7 +111,7 @@ public class LightsRenderer {
       Color backgroundFill) {
     var timer = CodeTimer.get();
 
-    var visibleArea = zoneView.getVisibleArea(view);
+    var visibleArea = zoneView.getVisibility(view).visibleArea();
 
     var originalClip = worldG.getClip();
     var bounds = originalClip.getBounds();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LumensRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/LumensRenderer.java
@@ -61,7 +61,7 @@ public class LumensRenderer {
     var timer = CodeTimer.get();
     var overlayOpacity = AppPreferences.lumensOverlayOpacity.get() / 255.0f;
 
-    var visibleArea = zoneView.getVisibleArea(view);
+    var visibleArea = zoneView.getVisibility(view).visibleArea();
     final var disjointLumensLevels = zoneView.getDisjointObscuredLumensLevels(view);
 
     var originalClip = worldG.getClip();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/RenderHelper.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/RenderHelper.java
@@ -20,7 +20,6 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.awt.Transparency;
 import java.awt.geom.AffineTransform;
-import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.util.function.Consumer;
@@ -128,7 +127,7 @@ public class RenderHelper {
 
     Graphics2D buffG = buffer.createGraphics();
     try {
-      buffG.setClip(new Area(new Rectangle(0, 0, buffer.getWidth(), buffer.getHeight())));
+      buffG.setClip(new Rectangle(0, 0, buffer.getWidth(), buffer.getHeight()));
       doRender(buffG, render);
     } finally {
       buffG.dispose();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/VisionOverlayRenderer.java
@@ -77,7 +77,7 @@ public class VisionOverlayRenderer {
     }
     if (zone.hasFog()) {
       currentTokenVisionArea = new Area(currentTokenVisionArea);
-      currentTokenVisionArea.intersect(zoneView.getExposedArea(tokenView));
+      currentTokenVisionArea.intersect(zoneView.getVisibility(tokenView).exposedArea());
     }
 
     // Keep the line a consistent thickness

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1181,11 +1181,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     // Regardless of vision settings, no need to render beyond the fog.
     Area clearArea = null;
     if (!view.isGMView()) {
-      if (zone.hasFog() && zoneView.isUsingVision()) {
-        clearArea = new Area(zoneView.getExposedArea(view));
-        clearArea.intersect(zoneView.getVisibleArea(view));
-      } else if (zone.hasFog()) {
-        clearArea = zoneView.getExposedArea(view);
+      if (zone.hasFog()) {
+        clearArea = zoneView.getVisibility(view).clearArea();
       } else if (zoneView.isUsingVision()) {
         clearArea = zoneView.getVisibleArea(view);
       }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -860,7 +860,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     timer.start("calcs-1");
     if (visibleScreenArea == null) {
       timer.start("ZoneRenderer-getVisibleArea");
-      Area a = zoneView.getVisibleArea(view);
+      Area a = zoneView.getVisibility(view).visibleArea();
       timer.stop("ZoneRenderer-getVisibleArea");
 
       timer.start("createTransformedArea");
@@ -1184,7 +1184,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       if (zone.hasFog()) {
         clearArea = zoneView.getVisibility(view).clearArea();
       } else if (zoneView.isUsingVision()) {
-        clearArea = zoneView.getVisibleArea(view);
+        clearArea = zoneView.getVisibility(view).visibleArea();
       }
 
       if (clearArea != null) {

--- a/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
+++ b/src/main/java/net/rptools/maptool/client/walker/astar/AbstractAStarWalker.java
@@ -235,7 +235,9 @@ public abstract class AbstractAStarWalker extends AbstractZoneWalker {
 
       var view = zoneRenderer.getPlayerView();
       newFowExposedArea =
-          zone.hasFog() && !view.isGMView() ? zoneView.getExposedArea(view) : new Area();
+          zone.hasFog() && !view.isGMView()
+              ? zoneView.getVisibility(view).exposedArea()
+              : new Area();
     }
 
     if (!Objects.equals(newFowExposedArea, fowExposedArea)) {

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -1316,7 +1316,7 @@ public class Zone {
    * @param view holds whether or not tokens are selected
    * @return the exposed area
    */
-  public Area getExposedArea(PlayerView view) {
+  public @Nonnull Area getExposedArea(PlayerView view) {
     Area combined = new Area(exposedArea);
 
     // Don't need to worry about StrictTokenOwnership since the PlayerView only contains tokens we


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5798

### Description of the Change

Updates `ZoneView` to cache the clear area and soft fog area alongside the visible area and exposed area from which they are derived. All four are cached in a new `Visibility` record and are thus flushed and recalculated together. This new structure is exposed via `ZoneView#getVisibility(PlayerView)`, and calls to the methods `ZoneView#getExposedArea(PlayerView)` and `ZoneView#getVisibleArea(PlayerView)` have been replaced with calls to `ZoneView#getVisibility(PlayerView)`.

The impact of the above change is that the fog renderer can save a few cycles as it does not have to recalculate the soft fog area or clear area each frame. It also reduces the memory pressure, since the `Area` intersections can results in quite large allocations when fog geometry gets complex.

Also included are two minor changes:
1. The documentation for the `PlayerView` constructors has been fixed regarding `PlayerView#isUsingTokenView()`.
2. `RenderHelper` now sets rectangular clips as a plain `Rectangle` rather than converting that to an `Area`. Not only is this less work and less code, the internals of `Graphics2D` can handle `Rectangle2D` clips more efficiently.

### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Improved the run time and memory performance of fog of war.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5799)
<!-- Reviewable:end -->
