### PR TITLE
Fix some LookupTable performance issues

### DIFF
--- a/messages/src/main/proto/message.proto
+++ b/messages/src/main/proto/message.proto
@@ -91,5 +91,7 @@ message Message {
     SetCampaignLandingMapMsg set_campaign_landing_map_msg = 75;
     SetWallTopologyMsg set_wall_topology_msg = 76;
     UpdateWallDataMsg update_wall_data_msg = 77;
+    PutLookupTableMsg update_lookup_table_msg = 78;
+    DeleteLookupTableMsg delete_lookup_table_msg = 79;
   }
 }

--- a/messages/src/main/proto/message_types.proto
+++ b/messages/src/main/proto/message_types.proto
@@ -392,3 +392,11 @@ message UpdatePlayerStatusMsg {
   string zone_guid = 2;
   bool loaded = 3;
 }
+
+message PutLookupTableMsg {
+  LookupTableDto table = 1;
+}
+
+message DeleteLookupTableMsg {
+  string tableName = 1;
+}

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -48,6 +48,7 @@ import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.InitiativeList;
 import net.rptools.maptool.model.InitiativeList.TokenInitiative;
 import net.rptools.maptool.model.Label;
+import net.rptools.maptool.model.LookupTable;
 import net.rptools.maptool.model.MacroButtonProperties;
 import net.rptools.maptool.model.Pointer;
 import net.rptools.maptool.model.TextMessage;
@@ -173,6 +174,8 @@ public class ClientMessageHandler implements MessageHandler {
         case UPDATE_PLAYER_STATUS_MSG -> handle(msg.getUpdatePlayerStatusMsg());
         case SET_WALL_TOPOLOGY_MSG -> handle(msg.getSetWallTopologyMsg());
         case UPDATE_WALL_DATA_MSG -> handle(msg.getUpdateWallDataMsg());
+        case UPDATE_LOOKUP_TABLE_MSG -> handle(msg.getUpdateLookupTableMsg());
+        case DELETE_LOOKUP_TABLE_MSG -> handle(msg.getDeleteLookupTableMsg());
         default -> log.warn(msgType + "not handled.");
       }
       log.debug(id + " handled: " + msgType);
