### PR TITLE
Fix token state opacity and dot position

### DIFF
--- a/common/src/main/java/net/rptools/lib/AwtUtil.java
+++ b/common/src/main/java/net/rptools/lib/AwtUtil.java
@@ -15,6 +15,7 @@
 package net.rptools.lib;
 
 import java.awt.Dimension;
+import java.awt.geom.Rectangle2D;
 
 public final class AwtUtil {
   private AwtUtil() {
@@ -47,5 +48,41 @@ public final class AwtUtil {
                       : (width / (double) dim.width) * dim.height);
       constrainTo(dim, size);
     }
+  }
+
+  /**
+   * Modifies {@code inner} so that it fits into {@code outer} and is centered within.
+   *
+   * <p>The aspect ration of {@code inner} is preserved, but this method will translate and scale it
+   * as needed to fit within {@code other}.
+   *
+   * @param inner
+   * @param outer
+   */
+  public static void fitInto(Rectangle2D inner, Rectangle2D outer) {
+    if (outer.getWidth() == 0 || outer.getHeight() == 0) {
+      inner.setRect(outer);
+      return;
+    }
+
+    var widthRatio = outer.getWidth() / inner.getWidth();
+    var heightRatio = outer.getHeight() / inner.getHeight();
+
+    boolean fitToWidth = widthRatio < heightRatio;
+    double x, y, width, height;
+    if (fitToWidth) {
+      x = outer.getMinX();
+      width = outer.getWidth();
+
+      height = inner.getHeight() * widthRatio;
+      y = outer.getMinY() + (outer.getHeight() - height) / 2.;
+    } else {
+      y = outer.getMinY();
+      height = outer.getHeight();
+
+      width = inner.getWidth() * heightRatio;
+      x = outer.getMinX() + (outer.getWidth() - width) / 2.;
+    }
+    inner.setRect(x, y, width, height);
   }
 }

