### PR TITLE
Better pen encapsulation

### DIFF
--- a/messages/src/main/proto/drawing_dto.proto
+++ b/messages/src/main/proto/drawing_dto.proto
@@ -19,18 +19,12 @@ message DrawnElementDto {
 }
 
 message PenDto {
-  enum mode {
-    MODE_SOLID = 0;
-    MODE_TRANSPARENT = 1;
-  }
-  mode foreground_mode = 1;
-  DrawablePaintDto foreground_color = 2;
-  mode background_mode = 3;
-  DrawablePaintDto background_color = 4;
-  float thickness = 5;
-  bool eraser = 6;
-  bool square_cap = 7;
-  float opacity = 8;
+  DrawablePaintDto foreground_paint = 1;
+  DrawablePaintDto background_paint = 2;
+  float thickness = 3;
+  bool eraser = 4;
+  bool square_cap = 5;
+  float opacity = 6;
 }
 
 message DrawableDto {

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -415,16 +415,11 @@ public class DrawingFunctions extends AbstractFunction {
    * @param pen the replacement pen.
    * @throws ParserException if the drawing is not found.
    */
-  protected void setPen(String functionName, Zone map, GUID guid, Object pen)
-      throws ParserException {
-    if (!(pen instanceof Pen))
-      throw new ParserException(
-          I18N.getText("macro.function.drawingFunction.invalidPen", functionName));
-    Pen p = new Pen((Pen) pen);
+  protected void setPen(String functionName, Zone map, GUID guid, Pen pen) throws ParserException {
     List<DrawnElement> drawableList = map.getAllDrawnElements();
     DrawnElement de = findDrawnElement(drawableList, guid);
     if (de != null) {
-      de.setPen(p);
+      de.setPen(new Pen(pen));
       return;
     }
     throw new ParserException(

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
@@ -71,20 +71,16 @@ public class DrawingSetterFunctions extends DrawingFunctions {
     } else if ("setPenColor".equalsIgnoreCase(functionName)) {
       String paint = parameters.get(2).toString();
       if ("".equalsIgnoreCase(paint)) {
-        getPen(functionName, map, guid).setForegroundMode(Pen.MODE_TRANSPARENT);
         getPen(functionName, map, guid).setPaint(null);
       } else {
-        getPen(functionName, map, guid).setForegroundMode(Pen.MODE_SOLID);
         getPen(functionName, map, guid).setPaint(FunctionUtil.getPaintFromString(paint));
       }
       return "";
     } else if ("setFillColor".equalsIgnoreCase(functionName)) {
       String paint = parameters.get(2).toString();
       if ("".equalsIgnoreCase(paint)) {
-        getPen(functionName, map, guid).setBackgroundMode(Pen.MODE_TRANSPARENT);
         getPen(functionName, map, guid).setBackgroundPaint(null);
       } else {
-        getPen(functionName, map, guid).setBackgroundMode(Pen.MODE_SOLID);
         getPen(functionName, map, guid).setBackgroundPaint(FunctionUtil.getPaintFromString(paint));
       }
       return "";

--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -545,18 +545,16 @@ public class ShapeFunctions extends AbstractFunction {
       if (penObject.keySet().contains("foreground")) {
         String fg = penObject.get("foreground").getAsString();
         if (fg.equalsIgnoreCase("transparent") || fg.equalsIgnoreCase("")) {
-          pen.setForegroundMode(Pen.MODE_TRANSPARENT);
+          pen.setPaint(null);
         } else {
-          pen.setForegroundMode(Pen.MODE_SOLID);
           pen.setPaint(FunctionUtil.getPaintFromString(fg));
         }
       }
       if (penObject.keySet().contains("background")) {
         String bg = penObject.get("background").getAsString();
         if (bg.equalsIgnoreCase("transparent") || bg.equalsIgnoreCase("")) {
-          pen.setBackgroundMode(Pen.MODE_TRANSPARENT);
+          pen.setBackgroundPaint(null);
         } else {
-          pen.setBackgroundMode(Pen.MODE_SOLID);
           pen.setBackgroundPaint(FunctionUtil.getPaintFromString(bg));
         }
       }

--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -531,7 +531,7 @@ public class ShapeFunctions extends AbstractFunction {
       return false;
     }
 
-    Pen pen = new Pen(Pen.DEFAULT);
+    Pen pen = new Pen();
     if (parameters.size() > 2) {
       String delimiter = ";";
       if (parameters.size() > 3) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.tool.drawing;
 
+import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Graphics2D;
 import java.awt.event.MouseEvent;
@@ -26,6 +27,7 @@ import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.Zone.Layer;
 import net.rptools.maptool.model.drawing.Drawable;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.Pen;
 
 /** Base class for tools that draw templates. */
@@ -87,8 +89,31 @@ public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOv
     return defaultValue;
   }
 
+  /**
+   * @return The pen to used for the finished template.
+   */
   protected Pen getPen() {
-    return MapTool.getFrame().getPen(isEraser());
+    var pen = MapTool.getFrame().getPen(isEraser());
+    pen.setBackgroundMode(Pen.MODE_SOLID);
+    return pen;
+  }
+
+  /**
+   * Get the pen set up to paint the overlay.
+   *
+   * @return The pen used to paint the overlay.
+   */
+  protected Pen getPenForOverlay() {
+    // Get the pen and modify to only show a cursor and the boundary
+    Pen pen = getPen(); // new copy of pen, OK to modify
+    pen.setBackgroundMode(Pen.MODE_SOLID);
+    pen.setForegroundMode(Pen.MODE_SOLID);
+    pen.setThickness(3);
+    if (pen.isEraser()) {
+      pen.setEraser(false);
+      pen.setPaint(new DrawableColorPaint(Color.WHITE));
+    }
+    return pen;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
@@ -94,7 +94,9 @@ public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOv
    */
   protected Pen getPen() {
     var pen = MapTool.getFrame().getPen(isEraser());
-    pen.setBackgroundMode(Pen.MODE_SOLID);
+    if (pen.getBackgroundPaint() == null) {
+      pen.setBackgroundPaint(new DrawableColorPaint(Color.black));
+    }
     return pen;
   }
 
@@ -106,8 +108,12 @@ public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOv
   protected Pen getPenForOverlay() {
     // Get the pen and modify to only show a cursor and the boundary
     Pen pen = getPen(); // new copy of pen, OK to modify
-    pen.setBackgroundMode(Pen.MODE_SOLID);
-    pen.setForegroundMode(Pen.MODE_SOLID);
+    if (pen.getBackgroundPaint() == null) {
+      pen.setBackgroundPaint(new DrawableColorPaint(Color.black));
+    }
+    if (pen.getPaint() == null) {
+      pen.setPaint(new DrawableColorPaint(Color.black));
+    }
     pen.setThickness(3);
     if (pen.isEraser()) {
       pen.setEraser(false);
@@ -153,7 +159,6 @@ public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOv
   }
 
   private boolean hasPaint(Pen pen) {
-    return pen.getForegroundMode() != Pen.MODE_TRANSPARENT
-        || pen.getBackgroundMode() != Pen.MODE_TRANSPARENT;
+    return pen.getPaint() != null || pen.getBackgroundPaint() != null;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
@@ -21,7 +21,6 @@ import java.awt.geom.AffineTransform;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.swing.SwingUtil;
-import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.tool.DefaultTool;
 import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
@@ -89,23 +88,7 @@ public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOv
   }
 
   protected Pen getPen() {
-    Pen pen = new Pen(MapTool.getFrame().getPen());
-    pen.setEraser(isEraser());
-
-    ColorPicker picker = MapTool.getFrame().getColorPicker();
-    if (picker.isFillForegroundSelected()) {
-      pen.setForegroundMode(Pen.MODE_SOLID);
-    } else {
-      pen.setForegroundMode(Pen.MODE_TRANSPARENT);
-    }
-    if (picker.isFillBackgroundSelected()) {
-      pen.setBackgroundMode(Pen.MODE_SOLID);
-    } else {
-      pen.setBackgroundMode(Pen.MODE_TRANSPARENT);
-    }
-    pen.setSquareCap(picker.isSquareCapSelected());
-    pen.setThickness(picker.getStrokeWidth());
-    return pen;
+    return MapTool.getFrame().getPen(isEraser());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
@@ -32,7 +32,6 @@ import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ScreenPoint;
 import net.rptools.maptool.client.events.ZoneActivated;
-import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.swing.label.FlatImageLabel;
 import net.rptools.maptool.client.swing.label.FlatImageLabelFactory;
 import net.rptools.maptool.client.tool.DefaultTool;
@@ -769,23 +768,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
    * @return Pen
    */
   protected Pen getPen() {
-    Pen pen = new Pen(MapTool.getFrame().getPen());
-    pen.setEraser(isEraser);
-
-    ColorPicker picker = MapTool.getFrame().getColorPicker();
-    if (picker.isFillForegroundSelected()) {
-      pen.setForegroundMode(Pen.MODE_SOLID);
-    } else {
-      pen.setForegroundMode(Pen.MODE_TRANSPARENT);
-    }
-    if (picker.isFillBackgroundSelected()) {
-      pen.setBackgroundMode(Pen.MODE_SOLID);
-    } else {
-      pen.setBackgroundMode(Pen.MODE_TRANSPARENT);
-    }
-    pen.setSquareCap(picker.isSquareCapSelected());
-    pen.setThickness(picker.getStrokeWidth());
-    return pen;
+    return MapTool.getFrame().getPen(isEraser);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -113,8 +113,7 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
   }
 
   private boolean hasPaint(Pen pen) {
-    return pen.getForegroundMode() != Pen.MODE_TRANSPARENT
-        || pen.getBackgroundMode() != Pen.MODE_TRANSPARENT;
+    return pen.getPaint() != null || pen.getBackgroundPaint() != null;
   }
 
   private Pen getPen() {
@@ -186,8 +185,9 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
           pen.setPaint(new DrawableColorPaint(Color.white));
           pen.setBackgroundPaint(new DrawableColorPaint(Color.white));
         }
-        if (isLinearTool()) {
-          pen.setForegroundMode(Pen.MODE_SOLID);
+        if (isLinearTool() && pen.getPaint() == null) {
+          // Make sure the user can see what they're drawing, even if it is a transparent line.
+          pen.setPaint(new DrawableColorPaint(Color.black));
         }
 
         drawable.draw(renderer.getZone(), g2, pen);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolUtil;
-import net.rptools.maptool.client.swing.colorpicker.ColorPicker;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
@@ -119,23 +118,7 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
   }
 
   private Pen getPen() {
-    Pen pen = new Pen(MapTool.getFrame().getPen());
-    pen.setEraser(isEraser());
-
-    ColorPicker picker = MapTool.getFrame().getColorPicker();
-    if (picker.isFillForegroundSelected()) {
-      pen.setForegroundMode(Pen.MODE_SOLID);
-    } else {
-      pen.setForegroundMode(Pen.MODE_TRANSPARENT);
-    }
-    if (picker.isFillBackgroundSelected()) {
-      pen.setBackgroundMode(Pen.MODE_SOLID);
-    } else {
-      pen.setBackgroundMode(Pen.MODE_TRANSPARENT);
-    }
-    pen.setSquareCap(picker.isSquareCapSelected());
-    pen.setThickness(picker.getStrokeWidth());
-    return pen;
+    return MapTool.getFrame().getPen(isEraser());
   }
 
   private Drawable toDrawable(Shape shape) {

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
@@ -15,7 +15,6 @@
 package net.rptools.maptool.client.tool.drawing;
 
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Paint;
 import java.awt.event.MouseEvent;
@@ -30,7 +29,6 @@ import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.model.drawing.AbstractTemplate;
-import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.Pen;
 import net.rptools.maptool.model.drawing.RadiusCellTemplate;
 
@@ -165,24 +163,6 @@ public class RadiusCellTemplateTool extends AbstractTemplateTool implements Mous
     g.setStroke(new BasicStroke(thickness));
     g.drawLine(vertex.x - halfCursor, vertex.y, vertex.x + halfCursor, vertex.y);
     g.drawLine(vertex.x, vertex.y - halfCursor, vertex.x, vertex.y + halfCursor);
-  }
-
-  /**
-   * Get the pen set up to paint the overlay.
-   *
-   * @return The pen used to paint the overlay.
-   */
-  protected Pen getPenForOverlay() {
-    // Get the pen and modify to only show a cursor and the boundary
-    Pen pen = getPen(); // new copy of pen, OK to modify
-    pen.setBackgroundMode(Pen.MODE_SOLID);
-    pen.setForegroundMode(Pen.MODE_SOLID);
-    pen.setThickness(3);
-    if (pen.isEraser()) {
-      pen.setEraser(false);
-      pen.setPaint(new DrawableColorPaint(Color.WHITE));
-    } // endif
-    return pen;
   }
 
   /**
@@ -332,19 +312,6 @@ public class RadiusCellTemplateTool extends AbstractTemplateTool implements Mous
       return;
     }
     resetTool(null);
-  }
-
-  /**
-   * It is OK to modify the pen returned by this method
-   *
-   * @see AbstractTemplateTool#getPen()
-   */
-  @Override
-  protected Pen getPen() {
-    // Just paint the foreground
-    Pen pen = super.getPen();
-    pen.setBackgroundMode(Pen.MODE_SOLID);
-    return pen;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
@@ -15,7 +15,6 @@
 package net.rptools.maptool.client.tool.drawing;
 
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Paint;
 import java.awt.event.MouseEvent;
@@ -30,7 +29,6 @@ import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.model.drawing.AbstractTemplate;
-import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.Pen;
 import net.rptools.maptool.model.drawing.RadiusTemplate;
 
@@ -166,24 +164,6 @@ public class RadiusTemplateTool extends AbstractTemplateTool implements MouseMot
     g.setStroke(new BasicStroke(thickness));
     g.drawLine(vertex.x - halfCursor, vertex.y, vertex.x + halfCursor, vertex.y);
     g.drawLine(vertex.x, vertex.y - halfCursor, vertex.x, vertex.y + halfCursor);
-  }
-
-  /**
-   * Get the pen set up to paint the overlay.
-   *
-   * @return The pen used to paint the overlay.
-   */
-  protected Pen getPenForOverlay() {
-    // Get the pen and modify to only show a cursor and the boundary
-    Pen pen = getPen(); // new copy of pen, OK to modify
-    pen.setBackgroundMode(Pen.MODE_SOLID);
-    pen.setForegroundMode(Pen.MODE_SOLID);
-    pen.setThickness(3);
-    if (pen.isEraser()) {
-      pen.setEraser(false);
-      pen.setPaint(new DrawableColorPaint(Color.WHITE));
-    } // endif
-    return pen;
   }
 
   /**
@@ -333,19 +313,6 @@ public class RadiusTemplateTool extends AbstractTemplateTool implements MouseMot
       return;
     }
     resetTool(null);
-  }
-
-  /**
-   * It is OK to modify the pen returned by this method
-   *
-   * @see AbstractTemplateTool#getPen()
-   */
-  @Override
-  protected Pen getPen() {
-    // Just paint the foreground
-    Pen pen = super.getPen();
-    pen.setBackgroundMode(Pen.MODE_SOLID);
-    return pen;
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1577,7 +1577,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
    * @return A new pen matching the color picker state.
    */
   public Pen getPen(boolean isEraser) {
-    var pen = new Pen(Pen.DEFAULT);
+    var pen = new Pen();
     pen.setEraser(isEraser);
 
     if (colorPicker.isFillForegroundSelected()) {

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -126,7 +126,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
   private static final int WINDOW_WIDTH = 800;
   private static final int WINDOW_HEIGHT = 600;
 
-  private final Pen pen = new Pen(Pen.DEFAULT);
   private final Map<MTFrame, DockableFrame> frameMap = new HashMap<MTFrame, DockableFrame>();
 
   /** Are the drawing measurements being painted? */
@@ -1571,12 +1570,35 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     assetPanel.addAssetRoot(new AssetDirectory(rootDir, AppConstants.IMAGE_FILE_FILTER));
   }
 
-  public Pen getPen() {
-    pen.setPaint(DrawablePaint.convertPaint(colorPicker.getForegroundPaint()));
-    pen.setBackgroundPaint(DrawablePaint.convertPaint(colorPicker.getBackgroundPaint()));
+  /**
+   * Creates a new {@link Pen} based on the color picker state.
+   *
+   * @param isEraser If {@code true}, the return pen will be an eraser.
+   * @return A new pen matching the color picker state.
+   */
+  public Pen getPen(boolean isEraser) {
+    var pen = new Pen(Pen.DEFAULT);
+    pen.setEraser(isEraser);
+
+    if (colorPicker.isFillForegroundSelected()) {
+      pen.setForegroundMode(Pen.MODE_SOLID);
+      pen.setPaint(DrawablePaint.convertPaint(colorPicker.getForegroundPaint()));
+    } else {
+      pen.setForegroundMode(Pen.MODE_TRANSPARENT);
+      pen.setPaint(null);
+    }
+    if (colorPicker.isFillBackgroundSelected()) {
+      pen.setBackgroundMode(Pen.MODE_SOLID);
+      pen.setBackgroundPaint(DrawablePaint.convertPaint(colorPicker.getBackgroundPaint()));
+    } else {
+      pen.setBackgroundMode(Pen.MODE_TRANSPARENT);
+      pen.setBackgroundPaint(null);
+    }
+
     pen.setThickness(colorPicker.getStrokeWidth());
     pen.setOpacity(colorPicker.getOpacity());
-    pen.setThickness(colorPicker.getStrokeWidth());
+    pen.setSquareCap(colorPicker.isSquareCapSelected());
+
     return pen;
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1581,17 +1581,13 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     pen.setEraser(isEraser);
 
     if (colorPicker.isFillForegroundSelected()) {
-      pen.setForegroundMode(Pen.MODE_SOLID);
       pen.setPaint(DrawablePaint.convertPaint(colorPicker.getForegroundPaint()));
     } else {
-      pen.setForegroundMode(Pen.MODE_TRANSPARENT);
       pen.setPaint(null);
     }
     if (colorPicker.isFillBackgroundSelected()) {
-      pen.setBackgroundMode(Pen.MODE_SOLID);
       pen.setBackgroundPaint(DrawablePaint.convertPaint(colorPicker.getBackgroundPaint()));
     } else {
-      pen.setBackgroundMode(Pen.MODE_TRANSPARENT);
       pen.setBackgroundPaint(null);
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawPanelPopupMenu.java
@@ -357,9 +357,7 @@ public class DrawPanelPopupMenu extends JPopupMenu {
   private Pen invertPen(Pen pen) {
     Pen newPen = new Pen(pen);
     newPen.setBackgroundPaint(pen.getPaint());
-    newPen.setBackgroundMode(pen.getForegroundMode());
     newPen.setPaint(pen.getBackgroundPaint());
-    newPen.setForegroundMode(pen.getBackgroundMode());
     return newPen;
   }
 
@@ -422,17 +420,13 @@ public class DrawPanelPopupMenu extends JPopupMenu {
           Pen p = de.getPen();
           if (cp.getForegroundPaint() != null) {
             p.setPaint(DrawablePaint.convertPaint(cp.getForegroundPaint()));
-            p.setForegroundMode(0);
           } else {
             p.setPaint(null);
-            p.setForegroundMode(1);
           }
           if (cp.getBackgroundPaint() != null) {
             p.setBackgroundPaint(DrawablePaint.convertPaint(cp.getBackgroundPaint()));
-            p.setBackgroundMode(0);
           } else {
             p.setBackgroundPaint(null);
-            p.setBackgroundMode(1);
           }
           p.setThickness(cp.getStrokeWidth());
           p.setOpacity(cp.getOpacity());

--- a/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/drawpanel/DrawablesPanel.java
@@ -105,9 +105,7 @@ public class DrawablesPanel extends JComponent {
     for (DrawnElement element : drawableList) {
       Drawable drawable = element.getDrawable();
       Pen pen = element.getPen();
-      if (pen.getOpacity() != 1
-          && pen.getOpacity()
-              != 0 /* handle legacy pens, besides, it doesn't make sense to have a non visible pen */) {
+      if (pen.getOpacity() != 1) {
         g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, pen.getOpacity()));
       }
       // If we are only drawing cuts, make the pen visible
@@ -149,7 +147,7 @@ public class DrawablesPanel extends JComponent {
       drawnBounds = new Rectangle(drawnBounds);
       // Handle pen size
       Pen pen = element.getPen();
-      int penSize = pen.getForegroundMode() == Pen.MODE_TRANSPARENT ? 0 : (int) pen.getThickness();
+      int penSize = pen.getPaint() == null ? 0 : (int) pen.getThickness();
       drawnBounds.setRect(
           drawnBounds.getX() - penSize,
           drawnBounds.getY() - penSize,

--- a/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/PartitionedDrawableRenderer.java
@@ -270,9 +270,7 @@ public class PartitionedDrawableRenderer implements DrawableRenderer {
       }
       timer.stop("createChunk:CreateChunk");
 
-      if (pen.getOpacity() != 1 && pen.getOpacity() != 0 /*
-																 * handle legacy pens, besides, it doesn't make sense to have a non visible pen
-																 */) {
+      if (pen.getOpacity() != 1) {
         g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, pen.getOpacity()));
       }
 

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -2049,7 +2049,7 @@ public class Zone {
         continue;
       }
       // Are we possibly covering something up?
-      if (drawn.getPen().isEraser() && (drawn.getPen().getBackgroundMode() == Pen.MODE_SOLID)) {
+      if (drawn.getPen().isEraser() && (drawn.getPen().getBackgroundPaint() != null)) {
         area.add(drawnArea);
         eraserCount++;
         continue;

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -55,7 +55,7 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
   @Override
   public void draw(Zone zone, Graphics2D g, Pen pen) {
     if (pen == null) {
-      pen = Pen.DEFAULT;
+      pen = new Pen();
     }
     Stroke oldStroke = g.getStroke();
     g.setStroke(pen.getStroke());

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -66,24 +66,19 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
     } else if (pen.getOpacity() != 1) {
       g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, pen.getOpacity()));
     }
-    if (pen.getBackgroundMode() == Pen.MODE_SOLID) {
-      if (pen.getBackgroundPaint() != null) {
-        g.setPaint(pen.getBackgroundPaint().getPaint(this));
-      } else {
-        // **** Legacy support for 1.1
-        g.setColor(new Color(pen.getBackgroundColor()));
-      }
+
+    var backgroundPaint = pen.getBackgroundPaint();
+    if (backgroundPaint != null) {
+      g.setPaint(backgroundPaint.getPaint(this));
       drawBackground(zone, g);
     }
-    if (pen.getForegroundMode() == Pen.MODE_SOLID) {
-      if (pen.getPaint() != null) {
-        g.setPaint(pen.getPaint().getPaint(this));
-      } else {
-        // **** Legacy support for 1.1
-        g.setColor(new Color(pen.getColor()));
-      }
+
+    var foregroundPaint = pen.getPaint();
+    if (foregroundPaint != null) {
+      g.setPaint(foregroundPaint.getPaint(this));
       draw(zone, g);
     }
+
     g.setComposite(oldComposite);
     g.setStroke(oldStroke);
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -58,7 +58,7 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
       pen = Pen.DEFAULT;
     }
     Stroke oldStroke = g.getStroke();
-    g.setStroke(new BasicStroke(pen.getThickness(), pen.getStrokeCap(), pen.getStrokeJoin()));
+    g.setStroke(pen.getStroke());
 
     Composite oldComposite = g.getComposite();
     if (pen.isEraser()) {

--- a/src/main/java/net/rptools/maptool/model/drawing/Pen.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Pen.java
@@ -16,23 +16,23 @@ package net.rptools.maptool.model.drawing;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.io.Serial;
+import java.io.Serializable;
+import javax.annotation.Nullable;
 import net.rptools.maptool.server.proto.drawing.PenDto;
 
 /**
- * The color and thickness to draw a {@link Drawable}with. Also used to erase by drawing {@link
- * Drawable}s with a Pen whose {@link #setEraser}is true.
+ * The color and thickness to draw a {@link Drawable} with. Also used to erase by drawing {@link
+ * Drawable}s with a Pen whose {@link #isEraser()} is true.
  */
-public class Pen {
-  public static final int MODE_SOLID = 0;
-  public static final int MODE_TRANSPARENT = 1;
+public class Pen implements Serializable {
+  private static final int MODE_SOLID = 0;
+  private static final int MODE_TRANSPARENT = 1;
 
   public static final Pen DEFAULT = new Pen(new DrawableColorPaint(Color.black), 3.0f);
 
-  private int foregroundMode = MODE_SOLID;
-  private DrawablePaint paint;
-
-  private int backgroundMode = MODE_SOLID;
-  private DrawablePaint backgroundPaint;
+  private @Nullable DrawablePaint paint;
+  private @Nullable DrawablePaint backgroundPaint;
 
   private float thickness;
   private boolean eraser;
@@ -40,16 +40,18 @@ public class Pen {
   private float opacity = 1;
 
   // ***** Legacy support, these supports drawables from 1.1
-  private int color;
-  private int backgroundColor;
+  @Deprecated private int foregroundMode = MODE_SOLID;
+  @Deprecated private int backgroundMode = MODE_SOLID;
+  @Deprecated private int color;
+  @Deprecated private int backgroundColor;
 
   public Pen() {}
 
-  public Pen(DrawablePaint paint, float thickness) {
+  public Pen(@Nullable DrawablePaint paint, float thickness) {
     this(paint, thickness, false, true);
   }
 
-  public Pen(DrawablePaint paint, float thickness, boolean eraser, boolean squareCap) {
+  public Pen(@Nullable DrawablePaint paint, float thickness, boolean eraser, boolean squareCap) {
     this.paint = paint;
     this.thickness = thickness;
     this.eraser = eraser;
@@ -58,13 +60,46 @@ public class Pen {
 
   public Pen(Pen copy) {
     this.paint = copy.paint;
-    this.foregroundMode = copy.foregroundMode;
     this.backgroundPaint = copy.backgroundPaint;
-    this.backgroundMode = copy.backgroundMode;
     this.thickness = copy.thickness;
     this.eraser = copy.eraser;
     this.squareCap = copy.squareCap;
     this.opacity = copy.opacity;
+  }
+
+  @Serial
+  private Object readResolve() {
+    // Legacy paints had used the `int` color fields along with the modes to determine what to draw,
+    // and did not have the `DrawablePaint` fields set.
+    // Modern paints will always have the mode set to MODE_TRANSPARENT when the paint is null.
+    boolean isLegacyPaint = false;
+    if (foregroundMode == MODE_SOLID && paint == null) {
+      paint = new DrawableColorPaint(color);
+      isLegacyPaint = true;
+    }
+    if (backgroundMode == MODE_SOLID && backgroundPaint == null) {
+      backgroundPaint = new DrawableColorPaint(backgroundColor);
+      isLegacyPaint = true;
+    }
+    if (isLegacyPaint && opacity <= 0) {
+      opacity = 1;
+    }
+
+    return this;
+  }
+
+  @Serial
+  private Object writeReplace() {
+    // Set the legacy fields for best compatibility when downgrading campaigns, and to make sure
+    // that `readResolve()` can properly interpret the saved pen.
+
+    this.foregroundMode = paint == null ? MODE_TRANSPARENT : MODE_SOLID;
+    this.backgroundMode = backgroundPaint == null ? MODE_TRANSPARENT : MODE_SOLID;
+
+    this.color = paint instanceof DrawableColorPaint dcp ? dcp.getColor() : 0;
+    this.backgroundColor = backgroundPaint instanceof DrawableColorPaint dcp ? dcp.getColor() : 0;
+
+    return this;
   }
 
   public BasicStroke getStroke() {
@@ -73,19 +108,19 @@ public class Pen {
     return new BasicStroke(thickness, cap, join);
   }
 
-  public DrawablePaint getPaint() {
+  public @Nullable DrawablePaint getPaint() {
     return paint;
   }
 
-  public void setPaint(DrawablePaint paint) {
+  public void setPaint(@Nullable DrawablePaint paint) {
     this.paint = paint;
   }
 
-  public DrawablePaint getBackgroundPaint() {
+  public @Nullable DrawablePaint getBackgroundPaint() {
     return backgroundPaint;
   }
 
-  public void setBackgroundPaint(DrawablePaint paint) {
+  public void setBackgroundPaint(@Nullable DrawablePaint paint) {
     this.backgroundPaint = paint;
   }
 
@@ -105,22 +140,6 @@ public class Pen {
     this.thickness = thickness;
   }
 
-  public int getBackgroundMode() {
-    return backgroundMode;
-  }
-
-  public void setBackgroundMode(int backgroundMode) {
-    this.backgroundMode = backgroundMode;
-  }
-
-  public int getForegroundMode() {
-    return foregroundMode;
-  }
-
-  public void setForegroundMode(int foregroundMode) {
-    this.foregroundMode = foregroundMode;
-  }
-
   public float getOpacity() {
     return opacity;
   }
@@ -137,30 +156,15 @@ public class Pen {
     this.squareCap = squareCap;
   }
 
-  // ***** Legacy support, these supports drawables from 1.1
-  // Note the lack of mutators
-  public int getColor() {
-    return color;
-  }
-
-  public int getBackgroundColor() {
-    return backgroundColor;
-  }
-
   public static Pen fromDto(PenDto dto) {
     var pen = new Pen();
+    pen.paint = dto.hasForegroundPaint() ? DrawablePaint.fromDto(dto.getForegroundPaint()) : null;
+    pen.backgroundPaint =
+        dto.hasBackgroundPaint() ? DrawablePaint.fromDto(dto.getBackgroundPaint()) : null;
     pen.eraser = dto.getEraser();
-    pen.foregroundMode = dto.getForegroundModeValue();
-    pen.backgroundMode = dto.getBackgroundModeValue();
     pen.thickness = dto.getThickness();
     pen.opacity = dto.getOpacity();
     pen.squareCap = dto.getSquareCap();
-    if (dto.hasForegroundColor()) {
-      pen.paint = DrawablePaint.fromDto(dto.getForegroundColor());
-    }
-    if (dto.hasBackgroundColor()) {
-      pen.backgroundPaint = DrawablePaint.fromDto(dto.getBackgroundColor());
-    }
     return pen;
   }
 
@@ -168,17 +172,14 @@ public class Pen {
     var dto =
         PenDto.newBuilder()
             .setEraser(eraser)
-            .setForegroundMode(PenDto.mode.forNumber(foregroundMode))
-            .setBackgroundMode(PenDto.mode.forNumber(backgroundMode))
             .setThickness(thickness)
             .setOpacity(opacity)
             .setSquareCap(squareCap);
-
     if (paint != null) {
-      dto.setForegroundColor(paint.toDto());
+      dto.setForegroundPaint(paint.toDto());
     }
     if (backgroundPaint != null) {
-      dto.setBackgroundColor(backgroundPaint.toDto());
+      dto.setBackgroundPaint(backgroundPaint.toDto());
     }
     return dto.build();
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/Pen.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Pen.java
@@ -29,8 +29,6 @@ public class Pen implements Serializable {
   private static final int MODE_SOLID = 0;
   private static final int MODE_TRANSPARENT = 1;
 
-  public static final Pen DEFAULT = new Pen(new DrawableColorPaint(Color.black), 3.0f);
-
   private @Nullable DrawablePaint paint;
   private @Nullable DrawablePaint backgroundPaint;
 
@@ -45,26 +43,40 @@ public class Pen implements Serializable {
   @Deprecated private int color;
   @Deprecated private int backgroundColor;
 
-  public Pen() {}
-
-  public Pen(@Nullable DrawablePaint paint, float thickness) {
-    this(paint, thickness, false, true);
-  }
-
-  public Pen(@Nullable DrawablePaint paint, float thickness, boolean eraser, boolean squareCap) {
+  /** "Primary" pen constructor that sets all fields */
+  public Pen(
+      @Nullable DrawablePaint paint,
+      @Nullable DrawablePaint backgroundPaint,
+      float thickness,
+      boolean eraser,
+      boolean squareCap,
+      float opacity) {
     this.paint = paint;
+    this.backgroundPaint = backgroundPaint;
     this.thickness = thickness;
     this.eraser = eraser;
     this.squareCap = squareCap;
+    this.opacity = opacity;
+  }
+
+  public Pen() {
+    this(
+        new DrawableColorPaint(Color.black),
+        new DrawableColorPaint(Color.black),
+        3.0f,
+        false,
+        true,
+        1.f);
   }
 
   public Pen(Pen copy) {
-    this.paint = copy.paint;
-    this.backgroundPaint = copy.backgroundPaint;
-    this.thickness = copy.thickness;
-    this.eraser = copy.eraser;
-    this.squareCap = copy.squareCap;
-    this.opacity = copy.opacity;
+    this(
+        copy.paint,
+        copy.backgroundPaint,
+        copy.thickness,
+        copy.eraser,
+        copy.squareCap,
+        copy.opacity);
   }
 
   @Serial
@@ -157,15 +169,13 @@ public class Pen implements Serializable {
   }
 
   public static Pen fromDto(PenDto dto) {
-    var pen = new Pen();
-    pen.paint = dto.hasForegroundPaint() ? DrawablePaint.fromDto(dto.getForegroundPaint()) : null;
-    pen.backgroundPaint =
-        dto.hasBackgroundPaint() ? DrawablePaint.fromDto(dto.getBackgroundPaint()) : null;
-    pen.eraser = dto.getEraser();
-    pen.thickness = dto.getThickness();
-    pen.opacity = dto.getOpacity();
-    pen.squareCap = dto.getSquareCap();
-    return pen;
+    return new Pen(
+        dto.hasForegroundPaint() ? DrawablePaint.fromDto(dto.getForegroundPaint()) : null,
+        dto.hasBackgroundPaint() ? DrawablePaint.fromDto(dto.getBackgroundPaint()) : null,
+        dto.getThickness(),
+        dto.getEraser(),
+        dto.getSquareCap(),
+        dto.getOpacity());
   }
 
   public PenDto toDto() {

--- a/src/main/java/net/rptools/maptool/model/drawing/Pen.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/Pen.java
@@ -67,6 +67,12 @@ public class Pen {
     this.opacity = copy.opacity;
   }
 
+  public BasicStroke getStroke() {
+    var cap = squareCap ? BasicStroke.CAP_SQUARE : BasicStroke.CAP_ROUND;
+    var join = squareCap ? BasicStroke.JOIN_MITER : BasicStroke.JOIN_ROUND;
+    return new BasicStroke(thickness, cap, join);
+  }
+
   public DrawablePaint getPaint() {
     return paint;
   }
@@ -129,16 +135,6 @@ public class Pen {
 
   public void setSquareCap(boolean squareCap) {
     this.squareCap = squareCap;
-  }
-
-  public int getStrokeCap() {
-    if (squareCap) return BasicStroke.CAP_SQUARE;
-    else return BasicStroke.CAP_ROUND;
-  }
-
-  public int getStrokeJoin() {
-    if (squareCap) return BasicStroke.JOIN_MITER;
-    else return BasicStroke.JOIN_ROUND;
   }
 
   // ***** Legacy support, these supports drawables from 1.1


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5848

### Description of the Change

Adds `Pen#readResolve()` and `Pen#writeReplace()` so that callers don't have to check the various edges cases for pens (null paints, zero opacity). The foreground and background modes are now considered legacy state, along with the already-legacy color fields. These are all now only used in `#readResolve()` to set the modern paints if needed. They are also set in `#writeReplace()` to increase the chance of campaigns being downgraded to earlier MT versions.

This avoids an edge case where the default pen would have a solid background mode with a null background paint. The result is effectively that the pen has a black background, but it would not be recognized as such, e.g., by the Draw Explorer's _Get Properties_. This is usually not observable, but can be seen by using the experimental `shape.draw()` without providing a pen. 

Also included is some other pen-related cleanup:
- `MapToolFrame#getPen()` sets all the pen properties from the colour picker, instead of having all callers have duplicated logic to account for transparency.
- Duplicated `#getPen()` and `#getPenForOverlay()` methods from `RadiusCellTemplateTool` and `RadiusTemplateTool` have been merged up into `AbstractTemplateTool`.
- Add `Pen#getStroke()` to build a `BasicStroke` based on the pen's `#thickness` and `#squareCap` rather than exposing the caps and joins separately.
- Reworked `Pen` constructors to be a bit more straightforward and useful. The "primary" constructor accepts all non-legacy properties, and the other constructors delegate to it. `#fromDto()` uses the primary constructor instead of the default, and `Pen#DEFAULT` is removed in favour of using the default constructor.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- 
- Fixed the background color for shapes  created with `shape.draw()` when no pen is provided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5850)
<!-- Reviewable:end -->