@@ -1091,6 +1094,23 @@ public class ClientMessageHandler implements MessageHandler {
           var wall = Wall.fromDto(updateWallDataMsg.getWall());
 
           zone.updateWall(wall);
+        });
+  }
+
+  private void handle(PutLookupTableMsg msg) {
+    EventQueue.invokeLater(
+        () -> {
+          var table = LookupTable.fromDto(msg.getTable());
+          client.getCampaign().getLookupTableMap().put(table.getName(), table);
+          MapTool.getFrame().getLookupTablePanel().updateView();
+        });
+  }
+
+  private void handle(DeleteLookupTableMsg msg) {
+    EventQueue.invokeLater(
+        () -> {
+          client.getCampaign().getLookupTableMap().remove(msg.getTableName());
+          MapTool.getFrame().getLookupTablePanel().updateView();
         });
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -841,6 +841,20 @@ public class ServerCommandClientImpl implements ServerCommand {
     makeServerCall(Message.newBuilder().setUpdatePlayerStatusMsg(msg).build());
   }
 
+  @Override
+  public void putLookupTable(LookupTable lookupTable) {
+    var msg = PutLookupTableMsg.newBuilder().setTable(lookupTable.toDto());
+    client.getCampaign().getLookupTableMap().put(lookupTable.getName(), lookupTable);
+    makeServerCall(Message.newBuilder().setUpdateLookupTableMsg(msg).build());
+  }
+
+  @Override
+  public void deleteLookupTable(String tableName) {
+    var msg = DeleteLookupTableMsg.newBuilder().setTableName(tableName);
+    client.getCampaign().getLookupTableMap().remove(tableName);
+    makeServerCall(Message.newBuilder().setDeleteLookupTableMsg(msg).build());
+  }
+
   /**
    * Some events become obsolete very quickly, such as dragging a token around. This queue always
    * has exactly one element, the more current version of the event. The event is then dispatched at

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -15,14 +15,15 @@
 package net.rptools.maptool.client.functions;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.LookupTable;
 import net.rptools.maptool.model.LookupTable.LookupEntry;
@@ -323,14 +324,12 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       int index = FunctionUtil.paramAsInteger(function, params, 1, false);
       LookupTable lookupTable = getMaptoolTable(name, function);
-      List<LookupEntry> entriesList = lookupTable.getEntryList();
-      if (index >= 0 && index < entriesList.size()) {
-        LookupEntry entry = entriesList.get(index);
-        return convertLookUpEntryToJson(entry);
-      } else {
+      LookupEntry entry = lookupTable.getEntryByIndex(index);
+      if (entry == null) {
         return "";
+      } else {
+        return convertLookUpEntryToJson(entry);
       }
-
     } else if ("getTableEntries".equalsIgnoreCase(function)) {
       /*
        * Parameters:
@@ -408,19 +407,22 @@ public class LookupTableFunction extends AbstractFunction {
       LookupTable lookupTable = getMaptoolTable(tblName, function);
       if (params.size() > 1) {
         String delim = (params.size() > 2) ? params.get(2).toString() : ",";
-        List<String> entriesToReset;
+
+        Stream<String> indicesAsStrings;
         if (delim.equalsIgnoreCase("json")) {
           JsonArray jsonArray = FunctionUtil.paramAsJsonArray(function, params, 1);
-          entriesToReset =
-              JSONMacroFunctions.getInstance()
-                  .getJsonArrayFunctions()
-                  .jsonArrayToListOfStrings(jsonArray);
+          indicesAsStrings = jsonArray.asList().stream().map(JsonElement::getAsString);
         } else {
-          entriesToReset = StrListFunctions.toList(params.get(1).toString(), delim);
+          indicesAsStrings = StrListFunctions.toList(params.get(1).toString(), delim).stream();
         }
-        lookupTable.reset(entriesToReset);
+
+        indicesAsStrings
+            .mapToInt(Integer::parseInt)
+            .mapToObj(lookupTable::getEntryByIndex)
+            .filter(Objects::nonNull)
+            .forEach(e -> e.setPicked(false));
       } else {
-        lookupTable.reset();
+        lookupTable.resetPicks();
       }
       MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
       return "";

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -301,16 +301,11 @@ public class LookupTableFunction extends AbstractFunction {
 
       FunctionUtil.checkNumberParam(function, params, 2, 2);
       String name = params.get(0).toString();
+      int roll = FunctionUtil.paramAsInteger(function, params, 1, true);
       LookupTable lookupTable = getMaptoolTable(name, function);
-      String roll = params.get(1).toString();
-      LookupEntry entry = lookupTable.getLookupDirect(roll);
-
+      LookupEntry entry = lookupTable.getEntryByRollResult(roll);
       if (entry == null) {
         return ""; // no entry was found
-      }
-      int rollInt = Integer.parseInt(roll);
-      if (rollInt < entry.getMin() || rollInt > entry.getMax()) {
-        return ""; // entry was found but doesn't match
       }
       return convertLookUpEntryToJson(entry);
 

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -195,6 +195,8 @@ public class LookupTableFunction extends AbstractFunction {
 
     } else if ("deleteTableEntry".equalsIgnoreCase(function)) {
 
+      // Note: unlike getTableEntry() and setTableEntry(), the roll in this case can actually be a
+      // roll expression. I don't like, but it's been that way forever, so..
       checkTrusted(function);
       FunctionUtil.checkNumberParam("deleteTableEntry", params, 2, 2);
       String name = params.get(0).toString();
@@ -202,14 +204,9 @@ public class LookupTableFunction extends AbstractFunction {
       LookupTable lookupTable = getMaptoolTable(name, function);
       LookupEntry entry = lookupTable.getLookup(roll);
       if (entry != null) {
-        List<LookupEntry> oldlist = new ArrayList<>(lookupTable.getEntryList());
-        lookupTable.clearEntries();
-        oldlist.stream()
-            .filter((e) -> (e != entry))
-            .forEachOrdered(
-                (e) -> lookupTable.addEntry(e.getMin(), e.getMax(), e.getValue(), e.getImageId()));
+        lookupTable.deleteEntry(entry);
+        MapTool.serverCommand().putLookupTable(lookupTable);
       }
-      MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
 
     } else if ("createTable".equalsIgnoreCase(function)) {

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -181,15 +181,15 @@ public class LookupTableFunction extends AbstractFunction {
       checkTrusted(function);
       FunctionUtil.checkNumberParam("addTableEntry", params, 4, 5);
       String name = params.get(0).toString();
-      String min = params.get(1).toString();
-      String max = params.get(2).toString();
+      int min = FunctionUtil.paramAsInteger(function, params, 1, true);
+      int max = FunctionUtil.paramAsInteger(function, params, 2, true);
       String value = params.get(3).toString();
       MD5Key asset = null;
       if (params.size() > 4) {
         asset = FunctionUtil.getAssetKeyFromString(params.get(4).toString());
       }
       LookupTable lookupTable = getMaptoolTable(name, function);
-      lookupTable.addEntry(Integer.parseInt(min), Integer.parseInt(max), value, asset);
+      lookupTable.addEntry(min, max, value, asset);
       MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
 

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -114,10 +114,13 @@ public class LookupTableFunction extends AbstractFunction {
       checkTrusted(function);
       FunctionUtil.checkNumberParam("setTableVisible", params, 2, 2);
       String name = params.get(0).toString();
-      String visible = params.get(1).toString();
+      String visibleStr = params.get(1).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
-      lookupTable.setVisible(FunctionUtil.getBooleanValue(visible));
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      boolean visible = FunctionUtil.getBooleanValue(visibleStr);
+      if (visible != lookupTable.getVisible()) {
+        lookupTable.setVisible(visible);
+        MapTool.serverCommand().putLookupTable(lookupTable);
+      }
       return lookupTable.getVisible() ? BigDecimal.ONE : BigDecimal.ZERO;
 
     } else if ("getTableAccess".equalsIgnoreCase(function)) {
@@ -135,8 +138,11 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       String access = params.get(1).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
-      lookupTable.setAllowLookup(FunctionUtil.getBooleanValue(access));
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      boolean allowLookup = FunctionUtil.getBooleanValue(access);
+      if (allowLookup != lookupTable.getAllowLookup()) {
+        lookupTable.setAllowLookup(FunctionUtil.getBooleanValue(access));
+        MapTool.serverCommand().putLookupTable(lookupTable);
+      }
       return lookupTable.getAllowLookup() ? BigDecimal.ONE : BigDecimal.ZERO;
 
     } else if ("getTableRoll".equalsIgnoreCase(function)) {
@@ -153,9 +159,11 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       String roll = params.get(1).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
+      if (!roll.equals(lookupTable.getRoll())) {
+        lookupTable.setRoll(roll);
+        MapTool.serverCommand().putLookupTable(lookupTable);
+      }
 
-      lookupTable.setRoll(roll);
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
       return roll;
 
     } else if ("clearTable".equalsIgnoreCase(function)) {
@@ -165,7 +173,7 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
       lookupTable.clearEntries();
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
 
     } else if ("addTableEntry".equalsIgnoreCase(function)) {
@@ -182,7 +190,7 @@ public class LookupTableFunction extends AbstractFunction {
       }
       LookupTable lookupTable = getMaptoolTable(name, function);
       lookupTable.addEntry(Integer.parseInt(min), Integer.parseInt(max), value, asset);
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
 
     } else if ("deleteTableEntry".equalsIgnoreCase(function)) {
@@ -201,7 +209,7 @@ public class LookupTableFunction extends AbstractFunction {
             .forEachOrdered(
                 (e) -> lookupTable.addEntry(e.getMin(), e.getMax(), e.getValue(), e.getImageId()));
       }
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
 
     } else if ("createTable".equalsIgnoreCase(function)) {
@@ -219,9 +227,10 @@ public class LookupTableFunction extends AbstractFunction {
       lookupTable.setName(name);
       lookupTable.setVisible(FunctionUtil.getBooleanValue(visible));
       lookupTable.setAllowLookup(FunctionUtil.getBooleanValue(lookups));
-      if (asset != null) lookupTable.setTableImage(asset);
-      MapTool.getCampaign().getLookupTableMap().put(name, lookupTable);
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      if (asset != null) {
+        lookupTable.setTableImage(asset);
+      }
+      MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
 
     } else if ("deleteTable".equalsIgnoreCase(function)) {
@@ -229,9 +238,9 @@ public class LookupTableFunction extends AbstractFunction {
       checkTrusted(function);
       FunctionUtil.checkNumberParam("deleteTable", params, 1, 1);
       String name = params.get(0).toString();
+      // Ensure that the table exists.
       LookupTable lookupTable = getMaptoolTable(name, function);
-      MapTool.getCampaign().getLookupTableMap().remove(name);
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      MapTool.serverCommand().deleteLookupTable(name);
       return "";
 
     } else if ("getTableImage".equalsIgnoreCase(function)) {
@@ -251,8 +260,10 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       MD5Key asset = FunctionUtil.getAssetKeyFromString(params.get(1).toString());
       LookupTable lookupTable = getMaptoolTable(name, function);
-      lookupTable.setTableImage(asset);
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      if (!Objects.equals(asset, lookupTable.getTableImage())) {
+        lookupTable.setTableImage(asset);
+        MapTool.serverCommand().putLookupTable(lookupTable);
+      }
       return "";
 
     } else if ("copyTable".equalsIgnoreCase(function)) {
@@ -264,8 +275,7 @@ public class LookupTableFunction extends AbstractFunction {
       LookupTable oldTable = getMaptoolTable(oldName, function);
       LookupTable newTable = new LookupTable(oldTable);
       newTable.setName(newName);
-      MapTool.getCampaign().getLookupTableMap().put(newName, newTable);
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      MapTool.serverCommand().putLookupTable(newTable);
       return "";
 
     } else if ("setTableEntry".equalsIgnoreCase(function)) {
@@ -286,13 +296,20 @@ public class LookupTableFunction extends AbstractFunction {
         return 0;
       }
 
-      entry.setValue(result);
-      if (imageId != null) {
+      boolean changed = false;
+      if (!result.equals(entry.getValue())) {
+        entry.setValue(result);
+        changed = true;
+      }
+      if (imageId != null && !imageId.equals(entry.getImageId())) {
         // So... how is one supposed to remove the image?
         entry.setImageId(imageId);
+        changed = true;
       }
 
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      if (changed) {
+        MapTool.serverCommand().putLookupTable(lookupTable);
+      }
       return 1;
 
     } else if ("getTableEntry".equalsIgnoreCase(function)) {
@@ -388,6 +405,7 @@ public class LookupTableFunction extends AbstractFunction {
       return entriesList.size();
 
     } else if ("resetTablePicks".equalsIgnoreCase(function)) {
+
       /*
        * resetTablePicks(tblName) - reset all entries on a table
        * resetTablePicks(tblName, entriesToReset) - reset specific entries from a String List with "," delim
@@ -417,17 +435,21 @@ public class LookupTableFunction extends AbstractFunction {
       } else {
         lookupTable.resetPicks();
       }
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      MapTool.serverCommand().putLookupTable(lookupTable);
       return "";
+
     } else if ("setTablePickOnce".equalsIgnoreCase(function)) {
 
       checkTrusted(function);
       FunctionUtil.checkNumberParam("setTablePickOnce", params, 2, 2);
       String name = params.get(0).toString();
-      String pickonce = params.get(1).toString();
+      String pickOnceStr = params.get(1).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
-      lookupTable.setPickOnce(FunctionUtil.getBooleanValue(pickonce));
-      MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
+      boolean pickOnce = FunctionUtil.getBooleanValue(pickOnceStr);
+      if (pickOnce != lookupTable.getPickOnce()) {
+        lookupTable.setPickOnce(pickOnce);
+        MapTool.serverCommand().putLookupTable(lookupTable);
+      }
       return lookupTable.getPickOnce() ? BigDecimal.ONE : BigDecimal.ZERO;
 
     } else if ("getTablePickOnce".equalsIgnoreCase(function)) {

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -272,28 +272,25 @@ public class LookupTableFunction extends AbstractFunction {
       checkTrusted(function);
       FunctionUtil.checkNumberParam("setTableEntry", params, 3, 4);
       String name = params.get(0).toString();
-      String roll = params.get(1).toString();
+      int roll = FunctionUtil.paramAsInteger(function, params, 1, true);
       String result = params.get(2).toString();
       MD5Key imageId = null;
       if (params.size() == 4) {
         imageId = FunctionUtil.getAssetKeyFromString(params.get(3).toString());
       }
-      LookupTable lookupTable = getMaptoolTable(name, function);
-      LookupEntry entry = lookupTable.getLookup(roll);
-      if (entry == null) return 0; // no entry was found
-      int rollInt = Integer.parseInt(roll);
-      if (rollInt < entry.getMin() || rollInt > entry.getMax())
-        return 0; // entry was found but doesn't match
-      List<LookupEntry> oldlist = new ArrayList<>(lookupTable.getEntryList());
-      lookupTable.clearEntries();
-      for (LookupEntry e : oldlist)
-        if (e != entry) {
-          lookupTable.addEntry(e.getMin(), e.getMax(), e.getValue(), e.getImageId());
-        } else {
-          if (imageId == null) imageId = e.getImageId();
 
-          lookupTable.addEntry(e.getMin(), e.getMax(), result, imageId);
-        }
+      LookupTable lookupTable = getMaptoolTable(name, function);
+      LookupEntry entry = lookupTable.getEntryByRollResult(roll);
+      if (entry == null) {
+        return 0;
+      }
+
+      entry.setValue(result);
+      if (imageId != null) {
+        // So... how is one supposed to remove the image?
+        entry.setImageId(imageId);
+      }
+
       MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
       return 1;
 

--- a/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/LookupTableFunction.java
@@ -144,7 +144,7 @@ public class LookupTableFunction extends AbstractFunction {
       FunctionUtil.checkNumberParam("getTableRoll", params, 1, 1);
       String name = params.get(0).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
-      return lookupTable.getRoll();
+      return lookupTable.calculateRoll();
 
     } else if ("setTableRoll".equalsIgnoreCase(function)) {
 
@@ -153,9 +153,10 @@ public class LookupTableFunction extends AbstractFunction {
       String name = params.get(0).toString();
       String roll = params.get(1).toString();
       LookupTable lookupTable = getMaptoolTable(name, function);
+
       lookupTable.setRoll(roll);
       MapTool.serverCommand().updateCampaign(MapTool.getCampaign().getCampaignProperties());
-      return lookupTable.getRoll();
+      return roll;
 
     } else if ("clearTable".equalsIgnoreCase(function)) {
 

--- a/src/main/java/net/rptools/maptool/client/ui/lookuptable/EditLookupTablePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/lookuptable/EditLookupTablePanel.java
@@ -126,7 +126,7 @@ public class EditLookupTablePanel extends AbeillePanel<LookupTableTableModel> {
     accepted = false;
 
     getTableNameTextField().setText(this.lookupTable.getName());
-    getTableRollTextField().setText(this.lookupTable.getRoll());
+    getTableRollTextField().setText(this.lookupTable.calculateRoll());
     tableImageAssetPanel.setImageId(this.lookupTable.getTableImage());
     getVisibleCheckbox().setSelected(this.lookupTable.getVisible());
     getAllowLookupCheckbox().setSelected(this.lookupTable.getAllowLookup());

--- a/src/main/java/net/rptools/maptool/client/ui/lookuptable/LookupTablePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/lookuptable/LookupTablePanel.java
@@ -214,10 +214,7 @@ public class LookupTablePanel extends AbeillePanel<LookupTableImagePanelModel> {
               LookupTable lookupTable = MapTool.getCampaign().getLookupTableMap().get(ids.get(0));
 
               if (MapTool.confirm("LookupTablePanel.confirm.delete", lookupTable.getName())) {
-                MapTool.getCampaign().getLookupTableMap().remove(lookupTable.getName());
-                MapTool.serverCommand()
-                    .updateCampaign(MapTool.getCampaign().getCampaignProperties());
-
+                MapTool.serverCommand().deleteLookupTable(lookupTable.getName());
                 imagePanel.clearSelection();
                 repaint();
               }
@@ -246,24 +243,15 @@ public class LookupTablePanel extends AbeillePanel<LookupTableImagePanelModel> {
                     Map<String, LookupTable> lookupTables =
                         MapTool.getCampaign().getLookupTableMap();
                     LookupTable newTable = PersistenceUtil.loadTable(selectedFile);
-                    Boolean alreadyExists = lookupTables.keySet().contains(newTable.getName());
-                    if (alreadyExists) {
-                      if (MapTool.confirm("LookupTablePanel.confirm.import", newTable.getName())) {
-                        lookupTables.remove(newTable.getName());
-                      } else {
-                        return;
-                      }
-                      lookupTables.put(newTable.getName(), newTable);
-                      imagePanel.clearSelection();
-                      imagePanel.repaint();
-                      MapTool.serverCommand()
-                          .updateCampaign(MapTool.getCampaign().getCampaignProperties());
+                    boolean alreadyExists = lookupTables.keySet().contains(newTable.getName());
+                    if (alreadyExists
+                        && !MapTool.confirm(
+                            "LookupTablePanel.confirm.import", newTable.getName())) {
+                      return;
                     }
-                    lookupTables.put(newTable.getName(), newTable);
+                    MapTool.serverCommand().putLookupTable(newTable);
                     imagePanel.clearSelection();
                     imagePanel.repaint();
-                    MapTool.serverCommand()
-                        .updateCampaign(MapTool.getCampaign().getCampaignProperties());
                   });
             });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -672,7 +672,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
   }
 
   private void updateImageTableCombo() {
-    List<String> typeList = new ArrayList<String>(MapTool.getCampaign().getLookupTables());
+    List<String> typeList =
+        new ArrayList<String>(MapTool.getCampaign().getLookupTableMap().keySet());
     Collections.sort(typeList);
 
     DefaultComboBoxModel model = new DefaultComboBoxModel(typeList.toArray());

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -307,12 +307,6 @@ public class Campaign implements Serializable {
     return campaignProperties.getLookupTableMap();
   }
 
-  public List<String> getLookupTables() {
-    List<String> list = new ArrayList<String>(getLookupTableMap().keySet());
-    Collections.sort(list);
-    return list;
-  }
-
   /**
    * Stub that calls <code>campaignProperties.getLightSourcesMap()</code>.
    *

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -56,6 +56,10 @@ public class LookupTable {
     entryList.addAll(table.entryList);
   }
 
+  public String getRoll() {
+    return defaultRoll;
+  }
+
   public void setRoll(String roll) {
     defaultRoll = roll;
   }
@@ -68,7 +72,7 @@ public class LookupTable {
     entryList.add(new LookupEntry(min, max, result, imageId));
   }
 
-  public String getRoll() {
+  public String calculateRoll() {
     if (getPickOnce()) {
       var entryIndex = getRandomPickOnce();
       if (entryIndex < 0) {

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -130,6 +130,10 @@ public class LookupTable {
     return entryList.get(index);
   }
 
+  public boolean deleteEntry(LookupEntry entry) {
+    return entryList.remove(entry);
+  }
+
   /**
    * Accepts a string containing a valid dice expression or integer which is evaluated and then the
    * matching entry in the table is returned.

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -68,10 +68,6 @@ public class LookupTable {
     entryList.add(new LookupEntry(min, max, result, imageId));
   }
 
-  public LookupEntry getLookup() throws ParserException {
-    return getLookup(null);
-  }
-
   public String getRoll() {
     return getDefaultRoll();
   }
@@ -202,7 +198,7 @@ public class LookupTable {
       List<LookupEntry> le = entryList;
       LookupEntry entry;
       int len = le.size();
-      List unpicked = new ArrayList<Integer>();
+      List<Integer> unpicked = new ArrayList<Integer>();
       for (int i = 0; i < len; i++) {
         entry = le.get(i);
         if (!entry.picked) {
@@ -244,13 +240,9 @@ public class LookupTable {
 
   /** Sets the picked flag on each table entry to false. */
   public void reset() {
-    List<LookupEntry> curList = entryList;
-    List<LookupEntry> newList = new ArrayList<>();
-    for (LookupEntry entry : curList) {
+    for (var entry : entryList) {
       entry.setPicked(false);
-      newList.add(entry);
     }
-    entryList = newList;
   }
 
   /**
@@ -293,7 +285,7 @@ public class LookupTable {
    *
    * @return MD5Key
    */
-  public MD5Key getTableImage() {
+  public @Nullable MD5Key getTableImage() {
     return tableImage;
   }
 
@@ -302,21 +294,16 @@ public class LookupTable {
    *
    * @param tableImage The MD5Key (Asset ID) for the image.
    */
-  public void setTableImage(MD5Key tableImage) {
+  public void setTableImage(@Nullable MD5Key tableImage) {
     this.tableImage = tableImage;
   }
 
   /**
    * Gets whether a table is flagged as Pick Once or not.
    *
-   * @return Boolean - true if table is Pick Once
+   * @return {@code true} if table is Pick Once
    */
   public boolean getPickOnce() {
-    // Older tables won't have it set.
-    if (pickOnce == null) {
-      pickOnce = false;
-    }
-
     return pickOnce;
   }
 
@@ -379,7 +366,7 @@ public class LookupTable {
      */
     @Deprecated private @Nullable String result;
 
-    public LookupEntry(int min, int max, String value, MD5Key imageId) {
+    public LookupEntry(int min, int max, @Nullable String value, @Nullable MD5Key imageId) {
       this.min = min;
       this.max = max;
       this.value = value;
@@ -400,7 +387,7 @@ public class LookupTable {
       return this;
     }
 
-    public MD5Key getImageId() {
+    public @Nullable MD5Key getImageId() {
       return imageId;
     }
 
@@ -420,7 +407,7 @@ public class LookupTable {
       return min;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
       return value;
     }
 
@@ -456,7 +443,7 @@ public class LookupTable {
     if (getTableImage() != null) {
       assetSet.add(getTableImage());
     }
-    for (LookupEntry entry : getEntryList()) {
+    for (LookupEntry entry : entryList) {
       if (entry.getImageId() != null) {
         assetSet.add(entry.getImageId());
       }

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -16,13 +16,13 @@ package net.rptools.maptool.model;
 
 import com.google.protobuf.StringValue;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.dicelib.expression.ExpressionParser;
 import net.rptools.dicelib.expression.Result;
 import net.rptools.lib.MD5Key;
-import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.server.proto.LookupEntryDto;
 import net.rptools.maptool.server.proto.LookupTableDto;
 import net.rptools.maptool.util.ExpressionParserFactory;
@@ -69,7 +69,15 @@ public class LookupTable {
   }
 
   public String getRoll() {
-    return getDefaultRoll();
+    if (getPickOnce()) {
+      var entryIndex = getRandomPickOnce();
+      if (entryIndex < 0) {
+        return NO_PICKS_LEFT;
+      }
+      return Integer.toString(entryIndex);
+    } else {
+      return getStandardDefaultRoll();
+    }
   }
 
   public void setName(String name) {
@@ -126,28 +134,15 @@ public class LookupTable {
    * @return A LookupEntry matching the roll.
    * @throws ParserException if roll can't be parsed as integer or die expression
    */
-  public LookupEntry getLookup(String roll) throws ParserException {
-    LookupEntry entry;
-
-    if (roll == null) {
-      roll = getDefaultRoll();
-    }
-
-    if (roll.equals(NO_PICKS_LEFT)) {
-      entry = new LookupEntry(0, 0, NO_PICKS_LEFT, null);
-      return entry;
-    }
-
-    if (getPickOnce()) {
-      entry = getPickOnceLookup(roll);
-    } else {
-      entry = getStandardLookup(roll);
-    }
-
-    return entry;
+  public @Nullable LookupEntry getLookup(String roll) throws ParserException {
+    return getPickOnce() ? getPickOnceLookup(roll) : getStandardLookup(roll);
   }
 
-  private @Nullable LookupEntry getStandardLookup(String roll) throws ParserException {
+  private @Nullable LookupEntry getStandardLookup(@Nullable String roll) throws ParserException {
+    if (roll == null) {
+      roll = getStandardDefaultRoll();
+    }
+
     int tableResult = 0;
     try {
       Result result = expressionParser.evaluate(roll);
@@ -161,18 +156,20 @@ public class LookupTable {
     }
   }
 
-  private LookupEntry getPickOnceLookup(String roll) throws ParserException {
+  private @Nonnull LookupEntry getPickOnceLookup(@Nullable String roll) throws ParserException {
+    int entryIndex;
     try {
-      int entryNum = Integer.parseInt(roll);
-      var entry = getEntryByIndex(entryNum);
-      if (entry == null) {
-        return new LookupEntry(0, 0, NO_PICKS_LEFT, null);
-      }
-
-      entry.setPicked(true);
-      return entry;
+      entryIndex = roll == null ? getRandomPickOnce() : Integer.parseInt(roll);
     } catch (NumberFormatException nfe) {
       throw new ParserException("Expected integer value for pick once table: " + roll);
+    }
+
+    var entry = getEntryByIndex(entryIndex);
+    if (entry == null) {
+      return new LookupEntry(0, 0, NO_PICKS_LEFT, null);
+    } else {
+      entry.setPicked(true);
+      return entry;
     }
   }
 
@@ -197,51 +194,49 @@ public class LookupTable {
     return val;
   }
 
-  private String getDefaultRoll() {
-    if (getPickOnce()) {
-      // For Pick Once tables this returns a random pick from those entries in the list that
-      // have not been picked.
-      List<LookupEntry> le = entryList;
-      LookupEntry entry;
-      int len = le.size();
-      List<Integer> unpicked = new ArrayList<Integer>();
-      for (int i = 0; i < len; i++) {
-        entry = le.get(i);
-        if (!entry.picked) {
-          unpicked.add(i);
-        }
+  /**
+   * Gets a random entry index, for use with pick once tables.
+   *
+   * @return A random entry index, or {@code -1} if there are no picks left.
+   */
+  private int getRandomPickOnce() {
+    // For Pick Once tables this returns a random pick from those entries in the list that
+    // have not been picked.
+    List<LookupEntry> le = entryList;
+    LookupEntry entry;
+    int len = le.size();
+    List<Integer> unpicked = new ArrayList<Integer>();
+    for (int i = 0; i < len; i++) {
+      entry = le.get(i);
+      if (!entry.picked) {
+        unpicked.add(i);
       }
-      if (unpicked.isEmpty()) {
-        return (NO_PICKS_LEFT);
-      }
-      try {
-        Result result = expressionParser.evaluate("d" + unpicked.size());
-        int index = Integer.parseInt(result.getValue().toString()) - 1;
-        return unpicked.get(index).toString();
-      } catch (ParserException e) {
-        MapTool.showError("Error getting default roll for Pick Once table ", e);
-        return (NO_PICKS_LEFT);
-      }
-    } else {
-      if (defaultRoll != null && defaultRoll.length() > 0) {
-        return defaultRoll;
-      }
-
-      // Find the min and max range
-      Integer min = null;
-      Integer max = null;
-
-      for (LookupEntry entry : entryList) {
-        if (min == null || entry.min < min) {
-          min = entry.min;
-        }
-        if (max == null || entry.max > max) {
-          max = entry.max;
-        }
-      }
-
-      return min != null ? "d" + (max - min + 1) + (min - 1 != 0 ? "+" + (min - 1) : "") : "";
     }
+    if (unpicked.isEmpty()) {
+      return -1;
+    }
+
+    var index = ThreadLocalRandom.current().nextInt(unpicked.size());
+    return unpicked.get(index);
+  }
+
+  private String getStandardDefaultRoll() {
+    if (defaultRoll != null && !defaultRoll.isEmpty()) {
+      return defaultRoll;
+    }
+
+    if (entryList.isEmpty()) {
+      return "";
+    }
+
+    var first = entryList.getFirst();
+    int min = first.min;
+    int max = first.max;
+    for (LookupEntry entry : entryList.subList(1, entryList.size())) {
+      min = Math.min(min, entry.min);
+      max = Math.max(max, entry.max);
+    }
+    return "d" + (max - min + 1) + (min - 1 != 0 ? "+" + (min - 1) : "");
   }
 
   /** Sets the picked flag on each table entry to false. */

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -366,6 +366,10 @@ public class LookupTable {
       return imageId;
     }
 
+    public void setImageId(@Nullable MD5Key imageId) {
+      this.imageId = imageId;
+    }
+
     public void setPicked(boolean b) {
       picked = b;
     }
@@ -384,6 +388,10 @@ public class LookupTable {
 
     public @Nullable String getValue() {
       return value;
+    }
+
+    public void setValue(@Nullable String value) {
+      this.value = value;
     }
 
     public static LookupEntry fromDto(LookupEntryDto dto) {

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -81,6 +81,23 @@ public class LookupTable {
   }
 
   /**
+   * Looks up an entry by its index in the list of entries.
+   *
+   * <p>This is useful for pick once tables where, unlike standard tables, the ranges are not used
+   * to lookup entries.
+   *
+   * @param index The index of the entry to look up.
+   * @return The entry at index {@code index}, or {@code null} if the index is out of bounds.
+   */
+  public @Nullable LookupEntry getEntryByIndex(int index) {
+    if (index < 0 || index >= entryList.size()) {
+      return null;
+    }
+
+    return entryList.get(index);
+  }
+
+  /**
    * Accepts a string containing a valid dice expression or integer which is evaluated and then the
    * matching entry in the table is returned.
    *
@@ -154,17 +171,13 @@ public class LookupTable {
   private LookupEntry getPickOnceLookup(String roll) throws ParserException {
     try {
       int entryNum = Integer.parseInt(roll);
-
-      if (entryNum < entryList.size()) {
-        LookupEntry entry = entryList.get(entryNum);
-        entry.setPicked(true);
-        entryList.set(entryNum, entry);
-
-        return entry;
-      } else {
+      var entry = getEntryByIndex(entryNum);
+      if (entry == null) {
         return new LookupEntry(0, 0, NO_PICKS_LEFT, null);
       }
 
+      entry.setPicked(true);
+      return entry;
     } catch (NumberFormatException nfe) {
       throw new ParserException("Expected integer value for pick once table: " + roll);
     }
@@ -239,36 +252,10 @@ public class LookupTable {
   }
 
   /** Sets the picked flag on each table entry to false. */
-  public void reset() {
+  public void resetPicks() {
     for (var entry : entryList) {
       entry.setPicked(false);
     }
-  }
-
-  /**
-   * Reset the picked status of specific entries, allowing them to be picked again in this PickOnce
-   * table. Note that this uses the same indexing scheme as {@link #getPickOnceLookup(String)} -
-   * these entries are identified by list index (starting at 0), and NOT by any configured range.
-   *
-   * @param entriesToReset a list of strings representing the integer indices of entries to reset
-   * @throws NumberFormatException if any of the string entries cannot be successfully parsed as an
-   *     integer.
-   */
-  public void reset(List<String> entriesToReset) {
-    Set<Integer> indicesToReset =
-        entriesToReset.stream()
-            .map(Integer::parseInt)
-            .collect(Collectors.toCollection(HashSet::new));
-    List<LookupEntry> curList = entryList;
-    List<LookupEntry> newList = new ArrayList<>();
-    for (int i = 0; i < curList.size(); i++) {
-      LookupEntry entry = curList.get(i);
-      if (indicesToReset.contains(i)) {
-        entry.setPicked(false);
-      }
-      newList.add(entry);
-    }
-    entryList = newList;
   }
 
   /**
@@ -315,7 +302,7 @@ public class LookupTable {
    */
   public void setPickOnce(boolean pickOnce) {
     this.pickOnce = pickOnce;
-    this.reset();
+    this.resetPicks();
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -81,6 +81,27 @@ public class LookupTable {
   }
 
   /**
+   * Finds the first entry that matches a given roll result.
+   *
+   * <p>This is useful for standard tables where each entry's range must be respected.
+   *
+   * @param rollResult The value to look up.
+   * @return The first entry whose range includes {@code rollResult}, or {@code null} if there is
+   *     none.
+   */
+  public @Nullable LookupEntry getEntryByRollResult(int rollResult) {
+    // For now this is a linear scan. In the future hopefully we can use some kind of accelerated
+    // search.
+    for (var entry : entryList) {
+      if (entry.min <= rollResult && rollResult <= entry.max) {
+        return entry;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Looks up an entry by its index in the list of entries.
    *
    * <p>This is useful for pick once tables where, unlike standard tables, the ranges are not used
@@ -126,46 +147,18 @@ public class LookupTable {
     return entry;
   }
 
-  /**
-   * Accepts a string containing a valid dice expression or integer which is evaluated and then the
-   * matching entry in the table is returned without filtering for picked entries.
-   *
-   * @param roll A string containing a dice expression or integer.
-   * @return A LookupEntry matching the roll.
-   */
-  public LookupEntry getLookupDirect(String roll) throws ParserException {
-    LookupEntry entry;
-
-    if (roll == null) {
-      return (null);
-    }
-
-    entry = getStandardLookup(roll);
-
-    return entry;
-  }
-
-  private LookupEntry getStandardLookup(String roll) throws ParserException {
+  private @Nullable LookupEntry getStandardLookup(String roll) throws ParserException {
     int tableResult = 0;
-    LookupEntry retEntry = null;
-
     try {
       Result result = expressionParser.evaluate(roll);
       tableResult = Integer.parseInt(result.getValue().toString());
 
       tableResult = constrainRoll(tableResult);
 
-      for (LookupEntry entry : entryList) {
-        if (tableResult >= entry.min && tableResult <= entry.max) {
-          retEntry = entry;
-        }
-      }
-
+      return getEntryByRollResult(tableResult);
     } catch (NumberFormatException nfe) {
       throw new ParserException("Error lookup up value: " + tableResult);
     }
-
-    return retEntry;
   }
 
   private LookupEntry getPickOnceLookup(String roll) throws ParserException {

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1140,12 +1140,9 @@ public class Token implements Cloneable {
     LookupTable lookupTable = MapTool.getCampaign().getLookupTableMap().get(getImageTableName());
     if (lookupTable == null) return getImageAssetId();
 
-    try {
-      LookupTable.LookupEntry result = lookupTable.getLookup(String.valueOf(getFacing()));
-      if (result != null) return result.getImageId();
-
-    } catch (ParserException p) {
-      /* do nothing  */
+    LookupTable.LookupEntry result = lookupTable.getEntryByRollResult(getFacing());
+    if (result != null) {
+      return result.getImageId();
     }
 
     return getImageAssetId();

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -238,4 +238,8 @@ public interface ServerCommand {
   void updateTokenProperty(Token token, Token.Update update, String value, BigDecimal value2);
 
   void updatePlayerStatus(Player player);
+
+  void putLookupTable(LookupTable lookupTable);
+
+  void deleteLookupTable(String tableName);
 }

--- a/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/server/ServerMessageHandler.java
@@ -267,7 +267,14 @@ public class ServerMessageHandler implements MessageHandler {
           handle(msg.getUpdateWallDataMsg());
           sendToClients(id, msg);
         }
-
+        case UPDATE_LOOKUP_TABLE_MSG -> {
+          handle(msg.getUpdateLookupTableMsg());
+          sendToClients(id, msg);
+        }
+        case DELETE_LOOKUP_TABLE_MSG -> {
+          handle(msg.getDeleteLookupTableMsg());
+          sendToClients(id, msg);
+        }
         default -> log.warn(msgType + " not handled.");
       }
       log.debug("from " + id + " handled: " + msgType);
@@ -742,6 +749,21 @@ public class ServerMessageHandler implements MessageHandler {
           var wall = Wall.fromDto(updateWallDataMsg.getWall());
 
           zone.updateWall(wall);
+        });
+  }
+
+  private void handle(PutLookupTableMsg msg) {
+    EventQueue.invokeLater(
+        () -> {
+          var table = LookupTable.fromDto(msg.getTable());
+          server.getCampaign().getLookupTableMap().put(table.getName(), table);
+        });
+  }
+
+  private void handle(DeleteLookupTableMsg msg) {
+    EventQueue.invokeLater(
+        () -> {
+          server.getCampaign().getLookupTableMap().remove(msg.getTableName());
         });
   }
 

--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -273,10 +273,12 @@ public class FunctionUtil {
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
     Object parameter = parameters.get(index);
-    if (parameter instanceof BigDecimal) return (BigDecimal) parameter;
+    if (parameter instanceof BigDecimal) {
+      return (BigDecimal) parameter;
+    }
     try {
       if (!allowString && parameter instanceof String) throw new NumberFormatException("String");
-      return (new BigDecimal(parameter.toString()));
+      return new BigDecimal(parameter.toString());
     } catch (NumberFormatException ne) {
       throw new ParserException(
           I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
@@ -299,7 +301,9 @@ public class FunctionUtil {
       throws ParserException {
     Object parameter = parameters.get(index);
     try {
-      if (!allowString && parameter instanceof String) throw new NumberFormatException("String");
+      if (!allowString && parameter instanceof String) {
+        throw new NumberFormatException("String");
+      }
       BigDecimal val = new BigDecimal(parameter.toString());
       return !val.equals(BigDecimal.ZERO); // true if any value except zero
     } catch (NumberFormatException ne) {
@@ -320,13 +324,15 @@ public class FunctionUtil {
    * @throws ParserException if the parameter can't be converted to BigDecimal, or if disallowed
    *     text
    */
-  public static Integer paramAsInteger(
+  public static int paramAsInteger(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
     Object parameter = parameters.get(index);
     try {
-      if (!allowString && parameter instanceof String) throw new NumberFormatException("String");
-      return Integer.valueOf(parameter.toString());
+      if (!allowString && parameter instanceof String) {
+        throw new NumberFormatException("String");
+      }
+      return Integer.parseInt(parameter.toString());
     } catch (NumberFormatException ne) {
       throw new ParserException(
           I18N.getText(KEY_NOT_INT, functionName, index + 1, parameter.toString()));
@@ -344,13 +350,15 @@ public class FunctionUtil {
    * @return the parameter as a Double
    * @throws ParserException if can't be converted to Double, or disallowed text
    */
-  public static Double paramAsDouble(
+  public static double paramAsDouble(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
     Object parameter = parameters.get(index);
     try {
-      if (!allowString && parameter instanceof String) throw new NumberFormatException("String");
-      return (Double.valueOf(parameter.toString()));
+      if (!allowString && parameter instanceof String) {
+        throw new NumberFormatException("String");
+      }
+      return Double.parseDouble(parameter.toString());
     } catch (NumberFormatException ne) {
       throw new ParserException(
           I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
@@ -368,13 +376,15 @@ public class FunctionUtil {
    * @return the parameter as a Float
    * @throws ParserException if can't be converted to Float, or if disallowed text
    */
-  public static Float paramAsFloat(
+  public static float paramAsFloat(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
     Object parameter = parameters.get(index);
     try {
-      if (!allowString && parameter instanceof String) throw new NumberFormatException("String");
-      return (Float.valueOf(parameter.toString()));
+      if (!allowString && parameter instanceof String) {
+        throw new NumberFormatException("String");
+      }
+      return Float.parseFloat(parameter.toString());
     } catch (NumberFormatException ne) {
       throw new ParserException(
           I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));

--- a/src/main/java/net/rptools/maptool/util/ImageSupport.java
+++ b/src/main/java/net/rptools/maptool/util/ImageSupport.java
@@ -27,7 +27,6 @@ import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.LookupTable;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.TokenFootprint;
-import net.rptools.parser.ParserException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -182,14 +181,9 @@ public class ImageSupport {
       LookupTable lookupTable =
           MapTool.getCampaign().getLookupTableMap().get(token.getImageTableName());
       if (lookupTable != null) {
-        try {
-          LookupTable.LookupEntry result =
-              lookupTable.getLookup(Integer.toString(token.getFacing()));
-          if (result != null) {
-            image = ImageManager.getImage(result.getImageId(), observers);
-          }
-        } catch (ParserException p) {
-          // do nothing
+        LookupTable.LookupEntry result = lookupTable.getEntryByRollResult(token.getFacing());
+        if (result != null) {
+          image = ImageManager.getImage(result.getImageId(), observers);
         }
       }
     }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4769

### Description of the Change

This largely fixes the performance issues with `LookupTable` itself, and with existing table functions. It doesn't resolve surrounding performance issues, such as the overhead of syncing large numbers of updates to other clients.

There are two independent parts to this PR: improving `LookupTable` performance; and improving the use of server commands. There is also a minor change to the `FunctionUtil.paramAs*()` functions to make them return primitives instead of boxed values, and to follow proper code style.

#### Part 1: LookupTable itself

There are two new methods on `LookupTable` that are more performant alternatives to `LookupTable#getLookup(String)` for many cases:
- `LookupTable#getEntryByRollResult(int)` allows for standard table lookup by finding the first entry with a range encompassing the argument. This is used by the internal `LookupTable#getStandardLookup(String)`, the macro functions `getTableEntry()` and `setTableEntry()`, and elsewhere in `ImageSupport#getTokenImage(Token, ImageObserver[])` and `Token#getTokenImageAssetId()`.
- `LookupTable#getEntryByIndex(int)` allows for pick-once lookups by directly indexing into the entry list. This is used by the internal `LookupTable#getPickOnceLookup(String)` as well as the macro functions `getTableEntryAtIndex()` and `resetTablePicks()`.

Neither of these methods support evaluating rolls, so they don't incur any penalty due to converting back and forth between `String` and `int`, or for invoking the expression parser. They also guarantee that they only return matching entries or `null`, meaning callers like `getTableEntry()` and `setTableEntry()` don't have to validate the results.

There are still some places that require roll support in the table: `deleteTableEntry()`, `table()`, `tableImage()` and `/table`. These must still call `LookupTable#getLookup(String)`. There is only a minor performance gain for this method by changing how it handles `null` arguments: instead of computing a default roll before calling `#getPickOnceLookup(String)` or `#getStandardLookup(String)`, the responsibility for default behaviour has been pushed down into these other methods where more performant decisions can be made. E.g., `getPickOnceLookup()` can completely avoid the expression parser when given a `null` argument. This will have greater impact if we ever change the structure of `LookupTable`, e.g., to maintain the list of unpicked entries instead of building this list dynamically each time.

#### Part 2: Server commands

The second major part of this PR is improvements to server commands when tables have been updated. First of all, when a macro function does not actually modify the table - such as when setting the same value as already exists - it will not try to sync the table to the server. Second, when a sync is required, instead of syncing the entire campaign properties, they will now only sync the affected table, using these two new server commands:
- `ServerCommand#putLookupTable(LookupTable)`: adds or updates a lookup table on all clients. An existing table with the same name will be replaced.
- `ServerCommand#deleteLookupTable(String)`: removes the named lookup table on all clients.

The **Table** panel has also been updated to use these server commands.

### Possible Drawbacks

Should be none

This still leaves a some performance on the table since `LookupTable` does not yet do any sort of accelerated lookups, either for standard or pick once tables.

### Documentation Notes

Should discourage the use of `table()`/`tableImage()` unless necessary, since they have more hidden costs than `getTableEntry()`.

### Release Notes

- Improve the performance when updating tables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5822)
<!-- Reviewable:end -->
