### PR TITLE
Update to macos-15-intel runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,20 +44,20 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew jpackage zipJpackageImage
     - name: Copy the RPM to the location required to build the ArchLinux package
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       run: cp releases/maptool-*.rpm package/archlinux/maptool/maptool.rpm
       continue-on-error: true
     - name: Build ArchLinux package
       uses: 2m/arch-pkgbuild-builder@v1.16
       # This only even makes sense on Ubuntu.
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       env:
         MAPTOOL_VERSION: ${{ github.event.release.tag_name }}
       with:
         target: 'pkgbuild'
         pkgname: 'package/archlinux/maptool'
     - name: Build uberJar on Windows
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
       run: ./gradlew shadowJar
       # For debugging purposes...
     - name: List releases
@@ -69,7 +69,7 @@ jobs:
       #   |__/|__//_//_/ /_/ \__,_/ \____/ |__/|__//____/
       #
     - name: Rename Windows Release Files
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
       run: |
         mkdir releases/renamed/
         cp releases/MapTool*.exe releases/renamed/MapTool-${{ github.event.release.tag_name }}.exe
@@ -80,7 +80,7 @@ jobs:
     - name: Upload Windows EXE Release Asset
       id: upload-release-asset-exe
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -91,7 +91,7 @@ jobs:
     - name: Upload Windows MSI Release Asset
       id: upload-release-asset-msi
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -102,7 +102,7 @@ jobs:
     - name: Upload Windows Image Release Asset
       id: upload-release-asset-windows-image
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -113,7 +113,7 @@ jobs:
     - name: Upload Uber Jar Release Asset
       id: upload-release-asset-jar
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -128,7 +128,7 @@ jobs:
       #   /_____//_//_/ /_/ \__,_//_/|_|
       #
     - name: Rename Linux Release Files
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         mkdir releases/renamed/
         cp releases/maptool*.x86_64.rpm releases/renamed/maptool-${{ github.event.release.tag_name }}.x86_64.rpm
@@ -139,7 +139,7 @@ jobs:
     - name: Upload Linux RPM Release Asset
       id: upload-release-asset-rpm
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -150,7 +150,7 @@ jobs:
     - name: Upload Linux DEB Release Asset
       id: upload-release-asset-deb
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -161,7 +161,7 @@ jobs:
     - name: Upload ArchLinux Release Asset
       id: upload-release-asset-arch
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -172,7 +172,7 @@ jobs:
     - name: Upload Linux Image Release Asset
       id: upload-release-asset-linux-image
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -187,7 +187,7 @@ jobs:
       #   /_/ /_/ /_/ \__,_/ \___/ \____//____/
       #
     - name: Rename Mac OS Release Files
-      if: matrix.os == 'macos-15-intel'
+      if: startsWith(matrix.os, 'macos')
       run: |
         mkdir releases/renamed/
         cp releases/MapTool*.dmg releases/renamed/MapTool-${{ github.event.release.tag_name }}.dmg
@@ -197,7 +197,7 @@ jobs:
     - name: Upload Mac DMG Release Asset
       id: upload-release-asset-dmg
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macos-15-intel'
+      if: startsWith(matrix.os, 'macos')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -208,7 +208,7 @@ jobs:
     - name: Upload Mac PKG Release Asset
       id: upload-release-asset-pkg
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macos-15-intel'
+      if: startsWith(matrix.os, 'macos')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -219,7 +219,7 @@ jobs:
     - name: Upload Mac Image Release Asset
       id: upload-release-asset-mac-image
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macos-15-intel'
+      if: startsWith(matrix.os, 'macos')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-13]
+        os: [windows-latest, ubuntu-latest, macos-15-intel]
         java: [ '21' ]
         distribution: ['temurin']
       fail-fast: false
@@ -187,7 +187,7 @@ jobs:
       #   /_/ /_/ /_/ \__,_/ \___/ \____//____/
       #
     - name: Rename Mac OS Release Files
-      if: matrix.os == 'macOS-13'
+      if: matrix.os == 'macos-15-intel'
       run: |
         mkdir releases/renamed/
         cp releases/MapTool*.dmg releases/renamed/MapTool-${{ github.event.release.tag_name }}.dmg
@@ -197,7 +197,7 @@ jobs:
     - name: Upload Mac DMG Release Asset
       id: upload-release-asset-dmg
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macOS-13'
+      if: matrix.os == 'macos-15-intel'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -208,7 +208,7 @@ jobs:
     - name: Upload Mac PKG Release Asset
       id: upload-release-asset-pkg
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macOS-13'
+      if: matrix.os == 'macos-15-intel'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -219,7 +219,7 @@ jobs:
     - name: Upload Mac Image Release Asset
       id: upload-release-asset-mac-image
       uses: actions/upload-release-asset@v1
-      if: matrix.os == 'macOS-13'
+      if: matrix.os == 'macos-15-intel'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-13]
+        os: [windows-latest, ubuntu-latest, macos-15-intel]
         java: [ '21' ]
         distribution: [ 'temurin']
       fail-fast: false


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5842

### Description of the Change

Replaces the `macos-13` runner with `macos-15-intel` in `verify-build.yml` and `publish.yml` workflows.

Also changes the `==` checks for the OS with `startsWith()` so we don't have to update them all whenver we change the label for an OS.

### Possible Drawbacks

Should be none, unless I'm unaware of an important difference between building on MacOS 15 vs MacOS 13.

### Documentation Notes

N/A

### Release Notes

- Updated MacOS build to run on MacOS 15 Sequoia.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5843)
<!-- Reviewable:end -->