--- a/messages/src/main/proto/data_transfer_objects.proto
+++ b/messages/src/main/proto/data_transfer_objects.proto
@@ -201,30 +201,67 @@ enum QuadrantDto {
 }
 
 message BooleanTokenOverlayDto {
-  enum BooleanTokenOverlayTypeDto {
+  TokenOverlayDto common = 1;
+  oneof child_type {
+    ShapeTokenOverlayDto shape = 2;
+    FlowShapeTokenOverlayDto flow_shape = 3;
+    ColorDotTokenOverlayDto color_dot = 4;
+    ImageTokenOverlayDto image = 5;
+    CornerImageTokenOverlayDto corner_image = 6;
+    FlowImageTokenOverlayDto flow_image = 7;
+    ShadedTokenOverlayDto shaded = 8;
+  }
+}
+
+message ShapeTokenOverlayDto {
+  enum TypeTag {
     X = 0;
     YIELD = 1;
     O = 2;
-    COLOR_DOT = 3;
-    DIAMOND = 4;
-    TRIANGLE = 5;
-    CROSS = 6;
-    FLOW_COLOR_DOT = 7;
-    FLOW_DIAMOND = 8;
-    FLOW_COLOR_SQUARE = 9;
-    FLOW_YIELD = 10;
-    SHADED = 11;
-    IMAGE = 12;
-    FLOW_IMAGE = 13;
-    CORNER_IMAGE = 14;
+    DIAMOND = 3;
+    TRIANGLE = 4;
+    CROSS = 5;
   }
-  TokenOverlayDto common = 1;
-  int32 color = 2;
-  StrokeDto stroke = 3;
-  QuadrantDto quadrant = 4;
-  int32 grid_size = 5;
-  string asset_id = 6;
-  BooleanTokenOverlayTypeDto type = 7;
+
+  int32 color = 1;
+  float stroke_width = 2;
+  TypeTag type = 3;
+}
+
+message FlowShapeTokenOverlayDto {
+  enum TypeTag {
+    DOT = 0;
+    SQUARE = 1;
+    DIAMOND = 2;
+    TRIANGLE = 3;
+    YIELD = 4;
+  }
+
+  int32 color = 1;
+  int32 grid_size = 2;
+  TypeTag type = 3;
+}
+
+message ColorDotTokenOverlayDto {
+  int32 color = 1;
+}
+
+message ImageTokenOverlayDto {
+  string asset_id = 1;
+}
+
+message CornerImageTokenOverlayDto {
+  string asset_id = 1;
+  QuadrantDto quadrant = 2;
+}
+
+message FlowImageTokenOverlayDto {
+  string asset_id = 1;
+  int32 gridSize = 2;
+}
+
+message ShadedTokenOverlayDto {
+  int32 color = 1;
 }
 
 message StrokeDto {
@@ -250,7 +287,6 @@ message TokenPropertyListDto {
 message LightSourceListDto {
   repeated LightSourceDto light_sources = 1;
 }
-
 
 enum WalkerMetricDto {
   NO_DIAGONALS = 0;

--- a/messages/src/main/proto/data_transfer_objects.proto
+++ b/messages/src/main/proto/data_transfer_objects.proto
@@ -244,6 +244,7 @@ message FlowShapeTokenOverlayDto {
 
 message ColorDotTokenOverlayDto {
   int32 color = 1;
+  QuadrantDto quadrant = 2;
 }
 
 message ImageTokenOverlayDto {

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -512,41 +512,39 @@ public class TokenStatesController
 
       // Get most of the colors and all of the widths from the XTokenOverlay
       OverlayType type = OverlayType.Image;
-      if (s instanceof XTokenOverlay) {
+      if (s instanceof XTokenOverlay xTokenOverlay) {
         type = OverlayType.X;
-        formPanel.getSpinner(WIDTH).setValue(((XTokenOverlay) s).getWidth());
-        ((ColorWell) formPanel.getComponent(COLOR)).setColor(((XTokenOverlay) s).getColor());
+        formPanel.getSpinner(WIDTH).setValue(xTokenOverlay.getWidth());
+        ((ColorWell) formPanel.getComponent(COLOR)).setColor(xTokenOverlay.getColor());
       } // endif
 
       // Get the the flow grid for most components from FlowColorDotTokenOverlay
-      if (s instanceof FlowColorDotTokenOverlay) {
+      if (s instanceof FlowColorDotTokenOverlay flowColorDotTokenOverlay) {
         type = OverlayType.GridDot;
-        int size = ((FlowColorDotTokenOverlay) s).getGrid();
+        int size = flowColorDotTokenOverlay.getGrid();
         formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
       } // endif
 
       // Handle the
-      if (s instanceof CornerImageTokenOverlay) {
+      if (s instanceof CornerImageTokenOverlay cornerImageTokenOverlay) {
         type = OverlayType.CornerImage;
         formPanel
             .getComboBox(CORNER)
-            .setSelectedIndex(((CornerImageTokenOverlay) s).getCorner().ordinal());
-      } else if (s instanceof FlowImageTokenOverlay) {
+            .setSelectedIndex(cornerImageTokenOverlay.getCorner().ordinal());
+      } else if (s instanceof FlowImageTokenOverlay flowImageTokenOverlay) {
         type = OverlayType.GridImage;
-        int size = ((FlowImageTokenOverlay) s).getGrid(); // Still need grid size
+        int size = flowImageTokenOverlay.getGrid(); // Still need grid size
         formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
       } else if (s instanceof ImageTokenOverlay) {
         type = OverlayType.Image;
-      } else if (s instanceof ColorDotTokenOverlay) {
+      } else if (s instanceof ColorDotTokenOverlay colorDotTokenOverlay) {
         type = OverlayType.Dot;
-        formPanel
-            .getComboBox(CORNER)
-            .setSelectedIndex(((ColorDotTokenOverlay) s).getCorner().ordinal());
+        formPanel.getComboBox(CORNER).setSelectedIndex(colorDotTokenOverlay.getCorner().ordinal());
       } else if (s instanceof OTokenOverlay) {
         type = OverlayType.Circle;
-      } else if (s instanceof ShadedTokenOverlay) {
+      } else if (s instanceof ShadedTokenOverlay shadedTokenOverlay) {
         type = OverlayType.Shaded;
-        ((ColorWell) formPanel.getComponent(COLOR)).setColor(((ShadedTokenOverlay) s).getColor());
+        ((ColorWell) formPanel.getComponent(COLOR)).setColor(shadedTokenOverlay.getColor());
       } else if (s instanceof CrossTokenOverlay) {
         type = OverlayType.Cross;
       } else if (s instanceof DiamondTokenOverlay) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractFlowShapeTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractFlowShapeTokenOverlay.java
@@ -1,0 +1,164 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.token;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Composite;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
+import net.rptools.maptool.model.Token;
+import net.rptools.maptool.server.proto.FlowShapeTokenOverlayDto;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract sealed class AbstractFlowShapeTokenOverlay extends BooleanTokenOverlay
+    permits FlowColorDotTokenOverlay,
+        FlowDiamondTokenOverlay,
+        FlowColorSquareTokenOverlay,
+        FlowYieldTokenOverlay,
+        FlowTriangleTokenOverlay {
+  private static final Logger log = LogManager.getLogger(AbstractFlowShapeTokenOverlay.class);
+  private static final Color DEFAULT_COLOR = Color.RED;
+  private static final int DEFAULT_GRID_SIZE = 3;
+
+  /** Color used when filling the overlay shape. */
+  private Color color;
+
+  /**
+   * @deprecated This is a hold over from when FlowColorDotTokenOverlay (and by extension the other
+   *     flow shape overlays) inherited from XTokenOverlay. It didn't do anything then, and does
+   *     nothing now.
+   */
+  @Deprecated private BasicStroke stroke;
+
+  /** Size of the grid used to place a token with this state. */
+  private int grid;
+
+  /** Flow used to define position of states */
+  private transient TokenOverlayFlow flow;
+
+  public AbstractFlowShapeTokenOverlay(String name, Color color, int gridSize) {
+    super(name);
+
+    if (color == null) {
+      color = DEFAULT_COLOR;
+    }
+    this.color = color;
+
+    if (gridSize <= 0) {
+      gridSize = DEFAULT_GRID_SIZE;
+    }
+    this.grid = gridSize;
+  }
+
+  public AbstractFlowShapeTokenOverlay(AbstractFlowShapeTokenOverlay other) {
+    super(other);
+    this.color = other.color;
+    this.grid = other.grid;
+  }
+
+  public final Color getColor() {
+    return color;
+  }
+
+  public final void setColor(Color color) {
+    this.color = color;
+  }
+
+  public final int getGrid() {
+    return grid;
+  }
+
+  /**
+   * Get the flow used to position the states.
+   *
+   * @return Flow used to position the states
+   */
+  protected final TokenOverlayFlow getFlow() {
+    if (flow == null) {
+      flow = TokenOverlayFlow.getInstance(grid);
+    }
+    return flow;
+  }
+
+  @Override
+  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
+    Color tempColor = g.getColor();
+    Composite tempComposite = g.getComposite();
+    try {
+      g.setColor(getColor());
+      if (getOpacity() != 100) {
+        g.setComposite(
+            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+      }
+      Rectangle2D gridCellBounds = getFlow().getStateBounds2D(bounds, token, getName());
+      Shape s = getShape(gridCellBounds);
+      g.fill(s);
+    } finally {
+      g.setColor(tempColor);
+      g.setComposite(tempComposite);
+    }
+  }
+
+  /**
+   * Return the overlay's shape.
+   *
+   * @param bounds Bounds of the token
+   * @param token Token being rendered.
+   * @return The shape of to render for the overlay.
+   */
+  @Deprecated
+  public final Shape getShape(Rectangle bounds, Token token) {
+    Rectangle2D gridCellBounds = getFlow().getStateBounds2D(bounds, token, getName());
+    return getShape(gridCellBounds);
+  }
+
+  public abstract Shape getShape(Rectangle2D bounds);
+
+  public final FlowShapeTokenOverlayDto toFlowShapeDto() {
+    var dto = FlowShapeTokenOverlayDto.newBuilder();
+    dto.setColor(color.getRGB());
+    dto.setGridSize(grid);
+    dto.setType(
+        switch (this) {
+          case FlowColorDotTokenOverlay ignored -> FlowShapeTokenOverlayDto.TypeTag.DOT;
+          case FlowColorSquareTokenOverlay ignored -> FlowShapeTokenOverlayDto.TypeTag.SQUARE;
+          case FlowDiamondTokenOverlay ignored -> FlowShapeTokenOverlayDto.TypeTag.DIAMOND;
+          case FlowTriangleTokenOverlay ignored -> FlowShapeTokenOverlayDto.TypeTag.TRIANGLE;
+          case FlowYieldTokenOverlay ignored -> FlowShapeTokenOverlayDto.TypeTag.YIELD;
+        });
+    return dto.build();
+  }
+
+  public static AbstractFlowShapeTokenOverlay fromDto(FlowShapeTokenOverlayDto dto) {
+    var color = new Color(dto.getColor(), true);
+    var gridSize = dto.getGridSize();
+    return switch (dto.getType()) {
+      case DOT -> new FlowColorDotTokenOverlay(DEFAULT_STATE_NAME, color, gridSize);
+      case SQUARE -> new FlowColorSquareTokenOverlay(DEFAULT_STATE_NAME, color, gridSize);
+      case DIAMOND -> new FlowDiamondTokenOverlay(DEFAULT_STATE_NAME, color, gridSize);
+      case TRIANGLE -> new FlowTriangleTokenOverlay(DEFAULT_STATE_NAME, color, gridSize);
+      case YIELD -> new FlowYieldTokenOverlay(DEFAULT_STATE_NAME, color, gridSize);
+      case UNRECOGNIZED -> {
+        log.error("Unrecognized AbstractShapeOverlay type");
+        yield null;
+      }
+    };
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractFlowShapeTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractFlowShapeTokenOverlay.java
@@ -14,10 +14,8 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
@@ -98,22 +96,11 @@ public abstract sealed class AbstractFlowShapeTokenOverlay extends BooleanTokenO
   }
 
   @Override
-  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    Composite tempComposite = g.getComposite();
-    try {
-      g.setColor(getColor());
-      if (getOpacity() != 100) {
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      }
-      Rectangle2D gridCellBounds = getFlow().getStateBounds2D(bounds, token, getName());
-      Shape s = getShape(gridCellBounds);
-      g.fill(s);
-    } finally {
-      g.setColor(tempColor);
-      g.setComposite(tempComposite);
-    }
+  public final void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
+    g.setColor(getColor());
+    Rectangle2D gridCellBounds = getFlow().getStateBounds2D(bounds, token, getName());
+    Shape s = getShape(getFlow().getStateBounds2D(bounds, token, getName()));
+    g.fill(s);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractShapeTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractShapeTokenOverlay.java
@@ -14,14 +14,11 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.Stroke;
 import java.awt.geom.Rectangle2D;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.server.proto.ShapeTokenOverlayDto;
@@ -119,23 +116,9 @@ public abstract sealed class AbstractShapeTokenOverlay extends BooleanTokenOverl
 
   @Override
   public final void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    Stroke tempStroke = g.getStroke();
-    Composite tempComposite = g.getComposite();
-    try {
-      g.setColor(color);
-      g.setStroke(stroke);
-      if (getOpacity() != 100) {
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      }
-
-      g.draw(getShape(bounds));
-    } finally {
-      g.setColor(tempColor);
-      g.setStroke(tempStroke);
-      g.setComposite(tempComposite);
-    }
+    g.setColor(color);
+    g.setStroke(stroke);
+    g.draw(getShape(bounds));
   }
 
   public abstract Shape getShape(Rectangle2D bounds);

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractShapeTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractShapeTokenOverlay.java
@@ -1,0 +1,179 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.token;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Composite;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.Stroke;
+import java.awt.geom.Rectangle2D;
+import net.rptools.maptool.model.Token;
+import net.rptools.maptool.server.proto.ShapeTokenOverlayDto;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract sealed class AbstractShapeTokenOverlay extends BooleanTokenOverlay
+    permits CrossTokenOverlay,
+        DiamondTokenOverlay,
+        OTokenOverlay,
+        TriangleTokenOverlay,
+        YieldTokenOverlay,
+        XTokenOverlay {
+  private static final Logger log = LogManager.getLogger(AbstractShapeTokenOverlay.class);
+  private static final Color DEFAULT_COLOR = Color.RED;
+  private static final int DEFAULT_STROKE_WIDTH = 3;
+
+  private static BasicStroke createStroke(float strokeWidth) {
+    return new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL);
+  }
+
+  /** Color used when drawing the overlay shape. */
+  private Color color;
+
+  /** Stroke used to draw the lines of othe overlay shape. */
+  private BasicStroke stroke;
+
+  public AbstractShapeTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name);
+
+    if (color == null) {
+      color = DEFAULT_COLOR;
+    }
+    this.color = color;
+
+    if (strokeWidth <= 0) {
+      strokeWidth = DEFAULT_STROKE_WIDTH;
+    }
+    this.stroke = createStroke(strokeWidth);
+  }
+
+  public AbstractShapeTokenOverlay(AbstractShapeTokenOverlay other) {
+    super(other);
+    this.color = other.color;
+    this.stroke = other.stroke;
+  }
+
+  /**
+   * Get the color to use when drawing the overlay's shape.
+   *
+   * @return Returns the current value of color.
+   */
+  public final Color getColor() {
+    return color;
+  }
+
+  /**
+   * Set the value of color for the overlay.
+   *
+   * @param aColor The color to set.
+   */
+  public final void setColor(Color aColor) {
+    color = aColor;
+  }
+
+  /**
+   * Get the stroke to use when drawing the overlay's shape.
+   *
+   * @return Returns the current value of stroke.
+   */
+  public final BasicStroke getStroke() {
+    return stroke;
+  }
+
+  /**
+   * Get the stroke width for the overlay.
+   *
+   * @return Returns the width of the stroke returned by {@link #getStroke()}.
+   */
+  public final int getWidth() {
+    return (int) stroke.getLineWidth();
+  }
+
+  /**
+   * Set the stroke width for the overlay.
+   *
+   * @param strokeWidth The width to set for the stroke.
+   */
+  public final void setWidth(int strokeWidth) {
+    if (strokeWidth <= 0) {
+      strokeWidth = DEFAULT_STROKE_WIDTH;
+    }
+    stroke = createStroke(strokeWidth);
+  }
+
+  @Override
+  public final void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
+    Color tempColor = g.getColor();
+    Stroke tempStroke = g.getStroke();
+    Composite tempComposite = g.getComposite();
+    try {
+      g.setColor(color);
+      g.setStroke(stroke);
+      if (getOpacity() != 100) {
+        g.setComposite(
+            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+      }
+
+      g.draw(getShape(bounds));
+    } finally {
+      g.setColor(tempColor);
+      g.setStroke(tempStroke);
+      g.setComposite(tempComposite);
+    }
+  }
+
+  public abstract Shape getShape(Rectangle2D bounds);
+
+  public final ShapeTokenOverlayDto toShapeDto() {
+    var dto = ShapeTokenOverlayDto.newBuilder();
+    dto.setColor(color.getRGB());
+    dto.setStrokeWidth(stroke.getLineWidth());
+    dto.setType(
+        switch (this) {
+          case CrossTokenOverlay ignored -> ShapeTokenOverlayDto.TypeTag.CROSS;
+          case DiamondTokenOverlay ignored -> ShapeTokenOverlayDto.TypeTag.DIAMOND;
+          case OTokenOverlay ignored -> ShapeTokenOverlayDto.TypeTag.O;
+          case TriangleTokenOverlay ignored -> ShapeTokenOverlayDto.TypeTag.TRIANGLE;
+          case YieldTokenOverlay ignored -> ShapeTokenOverlayDto.TypeTag.YIELD;
+          case XTokenOverlay ignored -> ShapeTokenOverlayDto.TypeTag.X;
+        });
+    return dto.build();
+  }
+
+  public static AbstractShapeTokenOverlay fromDto(ShapeTokenOverlayDto dto) {
+    var color = new Color(dto.getColor(), true);
+    var strokeWidth = (int) dto.getStrokeWidth();
+    var overlay =
+        switch (dto.getType()) {
+          case X -> new XTokenOverlay(DEFAULT_STATE_NAME, color, strokeWidth);
+          case YIELD -> new YieldTokenOverlay(DEFAULT_STATE_NAME, color, strokeWidth);
+          case O -> new OTokenOverlay(DEFAULT_STATE_NAME, color, strokeWidth);
+          case DIAMOND -> new DiamondTokenOverlay(DEFAULT_STATE_NAME, color, strokeWidth);
+          case TRIANGLE -> new TriangleTokenOverlay(DEFAULT_STATE_NAME, color, strokeWidth);
+          case CROSS -> new CrossTokenOverlay(DEFAULT_STATE_NAME, color, strokeWidth);
+          case UNRECOGNIZED -> null;
+        };
+    if (overlay == null) {
+      log.error("Unrecognized AbstractShapeOverlay type");
+      return null;
+    }
+
+    return overlay;
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractTokenOverlay.java
@@ -56,7 +56,7 @@ public abstract class AbstractTokenOverlay implements Cloneable {
   /** Flag indicating that this token overlay is displayed to the owner. */
   private boolean showOwner;
 
-  /** Flag indicating that this token overlay is displayed to the everybody else. */
+  /** Flag indicating that this token overlay is displayed to everybody else. */
   private boolean showOthers;
 
   /*---------------------------------------------------------------------------------------------
@@ -82,6 +82,17 @@ public abstract class AbstractTokenOverlay implements Cloneable {
   protected AbstractTokenOverlay(String aName) {
     assert aName != null : "A name is required but null was passed.";
     name = aName;
+  }
+
+  protected AbstractTokenOverlay(AbstractTokenOverlay other) {
+    this.name = other.name;
+    this.order = other.order;
+    this.group = other.group;
+    this.mouseover = other.mouseover;
+    this.opacity = other.opacity;
+    this.showGM = other.showGM;
+    this.showOwner = other.showOwner;
+    this.showOthers = other.showOthers;
   }
 
   /*---------------------------------------------------------------------------------------------

--- a/src/main/java/net/rptools/maptool/client/ui/token/BooleanTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/BooleanTokenOverlay.java
@@ -20,17 +20,23 @@ import java.awt.Rectangle;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
 import net.rptools.maptool.util.FunctionUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * An overlay that may be applied to a token to show state.
  *
  * @author jgorrell
  */
-public abstract class BooleanTokenOverlay extends AbstractTokenOverlay {
-
-  /*---------------------------------------------------------------------------------------------
-   * Constructors
-   *-------------------------------------------------------------------------------------------*/
+public abstract sealed class BooleanTokenOverlay extends AbstractTokenOverlay
+    permits AbstractShapeTokenOverlay,
+        AbstractFlowShapeTokenOverlay,
+        ColorDotTokenOverlay,
+        ImageTokenOverlay,
+        CornerImageTokenOverlay,
+        FlowImageTokenOverlay,
+        ShadedTokenOverlay {
+  private static final Logger log = LogManager.getLogger(BooleanTokenOverlay.class);
 
   /**
    * Create an overlay with the passed name.
@@ -41,29 +47,25 @@ public abstract class BooleanTokenOverlay extends AbstractTokenOverlay {
     super(aName);
   }
 
-  /*---------------------------------------------------------------------------------------------
-   * AbstractTokenOverlay Methods
-   *-------------------------------------------------------------------------------------------*/
+  protected BooleanTokenOverlay(BooleanTokenOverlay other) {
+    super(other);
+  }
 
-  /**
-   * @see AbstractTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     java.awt.Rectangle, java.lang.Object)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds, Object value) {
+  public abstract BooleanTokenOverlay clone();
+
+  @Override
+  public final void paintOverlay(Graphics2D g, Token token, Rectangle bounds, Object value) {
     if (FunctionUtil.getBooleanValue(value)) {
       // Apply Alpha Transparency
       float opacity = token.getTokenOpacity();
-      if (opacity < 1.0f)
+      if (opacity < 1.0f) {
         g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));
+      }
 
       paintOverlay(g, token, bounds);
     }
   }
-
-  /*---------------------------------------------------------------------------------------------
-   * Abstract Methods
-   *-------------------------------------------------------------------------------------------*/
 
   /**
    * Paint the overlay for the passed token.
@@ -79,55 +81,43 @@ public abstract class BooleanTokenOverlay extends AbstractTokenOverlay {
   public abstract void paintOverlay(Graphics2D g, Token token, Rectangle bounds);
 
   public static BooleanTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    switch (dto.getType()) {
-      case X -> {
-        return XTokenOverlay.fromDto(dto);
-      }
-      case YIELD -> {
-        return YieldTokenOverlay.fromDto(dto);
-      }
-      case O -> {
-        return OTokenOverlay.fromDto(dto);
-      }
-      case COLOR_DOT -> {
-        return ColorDotTokenOverlay.fromDto(dto);
-      }
-      case DIAMOND -> {
-        return DiamondTokenOverlay.fromDto(dto);
-      }
-      case TRIANGLE -> {
-        return TriangleTokenOverlay.fromDto(dto);
-      }
-      case CROSS -> {
-        return CrossTokenOverlay.fromDto(dto);
-      }
-      case FLOW_COLOR_DOT -> {
-        return FlowColorDotTokenOverlay.fromDto(dto);
-      }
-      case FLOW_DIAMOND -> {
-        return FlowDiamondTokenOverlay.fromDto(dto);
-      }
-      case FLOW_COLOR_SQUARE -> {
-        return FlowColorSquareTokenOverlay.fromDto(dto);
-      }
-      case FLOW_YIELD -> {
-        return FlowYieldTokenOverlay.fromDto(dto);
-      }
-      case SHADED -> {
-        return ShadedTokenOverlay.fromDto(dto);
-      }
-      case IMAGE -> {
-        return ImageTokenOverlay.fromDto(dto);
-      }
-      case FLOW_IMAGE -> {
-        return FlowImageTokenOverlay.fromDto(dto);
-      }
-      case CORNER_IMAGE -> {
-        return CornerImageTokenOverlay.fromDto(dto);
-      }
+    BooleanTokenOverlay overlay =
+        switch (dto.getChildTypeCase()) {
+          case SHAPE -> AbstractShapeTokenOverlay.fromDto(dto.getShape());
+          case FLOW_SHAPE -> AbstractFlowShapeTokenOverlay.fromDto(dto.getFlowShape());
+          case COLOR_DOT -> ColorDotTokenOverlay.fromDto(dto.getColorDot());
+          case IMAGE -> ImageTokenOverlay.fromDto(dto.getImage());
+          case CORNER_IMAGE -> CornerImageTokenOverlay.fromDto(dto.getCornerImage());
+          case FLOW_IMAGE -> FlowImageTokenOverlay.fromDto(dto.getFlowImage());
+          case SHADED -> ShadedTokenOverlay.fromDto(dto.getShaded());
+          case CHILDTYPE_NOT_SET -> {
+            log.error("Unrecognized BooleanTokenOverlay type");
+            yield null;
+          }
+        };
+    if (overlay != null) {
+      overlay.fillFrom(dto.getCommon());
     }
-    return null;
+    return overlay;
   }
 
-  public abstract BooleanTokenOverlayDto toDto();
+  public final BooleanTokenOverlayDto toDto() {
+    var message = BooleanTokenOverlayDto.newBuilder();
+    message.setCommon(getCommonDto());
+    switch (this) {
+      case AbstractShapeTokenOverlay shapeOverlay -> message.setShape(shapeOverlay.toShapeDto());
+      case AbstractFlowShapeTokenOverlay flowShapeOverlay ->
+          message.setFlowShape(flowShapeOverlay.toFlowShapeDto());
+      case ColorDotTokenOverlay colorDotTokenOverlay ->
+          message.setColorDot(colorDotTokenOverlay.toColorDotDto());
+      case ImageTokenOverlay imageTokenOverlay -> message.setImage(imageTokenOverlay.toImageDto());
+      case CornerImageTokenOverlay cornerImageTokenOverlay ->
+          message.setCornerImage(cornerImageTokenOverlay.toCornerImageDto());
+      case FlowImageTokenOverlay flowImageTokenOverlay ->
+          message.setFlowImage(flowImageTokenOverlay.toFlowImageDto());
+      case ShadedTokenOverlay shadedTokenOverlay ->
+          message.setShaded(shadedTokenOverlay.toShadedDto());
+    }
+    return message.build();
+  }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/BooleanTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/BooleanTokenOverlay.java
@@ -56,14 +56,19 @@ public abstract sealed class BooleanTokenOverlay extends AbstractTokenOverlay
 
   @Override
   public final void paintOverlay(Graphics2D g, Token token, Rectangle bounds, Object value) {
-    if (FunctionUtil.getBooleanValue(value)) {
+    if (!FunctionUtil.getBooleanValue(value)) {
+      return;
+    }
+
+    g = (Graphics2D) g.create();
+    try {
       // Apply Alpha Transparency
-      float opacity = token.getTokenOpacity();
-      if (opacity < 1.0f) {
-        g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));
-      }
+      float opacity = token.getTokenOpacity() * getOpacity() / 100.f;
+      g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));
 
       paintOverlay(g, token, bounds);
+    } finally {
+      g.dispose();
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/ColorDotTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ColorDotTokenOverlay.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.drawing.AbstractTemplate.Quadrant;
 import net.rptools.maptool.server.proto.ColorDotTokenOverlayDto;
+import net.rptools.maptool.server.proto.QuadrantDto;
 
 /**
  * Token overlay that draws a colored dot in one of the corners.
@@ -125,11 +126,14 @@ public final class ColorDotTokenOverlay extends BooleanTokenOverlay {
   public ColorDotTokenOverlayDto toColorDotDto() {
     var dto = ColorDotTokenOverlayDto.newBuilder();
     dto.setColor(color.getRGB());
+    // Fixes #5828
+    dto.setQuadrant(QuadrantDto.valueOf(corner.name()));
     return dto.build();
   }
 
   public static ColorDotTokenOverlay fromDto(ColorDotTokenOverlayDto dto) {
     var color = new Color(dto.getColor(), true);
-    return new ColorDotTokenOverlay(DEFAULT_STATE_NAME, color, Quadrant.SOUTH_EAST);
+    var quadrant = Quadrant.valueOf(dto.getQuadrant().name());
+    return new ColorDotTokenOverlay(DEFAULT_STATE_NAME, color, quadrant);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/ColorDotTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ColorDotTokenOverlay.java
@@ -14,10 +14,8 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
@@ -106,21 +104,9 @@ public final class ColorDotTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    Composite tempComposite = g.getComposite();
-    try {
-      g.setColor(getColor());
-      if (getOpacity() != 100) {
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      }
-
-      var shape = getShape(bounds);
-      g.fill(shape);
-    } finally {
-      g.setColor(tempColor);
-      g.setComposite(tempComposite);
-    }
+    g.setColor(getColor());
+    var shape = getShape(bounds);
+    g.fill(shape);
   }
 
   public ColorDotTokenOverlayDto toColorDotDto() {

--- a/src/main/java/net/rptools/maptool/client/ui/token/ColorDotTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ColorDotTokenOverlay.java
@@ -15,16 +15,18 @@
 package net.rptools.maptool.client.ui.token;
 
 import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.Stroke;
 import java.awt.geom.Ellipse2D;
+import java.awt.geom.Rectangle2D;
+import java.util.Objects;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.drawing.AbstractTemplate.Quadrant;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import net.rptools.maptool.server.proto.ColorDotTokenOverlayDto;
 
 /**
  * Token overlay that draws a colored dot in one of the corners.
@@ -32,84 +34,44 @@ import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
  * @author giliath
  * @version $Revision$ $Date$ $Author$
  */
-public class ColorDotTokenOverlay extends XTokenOverlay {
+public final class ColorDotTokenOverlay extends BooleanTokenOverlay {
+  /** Color used when filling the dot. */
+  private Color color;
+
+  /**
+   * @deprecated This is a hold over from when ColorDotTokenOverlay inherited from XTokenOverlay. It
+   *     didn't do anything then, and does nothing now.
+   */
+  @Deprecated private BasicStroke stroke;
 
   /** The corner where the dot is placed */
-  private Quadrant corner = Quadrant.SOUTH_EAST;
-
-  /** Default constructor needed for XML encoding/decoding */
-  public ColorDotTokenOverlay() {
-    this(DEFAULT_STATE_NAME, Color.RED, Quadrant.SOUTH_EAST);
-  }
+  private Quadrant corner;
 
   /**
    * Create a new dot token overlay
    *
-   * @param aName Name of the token overlay
-   * @param aColor Color of the dot
-   * @param aCorner Corner containing the dot
+   * @param name Name of the token overlay
+   * @param color Color of the dot
+   * @param corner Corner containing the dot
    */
-  public ColorDotTokenOverlay(String aName, Color aColor, Quadrant aCorner) {
-    super(aName, aColor, 0);
-    if (aCorner != null) corner = aCorner;
+  public ColorDotTokenOverlay(String name, Color color, Quadrant corner) {
+    super(name);
+    this.color = Objects.requireNonNullElse(color, Color.red);
+    this.corner = Objects.requireNonNullElse(corner, Quadrant.SOUTH_EAST);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new ColorDotTokenOverlay(getName(), getColor(), getCorner());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public ColorDotTokenOverlay(ColorDotTokenOverlay other) {
+    super(other);
+    this.color = other.color;
+    this.corner = other.corner;
   }
 
-  /**
-   * @see BooleanTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     Rectangle)
-   */
-  @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    Stroke tempStroke = g.getStroke();
-    Composite tempComposite = g.getComposite();
-    try {
-      g.setColor(getColor());
-      g.setStroke(getStroke());
+  public Color getColor() {
+    return color;
+  }
 
-      double size = bounds.width * 0.2;
-      double offset = bounds.width * 0.8;
-      double x = 0;
-      double y = 0;
-      switch (corner) {
-        case SOUTH_EAST:
-          x = y = offset;
-          break;
-        case SOUTH_WEST:
-          y = offset;
-          break;
-        case NORTH_EAST:
-          x = offset;
-          break;
-        case NORTH_WEST:
-          break;
-      } // endswitch
-      Shape s = new Ellipse2D.Double(x, y, size, size);
-      if (getOpacity() != 100)
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      g.fill(s);
-    } finally {
-      g.setColor(tempColor);
-      g.setStroke(tempStroke);
-      g.setComposite(tempComposite);
-    }
+  public void setColor(Color color) {
+    this.color = color;
   }
 
   /**
@@ -119,13 +81,55 @@ public class ColorDotTokenOverlay extends XTokenOverlay {
     return corner;
   }
 
-  public static ColorDotTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new ColorDotTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
+  @Override
+  public ColorDotTokenOverlay clone() {
+    return new ColorDotTokenOverlay(this);
   }
 
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.COLOR_DOT).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var size = bounds.getWidth() / 5;
+    var offset = bounds.getWidth() - size;
+    final double x =
+        switch (corner) {
+          case SOUTH_EAST, NORTH_EAST -> offset;
+          case SOUTH_WEST, NORTH_WEST -> 0;
+        };
+    final double y =
+        switch (corner) {
+          case SOUTH_EAST, SOUTH_WEST -> offset;
+          case NORTH_EAST, NORTH_WEST -> 0;
+        };
+
+    return new Ellipse2D.Double(x + bounds.getMinX(), y + bounds.getMinY(), size, size);
+  }
+
+  @Override
+  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
+    Color tempColor = g.getColor();
+    Composite tempComposite = g.getComposite();
+    try {
+      g.setColor(getColor());
+      if (getOpacity() != 100) {
+        g.setComposite(
+            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+      }
+
+      var shape = getShape(bounds);
+      g.fill(shape);
+    } finally {
+      g.setColor(tempColor);
+      g.setComposite(tempComposite);
+    }
+  }
+
+  public ColorDotTokenOverlayDto toColorDotDto() {
+    var dto = ColorDotTokenOverlayDto.newBuilder();
+    dto.setColor(color.getRGB());
+    return dto.build();
+  }
+
+  public static ColorDotTokenOverlay fromDto(ColorDotTokenOverlayDto dto) {
+    var color = new Color(dto.getColor(), true);
+    return new ColorDotTokenOverlay(DEFAULT_STATE_NAME, color, Quadrant.SOUTH_EAST);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
@@ -14,8 +14,6 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
-import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
@@ -104,28 +102,18 @@ public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    Composite tempComposite = g.getComposite();
-    try {
-      if (getOpacity() != 100) {
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      }
+    BufferedImage image = ImageManager.getImageAndWait(assetId);
+    Rectangle2D imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
+    AwtUtil.fitInto(imageBounds, bounds);
+    imageBounds = getBounds(imageBounds);
 
-      BufferedImage image = ImageManager.getImageAndWait(assetId);
-      Rectangle2D imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
-      AwtUtil.fitInto(imageBounds, bounds);
-      imageBounds = getBounds(imageBounds);
+    // Paint it at the right location
+    int width = (int) imageBounds.getWidth();
+    int height = (int) imageBounds.getHeight();
+    int x = (int) imageBounds.getMinX();
+    int y = (int) imageBounds.getMinY();
 
-      // Paint it at the right location
-      int width = (int) imageBounds.getWidth();
-      int height = (int) imageBounds.getHeight();
-      int x = (int) imageBounds.getMinX();
-      int y = (int) imageBounds.getMinY();
-
-      g.drawImage(image, x, y, width, height, null);
-    } finally {
-      g.setComposite(tempComposite);
-    }
+    g.drawImage(image, x, y, width, height, null);
   }
 
   public CornerImageTokenOverlayDto toCornerImageDto() {

--- a/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
@@ -14,77 +14,59 @@
  */
 package net.rptools.maptool.client.ui.token;
 
+import java.awt.AlphaComposite;
+import java.awt.Composite;
+import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.drawing.AbstractTemplate.Quadrant;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import net.rptools.maptool.server.proto.CornerImageTokenOverlayDto;
 import net.rptools.maptool.server.proto.QuadrantDto;
+import net.rptools.maptool.util.ImageManager;
 
 /**
  * Place an image in a given corner.
  *
  * @author Jay
  */
-public class CornerImageTokenOverlay extends ImageTokenOverlay {
+public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
+
+  /** ID of the image displayed in the overlay. */
+  private MD5Key assetId;
 
   /** The corner where the image is placed */
-  private Quadrant corner = Quadrant.SOUTH_EAST;
-
-  /** Needed for serialization */
-  public CornerImageTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, null, Quadrant.SOUTH_EAST);
-  }
+  private Quadrant corner;
 
   /**
    * Create the complete image overlay.
    *
    * @param name Name of the new token overlay
-   * @param anAssetId Id of the image displayed in the new token overlay.
-   * @param aCorner Corner that contains the image.
+   * @param assetId Id of the image displayed in the new token overlay.
+   * @param corner Corner that contains the image.
    */
-  public CornerImageTokenOverlay(String name, MD5Key anAssetId, Quadrant aCorner) {
-    super(name, anAssetId);
-    corner = aCorner;
+  public CornerImageTokenOverlay(String name, MD5Key assetId, Quadrant corner) {
+    super(name);
+    this.assetId = assetId;
+    this.corner = corner;
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new CornerImageTokenOverlay(getName(), getAssetId(), corner);
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public CornerImageTokenOverlay(CornerImageTokenOverlay other) {
+    super(other);
+    this.assetId = other.assetId;
+    this.corner = other.corner;
   }
 
-  /**
-   * @see ImageTokenOverlay#getImageBounds(java.awt.Rectangle, Token)
-   */
   @Override
-  public Rectangle getImageBounds(Rectangle bounds, Token token) {
-    int x = (bounds.width + 1) / 2;
-    int y = (bounds.height + 1) / 2;
-    switch (corner) {
-      case SOUTH_EAST:
-        break;
-      case SOUTH_WEST:
-        x = 0;
-        break;
-      case NORTH_EAST:
-        y = 0;
-        break;
-      case NORTH_WEST:
-        x = y = 0;
-        break;
-    } // endswitch
-    return new Rectangle(x, y, bounds.width / 2, bounds.height / 2);
+  public CornerImageTokenOverlay clone() {
+    return new CornerImageTokenOverlay(this);
+  }
+
+  public MD5Key getAssetId() {
+    return assetId;
   }
 
   /**
@@ -94,17 +76,68 @@ public class CornerImageTokenOverlay extends ImageTokenOverlay {
     return corner;
   }
 
-  public static CornerImageTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new CornerImageTokenOverlay();
-    overlay.fillFrom(dto);
-    overlay.corner = Quadrant.valueOf(dto.getQuadrant().name());
-    return overlay;
+  public Rectangle2D getBounds(Rectangle2D bounds) {
+    var result = new Rectangle2D.Double();
+    result.setRect(bounds);
+
+    // Push the image into one of the corners.
+    result.width /= 2;
+    result.height /= 2;
+    switch (corner) {
+      case NORTH_WEST -> {
+        // Already at (0, 0)
+      }
+      case NORTH_EAST -> {
+        result.x += result.width;
+      }
+      case SOUTH_EAST -> {
+        result.x += result.width;
+        result.y += result.height;
+      }
+      case SOUTH_WEST -> {
+        result.y += result.height;
+      }
+    }
+
+    return result;
   }
 
-  public BooleanTokenOverlayDto toDto() {
-    return getDto()
-        .setQuadrant(QuadrantDto.valueOf(corner.name()))
-        .setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.CORNER_IMAGE)
-        .build();
+  @Override
+  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
+    Composite tempComposite = g.getComposite();
+    try {
+      if (getOpacity() != 100) {
+        g.setComposite(
+            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+      }
+
+      BufferedImage image = ImageManager.getImageAndWait(assetId);
+      Rectangle2D imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
+      AwtUtil.fitInto(imageBounds, bounds);
+      imageBounds = getBounds(imageBounds);
+
+      // Paint it at the right location
+      int width = (int) imageBounds.getWidth();
+      int height = (int) imageBounds.getHeight();
+      int x = (int) imageBounds.getMinX();
+      int y = (int) imageBounds.getMinY();
+
+      g.drawImage(image, x, y, width, height, null);
+    } finally {
+      g.setComposite(tempComposite);
+    }
+  }
+
+  public CornerImageTokenOverlayDto toCornerImageDto() {
+    var dto = CornerImageTokenOverlayDto.newBuilder();
+    dto.setAssetId(assetId.toString());
+    dto.setQuadrant(QuadrantDto.valueOf(corner.name()));
+    return dto.build();
+  }
+
+  public static CornerImageTokenOverlay fromDto(CornerImageTokenOverlayDto dto) {
+    var assetId = new MD5Key(dto.getAssetId());
+    var quadrant = Quadrant.valueOf(dto.getQuadrant().name());
+    return new CornerImageTokenOverlay(DEFAULT_STATE_NAME, assetId, quadrant);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/CrossTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/CrossTokenOverlay.java
@@ -14,15 +14,10 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Stroke;
-import java.awt.geom.Line2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.Shape;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Place a cross over a token.
@@ -30,70 +25,36 @@ import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
  * @author jgorrell
  * @version $Revision$ $Date$ $Author$
  */
-public class CrossTokenOverlay extends XTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public CrossTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED, 5);
-  }
+public final class CrossTokenOverlay extends AbstractShapeTokenOverlay {
 
   /**
    * Create a Cross token overlay with the given name.
    *
-   * @param aName Name of this token overlay.
-   * @param aColor The color of this token overlay.
-   * @param aWidth The width of the lines in this token overlay.
+   * @param name Name of this token overlay.
+   * @param color The color of this token overlay.
+   * @param strokeWidth The width of the lines in this token overlay.
    */
-  public CrossTokenOverlay(String aName, Color aColor, int aWidth) {
-    super(aName, aColor, aWidth);
+  public CrossTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name, color, strokeWidth);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public CrossTokenOverlay(CrossTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new CrossTokenOverlay(getName(), getColor(), getWidth());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public CrossTokenOverlay clone() {
+    return new CrossTokenOverlay(this);
   }
 
-  /**
-   * @see XTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     java.awt.Rectangle)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    g.setColor(getColor());
-    Stroke tempStroke = g.getStroke();
-    g.setStroke(getStroke());
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    g.draw(
-        new Line2D.Double(0, (double) bounds.height / 2, bounds.width, (double) bounds.height / 2));
-    g.draw(
-        new Line2D.Double((double) bounds.width / 2, 0, (double) bounds.width / 2, bounds.height));
-    g.setColor(tempColor);
-    g.setStroke(tempStroke);
-    g.setComposite(tempComposite);
-  }
-
-  public static CrossTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new CrossTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.CROSS).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var path = new Path2D.Double();
+    path.moveTo(bounds.getMinX(), bounds.getCenterY());
+    path.lineTo(bounds.getMaxX(), bounds.getCenterY());
+    path.moveTo(bounds.getCenterX(), bounds.getMinY());
+    path.lineTo(bounds.getCenterX(), bounds.getMaxY());
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/DiamondTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/DiamondTokenOverlay.java
@@ -14,15 +14,10 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Stroke;
-import java.awt.geom.Line2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.Shape;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Place a diamond over a token.
@@ -30,72 +25,36 @@ import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
  * @author pwright
  * @version $Revision$ $Date$ $Author$
  */
-public class DiamondTokenOverlay extends XTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public DiamondTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED, 5);
-  }
+public final class DiamondTokenOverlay extends AbstractShapeTokenOverlay {
 
   /**
    * Create a Diamond token overlay with the given name.
    *
-   * @param aName Name of this token overlay.
-   * @param aColor The color of this token overlay.
-   * @param aWidth The width of the lines in this token overlay.
+   * @param name Name of this token overlay.
+   * @param color The color of this token overlay.
+   * @param strokeWidth The width of the lines in this token overlay.
    */
-  public DiamondTokenOverlay(String aName, Color aColor, int aWidth) {
-    super(aName, aColor, aWidth);
+  public DiamondTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name, color, strokeWidth);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public DiamondTokenOverlay(DiamondTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new DiamondTokenOverlay(getName(), getColor(), getWidth());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public DiamondTokenOverlay clone() {
+    return new DiamondTokenOverlay(this);
   }
 
-  /**
-   * @see XTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     java.awt.Rectangle)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    double hc = (double) bounds.width / 2;
-    double vc = (double) bounds.height / 2;
-    Color tempColor = g.getColor();
-    g.setColor(getColor());
-    Stroke tempStroke = g.getStroke();
-    g.setStroke(getStroke());
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    g.draw(new Line2D.Double(0, vc, hc, 0));
-    g.draw(new Line2D.Double(hc, 0, bounds.width, vc));
-    g.draw(new Line2D.Double(bounds.width, vc, hc, bounds.height));
-    g.draw(new Line2D.Double(hc, bounds.height, 0, vc));
-    g.setColor(tempColor);
-    g.setStroke(tempStroke);
-    g.setComposite(tempComposite);
-  }
-
-  public static DiamondTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new DiamondTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.DIAMOND).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var path = new Path2D.Double();
+    path.moveTo(bounds.getMinX(), bounds.getCenterY());
+    path.lineTo(bounds.getCenterX(), bounds.getMinY());
+    path.lineTo(bounds.getMaxX(), bounds.getCenterY());
+    path.lineTo(bounds.getCenterX(), bounds.getMaxY());
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowColorDotTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowColorDotTokenOverlay.java
@@ -14,138 +14,42 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.Stroke;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
 
 /**
  * Paint a dot so that it doesn't overlay any other states being displayed in the same grid.
  *
  * @author Jay
  */
-public class FlowColorDotTokenOverlay extends XTokenOverlay {
-
-  /** Size of the grid used to place a token with this state. */
-  private int grid;
-
-  /** Flow used to define position of states */
-  private transient TokenOverlayFlow flow;
-
-  /** Default constructor needed for XML encoding/decoding */
-  public FlowColorDotTokenOverlay() {
-    this(DEFAULT_STATE_NAME, Color.RED, -1);
-  }
+public final class FlowColorDotTokenOverlay extends AbstractFlowShapeTokenOverlay {
 
   /**
    * Create a new dot token overlay
    *
-   * @param aName Name of the token overlay
-   * @param aColor Color of the dot
-   * @param aGrid Size of the overlay grid for this state. All states with the same grid size share
-   *     the same overlay.
+   * @param name Name of the token overlay
+   * @param color Color of the dot
+   * @param gridSize Size of the overlay grid for this state. All states with the same grid size
+   *     share the same overlay.
    */
-  public FlowColorDotTokenOverlay(String aName, Color aColor, int aGrid) {
-    super(aName, aColor, 0);
-    grid = aGrid;
+  public FlowColorDotTokenOverlay(String name, Color color, int gridSize) {
+    super(name, color, gridSize);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new FlowColorDotTokenOverlay(getName(), getColor(), grid);
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
-  }
-
-  /**
-   * Get the flow used to position the states.
-   *
-   * @return Flow used to position the states
-   */
-  protected TokenOverlayFlow getFlow() {
-    if (flow == null && grid > 0) flow = TokenOverlayFlow.getInstance(grid);
-    return flow;
-  }
-
-  /**
-   * @see BooleanTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     Rectangle)
-   */
-  @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    Stroke tempStroke = g.getStroke();
-    Composite tempComposite = g.getComposite();
-    try {
-      g.setColor(getColor());
-      g.setStroke(getStroke());
-      if (getOpacity() != 100)
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      Shape s = getShape(bounds, aToken);
-      g.fill(s);
-    } finally {
-      g.setColor(tempColor);
-      g.setStroke(tempStroke);
-      g.setComposite(tempComposite);
-    }
-  }
-
-  /**
-   * Return an ellipse.
-   *
-   * @param bounds Bounds of the token
-   * @param token Token being rendered.
-   * @return An ellipse that fits inside of the bounding box returned by the flow.
-   */
-  public Shape getShape(Rectangle bounds, Token token) {
-    Rectangle2D r = getFlow().getStateBounds2D(bounds, token, getName());
-    return new Ellipse2D.Double(r.getX(), r.getY(), r.getWidth(), r.getHeight());
-  }
-
-  /**
-   * @return Getter for grid
-   */
-  public int getGrid() {
-    return grid;
+  public FlowColorDotTokenOverlay(FlowColorDotTokenOverlay other) {
+    super(other);
   }
 
   @Override
-  protected BooleanTokenOverlayDto.Builder getDto() {
-    return super.getDto().setGridSize(grid);
+  public FlowColorDotTokenOverlay clone() {
+    return new FlowColorDotTokenOverlay(this);
   }
 
   @Override
-  protected void fillFrom(BooleanTokenOverlayDto dto) {
-    super.fillFrom(dto);
-    grid = dto.getGridSize();
-  }
-
-  public static FlowColorDotTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new FlowColorDotTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto()
-        .setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.FLOW_COLOR_DOT)
-        .build();
+  public Shape getShape(Rectangle2D bounds) {
+    return new Ellipse2D.Double(
+        bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowColorSquareTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowColorSquareTokenOverlay.java
@@ -15,68 +15,39 @@
 package net.rptools.maptool.client.ui.token;
 
 import java.awt.Color;
-import java.awt.Rectangle;
 import java.awt.Shape;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Paint a square so that it doesn't overlay any other states being displayed in the same grid.
  *
  * @author Jay
  */
-public class FlowColorSquareTokenOverlay extends FlowColorDotTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public FlowColorSquareTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED, -1);
-  }
+public final class FlowColorSquareTokenOverlay extends AbstractFlowShapeTokenOverlay {
 
   /**
    * Create a new dot token overlay
    *
-   * @param aName Name of the token overlay
-   * @param aColor Color of the dot
-   * @param aGrid Size of the overlay grid for this state. All states with the same grid size share
-   *     the same overlay.
+   * @param name Name of the token overlay
+   * @param color Color of the dot
+   * @param gridSize Size of the overlay grid for this state. All states with the same grid size
+   *     share the same overlay.
    */
-  public FlowColorSquareTokenOverlay(String aName, Color aColor, int aGrid) {
-    super(aName, aColor, aGrid);
+  public FlowColorSquareTokenOverlay(String name, Color color, int gridSize) {
+    super(name, color, gridSize);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public FlowColorSquareTokenOverlay(FlowColorSquareTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new FlowColorSquareTokenOverlay(getName(), getColor(), getGrid());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public FlowColorSquareTokenOverlay clone() {
+    return new FlowColorSquareTokenOverlay(this);
   }
 
-  /**
-   * @see FlowColorDotTokenOverlay#getShape(java.awt.Rectangle, net.rptools.maptool.model.Token)
-   */
   @Override
-  public Shape getShape(Rectangle bounds, Token token) {
-    return getFlow().getStateBounds2D(bounds, token, getName());
-  }
-
-  public static FlowColorSquareTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new FlowColorSquareTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto()
-        .setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.FLOW_COLOR_SQUARE)
-        .build();
+  public Shape getShape(Rectangle2D bounds) {
+    return bounds;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowDiamondTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowDiamondTokenOverlay.java
@@ -15,76 +15,46 @@
 package net.rptools.maptool.client.ui.token;
 
 import java.awt.Color;
-import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.geom.GeneralPath;
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
 
 /**
  * Paint a square so that it doesn't overlay any other states being displayed in the same grid.
  *
  * @author Jay
  */
-public class FlowDiamondTokenOverlay extends FlowColorDotTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public FlowDiamondTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED, -1);
-  }
+public final class FlowDiamondTokenOverlay extends AbstractFlowShapeTokenOverlay {
 
   /**
    * Create a new dot token overlay
    *
-   * @param aName Name of the token overlay
-   * @param aColor Color of the dot
-   * @param aGrid Size of the overlay grid for this state. All states with the same grid size share
+   * @param name Name of the token overlay
+   * @param color Color of the dot
+   * @param grid Size of the overlay grid for this state. All states with the same grid size share
    *     the same overlay.
    */
-  public FlowDiamondTokenOverlay(String aName, Color aColor, int aGrid) {
-    super(aName, aColor, aGrid);
+  public FlowDiamondTokenOverlay(String name, Color color, int grid) {
+    super(name, color, grid);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public FlowDiamondTokenOverlay(FlowDiamondTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new FlowDiamondTokenOverlay(getName(), getColor(), getGrid());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public FlowDiamondTokenOverlay clone() {
+    return new FlowDiamondTokenOverlay(this);
   }
 
-  /**
-   * @see FlowColorDotTokenOverlay#getShape(java.awt.Rectangle, net.rptools.maptool.model.Token)
-   */
   @Override
-  public Shape getShape(Rectangle bounds, Token token) {
-    Rectangle2D r = getFlow().getStateBounds2D(bounds, token, getName());
-    GeneralPath p = new GeneralPath();
-    p.moveTo((float) r.getCenterX(), (float) r.getY());
-    p.lineTo((float) r.getX(), (float) r.getCenterY());
-    p.lineTo((float) r.getCenterX(), (float) r.getMaxY());
-    p.lineTo((float) r.getMaxX(), (float) r.getCenterY());
-    p.lineTo((float) r.getCenterX(), (float) r.getY());
-    p.closePath();
-    return p;
-  }
-
-  public static FlowDiamondTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new FlowDiamondTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.FLOW_DIAMOND).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var path = new Path2D.Double();
+    path.moveTo((float) bounds.getCenterX(), (float) bounds.getY());
+    path.lineTo((float) bounds.getX(), (float) bounds.getCenterY());
+    path.lineTo((float) bounds.getCenterX(), (float) bounds.getMaxY());
+    path.lineTo((float) bounds.getMaxX(), (float) bounds.getCenterY());
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
@@ -14,10 +14,17 @@
  */
 package net.rptools.maptool.client.ui.token;
 
+import java.awt.AlphaComposite;
+import java.awt.Composite;
+import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import net.rptools.maptool.server.proto.FlowImageTokenOverlayDto;
+import net.rptools.maptool.util.ImageManager;
 
 /**
  * An overlay that allows multiple images to be placed on the token so that they do not interfere
@@ -25,7 +32,11 @@ import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
  *
  * @author Jay
  */
-public class FlowImageTokenOverlay extends ImageTokenOverlay {
+public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
+  private static final int DEFAULT_GRID_SIZE = 3;
+
+  /** ID of the image displayed in the overlay. */
+  private MD5Key assetId;
 
   /** Size of the grid used to place a token with this state. */
   private int grid;
@@ -33,22 +44,38 @@ public class FlowImageTokenOverlay extends ImageTokenOverlay {
   /** Flow used to define position of states */
   private transient TokenOverlayFlow flow;
 
-  /** Needed for serialization */
-  public FlowImageTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, null, -1);
-  }
-
   /**
    * Create the image overlay flow for the name, asset and grid
    *
    * @param name Name of the new state
    * @param assetId Asset displayed for the state
-   * @param aGrid Size of the overlay grid for this state. All states with the same grid size share
-   *     the same overlay.
+   * @param gridSize Size of the overlay grid for this state. All states with the same grid size
+   *     share the same overlay.
    */
-  public FlowImageTokenOverlay(String name, MD5Key assetId, int aGrid) {
-    super(name, assetId);
-    grid = aGrid;
+  public FlowImageTokenOverlay(String name, MD5Key assetId, int gridSize) {
+    super(name);
+
+    this.assetId = assetId;
+
+    if (gridSize <= 0) {
+      gridSize = DEFAULT_GRID_SIZE;
+    }
+    this.grid = gridSize;
+  }
+
+  public FlowImageTokenOverlay(FlowImageTokenOverlay other) {
+    super(other);
+    this.assetId = other.assetId;
+    this.grid = other.grid;
+  }
+
+  @Override
+  public FlowImageTokenOverlay clone() {
+    return new FlowImageTokenOverlay(this);
+  }
+
+  public MD5Key getAssetId() {
+    return assetId;
   }
 
   /**
@@ -56,33 +83,39 @@ public class FlowImageTokenOverlay extends ImageTokenOverlay {
    *
    * @return Flow used to position the states
    */
-  protected TokenOverlayFlow getFlow() {
-    if (flow == null && grid > 0) flow = TokenOverlayFlow.getInstance(grid);
+  private TokenOverlayFlow getFlow() {
+    if (flow == null) {
+      flow = TokenOverlayFlow.getInstance(grid);
+    }
     return flow;
   }
 
-  /**
-   * @see ImageTokenOverlay#getImageBounds(java.awt.Rectangle, Token)
-   */
   @Override
-  public Rectangle getImageBounds(Rectangle bounds, Token token) {
-    return getFlow().getStateBounds(bounds, token, getName());
-  }
+  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
+    Composite tempComposite = g.getComposite();
+    try {
+      if (getOpacity() != 100) {
+        g.setComposite(
+            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+      }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new FlowImageTokenOverlay(getName(), getAssetId(), grid);
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+      BufferedImage image = ImageManager.getImageAndWait(assetId);
+
+      var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
+      AwtUtil.fitInto(imageBounds, bounds);
+
+      var gridCellBounds = getFlow().getStateBounds2D(imageBounds, token, getName());
+
+      // Paint it at the right location
+      int width = (int) gridCellBounds.getWidth();
+      int height = (int) gridCellBounds.getHeight();
+      int x = (int) gridCellBounds.getMinX();
+      int y = (int) gridCellBounds.getMinY();
+
+      g.drawImage(image, x, y, width, height, null);
+    } finally {
+      g.setComposite(tempComposite);
+    }
   }
 
   /**
@@ -92,17 +125,16 @@ public class FlowImageTokenOverlay extends ImageTokenOverlay {
     return grid;
   }
 
-  public static FlowImageTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new FlowImageTokenOverlay();
-    overlay.fillFrom(dto);
-    overlay.grid = dto.getGridSize();
-    return overlay;
+  public FlowImageTokenOverlayDto toFlowImageDto() {
+    var dto = FlowImageTokenOverlayDto.newBuilder();
+    dto.setAssetId(assetId.toString());
+    dto.setGridSize(grid);
+    return dto.build();
   }
 
-  public BooleanTokenOverlayDto toDto() {
-    return getDto()
-        .setGridSize(grid)
-        .setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.FLOW_IMAGE)
-        .build();
+  public static FlowImageTokenOverlay fromDto(FlowImageTokenOverlayDto dto) {
+    var assetId = new MD5Key(dto.getAssetId());
+    var gridSize = dto.getGridSize();
+    return new FlowImageTokenOverlay(DEFAULT_STATE_NAME, assetId, gridSize);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
@@ -14,8 +14,6 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
-import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
@@ -92,30 +90,20 @@ public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    Composite tempComposite = g.getComposite();
-    try {
-      if (getOpacity() != 100) {
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      }
+    BufferedImage image = ImageManager.getImageAndWait(assetId);
 
-      BufferedImage image = ImageManager.getImageAndWait(assetId);
+    var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
+    AwtUtil.fitInto(imageBounds, bounds);
 
-      var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
-      AwtUtil.fitInto(imageBounds, bounds);
+    var gridCellBounds = getFlow().getStateBounds2D(imageBounds, token, getName());
 
-      var gridCellBounds = getFlow().getStateBounds2D(imageBounds, token, getName());
+    // Paint it at the right location
+    int width = (int) gridCellBounds.getWidth();
+    int height = (int) gridCellBounds.getHeight();
+    int x = (int) gridCellBounds.getMinX();
+    int y = (int) gridCellBounds.getMinY();
 
-      // Paint it at the right location
-      int width = (int) gridCellBounds.getWidth();
-      int height = (int) gridCellBounds.getHeight();
-      int x = (int) gridCellBounds.getMinX();
-      int y = (int) gridCellBounds.getMinY();
-
-      g.drawImage(image, x, y, width, height, null);
-    } finally {
-      g.setComposite(tempComposite);
-    }
+    g.drawImage(image, x, y, width, height, null);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowTriangleTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowTriangleTokenOverlay.java
@@ -15,64 +15,45 @@
 package net.rptools.maptool.client.ui.token;
 
 import java.awt.Color;
-import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.geom.GeneralPath;
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
-import net.rptools.maptool.model.Token;
 
 /**
  * Paint a square so that it doesn't overlay any other states being displayed in the same grid.
  *
  * @author Jay
  */
-public class FlowTriangleTokenOverlay extends FlowColorDotTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public FlowTriangleTokenOverlay() {
-    this(DEFAULT_STATE_NAME, Color.RED, -1);
-  }
+public final class FlowTriangleTokenOverlay extends AbstractFlowShapeTokenOverlay {
 
   /**
    * Create a new dot token overlay
    *
-   * @param aName Name of the token overlay
-   * @param aColor Color of the dot
-   * @param aGrid Size of the overlay grid for this state. All states with the same grid size share
-   *     the same overlay.
+   * @param name Name of the token overlay
+   * @param color Color of the dot
+   * @param gridSize Size of the overlay grid for this state. All states with the same grid size
+   *     share the same overlay.
    */
-  public FlowTriangleTokenOverlay(String aName, Color aColor, int aGrid) {
-    super(aName, aColor, aGrid);
+  public FlowTriangleTokenOverlay(String name, Color color, int gridSize) {
+    super(name, color, gridSize);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new FlowTriangleTokenOverlay(getName(), getColor(), getGrid());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public FlowTriangleTokenOverlay(FlowTriangleTokenOverlay other) {
+    super(other);
   }
 
-  /**
-   * @see FlowColorDotTokenOverlay#getShape(java.awt.Rectangle, net.rptools.maptool.model.Token)
-   */
   @Override
-  public Shape getShape(Rectangle bounds, Token token) {
-    Rectangle2D r = getFlow().getStateBounds2D(bounds, token, getName());
-    GeneralPath p = new GeneralPath();
-    p.moveTo((float) r.getCenterX(), (float) r.getY());
-    p.lineTo((float) r.getX(), (float) r.getMaxY());
-    p.lineTo((float) r.getMaxX(), (float) r.getMaxY());
-    p.lineTo((float) r.getCenterX(), (float) r.getY());
-    p.closePath();
-    return p;
+  public FlowTriangleTokenOverlay clone() {
+    return new FlowTriangleTokenOverlay(this);
+  }
+
+  @Override
+  public Shape getShape(Rectangle2D bounds) {
+    var path = new Path2D.Double();
+    path.moveTo((float) bounds.getCenterX(), (float) bounds.getY());
+    path.lineTo((float) bounds.getX(), (float) bounds.getMaxY());
+    path.lineTo((float) bounds.getMaxX(), (float) bounds.getMaxY());
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowYieldTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowYieldTokenOverlay.java
@@ -15,75 +15,46 @@
 package net.rptools.maptool.client.ui.token;
 
 import java.awt.Color;
-import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.geom.GeneralPath;
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
 
 /**
  * Paint a square so that it doesn't overlay any other states being displayed in the same grid.
  *
  * @author Jay
  */
-public class FlowYieldTokenOverlay extends FlowColorDotTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public FlowYieldTokenOverlay() {
-    this(DEFAULT_STATE_NAME, Color.RED, -1);
-  }
+public final class FlowYieldTokenOverlay extends AbstractFlowShapeTokenOverlay {
 
   /**
    * Create a new dot token overlay
    *
-   * @param aName Name of the token overlay
-   * @param aColor Color of the dot
-   * @param aGrid Size of the overlay grid for this state. All states with the same grid size share
-   *     the same overlay.
+   * @param name Name of the token overlay
+   * @param color Color of the dot
+   * @param gridSize Size of the overlay grid for this state. All states with the same grid size
+   *     share the same overlay.
    */
-  public FlowYieldTokenOverlay(String aName, Color aColor, int aGrid) {
-    super(aName, aColor, aGrid);
+  public FlowYieldTokenOverlay(String name, Color color, int gridSize) {
+    super(name, color, gridSize);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public FlowYieldTokenOverlay(FlowYieldTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new FlowYieldTokenOverlay(getName(), getColor(), getGrid());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public FlowYieldTokenOverlay clone() {
+    return new FlowYieldTokenOverlay(this);
   }
 
-  /**
-   * @see FlowColorDotTokenOverlay#getShape(java.awt.Rectangle, net.rptools.maptool.model.Token)
-   */
   @Override
-  public Shape getShape(Rectangle bounds, Token token) {
-    Rectangle2D r = getFlow().getStateBounds2D(bounds, token, getName());
-    GeneralPath p = new GeneralPath();
-    p.moveTo((float) r.getX(), (float) r.getY());
-    p.lineTo((float) r.getCenterX(), (float) r.getMaxY());
-    p.lineTo((float) r.getMaxX(), (float) r.getY());
-    p.lineTo((float) r.getX(), (float) r.getY());
-    p.closePath();
-    return p;
-  }
-
-  public static FlowYieldTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new FlowYieldTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.FLOW_YIELD).build();
+  public Shape getShape(Rectangle2D r) {
+    var path = new Path2D.Double();
+    path.moveTo((float) r.getX(), (float) r.getY());
+    path.lineTo((float) r.getCenterX(), (float) r.getMaxY());
+    path.lineTo((float) r.getMaxX(), (float) r.getY());
+    path.lineTo((float) r.getX(), (float) r.getY());
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
@@ -63,28 +63,18 @@ public final class ImageTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    Composite tempComposite = g.getComposite();
-    try {
-      if (getOpacity() != 100) {
-        g.setComposite(
-            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-      }
+    BufferedImage image = ImageManager.getImageAndWait(assetId);
 
-      BufferedImage image = ImageManager.getImageAndWait(assetId);
+    var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
+    AwtUtil.fitInto(imageBounds, bounds);
 
-      var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
-      AwtUtil.fitInto(imageBounds, bounds);
+    // Paint it at the right location
+    int width = (int) imageBounds.getWidth();
+    int height = (int) imageBounds.getHeight();
+    int x = (int) imageBounds.getMinX();
+    int y = (int) imageBounds.getMinY();
 
-      // Paint it at the right location
-      int width = (int) imageBounds.getWidth();
-      int height = (int) imageBounds.getHeight();
-      int x = (int) imageBounds.getMinX();
-      int y = (int) imageBounds.getMinY();
-
-      g.drawImage(image, x, y, width, height, null);
-    } finally {
-      g.setComposite(tempComposite);
-    }
+    g.drawImage(image, x, y, width, height, null);
   }
 
   public ImageTokenOverlayDto toImageDto() {

--- a/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
@@ -15,86 +15,43 @@
 package net.rptools.maptool.client.ui.token;
 
 import java.awt.*;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import net.rptools.maptool.server.proto.ImageTokenOverlayDto;
 import net.rptools.maptool.util.ImageManager;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * This is a token overlay that shows an image over the entire token
  *
  * @author Jay
  */
-public class ImageTokenOverlay extends BooleanTokenOverlay {
+public final class ImageTokenOverlay extends BooleanTokenOverlay {
 
-  /** If of the image displayed in the overlay. */
+  /** ID of the image displayed in the overlay. */
   private MD5Key assetId;
-
-  /** Logger instance for this class. */
-  private static final Logger LOGGER = LogManager.getLogger(ImageTokenOverlay.class);
-
-  /** Needed for serialization */
-  public ImageTokenOverlay() {
-    this(DEFAULT_STATE_NAME, null);
-  }
 
   /**
    * Create the complete image overlay.
    *
    * @param name Name of the new token overlay
-   * @param anAssetId Id of the image displayed in the new token overlay.
+   * @param assetId ID of the image displayed in the new token overlay.
    */
-  public ImageTokenOverlay(String name, MD5Key anAssetId) {
+  public ImageTokenOverlay(String name, MD5Key assetId) {
     super(name);
-    assetId = anAssetId;
+    this.assetId = assetId;
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new ImageTokenOverlay(getName(), assetId);
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public ImageTokenOverlay(ImageTokenOverlay other) {
+    super(other);
+    this.assetId = other.assetId;
   }
 
-  /**
-   * @see BooleanTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     java.awt.Rectangle)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-
-    // Get the image
-    Rectangle iBounds = getImageBounds(bounds, token);
-    Dimension d = iBounds.getSize();
-
-    BufferedImage image = ImageManager.getImageAndWait(assetId);
-    Dimension size = new Dimension(image.getWidth(), image.getHeight());
-    AwtUtil.constrainTo(size, d.width, d.height);
-
-    // Paint it at the right location
-    int width = size.width;
-    int height = size.height;
-    int x = iBounds.x + (d.width - width) / 2;
-    int y = iBounds.y + (d.height - height) / 2;
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    g.drawImage(image, x, y, size.width, size.height, null);
-    g.setComposite(tempComposite);
+  public ImageTokenOverlay clone() {
+    return new ImageTokenOverlay(this);
   }
 
   /**
@@ -104,36 +61,40 @@ public class ImageTokenOverlay extends BooleanTokenOverlay {
     return assetId;
   }
 
-  /**
-   * Calculate the image bounds from the token bounds
-   *
-   * @param bounds Bounds of the token passed to the overlay.
-   * @param token Token being decorated.
-   * @return The bounds w/in the token where the image is painted.
-   */
-  public Rectangle getImageBounds(Rectangle bounds, Token token) {
-    return bounds;
+  @Override
+  public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
+    Composite tempComposite = g.getComposite();
+    try {
+      if (getOpacity() != 100) {
+        g.setComposite(
+            AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+      }
+
+      BufferedImage image = ImageManager.getImageAndWait(assetId);
+
+      var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
+      AwtUtil.fitInto(imageBounds, bounds);
+
+      // Paint it at the right location
+      int width = (int) imageBounds.getWidth();
+      int height = (int) imageBounds.getHeight();
+      int x = (int) imageBounds.getMinX();
+      int y = (int) imageBounds.getMinY();
+
+      g.drawImage(image, x, y, width, height, null);
+    } finally {
+      g.setComposite(tempComposite);
+    }
   }
 
-  protected void fillFrom(BooleanTokenOverlayDto dto) {
-    fillFrom(dto.getCommon());
-    assetId = new MD5Key(dto.getAssetId());
-  }
-
-  protected BooleanTokenOverlayDto.Builder getDto() {
-    var dto = BooleanTokenOverlayDto.newBuilder();
-    dto.setCommon(getCommonDto());
+  public ImageTokenOverlayDto toImageDto() {
+    var dto = ImageTokenOverlayDto.newBuilder();
     dto.setAssetId(assetId.toString());
-    return dto;
+    return dto.build();
   }
 
-  public static ImageTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new ImageTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.IMAGE).build();
+  public static ImageTokenOverlay fromDto(ImageTokenOverlayDto dto) {
+    var assetId = new MD5Key(dto.getAssetId());
+    return new ImageTokenOverlay(DEFAULT_STATE_NAME, assetId);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/OTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/OTokenOverlay.java
@@ -14,85 +14,47 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Stroke;
+import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Draw an empty circle over a token.
  *
  * @author jgorrell
  */
-public class OTokenOverlay extends XTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public OTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED, 5);
-  }
+public final class OTokenOverlay extends AbstractShapeTokenOverlay {
 
   /**
    * Create an O token overlay with the given name.
    *
-   * @param aName Name of this token overlay.
-   * @param aColor The color of this token overlay.
-   * @param aWidth The width of the lines in this token overlay.
+   * @param name Name of this token overlay.
+   * @param color The color of this token overlay.
+   * @param strokeWidth The width of the lines in this token overlay.
    */
-  public OTokenOverlay(String aName, Color aColor, int aWidth) {
-    super(aName, aColor, aWidth);
+  public OTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name, color, strokeWidth);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
-  @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new OTokenOverlay(getName(), getColor(), getWidth());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public OTokenOverlay(OTokenOverlay other) {
+    super(other);
   }
 
-  /**
-   * @see BooleanTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     Rectangle)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    g.setColor(getColor());
-    Stroke tempStroke = g.getStroke();
-    g.setStroke(getStroke());
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+  public OTokenOverlay clone() {
+    return new OTokenOverlay(this);
+  }
+
+  @Override
+  public Shape getShape(Rectangle2D bounds) {
     double offset = getStroke().getLineWidth() / 2.0;
-    g.draw(
+    var path =
         new Ellipse2D.Double(
-            0 + offset, 0 + offset, bounds.width - offset * 2, bounds.height - offset * 2));
-    g.setColor(tempColor);
-    g.setStroke(tempStroke);
-    g.setComposite(tempComposite);
-  }
-
-  public static OTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new OTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.O).build();
+            bounds.getMinX() + offset,
+            bounds.getMinY() + offset,
+            bounds.getWidth() - 2 * offset,
+            bounds.getHeight() - 2 * offset);
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/ShadedTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ShadedTokenOverlay.java
@@ -19,81 +19,40 @@ import java.awt.Color;
 import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.util.Objects;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import net.rptools.maptool.server.proto.ShadedTokenOverlayDto;
 
 /**
  * Paints a single reduced alpha color over the token.
  *
  * @author jgorrell
  */
-public class ShadedTokenOverlay extends BooleanTokenOverlay {
-
-  /*---------------------------------------------------------------------------------------------
-   * Instance Variables
-   *-------------------------------------------------------------------------------------------*/
-
+public final class ShadedTokenOverlay extends BooleanTokenOverlay {
   /** The color that is painted over the token. */
   private Color color;
-
-  /*---------------------------------------------------------------------------------------------
-   * Constructors
-   *-------------------------------------------------------------------------------------------*/
-
-  /** Default constructor needed for XML encoding/decoding */
-  public ShadedTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED);
-  }
 
   /**
    * Create the new token overlay
    *
-   * @param aName Name of the new overlay.
-   * @param aColor The color that is painted over the token. If the alpha is 100%, it will be
-   *     reduced to 25%.
+   * @param name Name of the new overlay.
+   * @param color The color that is painted over the token. If the alpha is 100%, it will be reduced
+   *     to 25%.
    */
-  public ShadedTokenOverlay(String aName, Color aColor) {
-    super(aName);
-    assert aColor != null : "A color is required but null was passed.";
-    color = aColor;
+  public ShadedTokenOverlay(String name, Color color) {
+    super(name);
+    this.color = Objects.requireNonNullElse(color, Color.red);
     setOpacity(25);
   }
 
-  /*---------------------------------------------------------------------------------------------
-   * TokenOverlay Abstract Method Implementations
-   *-------------------------------------------------------------------------------------------*/
-
-  /**
-   * @see BooleanTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     Rectangle)
-   */
-  @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color temp = g.getColor();
-    g.setColor(color);
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    g.fill(bounds);
-    g.setColor(temp);
-    g.setComposite(tempComposite);
+  public ShadedTokenOverlay(ShadedTokenOverlay other) {
+    super(other);
+    this.color = other.color;
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new ShadedTokenOverlay(getName(), getColor());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public ShadedTokenOverlay clone() {
+    return new ShadedTokenOverlay(this);
   }
 
   /**
@@ -114,18 +73,28 @@ public class ShadedTokenOverlay extends BooleanTokenOverlay {
     color = aColor;
   }
 
-  public static ShadedTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new ShadedTokenOverlay();
-    overlay.fillFrom(dto.getCommon());
-    overlay.color = new Color(dto.getColor(), true);
-    return overlay;
+  @Override
+  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
+    Color temp = g.getColor();
+    g.setColor(color);
+    Composite tempComposite = g.getComposite();
+    if (getOpacity() != 100) {
+      g.setComposite(
+          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
+    }
+    g.fill(bounds);
+    g.setColor(temp);
+    g.setComposite(tempComposite);
   }
 
-  public BooleanTokenOverlayDto toDto() {
-    var dto = BooleanTokenOverlayDto.newBuilder();
-    dto.setCommon(getCommonDto());
+  public ShadedTokenOverlayDto toShadedDto() {
+    var dto = ShadedTokenOverlayDto.newBuilder();
     dto.setColor(color.getRGB());
-    dto.setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.SHADED);
     return dto.build();
+  }
+
+  public static ShadedTokenOverlay fromDto(ShadedTokenOverlayDto dto) {
+    var color = new Color(dto.getColor(), true);
+    return new ShadedTokenOverlay(DEFAULT_STATE_NAME, color);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/ShadedTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ShadedTokenOverlay.java
@@ -14,9 +14,7 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.util.Objects;
@@ -75,16 +73,8 @@ public final class ShadedTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color temp = g.getColor();
     g.setColor(color);
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100) {
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    }
     g.fill(bounds);
-    g.setColor(temp);
-    g.setComposite(tempComposite);
   }
 
   public ShadedTokenOverlayDto toShadedDto() {

--- a/src/main/java/net/rptools/maptool/client/ui/token/TokenOverlayFlow.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TokenOverlayFlow.java
@@ -99,7 +99,7 @@ public class TokenOverlayFlow {
    * @param state The state being rendered.
    * @return The bounds used to paint the state.
    */
-  public Rectangle2D getStateBounds2D(Rectangle bounds, Token token, String state) {
+  public Rectangle2D getStateBounds2D(Rectangle2D bounds, Token token, String state) {
 
     // Find the list of states already drawn on the token
     List<String> states = savedStates.computeIfAbsent(token.getId(), k -> new LinkedList<String>());
@@ -148,10 +148,10 @@ public class TokenOverlayFlow {
 
     // Build the rectangle from the passed bounds
     return new Rectangle2D.Double(
-        offsets[col] * bounds.width + bounds.x,
-        offsets[row] * bounds.height + bounds.y,
-        size * bounds.width,
-        size * bounds.height);
+        offsets[col] * bounds.getWidth() + bounds.getMinX(),
+        offsets[row] * bounds.getHeight() + bounds.getMinY(),
+        size * bounds.getWidth(),
+        size * bounds.getHeight());
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/TriangleTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TriangleTokenOverlay.java
@@ -14,15 +14,10 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Stroke;
-import java.awt.geom.Line2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.Shape;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Place a Triangle (triangle point down) over a token.
@@ -30,71 +25,36 @@ import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
  * @author pwright
  * @version $Revision$ $Date$ $Author$
  */
-public class TriangleTokenOverlay extends XTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public TriangleTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.MAGENTA, 5);
-  }
+public final class TriangleTokenOverlay extends AbstractShapeTokenOverlay {
 
   /**
    * Create a Triangle token overlay with the given name.
    *
-   * @param aName Name of this token overlay.
-   * @param aColor The color of this token overlay.
-   * @param aWidth The width of the lines in this token overlay.
+   * @param name Name of this token overlay.
+   * @param color The color of this token overlay.
+   * @param strokeWidth The width of the lines in this token overlay.
    */
-  public TriangleTokenOverlay(String aName, Color aColor, int aWidth) {
-    super(aName, aColor, aWidth);
+  public TriangleTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name, color, strokeWidth);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public TriangleTokenOverlay(TriangleTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new TriangleTokenOverlay(getName(), getColor(), getWidth());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public TriangleTokenOverlay clone() {
+    return new TriangleTokenOverlay(this);
   }
 
-  /**
-   * @see XTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     java.awt.Rectangle)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    double hc = (double) bounds.width / 2;
-    double vc = bounds.height * 0.866;
-    Color tempColor = g.getColor();
-    g.setColor(getColor());
-    Stroke tempStroke = g.getStroke();
-    g.setStroke(getStroke());
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    g.draw(new Line2D.Double(0, vc, bounds.width, vc));
-    g.draw(new Line2D.Double(bounds.width, vc, hc, 0));
-    g.draw(new Line2D.Double(hc, 0, 0, vc));
-    g.setColor(tempColor);
-    g.setStroke(tempStroke);
-    g.setComposite(tempComposite);
-  }
-
-  public static TriangleTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new TriangleTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.TRIANGLE).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var adjustY = bounds.getHeight() * 0.134;
+    var path = new Path2D.Double();
+    path.moveTo(bounds.getMinX(), bounds.getMaxY() - adjustY);
+    path.lineTo(bounds.getCenterX(), bounds.getMinY());
+    path.lineTo(bounds.getMaxX(), bounds.getMaxY() - adjustY);
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/XTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/XTokenOverlay.java
@@ -14,162 +14,45 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
-import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Stroke;
-import java.awt.geom.Line2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.Mapper;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.Shape;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Draw an X over a token.
  *
  * @author jgorrell
  */
-public class XTokenOverlay extends BooleanTokenOverlay {
-
-  /** Color for the X */
-  private Color color;
-
-  /** Stroke used to draw the line */
-  private BasicStroke stroke;
-
-  /** Default constructor needed for XML encoding/decoding */
-  public XTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.RED, 5);
-  }
+public final class XTokenOverlay extends AbstractShapeTokenOverlay {
 
   /**
-   * Create a X token overlay with the given name.
+   * Create an X token overlay with the given name.
    *
-   * @param aName Name of this token overlay.
-   * @param aColor The color of this token overlay.
-   * @param aWidth The width of the lines in this token overlay.
+   * @param name Name of this token overlay.
+   * @param color The color of this token overlay.
+   * @param strokeWidth The width of the lines in this token overlay.
    */
-  public XTokenOverlay(String aName, Color aColor, int aWidth) {
-    super(aName);
-    if (aColor == null) {
-      aColor = Color.RED;
-    }
-    color = aColor;
-    if (aWidth <= 0) {
-      aWidth = 3;
-    }
-    stroke = new BasicStroke(aWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL);
+  public XTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name, color, strokeWidth);
   }
 
-  /**
-   * @see BooleanTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     Rectangle)
-   */
+  public XTokenOverlay(XTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    Color tempColor = g.getColor();
-    g.setColor(color);
-    Stroke tempStroke = g.getStroke();
-    g.setStroke(stroke);
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100) {
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    }
-    g.draw(new Line2D.Double(0, 0, bounds.width, bounds.height));
-    g.draw(new Line2D.Double(0, bounds.height, bounds.width, 0));
-    g.setColor(tempColor);
-    g.setStroke(tempStroke);
-    g.setComposite(tempComposite);
+  public XTokenOverlay clone() {
+    return new XTokenOverlay(this);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new XTokenOverlay(getName(), getColor(), getWidth());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
-  }
-
-  /**
-   * Get the color for this XTokenOverlay.
-   *
-   * @return Returns the current value of color.
-   */
-  public Color getColor() {
-    return color;
-  }
-
-  /**
-   * Get the stroke for this XTokenOverlay.
-   *
-   * @return Returns the current value of stroke.
-   */
-  public BasicStroke getStroke() {
-    return stroke;
-  }
-
-  /**
-   * Set the value of color for this XTokenOverlay.
-   *
-   * @param aColor The color to set.
-   */
-  public void setColor(Color aColor) {
-    color = aColor;
-  }
-
-  /**
-   * Get the width for this XTokenOverlay.
-   *
-   * @return Returns the current value of width.
-   */
-  public int getWidth() {
-    return (int) stroke.getLineWidth();
-  }
-
-  /**
-   * Set the value of width for this XTokenOverlay.
-   *
-   * @param aWidth The width to set.
-   */
-  public void setWidth(int aWidth) {
-    if (aWidth <= 0) {
-      aWidth = 3;
-    }
-    stroke = new BasicStroke(aWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL);
-  }
-
-  protected void fillFrom(BooleanTokenOverlayDto dto) {
-    fillFrom(dto.getCommon());
-    color = new Color(dto.getColor(), true);
-    stroke = Mapper.map(dto.getStroke());
-  }
-
-  protected BooleanTokenOverlayDto.Builder getDto() {
-    var dto = BooleanTokenOverlayDto.newBuilder();
-    dto.setCommon(getCommonDto());
-    dto.setColor(color.getRGB());
-    dto.setStroke(Mapper.map(stroke));
-    return dto;
-  }
-
-  public static XTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new XTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.X).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var path = new Path2D.Double();
+    path.moveTo(bounds.getMinX(), bounds.getMinY());
+    path.lineTo(bounds.getMaxX(), bounds.getMaxY());
+    path.moveTo(bounds.getMinX(), bounds.getMaxY());
+    path.lineTo(bounds.getMaxX(), bounds.getMinY());
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/YieldTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/YieldTokenOverlay.java
@@ -14,15 +14,10 @@
  */
 package net.rptools.maptool.client.ui.token;
 
-import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Composite;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.Stroke;
-import java.awt.geom.Line2D;
-import net.rptools.maptool.model.Token;
-import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
+import java.awt.Shape;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Place a Yield (triangle point down) over a token.
@@ -30,71 +25,36 @@ import net.rptools.maptool.server.proto.BooleanTokenOverlayDto;
  * @author pwright
  * @version $Revision$ $Date$ $Author$
  */
-public class YieldTokenOverlay extends XTokenOverlay {
-
-  /** Default constructor needed for XML encoding/decoding */
-  public YieldTokenOverlay() {
-    this(BooleanTokenOverlay.DEFAULT_STATE_NAME, Color.YELLOW, 5);
-  }
+public final class YieldTokenOverlay extends AbstractShapeTokenOverlay {
 
   /**
    * Create a Yield token overlay with the given name.
    *
-   * @param aName Name of this token overlay.
-   * @param aColor The color of this token overlay.
-   * @param aWidth The width of the lines in this token overlay.
+   * @param name Name of this token overlay.
+   * @param color The color of this token overlay.
+   * @param strokeWidth The width of the lines in this token overlay.
    */
-  public YieldTokenOverlay(String aName, Color aColor, int aWidth) {
-    super(aName, aColor, aWidth);
+  public YieldTokenOverlay(String name, Color color, int strokeWidth) {
+    super(name, color, strokeWidth);
   }
 
-  /**
-   * @see BooleanTokenOverlay#clone()
-   */
+  public YieldTokenOverlay(YieldTokenOverlay other) {
+    super(other);
+  }
+
   @Override
-  public Object clone() {
-    BooleanTokenOverlay overlay = new YieldTokenOverlay(getName(), getColor(), getWidth());
-    overlay.setOrder(getOrder());
-    overlay.setGroup(getGroup());
-    overlay.setMouseover(isMouseover());
-    overlay.setOpacity(getOpacity());
-    overlay.setShowGM(isShowGM());
-    overlay.setShowOwner(isShowOwner());
-    overlay.setShowOthers(isShowOthers());
-    return overlay;
+  public YieldTokenOverlay clone() {
+    return new YieldTokenOverlay(this);
   }
 
-  /**
-   * @see XTokenOverlay#paintOverlay(java.awt.Graphics2D, net.rptools.maptool.model.Token,
-   *     java.awt.Rectangle)
-   */
   @Override
-  public void paintOverlay(Graphics2D g, Token aToken, Rectangle bounds) {
-    double hc = (double) bounds.width / 2;
-    double vc = bounds.height * 0.134;
-    Color tempColor = g.getColor();
-    g.setColor(getColor());
-    Stroke tempStroke = g.getStroke();
-    g.setStroke(getStroke());
-    Composite tempComposite = g.getComposite();
-    if (getOpacity() != 100)
-      g.setComposite(
-          AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) getOpacity() / 100));
-    g.draw(new Line2D.Double(0, vc, bounds.width, vc));
-    g.draw(new Line2D.Double(bounds.width, vc, hc, bounds.height));
-    g.draw(new Line2D.Double(hc, bounds.height, 0, vc));
-    g.setColor(tempColor);
-    g.setStroke(tempStroke);
-    g.setComposite(tempComposite);
-  }
-
-  public static YieldTokenOverlay fromDto(BooleanTokenOverlayDto dto) {
-    var overlay = new YieldTokenOverlay();
-    overlay.fillFrom(dto);
-    return overlay;
-  }
-
-  public BooleanTokenOverlayDto toDto() {
-    return getDto().setType(BooleanTokenOverlayDto.BooleanTokenOverlayTypeDto.YIELD).build();
+  public Shape getShape(Rectangle2D bounds) {
+    var adjustY = bounds.getHeight() * 0.134;
+    var path = new Path2D.Double();
+    path.moveTo(bounds.getMinX(), bounds.getMinY() + adjustY);
+    path.lineTo(bounds.getCenterX(), bounds.getMaxY());
+    path.lineTo(bounds.getMaxX(), bounds.getMinY() + adjustY);
+    path.closePath();
+    return path;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -148,7 +148,7 @@ public class CampaignProperties implements Serializable {
     categorizedLights = new CategorizedLights(properties.categorizedLights);
 
     for (BooleanTokenOverlay overlay : properties.tokenStates.values()) {
-      overlay = (BooleanTokenOverlay) overlay.clone();
+      overlay = overlay.clone();
       tokenStates.put(overlay.getName(), overlay);
     } // endfor
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #4726
Fixes #5828

### Description of the Change

Reworks the `BooleanTokenOverlay` hierarchy so it is easier to follow, there's less duplicated logic, and so it can be better consumed by other components (useful for #5811). All concrete classes are now `final`, and inherit only from `abstract` classes. The abstract classes are also now `sealed` so we can be guaranteed to consume all possible cases in the `switch`es that use them.

The DTOs have been reworked to match the new structure. `BooleanTokenOverlayDto` no longer contains all possible fields for all implementations, but now only contains the common fields and a union of possible message types for the various derived types that carry the fields they need.

Notable details on the above:
- `AbstractShapeTokenOverlay` as a base class contains all the state for `CrossTokenOverlay`, `DiamondTokenOverlay`, `OTokenOverlay`, `TriangleTokenOverlay`, `XTokenOverlay`, `YieldTokenOverlay`. So all these are represented by the singular `ShapeTokenOverlayDto`.
- Similarly, `AbstractFlowShapeTokenOverlay` contains all the state for `FlowColorDotTokenOverlay`, `FlowColorSquareTokenOverlay`, `FlowDiamondTokenOverlay`, `FlowTriangleTokenOverlay`, `FlowYieldTokenOverlay`, all of which are represented by `FlowShapeTokenOverlayDto`
- All other state types derive directly from `BooleanTokenOverlay` and have their own DTO messages.

#4726 is fixed by moving the decision to set the graphics composite up into `BooleanTokenOverlay#paintOverlay(Graphics2D, Token, Rectangle, Object)`, and combining the token opacity and state opacity there. This method also creates a new graphics object so that the derived classes do not all have to do it and can instead focus just on drawing.

#5828 is fixed by adding the `quadrant` field to `ColorDotTokenOverlayDto`.


### Possible Drawbacks

Should be none

### Documentation Notes

N/A

### Release Notes

- Fixed an issue with states where the token's opacity was not accounted for.
- Fixed an issue with dot states where the selected corner was not synced to other clients.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5829)
<!-- Reviewable:end -->
