### PR TITLE
Enforce a minimum int size to buffered image

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
@@ -90,8 +90,8 @@ public class DrawablesPanel extends JComponent {
       boolean showEraser) {
     BufferedImage backBuffer =
         new BufferedImage(
-            (int) (viewport.width * scale),
-            (int) (viewport.height * scale),
+            (int) Math.max(1, viewport.width * scale),
+            (int) Math.max(1, viewport.height * scale),
             Transparency.TRANSLUCENT);
     Graphics2D g = backBuffer.createGraphics();
     g.setClip(0, 0, backBuffer.getWidth(), backBuffer.getHeight());


### PR DESCRIPTION
fixes #5837

### Description of the Change
When creating a new buffered image for a drawable for previewing in the Drawables Panel, the scaled image results now has a minimum width or height of 1.

### Possible Drawbacks
None envisaged.

### Documentation Notes

### Release Notes
Fixed an issue where scaled drawables previewed in the DrawablesPanel would have a 0  width or height.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5838)
<!-- Reviewable:end -->
