### PR TITLE
Handlebars relative template loader

### DIFF
--- a/src/main/java/net/rptools/maptool/util/HandlebarsUtil.java
+++ b/src/main/java/net/rptools/maptool/util/HandlebarsUtil.java
@@ -25,17 +25,24 @@ import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.jknack.handlebars.helper.ext.AssignHelper;
 import com.github.jknack.handlebars.helper.ext.IncludeHelper;
 import com.github.jknack.handlebars.helper.ext.NumberHelper;
+import com.github.jknack.handlebars.io.AbstractTemplateLoader;
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import com.github.jknack.handlebars.io.TemplateLoader;
-import com.github.jknack.handlebars.io.URLTemplateLoader;
+import com.github.jknack.handlebars.io.TemplateSource;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Base64;
+import javax.annotation.Nonnull;
 import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.library.Library;
+import net.rptools.maptool.model.library.LibraryManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -52,38 +59,52 @@ public class HandlebarsUtil<T> {
   /** Logging class instance. */
   private static final Logger log = LogManager.getLogger(Token.class);
 
-  /** Handlebars partial template loader that uses Add-On Library URIs */
-  private static class LibraryTemplateLoader extends URLTemplateLoader {
-    /** Path to template being resolved, relative paths are resolved relative to its parent. */
-    Path current;
+  /** Handlebars partial template source that uses Add-On files */
+  private static record LibraryTemplateSource(@Nonnull Library library, @Nonnull String filename)
+      implements TemplateSource {
+    @Override
+    public long lastModified() {
+      // No modification time is available.
+      return -1;
+    }
 
-    private LibraryTemplateLoader(String current, String prefix, String suffix) {
+    @Override
+    @Nonnull
+    public String content(@Nonnull final Charset charset) throws IOException {
+      try {
+        // The library API requires a URL even if it only uses the path.
+        var url = new URI("lib", library.getNamespace().join(), filename, null).toURL();
+        try (var is = library.read(url).join()) {
+          return new String(is.readAllBytes(), charset);
+        }
+      } catch (URISyntaxException e) {
+        throw new AssertionError("lib URL of namespace and filename should be valid", e);
+      }
+    }
+  }
+
+  /** Handlebars partial template loader that uses Add-On Library URIs */
+  private static class LibraryTemplateLoader extends AbstractTemplateLoader {
+    /** Path to template being resolved, relative paths are resolved relative to its parent. */
+    @Nonnull final Path current;
+
+    @Nonnull final Library library;
+
+    private LibraryTemplateLoader(@Nonnull String current, @Nonnull Library library) {
       if (!current.startsWith("/")) {
         current = "/" + current;
       }
       this.current = new File(current).toPath();
-      setPrefix(prefix);
-      setSuffix(suffix);
+      this.library = library;
+      setPrefix(TemplateLoader.DEFAULT_PREFIX);
+      setSuffix(TemplateLoader.DEFAULT_SUFFIX);
     }
 
-    private LibraryTemplateLoader(String current, String prefix) {
-      this(current, prefix, DEFAULT_SUFFIX);
-    }
-
-    private LibraryTemplateLoader(String current) {
-      this(current, DEFAULT_PREFIX, DEFAULT_SUFFIX);
-    }
-
-    /** Normalize locations by removing redundant path components */
+    /** Resolve possibly relative uri to a new location relative to current rooted below prefix */
     @Override
-    protected String normalize(final String location) {
-      return new File(location).toPath().normalize().toString();
-    }
-
-    /** Resolve possibly relative uri relative to current rooted below prefix */
-    @Override
-    public String resolve(final String uri) {
-      var location = current.resolveSibling(uri).normalize().toString();
+    @Nonnull
+    public String resolve(@Nonnull final String path) {
+      var location = current.resolveSibling(path).normalize().toString();
       if (location.startsWith("/")) {
         location = location.substring(1);
       }
@@ -91,11 +112,9 @@ public class HandlebarsUtil<T> {
     }
 
     @Override
-    protected URL getResource(String location) throws IOException {
-      if (location.startsWith("/")) {
-        location = location.substring(1);
-      }
-      return new URL("lib://" + location);
+    @Nonnull
+    public LibraryTemplateSource sourceAt(@Nonnull final String location) {
+      return new LibraryTemplateSource(library, resolve(location));
     }
   }
 
@@ -155,7 +174,12 @@ public class HandlebarsUtil<T> {
    * @throws IOException If there is an error compiling the template.
    */
   public HandlebarsUtil(String stringTemplate, URL entry) throws IOException {
-    this(stringTemplate, new LibraryTemplateLoader(entry.getHost() + entry.getPath()));
+    this(
+        stringTemplate,
+        new LibraryTemplateLoader(
+            entry.getPath(),
+            // Template is defined by AddOn so library should always be present.
+            new LibraryManager().getLibrary(entry).join().orElseThrow()));
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Issue with implementation mentioned in https://github.com/RPTools/maptool/pull/4921#issuecomment-3318256396. I don't fully understand what the problem is but this appears to be the alternative.

### Description of the Change

This replaces the implementation of the Handlebars Template Loader to use the AddOn Library directly instead of via fetching a lib:// URL.

This still constructs a URL because the Library URI requires it.

### Possible Drawbacks

No longer possible to fetch handlebars partial templates from another AddOn library, but this may be desirable.

### Release Notes

* Replaced Handlebars Partial Template library loader with one scoped to the same AddOn

### Notes

Related to https://github.com/RPTools/maptool/pull/5807
Either should fix the failure to load, but the other PR should be merged regardless because it's possible to fetch handlebars partial templates from within the WebView.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5808)
<!-- Reviewable:end -->
