### PR TITLE
Make `Scale` read-only

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -2363,7 +2363,7 @@ public class AppActions {
           if (campaign.currentView != null) {
             current.setZoneScale(campaign.currentView);
           }
-          current.getZoneScale().reset();
+          current.setZoneScale(current.getZoneScale().withResetZoomLevel());
         }
         MapTool.getAutoSaveManager().tidy();
 

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -831,9 +831,11 @@ public class AppActions {
           ScreenPoint screenPoint = renderer.getPointUnderMouse();
           if (screenPoint == null) {
             // Pick the middle of the map
-            screenPoint = ScreenPoint.fromZonePoint(renderer, renderer.getCenterPoint());
+            var centerPoint = renderer.getCenterPoint();
+            screenPoint =
+                renderer.getViewModel().getZoneScale().toScreenSpace(centerPoint.x, centerPoint.y);
           }
-          ZonePoint zonePoint = screenPoint.convertToZone(renderer);
+          ZonePoint zonePoint = screenPoint.convertToZone(renderer.getViewModel().getZoneScale());
           pasteTokens(zonePoint, renderer.getActiveLayer());
           keepIdsOnPaste = false; // once pasted, subsequent paste should have new ids
           renderer.repaint();

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1809,7 +1809,10 @@ public class AppActions {
           ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
           if (renderer != null) {
             Dimension size = renderer.getSize();
-            renderer.zoomIn(size.width / 2, size.height / 2);
+
+            var viewModel = renderer.getViewModel();
+            viewModel.setZoneScale(
+                viewModel.getZoneScale().zoomedIn(size.width / 2, size.height / 2));
             renderer.maybeForcePlayersView();
           }
         }
@@ -1828,7 +1831,10 @@ public class AppActions {
           ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
           if (renderer != null) {
             Dimension size = renderer.getSize();
-            renderer.zoomOut(size.width / 2, size.height / 2);
+
+            var viewModel = renderer.getViewModel();
+            viewModel.setZoneScale(
+                viewModel.getZoneScale().zoomedOut(size.width / 2, size.height / 2));
             renderer.maybeForcePlayersView();
           }
         }
@@ -1846,22 +1852,26 @@ public class AppActions {
         @Override
         protected void executeAction() {
           ZoneRenderer renderer = MapTool.getFrame().getCurrentZoneRenderer();
-          if (renderer != null) {
-            // Revert to last zoom if we have one, but don't if the user has manually
-            // changed the scale since the last reset zoom (one to one index)
-            if (lastZoom != null
-                && renderer.getScale() == renderer.getZoneScale().getOneToOneScale()) {
-              // Go back to the previous zoom
-              renderer.setScale(lastZoom);
-
-              // But make sure the next time we'll go back to 1:1
-              lastZoom = null;
-            } else {
-              lastZoom = renderer.getScale();
-              renderer.zoomReset(renderer.getWidth() / 2, renderer.getHeight() / 2);
-            }
-            renderer.maybeForcePlayersView();
+          if (renderer == null) {
+            return;
           }
+
+          var viewModel = renderer.getViewModel();
+          var zoneScale = viewModel.getZoneScale();
+
+          // Revert to last zoom if we have one, but don't if the user has manually
+          // changed the scale since the last reset zoom (one to one index)
+          if (lastZoom != null && zoneScale.getScale() == zoneScale.getOneToOneScale()) {
+            // Go back to the previous zoom
+            viewModel.setZoneScale(zoneScale.withCenteredScale(lastZoom, renderer.getSize()));
+            // But make sure the next time we'll go back to 1:1
+            lastZoom = null;
+          } else {
+            lastZoom = zoneScale.getScale();
+            viewModel.setZoneScale(
+                zoneScale.withCenteredScale(zoneScale.getOneToOneScale(), renderer.getSize()));
+          }
+          renderer.maybeForcePlayersView();
         }
       };
 
@@ -2360,10 +2370,9 @@ public class AppActions {
         MapTool.setCampaign(campaign.campaign, campaign.currentZoneId);
         ZoneRenderer current = MapTool.getFrame().getCurrentZoneRenderer();
         if (current != null) {
-          if (campaign.currentView != null) {
-            current.setZoneScale(campaign.currentView);
-          }
-          current.setZoneScale(current.getZoneScale().withResetZoomLevel());
+          Scale scale = campaign.currentView == null ? new Scale() : campaign.currentView;
+          scale = scale.withResetZoomLevel();
+          current.getViewModel().setZoneScale(scale);
         }
         MapTool.getAutoSaveManager().tidy();
 

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -923,8 +923,12 @@ public class ClientMessageHandler implements MessageHandler {
           if (AppPreferences.fitGmView.get()) {
             renderer.enforceView(x, y, scale, gmWidth, gmHeight);
           } else {
-            renderer.setScale(scale);
-            renderer.centerOn(new ZonePoint(x, y));
+            var viewModel = renderer.getViewModel();
+            viewModel.setZoneScale(
+                viewModel
+                    .getZoneScale()
+                    .withCenteredScale(scale, renderer.getSize())
+                    .centeredOn(x, y, renderer.getSize()));
           }
         });
   }

--- a/src/main/java/net/rptools/maptool/client/ScreenPoint.java
+++ b/src/main/java/net/rptools/maptool/client/ScreenPoint.java
@@ -15,7 +15,7 @@
 package net.rptools.maptool.client;
 
 import java.awt.geom.Point2D;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.model.ZonePoint;
 
 public class ScreenPoint extends Point2D.Double {
@@ -23,35 +23,28 @@ public class ScreenPoint extends Point2D.Double {
     super(x, y);
   }
 
-  public static Point2D.Double convertToZone2d(ZoneRenderer renderer, double x, double y) {
-    double scale = renderer.getScale();
-    return new Point2D.Double(
-        (x - renderer.getViewOffsetX()) / scale, (y - renderer.getViewOffsetY()) / scale);
-  }
-
   /**
    * Translate the point from screen x,y to zone x,y.
    *
-   * @param renderer the {@link ZoneRenderer} for the "screen view" of the {@link
-   *     net.rptools.maptool.model.Zone}.
+   * @param zoneScale the "screen view" of the {@link net.rptools.maptool.model.Zone}.
    * @param x the x screen co-ordinate.
    * @param y the y screen co-ordinate.
    * @return the {@link ZonePoint} representing the screen point.
    */
-  public static ZonePoint convertToZone(ZoneRenderer renderer, double x, double y) {
-    var doublePrecision = convertToZone2d(renderer, x, y);
-    return new ZonePoint((int) Math.floor(doublePrecision.x), (int) Math.floor(doublePrecision.y));
+  private static ZonePoint convertToZone(Scale zoneScale, double x, double y) {
+    var doublePrecision = zoneScale.toWorldSpace(x, y);
+    return new ZonePoint(
+        (int) Math.floor(doublePrecision.getX()), (int) Math.floor(doublePrecision.getY()));
   }
 
   /**
    * Translate the point from screen x,y to zone x,y.
    *
-   * @param renderer the {@link ZoneRenderer} for the "screen view" of the {@link
-   *     net.rptools.maptool.model.Zone}
+   * @param scale the "screen view" of the {@link net.rptools.maptool.model.Zone}
    * @return the {@link ZonePoint} representing the screen point.
    */
-  public ZonePoint convertToZone(ZoneRenderer renderer) {
-    return convertToZone(renderer, this.x, this.y);
+  public ZonePoint convertToZone(Scale scale) {
+    return convertToZone(scale, this.x, this.y);
   }
 
   /**
@@ -59,67 +52,27 @@ public class ScreenPoint extends Point2D.Double {
    * zone point required is on the "zone point grid" as opposed to the area of zone space designated
    * by the zone point.
    *
-   * @param renderer the {@link ZoneRenderer} for the "screen view" of the {@link
-   *     net.rptools.maptool.model.Zone}.
+   * @param zoneScale the "screen view" of the {@link net.rptools.maptool.model.Zone}.
    * @return the {@link ZonePoint} representing the screen point.
    */
-  public ZonePoint convertToZoneRnd(ZoneRenderer renderer) {
-    double scale = renderer.getScale();
-    double rndAdj = 0.5 * scale;
-    return convertToZone(renderer, this.x + rndAdj, this.y + rndAdj);
-  }
-
-  public static ScreenPoint fromZonePoint(ZoneRenderer renderer, ZonePoint zp) {
-    return fromZonePoint(renderer, zp.x, zp.y);
-  }
-
-  public static ScreenPoint fromZonePoint(ZoneRenderer renderer, double x, double y) {
-    return renderer.getZoneScale().toScreenSpace(x, y);
+  public ZonePoint convertToZoneRnd(Scale zoneScale) {
+    double rndAdj = 0.5 * zoneScale.getScale();
+    return convertToZone(zoneScale, this.x + rndAdj, this.y + rndAdj);
   }
 
   /**
    * Converts a ZonePoint to a screen coordinate (ScreenPoint) and rounding both axis values to
    * longs.
    *
-   * @param renderer the ZoneRenderer to use for scaling the coordinate
+   * @param zoneScale the "screen view" of the {@link net.rptools.maptool.model.Zone}.
    * @param x X axis coordinate
    * @param y Y axis coordinate
    * @return new ScreenPoint
    */
-  public static ScreenPoint fromZonePointRnd(ZoneRenderer renderer, double x, double y) {
-    ScreenPoint sp = fromZonePoint(renderer, x, y);
+  public static ScreenPoint fromZonePointRnd(Scale zoneScale, double x, double y) {
+    ScreenPoint sp = zoneScale.toScreenSpace(x, y);
     sp.x = Math.round(sp.x);
     sp.y = Math.round(sp.y);
-    return sp;
-  }
-
-  /**
-   * Same as {@link #fromZonePointRnd(ZoneRenderer, double, double)} but always rounds up.
-   *
-   * @param renderer the ZoneRenderer to use for scaling the coordinate
-   * @param x X axis coordinate
-   * @param y Y axis coordinate
-   * @return new ScreenPoint
-   */
-  public static ScreenPoint fromZonePointHigh(ZoneRenderer renderer, double x, double y) {
-    ScreenPoint sp = fromZonePoint(renderer, x, y);
-    sp.x = Math.ceil(sp.x);
-    sp.y = Math.ceil(sp.y);
-    return sp;
-  }
-
-  /**
-   * Same as {@link #fromZonePointRnd(ZoneRenderer, double, double)} but always rounds down.
-   *
-   * @param renderer the ZoneRenderer to use for scaling the coordinate
-   * @param x X axis coordinate
-   * @param y Y axis coordinate
-   * @return new ScreenPoint
-   */
-  public static ScreenPoint fromZonePointLow(ZoneRenderer renderer, double x, double y) {
-    ScreenPoint sp = fromZonePoint(renderer, x, y);
-    sp.x = Math.floor(sp.x);
-    sp.y = Math.floor(sp.y);
     return sp;
   }
 

--- a/src/main/java/net/rptools/maptool/client/events/RepaintZoneRequested.java
+++ b/src/main/java/net/rptools/maptool/client/events/RepaintZoneRequested.java
@@ -1,0 +1,19 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.events;
+
+import net.rptools.maptool.model.Zone;
+
+public record RepaintZoneRequested(Zone zone) {}

--- a/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenLocationFunctions.java
@@ -571,19 +571,24 @@ public class TokenLocationFunctions extends AbstractFunction {
    * @throws ParserException if an error occurs.
    */
   private String gotoLoc(VariableResolver resolver, List<Object> args) throws ParserException {
-    int x;
-    int y;
+    var renderer = MapTool.getFrame().getCurrentZoneRenderer();
 
+    ZonePoint point;
     if (args.size() < 2) {
       Token token = FunctionUtil.getTokenFromParam(resolver, "goto", args, 0, -1);
-      x = token.getX();
-      y = token.getY();
-      MapTool.getFrame().getCurrentZoneRenderer().centerOn(new ZonePoint(x, y));
+      point = new ZonePoint(token.getX(), token.getY());
     } else {
-      x = FunctionUtil.paramAsInteger("goto", args, 0, false);
-      y = FunctionUtil.paramAsInteger("goto", args, 1, false);
-      MapTool.getFrame().getCurrentZoneRenderer().centerOn(new CellPoint(x, y));
+      var x = FunctionUtil.paramAsInteger("goto", args, 0, false);
+      var y = FunctionUtil.paramAsInteger("goto", args, 1, false);
+      point = renderer.getZone().getGrid().convert(new CellPoint(x, y));
     }
+    renderer
+        .getViewModel()
+        .setZoneScale(
+            renderer
+                .getViewModel()
+                .getZoneScale()
+                .centeredOn(point.x, point.y, renderer.getSize()));
 
     return "";
   }

--- a/src/main/java/net/rptools/maptool/client/functions/ZoomFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ZoomFunctions.java
@@ -50,14 +50,15 @@ public class ZoomFunctions extends AbstractFunction {
       throws ParserException {
     if ("getZoom".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, args, 0, 0);
-      return Double.valueOf(
-              MapTool.getFrame().getCurrentZoneRenderer().getViewModel().getZoneScale().getScale())
-          .toString();
+      var viewModel = MapTool.getFrame().getCurrentZoneRenderer().getViewModel();
+      return Double.valueOf(viewModel.getZoneScale().getScale()).toString();
     }
     if ("setZoom".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 1);
-      Double zoom = FunctionUtil.paramAsDouble(functionName, args, 0, true);
-      MapTool.getFrame().getCurrentZoneRenderer().setScale(zoom);
+      double zoom = FunctionUtil.paramAsDouble(functionName, args, 0, true);
+      var renderer = MapTool.getFrame().getCurrentZoneRenderer();
+      var viewModel = renderer.getViewModel();
+      viewModel.setZoneScale(viewModel.getZoneScale().withCenteredScale(zoom, renderer.getSize()));
       return "";
     }
     if ("getViewArea".equalsIgnoreCase(functionName)) {

--- a/src/main/java/net/rptools/maptool/client/functions/ZoomFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ZoomFunctions.java
@@ -19,6 +19,7 @@ import java.awt.Rectangle;
 import java.util.List;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.ScreenPoint;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Grid;
@@ -49,7 +50,9 @@ public class ZoomFunctions extends AbstractFunction {
       throws ParserException {
     if ("getZoom".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, args, 0, 0);
-      return Double.valueOf(MapTool.getFrame().getCurrentZoneRenderer().getScale()).toString();
+      return Double.valueOf(
+              MapTool.getFrame().getCurrentZoneRenderer().getViewModel().getZoneScale().getScale())
+          .toString();
     }
     if ("setZoom".equalsIgnoreCase(functionName)) {
       FunctionUtil.checkNumberParam(functionName, args, 1, 1);
@@ -103,14 +106,15 @@ public class ZoomFunctions extends AbstractFunction {
   private static Object getViewArea(boolean pixels, String delim) {
     ZoneRenderer zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
 
-    int offsetX = zoneRenderer.getViewOffsetX() * -1;
-    int offsetY = zoneRenderer.getViewOffsetY() * -1;
     int width = zoneRenderer.getWidth();
     int height = zoneRenderer.getHeight();
 
     // convert zoomed pixels to true pixels
-    ZonePoint topLeft = convertToZone(zoneRenderer, offsetX, offsetY);
-    ZonePoint bottomRight = convertToZone(zoneRenderer, offsetX + width, offsetY + height);
+
+    ZonePoint topLeft =
+        new ScreenPoint(0, 0).convertToZone(zoneRenderer.getViewModel().getZoneScale());
+    ZonePoint bottomRight =
+        new ScreenPoint(width, height).convertToZone(zoneRenderer.getViewModel().getZoneScale());
 
     if (pixels) {
       if ("json".equalsIgnoreCase(delim)) {
@@ -128,21 +132,6 @@ public class ZoomFunctions extends AbstractFunction {
         return createBoundsAsStringProps(delim, z1.x, z1.y, z2.x, z2.y);
       }
     }
-  }
-
-  /**
-   * Returns zonePoint from x and y pixel coordinates, and from the scale of the renderer
-   *
-   * @param renderer the renderer of the zone
-   * @param x the x coordinate
-   * @param y the y coordinate
-   * @return ZonePoint of the coordinates
-   */
-  public static ZonePoint convertToZone(ZoneRenderer renderer, double x, double y) {
-    double scale = renderer.getScale();
-    double zX = (int) Math.floor(x / scale);
-    double zY = (int) Math.floor(y / scale);
-    return new ZonePoint((int) zX, (int) zY);
   }
 
   private static Object createBoundsAsStringProps(
@@ -209,14 +198,13 @@ public class ZoomFunctions extends AbstractFunction {
   private static Object getViewCenter(boolean pixels, String delim) {
     ZoneRenderer zoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
 
-    int offsetX = zoneRenderer.getViewOffsetX() * -1;
     int width = zoneRenderer.getWidth();
-
-    int offsetY = zoneRenderer.getViewOffsetY() * -1;
     int height = zoneRenderer.getHeight();
 
-    ZonePoint topLeft = convertToZone(zoneRenderer, offsetX, offsetY);
-    ZonePoint bottomRight = convertToZone(zoneRenderer, offsetX + width, offsetY + height);
+    ZonePoint topLeft =
+        new ScreenPoint(0, 0).convertToZone(zoneRenderer.getViewModel().getZoneScale());
+    ZonePoint bottomRight =
+        new ScreenPoint(width, height).convertToZone(zoneRenderer.getViewModel().getZoneScale());
 
     int centerX = (topLeft.x + bottomRight.x) / 2;
     int centerY = (topLeft.y + bottomRight.y) / 2;

--- a/src/main/java/net/rptools/maptool/client/macro/impl/GotoMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/GotoMacro.java
@@ -23,7 +23,6 @@ import net.rptools.maptool.client.macro.MacroContext;
 import net.rptools.maptool.client.macro.MacroDefinition;
 import net.rptools.maptool.model.CellPoint;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
 
 @MacroDefinition(
@@ -31,30 +30,41 @@ import net.rptools.maptool.model.ZonePoint;
     aliases = {"g"},
     description = "goto.description")
 public class GotoMacro implements Macro {
-  private static Pattern COORD_PATTERN = Pattern.compile("(-?\\d+)\\s*,?\\s*(-?\\d+)");
+  private static final Pattern COORD_PATTERN = Pattern.compile("(-?\\d+)\\s*,?\\s*(-?\\d+)");
 
   public void execute(
       MacroContext context, String parameter, MapToolMacroContext executionContext) {
+    var renderer = MapTool.getFrame().getCurrentZoneRenderer();
+    var zone = renderer.getZone();
+
     Matcher m = COORD_PATTERN.matcher(parameter.trim());
+
+    ZonePoint point;
     if (m.matches()) {
       // goto coordinate locations
       int x = Integer.parseInt(m.group(1));
       int y = Integer.parseInt(m.group(2));
-
-      MapTool.getFrame().getCurrentZoneRenderer().centerOn(new CellPoint(x, y));
+      point = zone.getGrid().convert(new CellPoint(x, y));
     } else {
       // goto token location
-      Zone zone = MapTool.getFrame().getCurrentZoneRenderer().getZone();
       Token token = zone.getTokenByName(parameter);
 
+      if (token == null) {
+        return;
+      }
       if (!MapTool.getPlayer().isGM() && !zone.isTokenVisible(token)) {
         return;
       }
-      if (token != null) {
-        int x = token.getX();
-        int y = token.getY();
-        MapTool.getFrame().getCurrentZoneRenderer().centerOn(new ZonePoint(x, y));
-      }
+
+      point = new ZonePoint(token.getX(), token.getY());
     }
+
+    renderer
+        .getViewModel()
+        .setZoneScale(
+            renderer
+                .getViewModel()
+                .getZoneScale()
+                .centeredOn(point.x, point.y, renderer.getSize()));
   }
 }

--- a/src/main/java/net/rptools/maptool/client/swing/ZoomStatusBar.java
+++ b/src/main/java/net/rptools/maptool/client/swing/ZoomStatusBar.java
@@ -22,7 +22,6 @@ import javax.swing.*;
 import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 
 /**
@@ -50,12 +49,12 @@ public class ZoomStatusBar extends JTextField implements ActionListener {
   public void actionPerformed(ActionEvent e) {
     JTextField target = (JTextField) e.getSource();
     if (MapTool.getFrame().getCurrentZoneRenderer() != null) {
-      double zoom;
-      ZoneRenderer renderer;
       try {
-        zoom = StringUtil.parseDecimal(target.getText());
-        renderer = MapTool.getFrame().getCurrentZoneRenderer();
-        renderer.setScale(zoom / 100);
+        var zoom = StringUtil.parseDecimal(target.getText());
+        var renderer = MapTool.getFrame().getCurrentZoneRenderer();
+        var viewModel = renderer.getViewModel();
+        viewModel.setZoneScale(
+            viewModel.getZoneScale().withCenteredScale(zoom / 100., renderer.getSize()));
         renderer.maybeForcePlayersView();
         update();
       } catch (ParseException ex) {
@@ -67,7 +66,8 @@ public class ZoomStatusBar extends JTextField implements ActionListener {
   public void update() {
     String zoom = "";
     if (MapTool.getFrame().getCurrentZoneRenderer() != null) {
-      double scale = MapTool.getFrame().getCurrentZoneRenderer().getZoneScale().getScale();
+      double scale =
+          MapTool.getFrame().getCurrentZoneRenderer().getViewModel().getZoneScale().getScale();
       scale *= 100;
 
       if (scale < 10) {

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -259,7 +259,9 @@ public abstract class DefaultTool extends Tool
       }
 
       setDragStart(mX, mY);
-      renderer.moveViewBy(mapDX, mapDY);
+
+      var viewModel = renderer.getViewModel();
+      viewModel.setZoneScale(viewModel.getZoneScale().translated(mapDX, mapDY));
     }
   }
 
@@ -318,11 +320,14 @@ public abstract class DefaultTool extends Tool
     if (!AppState.isZoomLocked()) {
       boolean direction = e.getWheelRotation() < 0;
       direction = isKeyDown('z') == direction;
+
+      var scale = renderer.getViewModel().getZoneScale();
       if (direction) {
-        renderer.zoomOut(e.getX(), e.getY());
+        scale = scale.zoomedOut(e.getX(), e.getY());
       } else {
-        renderer.zoomIn(e.getX(), e.getY());
+        scale = scale.zoomedIn(e.getX(), e.getY());
       }
+      renderer.getViewModel().setZoneScale(scale);
       renderer.maybeForcePlayersView();
     }
   }

--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -225,7 +225,11 @@ public abstract class DefaultTool extends Tool
     mouseY = e.getY();
 
     CellPoint cp =
-        getZone().getGrid().convert(new ScreenPoint(mouseX, mouseY).convertToZone(renderer));
+        getZone()
+            .getGrid()
+            .convert(
+                new ScreenPoint(mouseX, mouseY)
+                    .convertToZone(renderer.getViewModel().getZoneScale()));
     if (cp != null) {
       MapTool.getFrame().getCoordinateStatusBar().update(cp.x, cp.y);
     } else {

--- a/src/main/java/net/rptools/maptool/client/tool/MeasureTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/MeasureTool.java
@@ -112,7 +112,7 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
       ZonePoint lastZP = null;
       for (ZonePoint zp :
           Iterables.concat(gridlessPath.getCellPath(), List.of(currentGridlessPoint))) {
-        var sp = ScreenPoint.fromZonePoint(renderer, zp.x, zp.y);
+        var sp = renderer.getViewModel().getZoneScale().toScreenSpace(zp.x, zp.y);
         if (lastZP == null) {
           path2D.moveTo(sp.x, sp.y);
         } else {
@@ -134,7 +134,7 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
         g.draw(path2D);
 
         String distance = NumberFormat.getInstance().format(c);
-        ScreenPoint sp = ScreenPoint.fromZonePoint(renderer, lastZP.x, lastZP.y);
+        ScreenPoint sp = renderer.getViewModel().getZoneScale().toScreenSpace(lastZP.x, lastZP.y);
         GraphicsUtil.drawBoxedString(g, distance, (int) sp.x, (int) sp.y - 20);
       } finally {
         SwingUtil.restoreAntiAliasing(g, oldAA);
@@ -156,7 +156,9 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
                   renderer
                       .getZone()
                       .getGrid()
-                      .convert(new ScreenPoint(mouseX, mouseY).convertToZone(renderer));
+                      .convert(
+                          new ScreenPoint(mouseX, mouseY)
+                              .convertToZone(renderer.getViewModel().getZoneScale()));
               walker.toggleWaypoint(cp);
             } else if (gridlessPath != null) {
               gridlessPath.appendWaypoint(currentGridlessPoint);
@@ -177,7 +179,9 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
         walker = renderer.getZone().getGrid().createZoneWalker();
         walker.addWaypoints(cellPoint, cellPoint);
       } else {
-        currentGridlessPoint = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+        currentGridlessPoint =
+            new ScreenPoint(e.getX(), e.getY())
+                .convertToZone(renderer.getViewModel().getZoneScale());
         gridlessPath = new Path<>();
         gridlessPath.appendWaypoint(currentGridlessPoint);
       }
@@ -216,7 +220,9 @@ public class MeasureTool extends DefaultTool implements ZoneOverlay {
         CellPoint cellPoint = renderer.getCellAt(new ScreenPoint(e.getX(), e.getY()));
         walker.replaceLastWaypoint(cellPoint);
       } else if (gridlessPath != null) {
-        currentGridlessPoint = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+        currentGridlessPoint =
+            new ScreenPoint(e.getX(), e.getY())
+                .convertToZone(renderer.getViewModel().getZoneScale());
       }
       renderer.repaint();
     }

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -205,7 +205,11 @@ public class PointerTool extends DefaultTool {
 
   public void startTokenDrag(Token keyToken, Set<GUID> tokens) {
     startTokenDrag(
-        keyToken, tokens, new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer), false);
+        keyToken,
+        tokens,
+        new ScreenPoint(dragStartX, dragStartY)
+            .convertToZone(renderer.getViewModel().getZoneScale()),
+        false);
   }
 
   private void startTokenDrag(
@@ -314,7 +318,8 @@ public class PointerTool extends DefaultTool {
             .startTokenDrag(
                 token,
                 Collections.singleton(token.getId()),
-                new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer),
+                new ScreenPoint(dragStartX, dragStartY)
+                    .convertToZone(renderer.getViewModel().getZoneScale()),
                 false);
       }
     }
@@ -602,7 +607,8 @@ public class PointerTool extends DefaultTool {
     }
 
     if (isShowingPointer) {
-      ZonePoint zp = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
+      ZonePoint zp =
+          new ScreenPoint(mouseX, mouseY).convertToZone(renderer.getViewModel().getZoneScale());
       Pointer pointer =
           MapTool.getFrame().getPointerOverlay().getPointer(MapTool.getPlayer().getName());
       if (pointer != null) {
@@ -760,7 +766,8 @@ public class PointerTool extends DefaultTool {
         startTokenDrag(
             tokenUnderMouse,
             selectedTokenSet,
-            new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer),
+            new ScreenPoint(dragStartX, dragStartY)
+                .convertToZone(renderer.getViewModel().getZoneScale()),
             false);
         if (AppPreferences.hideMousePointerWhileDragging.get()) {
           SwingUtil.hidePointer(renderer);
@@ -1128,7 +1135,8 @@ public class PointerTool extends DefaultTool {
         // Pointer
         isShowingPointer = true;
 
-        ZonePoint zp = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
+        ZonePoint zp =
+            new ScreenPoint(mouseX, mouseY).convertToZone(renderer.getViewModel().getZoneScale());
         Pointer pointer = new Pointer(renderer.getZone(), zp.x, zp.y, 0, type);
         if (MapTool.getPlayer().isGM() && type.equals(Pointer.Type.LOOK_HERE)) {
           MapTool.serverCommand()
@@ -1790,7 +1798,8 @@ public class PointerTool extends DefaultTool {
         renderer.setShape4(new Rectangle2D.Double(dragAnchor.x - 5, dragAnchor.y - 5, 10, 10));
       }
 
-      ZonePoint zonePoint = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
+      ZonePoint zonePoint =
+          new ScreenPoint(mouseX, mouseY).convertToZone(renderer.getViewModel().getZoneScale());
       zonePoint.x += dragAnchor.x - tokenDragStart.x;
       zonePoint.y += dragAnchor.y - tokenDragStart.y;
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -1144,7 +1144,7 @@ public class PointerTool extends DefaultTool {
                   renderer.getZone().getId(),
                   zp.x,
                   zp.y,
-                  renderer.getScale(),
+                  renderer.getViewModel().getZoneScale().getScale(),
                   renderer.getWidth(),
                   renderer.getHeight());
         }

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -133,7 +133,11 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
 
   public void startTokenDrag(Token keyToken, Set<GUID> tokens) {
     startTokenDrag(
-        keyToken, tokens, new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer), false);
+        keyToken,
+        tokens,
+        new ScreenPoint(dragStartX, dragStartY)
+            .convertToZone(renderer.getViewModel().getZoneScale()),
+        false);
   }
 
   private void startTokenDrag(
@@ -219,7 +223,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
                 .startTokenDrag(
                     location.getToken(),
                     Collections.singleton(location.getToken().getId()),
-                    new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer),
+                    new ScreenPoint(dragStartX, dragStartY)
+                        .convertToZone(renderer.getViewModel().getZoneScale()),
                     false);
           }
           return;
@@ -622,7 +627,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         startTokenDrag(
             tokenUnderMouse,
             selectedTokenSet,
-            new ScreenPoint(dragStartX, dragStartY).convertToZone(renderer),
+            new ScreenPoint(dragStartX, dragStartY)
+                .convertToZone(renderer.getViewModel().getZoneScale()),
             false);
         SwingUtil.hidePointer(renderer);
       }
@@ -1007,7 +1013,10 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
           double scaledHeight = (footprintBounds.height * scale);
 
           ScreenPoint stampLocation =
-              ScreenPoint.fromZonePoint(renderer, footprintBounds.x, footprintBounds.y);
+              renderer
+                  .getViewModel()
+                  .getZoneScale()
+                  .toScreenSpace(footprintBounds.x, footprintBounds.y);
 
           // distance to place the resize image in the lower left corner of an unrotated stamp
           double tx = stampLocation.x + scaledWidth - resizeImg.getWidth();
@@ -1107,7 +1116,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
 
   public void adjustAnchor(double scaleX, double scaleY) {
     ZonePoint selectionTr =
-        ScreenPoint.convertToZone(renderer, selectionBoundBox.getX(), selectionBoundBox.getY());
+        new ScreenPoint(selectionBoundBox.getX(), selectionBoundBox.getY())
+            .convertToZone(renderer.getViewModel().getZoneScale());
     int gridSize = renderer.getZone().getGrid().getSize();
     int tokenX = tokenUnderMouse.getX() + tokenUnderMouse.getAnchor().x;
     int tokenY = tokenUnderMouse.getY() + tokenUnderMouse.getAnchor().y;
@@ -1171,7 +1181,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         renderer.setShape4(new Rectangle2D.Double(dragAnchor.x - 5, dragAnchor.y - 5, 10, 10));
       }
 
-      ZonePoint zonePoint = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
+      ZonePoint zonePoint =
+          new ScreenPoint(mouseX, mouseY).convertToZone(renderer.getViewModel().getZoneScale());
       zonePoint.x += dragAnchor.x - tokenDragStart.x;
       zonePoint.y += dragAnchor.y - tokenDragStart.y;
 
@@ -1283,7 +1294,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
       this.originalScaleY = tokenBeingResized.getScaleY();
       this.startDragReference =
           new ScreenPoint(dragStartX + dragOffsetX, dragStartY + dragOffsetY)
-              .convertToZone(renderer);
+              .convertToZone(renderer.getViewModel().getZoneScale());
 
       this.tokenImage = ImageManager.getImage(tokenBeingResized.getImageAssetId());
     }
@@ -1294,7 +1305,8 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
     }
 
     public void dragTo(int mouseX, int mouseY, boolean lockAspectRatio, boolean snapSizeToGrid) {
-      var currentZp = new ScreenPoint(mouseX, mouseY).convertToZone(renderer);
+      var currentZp =
+          new ScreenPoint(mouseX, mouseY).convertToZone(renderer.getViewModel().getZoneScale());
       if (snapSizeToGrid) { // snap size to grid
         currentZp = renderer.getZone().getGrid().getNearestVertex(currentZp);
       } else {

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -1006,7 +1006,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         }
         // Resize
         if (!token.isSnapToScale()) {
-          double scale = renderer.getScale();
+          double scale = renderer.getViewModel().getZoneScale().getScale();
           Rectangle footprintBounds = token.getFootprintBounds(renderer.getZone());
 
           double scaledWidth = (footprintBounds.width * scale);
@@ -1097,7 +1097,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
         && cellWidthSelected > 0
         && cellHeightSelected > 0) {
       double gridSize = renderer.getZone().getGrid().getSize();
-      double zoneScale = renderer.getScale();
+      double zoneScale = renderer.getViewModel().getZoneScale().getScale();
       double newScaleX =
           ((gridSize * cellWidthSelected) / (selectedWidth / zoneScale)) * currentScaleX;
       double newScaleY =

--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -140,8 +140,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     maskOverlay.paintOverlay(renderer, g);
 
     Graphics2D g2 = (Graphics2D) g.create();
-    g2.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-    g2.scale(renderer.getScale(), renderer.getScale());
+    g2.transform(renderer.getViewModel().getZoneScale().toScreenTransform());
     SwingUtil.useAntiAliasing(g2);
     g2.setComposite(AlphaComposite.SrcOver);
 
@@ -194,11 +193,11 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
   }
 
   private double getHandleRadius() {
-    return 4. / Math.min(1., renderer.getScale());
+    return 4. / Math.min(1., renderer.getViewModel().getZoneScale().getScale());
   }
 
   private double getWallHalfWidth() {
-    return 1.5 / Math.min(1, renderer.getScale());
+    return 1.5 / Math.min(1, renderer.getViewModel().getZoneScale().getScale());
   }
 
   private double getHandleSelectDistance() {

--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -38,7 +38,6 @@ import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.ScreenPoint;
 import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.swing.walls.WallConfigurationController;
 import net.rptools.maptool.client.tool.drawing.TopologyTool;
@@ -238,7 +237,8 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
   }
 
   private Point2D updateCurrentPosition(MouseEvent e) {
-    return currentPosition = ScreenPoint.convertToZone2d(renderer, e.getX(), e.getY());
+    return currentPosition =
+        renderer.getViewModel().getZoneScale().toWorldSpace(e.getX(), e.getY());
   }
 
   private Snap getSnapMode(MouseEvent e) {

--- a/src/main/java/net/rptools/maptool/client/tool/boardtool/BoardTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/boardtool/BoardTool.java
@@ -271,7 +271,8 @@ public class BoardTool extends DefaultTool {
   @Override
   public void mousePressed(java.awt.event.MouseEvent e) {
     if (SwingUtilities.isLeftMouseButton(e)) {
-      ZonePoint zp = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint zp =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
       Grid grid = renderer.getZone().getGrid();
       dragStart = new Point(zp.x - grid.getOffsetX(), zp.y - grid.getOffsetY());
       boardStart = new Point(boardPosition);
@@ -286,7 +287,8 @@ public class BoardTool extends DefaultTool {
   @Override
   public void mouseDragged(java.awt.event.MouseEvent e) {
     if (SwingUtilities.isLeftMouseButton(e)) {
-      ZonePoint zp = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint zp =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
 
       dragOffset.width = zp.x - dragStart.x;
       dragOffset.height = zp.y - dragStart.y;
@@ -307,7 +309,7 @@ public class BoardTool extends DefaultTool {
     Right,
     Up,
     Down
-  };
+  }
 
   /** Constructs actions to attach to key-presses. */
   @SuppressWarnings("serial")

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingLikeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractDrawingLikeTool.java
@@ -73,7 +73,7 @@ public abstract class AbstractDrawingLikeTool extends DefaultTool implements Zon
 
   protected ZonePoint getPoint(MouseEvent e) {
     ScreenPoint sp = new ScreenPoint(e.getX(), e.getY());
-    ZonePoint zp = sp.convertToZoneRnd(renderer);
+    ZonePoint zp = sp.convertToZoneRnd(renderer.getViewModel().getZoneScale());
     if (isSnapToCenter(e) && isLinearTool()) {
       // Only line tools will snap to center as the Alt key for rectangle, diamond and oval
       // is used for expand from center.
@@ -87,6 +87,7 @@ public abstract class AbstractDrawingLikeTool extends DefaultTool implements Zon
   /** Draws the shape measurement as part of the overlay. */
   protected void drawMeasurementOverlay(
       ZoneRenderer renderer, Graphics2D g, Measurement measurement) {
+    var scale = renderer.getViewModel().getZoneScale();
     switch (measurement) {
       case null -> {}
       case Measurement.Rectangular rectangular -> {
@@ -94,26 +95,19 @@ public abstract class AbstractDrawingLikeTool extends DefaultTool implements Zon
         ToolHelper.drawBoxedMeasurement(
             renderer,
             g,
-            ScreenPoint.fromZonePoint(renderer, rectangle.getX(), rectangle.getY()),
-            ScreenPoint.fromZonePoint(renderer, rectangle.getMaxX(), rectangle.getMaxY()));
+            scale.toScreenSpace(rectangle.getX(), rectangle.getY()),
+            scale.toScreenSpace(rectangle.getMaxX(), rectangle.getMaxY()));
       }
       case Measurement.LineSegment lineSegment -> {
-        var p1 =
-            ScreenPoint.fromZonePoint(renderer, lineSegment.p1().getX(), lineSegment.p1().getY());
-        var p2 =
-            ScreenPoint.fromZonePoint(renderer, lineSegment.p2().getX(), lineSegment.p2().getY());
+        var p1 = scale.toScreenSpace(lineSegment.p1().getX(), lineSegment.p1().getY());
+        var p2 = scale.toScreenSpace(lineSegment.p2().getX(), lineSegment.p2().getY());
         ToolHelper.drawMeasurement(renderer, g, p1, p2);
       }
       case Measurement.IsoRectangular isoRectangular -> {
         var north =
-            ScreenPoint.fromZonePoint(
-                renderer, isoRectangular.north().getX(), isoRectangular.north().getY());
-        var west =
-            ScreenPoint.fromZonePoint(
-                renderer, isoRectangular.west().getX(), isoRectangular.west().getY());
-        var east =
-            ScreenPoint.fromZonePoint(
-                renderer, isoRectangular.east().getX(), isoRectangular.east().getY());
+            scale.toScreenSpace(isoRectangular.north().getX(), isoRectangular.north().getY());
+        var west = scale.toScreenSpace(isoRectangular.west().getX(), isoRectangular.west().getY());
+        var east = scale.toScreenSpace(isoRectangular.east().getX(), isoRectangular.east().getY());
         ToolHelper.drawIsoRectangleMeasurement(renderer, g, north, west, east);
       }
     }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/AbstractTemplateTool.java
@@ -40,10 +40,7 @@ public abstract class AbstractTemplateTool extends DefaultTool implements ZoneOv
   private boolean isEraser;
 
   protected AffineTransform getPaintTransform(ZoneRenderer renderer) {
-    AffineTransform transform = new AffineTransform();
-    transform.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-    transform.scale(renderer.getScale(), renderer.getScale());
-    return transform;
+    return renderer.getViewModel().getZoneScale().toScreenTransform();
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/BurstTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/BurstTemplateTool.java
@@ -65,7 +65,8 @@ public class BurstTemplateTool extends RadiusTemplateTool {
    */
   @Override
   protected ZonePoint getCellAtMouse(MouseEvent e) {
-    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+    ZonePoint mouse =
+        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
     CellPoint cp = renderer.getZone().getGrid().convert(mouse);
     return renderer.getZone().getGrid().convert(cp);
   }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/ConeTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/ConeTemplateTool.java
@@ -76,7 +76,8 @@ public class ConeTemplateTool extends RadiusTemplateTool {
 
     // Set the direction based on the mouse location too
     ZonePoint vertex = template.getVertex();
-    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+    ZonePoint mouse =
+        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
     ((ConeTemplate) template)
         .setDirection(RadiusTemplate.Direction.findDirection(mouse.x, mouse.y, vertex.x, vertex.y));
   }

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
@@ -92,7 +92,8 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
     for (var element : drawableList) {
       var drawable = element.getDrawable();
       var id = drawable.getId();
-      ZonePoint pos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint pos =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
       if (drawable.getBounds(zone).contains(pos.x, pos.y)) {
         if (!selectedDrawings.contains(id)) selectedDrawings.add(id);
         else selectedDrawings.remove(id);
@@ -121,7 +122,7 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
 
     var scale = renderer.getScale();
 
-    var screenPoint = ScreenPoint.fromZonePoint(renderer, box.x, box.y);
+    var screenPoint = renderer.getViewModel().getZoneScale().toScreenSpace(box.x, box.y);
 
     var x = (int) (screenPoint.x - pen.getThickness() * scale / 2);
     var y = (int) (screenPoint.y - pen.getThickness() * scale / 2);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DeleteDrawingTool.java
@@ -120,9 +120,10 @@ public class DeleteDrawingTool extends DefaultTool implements ZoneOverlay, Mouse
     var box = element.getDrawable().getBounds(getZone());
     var pen = element.getPen();
 
-    var scale = renderer.getScale();
+    var zoneScale = renderer.getViewModel().getZoneScale();
+    var scale = zoneScale.getScale();
 
-    var screenPoint = renderer.getViewModel().getZoneScale().toScreenSpace(box.x, box.y);
+    var screenPoint = zoneScale.toScreenSpace(box.x, box.y);
 
     var x = (int) (screenPoint.x - pen.getThickness() * scale / 2);
     var y = (int) (screenPoint.y - pen.getThickness() * scale / 2);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
@@ -650,14 +650,15 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
    * @return The cell at the mouse point in screen coordinates.
    */
   private ZonePoint getCellAtMouse(MouseEvent e) {
+    var zoneScale = renderer.getViewModel().getZoneScale();
+
     // Find the cell that the mouse is in.
-    ZonePoint mouse =
-        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
+    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(zoneScale);
     CellPoint cp = getZone().getGrid().convert(mouse);
     ZonePoint working = getZone().getGrid().convert(cp);
 
     // If the mouse is over halfway to the next vertex, move it there (both X & Y)
-    int grid = (int) (getZone().getGrid().getSize() * renderer.getScale());
+    int grid = (int) (getZone().getGrid().getSize() * zoneScale.getScale());
     if (mouse.x - working.x >= grid / 2) {
       working.x += getZone().getGrid().getSize();
     }
@@ -759,10 +760,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
   }
 
   private AffineTransform getPaintTransform(ZoneRenderer renderer) {
-    AffineTransform transform = new AffineTransform();
-    transform.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-    transform.scale(renderer.getScale(), renderer.getScale());
-    return transform;
+    return renderer.getViewModel().getZoneScale().toScreenTransform();
   }
 
   /**
@@ -950,9 +948,10 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
     var box = drawnElement.getDrawable().getBounds(getZone());
     var pen = drawnElement.getPen();
 
-    var scale = renderer.getScale();
+    var zoneScale = renderer.getViewModel().getZoneScale();
+    var scale = zoneScale.getScale();
 
-    var screenPoint = renderer.getViewModel().getZoneScale().toScreenSpace(box.x, box.y);
+    var screenPoint = zoneScale.toScreenSpace(box.x, box.y);
 
     var x = (int) (screenPoint.x - pen.getThickness() * scale / 2);
     var y = (int) (screenPoint.y - pen.getThickness() * scale / 2);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
@@ -440,10 +440,10 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
         // Derive a zone rectangle from the screen rectangle
         ZonePoint zpMin =
             new ScreenPoint(drawingSelectionBox.getMinX(), drawingSelectionBox.getMinY())
-                .convertToZone(renderer);
+                .convertToZone(renderer.getViewModel().getZoneScale());
         ZonePoint zpMax =
             new ScreenPoint(drawingSelectionBox.getMaxX(), drawingSelectionBox.getMaxY())
-                .convertToZone(renderer);
+                .convertToZone(renderer.getViewModel().getZoneScale());
         Rectangle zoneTemplateSelectionBox =
             new Rectangle(zpMin.x, zpMin.y, zpMax.x - zpMin.x, zpMax.y - zpMin.y);
 
@@ -651,7 +651,8 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
    */
   private ZonePoint getCellAtMouse(MouseEvent e) {
     // Find the cell that the mouse is in.
-    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+    ZonePoint mouse =
+        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
     CellPoint cp = getZone().getGrid().convert(mouse);
     ZonePoint working = getZone().getGrid().convert(cp);
 
@@ -694,7 +695,9 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
       if (selectedTool == TemplatePointerTool.class && isTemplate
           || selectedTool == DrawingPointerTool.class && !isTemplate) {
         Area area = de.getDrawable().getArea(zone);
-        ZonePoint zonePos = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+        ZonePoint zonePos =
+            new ScreenPoint(e.getX(), e.getY())
+                .convertToZone(renderer.getViewModel().getZoneScale());
         if (area.contains(new Point(zonePos.x, zonePos.y))) {
           drawingsAtMouseList.add(de);
           if (de.equals(drawnElementAtMouse)) {
@@ -924,7 +927,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
         Pen pen = drawnElement.getPen();
         int x = (int) (bounds.getMinX() + bounds.getMaxX()) / 2;
         int y = (int) (bounds.getMaxY() + pen.getThickness());
-        ScreenPoint centerText = ScreenPoint.fromZonePoint(renderer, x, y);
+        ScreenPoint centerText = renderer.getViewModel().getZoneScale().toScreenSpace(x, y);
 
         FlatImageLabel fil = flatImageLabelCache.get(id);
         Dimension nameDimension = fil.getDimensions(g, drawingName);
@@ -949,7 +952,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
 
     var scale = renderer.getScale();
 
-    var screenPoint = ScreenPoint.fromZonePoint(renderer, box.x, box.y);
+    var screenPoint = renderer.getViewModel().getZoneScale().toScreenSpace(box.x, box.y);
 
     var x = (int) (screenPoint.x - pen.getThickness() * scale / 2);
     var y = (int) (screenPoint.y - pen.getThickness() * scale / 2);
@@ -1054,7 +1057,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
       Rectangle bounds = at.getBounds(zone);
       int x = (int) (bounds.getMinX() + bounds.getMaxX()) / 2;
       int y = (int) (bounds.getMaxY());
-      ScreenPoint centerText = ScreenPoint.fromZonePoint(renderer, x, y);
+      ScreenPoint centerText = renderer.getViewModel().getZoneScale().toScreenSpace(x, y);
 
       ToolHelper.drawMeasurement(g, moveDistance, (int) centerText.x, (int) centerText.y);
     }
@@ -1124,7 +1127,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
    */
   private void paintTemplateRadiusLabel(Graphics2D g, ZonePoint zp, AbstractTemplate at) {
     if (at.getRadius() > 0) {
-      ScreenPoint centerText = ScreenPoint.fromZonePoint(renderer, zp);
+      ScreenPoint centerText = renderer.getViewModel().getZoneScale().toScreenSpace(zp.x, zp.y);
       centerText.translate(CURSOR_WIDTH, -CURSOR_WIDTH);
       ToolHelper.drawMeasurement(
           g, at.getRadius() * getZone().getUnitsPerCell(), (int) centerText.x, (int) centerText.y);
@@ -1234,7 +1237,9 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
             .setControlCellRelative(workingCell.x - vertexCell.x, workingCell.y - vertexCell.y);
       }
       if (templateType.equals("ConeTemplate")) {
-        ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+        ZonePoint mouse =
+            new ScreenPoint(e.getX(), e.getY())
+                .convertToZone(renderer.getViewModel().getZoneScale());
         ((ConeTemplate) at)
             .setDirection(
                 RadiusTemplate.Direction.findDirection(mouse.x, mouse.y, vertex.x, vertex.y));

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingTool.java
@@ -169,8 +169,7 @@ public final class DrawingTool<StateT> extends AbstractDrawingLikeTool {
   @Override
   public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
     Graphics2D g2 = (Graphics2D) g.create();
-    g2.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-    g2.scale(renderer.getScale(), renderer.getScale());
+    g2.transform(renderer.getViewModel().getZoneScale().toScreenTransform());
 
     if (state != null) {
       // Linear tools are not filled until completed.

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/ExposeTool.java
@@ -93,9 +93,10 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
 
   @Override
   public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
+    var zoneScale = renderer.getViewModel().getZoneScale();
+
     Graphics2D g2 = (Graphics2D) g.create();
-    g2.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-    g2.scale(renderer.getScale(), renderer.getScale());
+    g2.transform(zoneScale.toScreenTransform());
 
     if (state != null) {
       var result = strategy.getShape(state, currentPoint, centerOnOrigin, false);
@@ -112,7 +113,7 @@ public final class ExposeTool<StateT> extends AbstractDrawingLikeTool {
         g2.setColor(color);
         g2.setStroke(
             new BasicStroke(
-                1 / (float) renderer.getScale(), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+                1 / (float) zoneScale.getScale(), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
         g2.draw(result.shape());
 
         // Measurements

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/LineTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/LineTemplateTool.java
@@ -235,7 +235,8 @@ public class LineTemplateTool extends RadiusTemplateTool implements PropertyChan
 
     // Quadrant change?
     if (pathVertex != null) {
-      ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint mouse =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
       int dx = mouse.x - vertex.x;
       int dy = mouse.y - vertex.y;
       AbstractTemplate.Quadrant quadrant =

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusCellTemplateTool.java
@@ -124,7 +124,8 @@ public class RadiusCellTemplateTool extends AbstractTemplateTool implements Mous
    * @return The cell at the mouse point in screen coordinates.
    */
   protected ZonePoint getCellAtMouse(MouseEvent e) {
-    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+    ZonePoint mouse =
+        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
     CellPoint cp = renderer.getZone().getGrid().convert(mouse);
     return renderer.getZone().getGrid().convert(cp);
   }
@@ -173,7 +174,7 @@ public class RadiusCellTemplateTool extends AbstractTemplateTool implements Mous
    */
   protected void paintRadius(Graphics2D g, ZonePoint p) {
     if (template.getRadius() > 0 && anchorSet) {
-      ScreenPoint centerText = ScreenPoint.fromZonePoint(renderer, p);
+      ScreenPoint centerText = renderer.getViewModel().getZoneScale().toScreenSpace(p.x, p.y);
       centerText.translate(CURSOR_WIDTH, -CURSOR_WIDTH);
       ToolHelper.drawMeasurement(
           g,

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
@@ -124,16 +124,21 @@ public class RadiusTemplateTool extends AbstractTemplateTool implements MouseMot
    * @return The cell at the mouse point in screen coordinates.
    */
   protected ZonePoint getCellAtMouse(MouseEvent e) {
+    var zoneScale = renderer.getViewModel().getZoneScale();
+
     // Find the cell that the mouse is in.
-    ZonePoint mouse =
-        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
+    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(zoneScale);
     CellPoint cp = renderer.getZone().getGrid().convert(mouse);
     ZonePoint working = renderer.getZone().getGrid().convert(cp);
 
     // If the mouse is over half way to the next vertex, move it there (both X & Y)
-    int grid = (int) (renderer.getZone().getGrid().getSize() * renderer.getScale());
-    if (mouse.x - working.x >= grid / 2) working.x += renderer.getZone().getGrid().getSize();
-    if (mouse.y - working.y >= grid / 2) working.y += renderer.getZone().getGrid().getSize();
+    int grid = (int) (renderer.getZone().getGrid().getSize() * zoneScale.getScale());
+    if (mouse.x - working.x >= grid / 2) {
+      working.x += renderer.getZone().getGrid().getSize();
+    }
+    if (mouse.y - working.y >= grid / 2) {
+      working.y += renderer.getZone().getGrid().getSize();
+    }
     return working;
   }
 

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/RadiusTemplateTool.java
@@ -125,7 +125,8 @@ public class RadiusTemplateTool extends AbstractTemplateTool implements MouseMot
    */
   protected ZonePoint getCellAtMouse(MouseEvent e) {
     // Find the cell that the mouse is in.
-    ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+    ZonePoint mouse =
+        new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
     CellPoint cp = renderer.getZone().getGrid().convert(mouse);
     ZonePoint working = renderer.getZone().getGrid().convert(cp);
 
@@ -174,7 +175,7 @@ public class RadiusTemplateTool extends AbstractTemplateTool implements MouseMot
    */
   protected void paintRadius(Graphics2D g, ZonePoint p) {
     if (template.getRadius() > 0 && anchorSet) {
-      ScreenPoint centerText = ScreenPoint.fromZonePoint(renderer, p);
+      ScreenPoint centerText = renderer.getViewModel().getZoneScale().toScreenSpace(p.x, p.y);
       centerText.translate(CURSOR_WIDTH, -CURSOR_WIDTH);
       ToolHelper.drawMeasurement(
           g,

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/TopologyTool.java
@@ -122,9 +122,10 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
   public void paintOverlay(ZoneRenderer renderer, Graphics2D g) {
     maskOverlay.paintOverlay(renderer, g);
 
+    var zoneScale = renderer.getViewModel().getZoneScale();
+
     Graphics2D g2 = (Graphics2D) g.create();
-    g2.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-    g2.scale(renderer.getScale(), renderer.getScale());
+    g2.transform(zoneScale.toScreenTransform());
 
     if (state != null) {
       var result = strategy.getShape(state, currentPoint, centerOnOrigin, false);
@@ -142,7 +143,7 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
           g2.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 255));
           g2.setStroke(
               new BasicStroke(
-                  1 / (float) renderer.getScale(), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+                  1 / (float) zoneScale.getScale(), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
           g2.draw(result.shape());
 
           g2.setColor(color);
@@ -216,8 +217,7 @@ public final class TopologyTool<StateT> extends AbstractDrawingLikeTool {
       Zone zone = renderer.getZone();
 
       Graphics2D g2 = (Graphics2D) g.create();
-      g2.translate(renderer.getViewOffsetX(), renderer.getViewOffsetY());
-      g2.scale(renderer.getScale(), renderer.getScale());
+      g2.transform(renderer.getViewModel().getZoneScale().toScreenTransform());
 
       var tokenMasks = zone.getTokenMaskTopologies(null);
       g2.setColor(AppStyle.tokenMblColor);

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/WallTemplateTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/WallTemplateTool.java
@@ -109,7 +109,8 @@ public class WallTemplateTool extends BurstTemplateTool {
 
       // Get mouse point as an offset from the vertex
       LineTemplate lt = ((LineTemplate) template);
-      ZonePoint mouse = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint mouse =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
       CellPoint mousePoint = renderer.getZone().getGrid().convert(mouse);
       CellPoint vertexPoint = renderer.getZone().getGrid().convert(lt.getVertex());
       mousePoint.x = mousePoint.x - vertexPoint.x;

--- a/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
@@ -36,6 +36,7 @@ import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.ColorWell;
 import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.tool.DefaultTool;
+import net.rptools.maptool.client.ui.zone.ZoneViewModel;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.CellPoint;
@@ -319,11 +320,13 @@ public class GridTool extends DefaultTool {
     }
     ZoneRenderer renderer = (ZoneRenderer) e.getSource();
     if (SwingUtil.isControlDown(e)) {
+      var scale = renderer.getViewModel().getZoneScale();
       if (e.getWheelRotation() > 0) {
-        renderer.zoomOut(e.getX(), e.getY());
+        scale = scale.zoomedOut(e.getX(), e.getY());
       } else {
-        renderer.zoomIn(e.getX(), e.getY());
+        scale = scale.zoomedIn(e.getX(), e.getY());
       }
+      renderer.getViewModel().setZoneScale(scale);
     } else {
       if (e.getWheelRotation() > 0) {
         adjustGridSize(renderer, Size.Increase);
@@ -454,15 +457,16 @@ public class GridTool extends DefaultTool {
       boolean direction = delta > 0;
       delta = Math.abs(delta);
       ZonePoint centerPoint = renderer.getCenterPoint();
+      ZoneViewModel viewModel = renderer.getViewModel();
 
-      var scale = renderer.getZoneScale();
+      var scale = viewModel.getZoneScale();
       for (int i = 0; i < delta; i++) {
         scale =
             direction
                 ? scale.zoomedOut(centerPoint.x, centerPoint.y)
                 : scale.zoomedIn(centerPoint.x, centerPoint.y);
       }
-      renderer.setZoneScale(scale);
+      viewModel.setZoneScale(scale);
 
       lastZoomIndex = zoomSlider.getValue();
     }

--- a/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
@@ -455,13 +455,15 @@ public class GridTool extends DefaultTool {
       delta = Math.abs(delta);
       ZonePoint centerPoint = renderer.getCenterPoint();
 
+      var scale = renderer.getZoneScale();
       for (int i = 0; i < delta; i++) {
-        if (direction) {
-          renderer.getZoneScale().zoomOut(centerPoint.x, centerPoint.y);
-        } else {
-          renderer.getZoneScale().zoomIn(centerPoint.x, centerPoint.y);
-        }
+        scale =
+            direction
+                ? scale.zoomedOut(centerPoint.x, centerPoint.y)
+                : scale.zoomedIn(centerPoint.x, centerPoint.y);
       }
+      renderer.setZoneScale(scale);
+
       lastZoomIndex = zoomSlider.getValue();
     }
 

--- a/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/gridtool/GridTool.java
@@ -266,7 +266,8 @@ public class GridTool extends DefaultTool {
   @Override
   public void mousePressed(java.awt.event.MouseEvent e) {
     if (SwingUtilities.isLeftMouseButton(e)) {
-      ZonePoint zp = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint zp =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
       int x = zp.x - renderer.getZone().getGrid().getOffsetX();
       int y = zp.y - renderer.getZone().getGrid().getOffsetY();
 
@@ -282,7 +283,8 @@ public class GridTool extends DefaultTool {
   @Override
   public void mouseDragged(java.awt.event.MouseEvent e) {
     if (SwingUtilities.isLeftMouseButton(e)) {
-      ZonePoint zp = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+      ZonePoint zp =
+          new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer.getViewModel().getZoneScale());
       int x = zp.x - dragOffsetX;
       int y = zp.y - dragOffsetY;
 

--- a/src/main/java/net/rptools/maptool/client/tool/texttool/TextTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/texttool/TextTool.java
@@ -135,7 +135,8 @@ public class TextTool extends DefaultTool implements ZoneOverlay {
       selectedNewLabel = false;
     }
     if (label != null) {
-      ScreenPoint sp = ScreenPoint.fromZonePoint(renderer, label.getX(), label.getY());
+      ScreenPoint sp =
+          renderer.getViewModel().getZoneScale().toScreenSpace(label.getX(), label.getY());
       dragOffsetX = (int) (e.getX() - sp.x);
       dragOffsetY = (int) (e.getY() - sp.y);
     }
@@ -150,7 +151,9 @@ public class TextTool extends DefaultTool implements ZoneOverlay {
         Label label = renderer.getLabelAt(e.getX(), e.getY());
         if (label == null) {
           if (selectedLabel == null) {
-            ZonePoint zp = new ScreenPoint(e.getX(), e.getY()).convertToZone(renderer);
+            ZonePoint zp =
+                new ScreenPoint(e.getX(), e.getY())
+                    .convertToZone(renderer.getViewModel().getZoneScale());
             label = new Label("", zp.x, zp.y);
             selectedLabel = label;
           } else {
@@ -197,7 +200,8 @@ public class TextTool extends DefaultTool implements ZoneOverlay {
     isDragging = true;
 
     ZonePoint zp =
-        new ScreenPoint(e.getX() - dragOffsetX, e.getY() - dragOffsetY).convertToZone(renderer);
+        new ScreenPoint(e.getX() - dragOffsetX, e.getY() - dragOffsetY)
+            .convertToZone(renderer.getViewModel().getZoneScale());
 
     selectedLabel.setX(zp.x);
     selectedLabel.setY(zp.y);

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -102,7 +102,6 @@ import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZoneFactory;
-import net.rptools.maptool.model.ZonePoint;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
 import net.rptools.maptool.model.drawing.DrawableTexturePaint;
@@ -1275,15 +1274,18 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
                 tree.clearSelection();
               }
               tree.addSelectionInterval(rowIndex, rowIndex);
-              if (row instanceof DrawnElement && e.getClickCount() == 2) {
-                DrawnElement de = (DrawnElement) row;
+              if (row instanceof DrawnElement de && e.getClickCount() == 2) {
                 var renderer = getCurrentZoneRenderer();
                 var zone = renderer.getZone();
-                getCurrentZoneRenderer()
-                    .centerOn(
-                        new ZonePoint(
-                            (int) de.getDrawable().getBounds(zone).getCenterX(),
-                            (int) de.getDrawable().getBounds(zone).getCenterY()));
+                var bounds = de.getDrawable().getBounds(zone);
+                var viewModel = renderer.getViewModel();
+                viewModel.setZoneScale(
+                    viewModel
+                        .getZoneScale()
+                        .centeredOn(
+                            (int) bounds.getCenterX(),
+                            (int) bounds.getCenterY(),
+                            renderer.getSize()));
               }
               /*
                * int[] treeRows = tree.getSelectionRows(); java.util.Arrays.sort(treeRows); drawablesPanel.clearSelectedIds(); for (int i = 0; i < treeRows.length; i++) { TreePath p =

--- a/src/main/java/net/rptools/maptool/client/ui/Scale.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Scale.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.ui;
 
+import java.awt.Dimension;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
@@ -72,7 +73,7 @@ public class Scale implements Serializable {
 
   @Serial
   private Object readResolve() {
-    // scale is authoratative, provided the associated zoom level lies within appropriate bounds.
+    // scale is authoritative, provided the associated zoom level lies within appropriate bounds.
     return new Scale(clampScale(this.scale), this.offsetX, this.offsetY);
   }
 
@@ -161,6 +162,19 @@ public class Scale implements Serializable {
     var newOffsetY = offsetY + y - newY;
 
     return new Scale(newScale, newOffsetX, newOffsetY);
+  }
+
+  public Scale withCenteredScale(double newScale, Dimension size) {
+    return withScale(newScale, size.width / 2, size.height / 2);
+  }
+
+  public Scale centeredOn(int x, int y, Dimension size) {
+    return withOffset(
+        size.width / 2 - (int) (x * scale) - 1, size.height / 2 - (int) (y * scale) - 1);
+  }
+
+  public Scale translated(int dx, int dy) {
+    return new Scale(scale, offsetX + dx, offsetY + dy);
   }
 
   public Scale withZoomLevel(int newZoomLevel, int x, int y) {

--- a/src/main/java/net/rptools/maptool/client/ui/Scale.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Scale.java
@@ -126,6 +126,20 @@ public class Scale implements Serializable {
     return oneToOneScale;
   }
 
+  public AffineTransform toWorldTransform() {
+    var transform = new AffineTransform();
+    transform.scale(1 / scale, 1 / scale);
+    transform.translate(-offsetX, -offsetY);
+    return transform;
+  }
+
+  public AffineTransform toScreenTransform() {
+    var transform = new AffineTransform();
+    transform.translate(offsetX, offsetY);
+    transform.scale(scale, scale);
+    return transform;
+  }
+
   public void reset() {
     setZoomLevel(0);
   }
@@ -167,6 +181,14 @@ public class Scale implements Serializable {
     zoomTo(x, y, oldScale);
   }
 
+  public Point2D toWorldSpace(Point2D screenPoint) {
+    return toWorldSpace(screenPoint.getX(), screenPoint.getY());
+  }
+
+  public Point2D toWorldSpace(double x, double y) {
+    return new Point2D.Double((x - offsetX) / scale, (y - offsetY) / scale);
+  }
+
   /**
    * Transforms a rectangle from screen space to world space.
    *
@@ -182,10 +204,7 @@ public class Scale implements Serializable {
   }
 
   public Area toWorldSpace(Area area) {
-    var transform = new AffineTransform();
-    transform.scale(1 / scale, 1 / scale);
-    transform.translate(-offsetX, -offsetY);
-    return area.createTransformedArea(transform);
+    return area.createTransformedArea(toWorldTransform());
   }
 
   /**
@@ -211,10 +230,7 @@ public class Scale implements Serializable {
   }
 
   public Area toScreenSpace(Area area) {
-    var transform = new AffineTransform();
-    transform.translate(offsetX, offsetY);
-    transform.scale(scale, scale);
-    return area.createTransformedArea(transform);
+    return area.createTransformedArea(toScreenTransform());
   }
 
   private PropertyChangeSupport getPropertyChangeSupport() {

--- a/src/main/java/net/rptools/maptool/client/ui/Scale.java
+++ b/src/main/java/net/rptools/maptool/client/ui/Scale.java
@@ -14,56 +14,103 @@
  */
 package net.rptools.maptool.client.ui;
 
-import java.awt.Point;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Objects;
 import net.rptools.maptool.client.ScreenPoint;
 
 public class Scale implements Serializable {
-  public static final String PROPERTY_SCALE = "scale";
-  public static final String PROPERTY_OFFSET = "offset";
   private static final int MIN_ZOOM_LEVEL = -175;
   private static final int MAX_ZOOM_LEVEL = 175;
 
   private final double oneToOneScale = 1; // Let this be configurable at some point
-  private double scale = oneToOneScale;
   private final double scaleIncrement = .075;
 
-  private int zoomLevel = 0;
+  /** Calculated from {@link #scale} */
+  private transient int zoomLevel;
+
+  private double scale;
   private int offsetX;
   private int offsetY;
-  private transient PropertyChangeSupport propertyChangeSupport;
+
+  public Scale(double scale, int offsetX, int offsetY) {
+    var zoomLevel = zoomLevelForScale(scale);
+    if (zoomLevel < MIN_ZOOM_LEVEL) {
+      zoomLevel = MIN_ZOOM_LEVEL;
+      scale = scaleForZoomLevel(zoomLevel);
+    } else if (zoomLevel > MAX_ZOOM_LEVEL) {
+      zoomLevel = MAX_ZOOM_LEVEL;
+      scale = scaleForZoomLevel(zoomLevel);
+    }
+
+    this.scale = scale;
+    this.offsetX = offsetX;
+    this.offsetY = offsetY;
+    this.zoomLevel = zoomLevel;
+  }
+
+  public Scale(int zoomLevel, int offsetX, int offsetY) {
+    zoomLevel = Math.clamp(zoomLevel, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
+
+    this.scale = scaleForZoomLevel(zoomLevel);
+    this.offsetX = offsetX;
+    this.offsetY = offsetY;
+    this.zoomLevel = zoomLevel;
+  }
 
   public Scale() {
-    this.offsetX = 0;
-    this.offsetY = 0;
+    this(0, 0, 0);
   }
 
   public Scale(Scale copy) {
-    this.offsetX = copy.offsetX;
-    this.offsetY = copy.offsetY;
-    setScale(copy.scale);
+    this(copy.scale, copy.offsetX, copy.offsetY);
   }
 
   @Serial
   private Object readResolve() {
-    // Make sure the zoom level is correct.
-    setScale(this.scale);
-    return this;
+    // scale is authoratative, provided the associated zoom level lies within appropriate bounds.
+    return new Scale(clampScale(this.scale), this.offsetX, this.offsetY);
   }
 
-  public void addPropertyChangeListener(PropertyChangeListener listener) {
-    getPropertyChangeSupport().addPropertyChangeListener(listener);
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof Scale other)) {
+      return false;
+    }
+
+    return other.scale == this.scale
+        && other.offsetX == this.offsetX
+        && other.offsetY == this.offsetY
+        && other.oneToOneScale == this.oneToOneScale
+        && other.scaleIncrement == this.scaleIncrement;
   }
 
-  public void removePropertyChangeListener(PropertyChangeListener listener) {
-    getPropertyChangeSupport().removePropertyChangeListener(listener);
+  @Override
+  public int hashCode() {
+    return Objects.hash(scale, offsetX, offsetY, oneToOneScale, scaleIncrement);
+  }
+
+  private int zoomLevelForScale(double scale) {
+    return (int) Math.round(Math.log(scale / oneToOneScale) / Math.log(1 + scaleIncrement));
+  }
+
+  private double scaleForZoomLevel(int zoomLevel) {
+    return zoomLevel == 0 ? oneToOneScale : oneToOneScale * Math.pow(1 + scaleIncrement, zoomLevel);
+  }
+
+  private double clampScale(double newScale) {
+    var newZoomLevel = zoomLevelForScale(newScale);
+    if (newZoomLevel <= MIN_ZOOM_LEVEL) {
+      return scaleForZoomLevel(MIN_ZOOM_LEVEL);
+    }
+    if (newZoomLevel >= MAX_ZOOM_LEVEL) {
+      return scaleForZoomLevel(MAX_ZOOM_LEVEL);
+    }
+    return newScale;
   }
 
   public int getOffsetX() {
@@ -74,52 +121,8 @@ public class Scale implements Serializable {
     return offsetY;
   }
 
-  public void setOffset(int x, int y) {
-
-    int oldX = offsetX;
-    int oldY = offsetY;
-
-    offsetX = x;
-    offsetY = y;
-
-    getPropertyChangeSupport()
-        .firePropertyChange(PROPERTY_OFFSET, new Point(oldX, oldY), new Point(offsetX, offsetY));
-  }
-
   public double getScale() {
     return scale;
-  }
-
-  public void setScale(double scale) {
-    if (scale <= 0.0) {
-      return;
-    }
-
-    // Determine zoomLevel appropriate for given scale
-    var zoomLevel =
-        (int) Math.round(Math.log(scale / oneToOneScale) / Math.log(1 + scaleIncrement));
-    // Check that we haven't gone out of bounds with our zooming.
-    if (zoomLevel < MIN_ZOOM_LEVEL) {
-      setZoomLevel(MIN_ZOOM_LEVEL);
-    } else if (zoomLevel > MAX_ZOOM_LEVEL) {
-      setZoomLevel(MAX_ZOOM_LEVEL);
-    } else {
-      // Acceptable scale. Use it.
-      var oldScale = this.scale;
-      this.scale = scale;
-      this.zoomLevel = zoomLevel;
-      getPropertyChangeSupport().firePropertyChange(PROPERTY_SCALE, oldScale, this.scale);
-    }
-  }
-
-  private void setScaleFromZoomLevel() {
-    double oldScale = this.scale;
-
-    // Check for zero just to avoid any possible imprecision.
-    this.scale =
-        zoomLevel == 0 ? oneToOneScale : oneToOneScale * Math.pow(1 + scaleIncrement, zoomLevel);
-
-    getPropertyChangeSupport().firePropertyChange(PROPERTY_SCALE, oldScale, scale);
   }
 
   public double getOneToOneScale() {
@@ -140,45 +143,54 @@ public class Scale implements Serializable {
     return transform;
   }
 
-  public void reset() {
-    setZoomLevel(0);
+  public Scale withOffset(int x, int y) {
+    return new Scale(scale, x, y);
   }
 
-  private void setZoomLevel(int zoomLevel) {
-    this.zoomLevel = Math.clamp(zoomLevel, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
-    setScaleFromZoomLevel();
+  public Scale withScale(double newScale, int x, int y) {
+    newScale = clampScale(newScale);
+
+    x -= offsetX;
+    y -= offsetY;
+
+    // Rounding reduces drift in offset from repeated zooming
+    int newX = (int) Math.round((x * newScale) / scale);
+    int newY = (int) Math.round((y * newScale) / scale);
+
+    var newOffsetX = offsetX + x - newX;
+    var newOffsetY = offsetY + y - newY;
+
+    return new Scale(newScale, newOffsetX, newOffsetY);
   }
 
-  private void scaleUp() {
-    setZoomLevel(zoomLevel + 1);
+  public Scale withZoomLevel(int newZoomLevel, int x, int y) {
+    newZoomLevel = Math.clamp(newZoomLevel, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
+    var newScale =
+        newZoomLevel == 0
+            ? oneToOneScale
+            : oneToOneScale * Math.pow(1 + scaleIncrement, newZoomLevel);
+
+    return withScale(newScale, x, y);
   }
 
-  private void scaleDown() {
-    setZoomLevel(zoomLevel - 1);
+  public Scale withResetZoomLevel() {
+    return new Scale(0, offsetX, offsetY);
   }
 
-  public void zoomReset(int x, int y) {
-    var oldScale = scale;
-    reset();
-    zoomTo(x, y, oldScale);
+  public Scale withZoomReset(int x, int y) {
+    return withZoomLevel(0, x, y);
   }
 
-  public void zoomIn(int x, int y) {
-    double oldScale = scale;
-    scaleUp();
-    zoomTo(x, y, oldScale);
+  public Scale zoomedIn(int x, int y) {
+    return withZoomLevel(zoomLevel + 1, x, y);
   }
 
-  public void zoomOut(int x, int y) {
-    double oldScale = scale;
-    scaleDown();
-    zoomTo(x, y, oldScale);
+  public Scale zoomedOut(int x, int y) {
+    return withZoomLevel(zoomLevel - 1, x, y);
   }
 
-  public void zoomScale(int x, int y, double scale) {
-    double oldScale = this.scale;
-    setScale(scale);
-    zoomTo(x, y, oldScale);
+  public Point2D toWorldSpace(ScreenPoint screenPoint) {
+    return new Point2D.Double((screenPoint.x - offsetX) / scale, (screenPoint.y - offsetY) / scale);
   }
 
   public Point2D toWorldSpace(Point2D screenPoint) {
@@ -231,26 +243,5 @@ public class Scale implements Serializable {
 
   public Area toScreenSpace(Area area) {
     return area.createTransformedArea(toScreenTransform());
-  }
-
-  private PropertyChangeSupport getPropertyChangeSupport() {
-    if (propertyChangeSupport == null) {
-      propertyChangeSupport = new PropertyChangeSupport(this);
-    }
-    return propertyChangeSupport;
-  }
-
-  private void zoomTo(int x, int y, double oldScale) {
-
-    // Keep the current pixel centered
-    x -= offsetX;
-    y -= offsetY;
-
-    // Rounding reduces drift in offset from repeated zooming
-    int newX = (int) Math.round((x * scale) / oldScale);
-    int newY = (int) Math.round((y * scale) / oldScale);
-
-    offsetX = offsetX - (newX - x);
-    offsetY = offsetY - (newY - y);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/ZoneImageGenerator.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ZoneImageGenerator.java
@@ -115,13 +115,13 @@ public class ZoneImageGenerator extends BufferedImage {
     }
 
     // preserve settings
-    Scale origScale = renderer.getZoneScale();
+    Scale origScale = renderer.getViewModel().getZoneScale();
     Rectangle origBounds = new Rectangle(renderer.getBounds());
 
     // set new temp vars
     Scale s =
         origScale.withOffset(origScale.getOffsetX() - rect.x, origScale.getOffsetY() - rect.y);
-    renderer.setZoneScale(s);
+    renderer.getViewModel().setZoneScale(s);
     renderer.setBounds(rect);
 
     // make a tiny buffered image for this (hopefully) small rectangle request
@@ -140,7 +140,7 @@ public class ZoneImageGenerator extends BufferedImage {
     raster = null;
 
     renderer.setBounds(origBounds);
-    renderer.setZoneScale(origScale);
+    renderer.getViewModel().setZoneScale(origScale);
   }
 
   ///////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/rptools/maptool/client/ui/ZoneImageGenerator.java
+++ b/src/main/java/net/rptools/maptool/client/ui/ZoneImageGenerator.java
@@ -115,12 +115,12 @@ public class ZoneImageGenerator extends BufferedImage {
     }
 
     // preserve settings
-    Scale origScale = new Scale(renderer.getZoneScale());
+    Scale origScale = renderer.getZoneScale();
     Rectangle origBounds = new Rectangle(renderer.getBounds());
 
     // set new temp vars
-    Scale s = new Scale(origScale);
-    s.setOffset(origScale.getOffsetX() - rect.x, origScale.getOffsetY() - rect.y);
+    Scale s =
+        origScale.withOffset(origScale.getOffsetX() - rect.x, origScale.getOffsetY() - rect.y);
     renderer.setZoneScale(s);
     renderer.setBounds(rect);
 

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -849,9 +849,7 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     extents.setSize((int) (extents.width * scale), (int) (extents.height * scale));
 
     // Setup the renderer to use the new extents
-    Scale s = new Scale();
-    s.setOffset(-extents.x, -extents.y);
-    s.setScale(scale);
+    Scale s = new Scale(scale, -extents.x, -extents.y);
     renderer.setZoneScale(s);
     renderer.setBounds(extents);
 

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -782,7 +782,7 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     // set up the renderer to encompass the whole extents of the map.
 
     origBounds = renderer.getBounds();
-    origScale = renderer.getZoneScale();
+    origScale = renderer.getViewModel().getZoneScale();
 
     setupZoneLayers();
     boolean viewAsPlayer = ExportRadioButtons.VIEW_PLAYER.isChecked();
@@ -844,13 +844,14 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     }
 
     // Rescale the bounds to match the view scale
-    double scale = renderer.getScale();
+    Scale originalZoneScale = renderer.getViewModel().getZoneScale();
+    double scale = originalZoneScale.getScale();
     extents.setLocation((int) (extents.x * scale), (int) (extents.y * scale));
     extents.setSize((int) (extents.width * scale), (int) (extents.height * scale));
 
     // Setup the renderer to use the new extents
-    Scale s = new Scale(scale, -extents.x, -extents.y);
-    renderer.setZoneScale(s);
+    Scale s = originalZoneScale.withOffset(-extents.x, -extents.y);
+    renderer.getViewModel().setZoneScale(s);
     renderer.setBounds(extents);
 
     waitingForPostScreenshot = true;
@@ -972,7 +973,7 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     assert waitingForPostScreenshot : "postScrenshot called without preScreenshot";
 
     renderer.setBounds(origBounds);
-    renderer.setZoneScale(origScale);
+    renderer.getViewModel().setZoneScale(origScale);
     restoreZoneLayers();
     waitingForPostScreenshot = false;
   }

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeTokenPopupMenu.java
@@ -29,7 +29,6 @@ import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.InitiativeList;
 import net.rptools.maptool.model.InitiativeList.TokenInitiative;
 import net.rptools.maptool.model.Token;
-import net.rptools.maptool.model.ZonePoint;
 
 /**
  * The popup menu for initiative tokens.
@@ -201,8 +200,10 @@ public class InitiativeTokenPopupMenu extends TokenPopupMenu {
         public void actionPerformed(ActionEvent e) {
           Token token = tokenInitiativeUnderMouse.getToken();
           final var renderer = getRenderer();
+          final var viewModel = renderer.getViewModel();
           final var selectionModel = renderer.getSelectionModel();
-          renderer.centerOn(new ZonePoint(token.getX(), token.getY()));
+          viewModel.setZoneScale(
+              viewModel.getZoneScale().centeredOn(token.getX(), token.getY(), renderer.getSize()));
           selectionModel.replaceSelection(Collections.singletonList(token.getId()));
         }
       };

--- a/src/main/java/net/rptools/maptool/client/ui/zone/PointerOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/PointerOverlay.java
@@ -51,7 +51,9 @@ public class PointerOverlay implements ZoneOverlay {
     for (PointerPair p : pointerList) {
       if (p.pointer.getZoneGUID().equals(zone.getId())) {
         ZonePoint zPoint = new ZonePoint(p.pointer.getX(), p.pointer.getY());
-        ScreenPoint sPoint = ScreenPoint.fromZonePointRnd(renderer, zPoint.x, zPoint.y);
+        ScreenPoint sPoint =
+            ScreenPoint.fromZonePointRnd(
+                renderer.getViewModel().getZoneScale(), zPoint.x, zPoint.y);
 
         int offX = 0;
         int offY = 0;

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -37,6 +37,7 @@ import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.events.RepaintZoneRequested;
 import net.rptools.maptool.client.events.ZoneLoaded;
 import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.events.MapToolEventBus;
@@ -129,6 +130,10 @@ public class ZoneViewModel {
     this.zone = zone;
     this.zoneView = zoneView;
     this.selectionModel = selectionModel;
+  }
+
+  public void repaintNeeded() {
+    new MapToolEventBus().getMainEventBus().post(new RepaintZoneRequested(zone));
   }
 
   /** Marks the zone as not loaded, so that it ensures once again that all assets are loaded. */

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.rptools.lib.CollectionUtil;
 import net.rptools.lib.MD5Key;
@@ -91,6 +92,8 @@ public class ZoneViewModel {
 
   // region These are updated externally.
 
+  private @Nonnull Zone.Layer activeLayer = Zone.Layer.getDefaultPlayerLayer();
+  private Scale zoneScale = new Scale();
   private final ZoneView zoneView;
   private final SelectionModel selectionModel;
   private final List<GUID> highlightCommonMacros = new ArrayList<>();
@@ -105,7 +108,6 @@ public class ZoneViewModel {
   private @Nullable String loadingProgress = "";
 
   private PlayerView playerView = new PlayerView(Player.Role.PLAYER);
-  private Scale zoneScale = new Scale();
   private final Rectangle2D viewport = new Rectangle2D.Double();
   private Area visibleArea = new Area();
 
@@ -158,6 +160,16 @@ public class ZoneViewModel {
 
   public Scale getZoneScale() {
     return zoneScale;
+  }
+
+  public void setZoneScale(Scale scale) {
+    if (!this.zoneScale.equals(scale)) {
+      this.zoneScale = scale;
+      MapTool.getFrame().getZoneRenderer(zone).invalidateCurrentViewCache();
+      MapTool.getFrame().getZoomStatusBar().update();
+      repaintNeeded();
+      // TODO Should we be calling renderer.maybeForcePlayersView() here?
+    }
   }
 
   public Rectangle2D getViewport() {
@@ -335,17 +347,15 @@ public class ZoneViewModel {
     }
   }
 
-  /** Updates {@link #zoneScale} and {@link #viewport}. */
+  /** Updates {@link #viewport} based on {@link #zoneScale}. */
   private void updateViewport() {
     var renderer = MapTool.getFrame().getZoneRenderer(this.zone);
     if (renderer == null) {
       // No viewport.
-      zoneScale = new Scale();
       viewport.setFrame(0, 0, 0, 0);
       return;
     }
 
-    zoneScale = renderer.getZoneScale();
     var screenBounds = new Rectangle2D.Double(0, 0, renderer.getWidth(), renderer.getHeight());
     viewport.setFrame(zoneScale.toWorldSpace(screenBounds));
   }
@@ -444,11 +454,7 @@ public class ZoneViewModel {
    * #tokenPositionsByLayer}, {@link #viewport}, {@link #playerView}, and {@link #visibleArea}.
    */
   private void updateVisibleTokens() {
-    double scale = 1;
-    var renderer = MapTool.getFrame().getZoneRenderer(this.zone);
-    if (renderer != null) {
-      scale = renderer.getZoneScale().getScale();
-    }
+    double scale = zoneScale.getScale();
 
     onScreenTokens.clear();
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -345,7 +345,7 @@ public class ZoneViewModel {
       return;
     }
 
-    zoneScale = new Scale(renderer.getZoneScale());
+    zoneScale = renderer.getZoneScale();
     var screenBounds = new Rectangle2D.Double(0, 0, renderer.getWidth(), renderer.getHeight());
     viewport.setFrame(zoneScale.toWorldSpace(screenBounds));
   }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/GridRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/GridRenderer.java
@@ -93,11 +93,12 @@ public class GridRenderer {
 
   public void renderGrid(Graphics2D g, PlayerView view) {
     if (!AppState.isShowGrid()
-        || zone.getGrid().getSize() * renderer.getScale() < ZoneRendererConstants.MIN_GRID_SIZE) {
+        || zone.getGrid().getSize() * renderer.getViewModel().getZoneScale().getScale()
+            < ZoneRendererConstants.MIN_GRID_SIZE) {
       return;
     }
     gridLineWeight = AppState.getGridLineWeight();
-    scale = (float) renderer.getScale();
+    scale = (float) renderer.getViewModel().getZoneScale().getScale();
     baseWidth = zone.getGrid().getSize() / 50f;
     if (gridColours == null) {
       setGridColours();

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/RenderHelper.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/RenderHelper.java
@@ -65,7 +65,7 @@ public class RenderHelper {
     timer.stop("%s-useAA", timerPrefix);
 
     timer.start("%s-setTransform", timerPrefix);
-    Scale scale = renderer.getZoneScale();
+    Scale scale = renderer.getViewModel().getZoneScale();
     AffineTransform af = new AffineTransform();
     af.translate(scale.getOffsetX(), scale.getOffsetY());
     af.scale(scale.getScale(), scale.getScale());

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -101,7 +101,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   /** Manages the selected tokens on the zone. */
   private final SelectionModel selectionModel;
 
-  private Scale zoneScale;
   private final Map<Zone.Layer, DrawableRenderer> drawableRenderers;
   private final List<ZoneOverlay> overlayList = new ArrayList<>();
   private final List<LabelLocation> labelLocationList = new LinkedList<>();
@@ -118,9 +117,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   private BufferedImage miniImage;
   private BufferedImage backBuffer;
   private boolean drawBackground = true;
-  private int lastX;
-  private int lastY;
-  private double lastScale;
+  private Scale lastZoneScale;
   private Area visibleScreenArea;
   private final List<ItemRenderer> itemRenderList = new LinkedList<>();
   private PlayerView lastView;
@@ -159,7 +156,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       throw new IllegalArgumentException("Zone cannot be null");
     }
     this.zone = zone;
-    this.zoneScale = new Scale();
     this.selectionModel = new SelectionModel(zone);
     this.zoneView = new ZoneView(zone);
     this.viewModel = new ZoneViewModel(zone, zoneView, selectionModel);
@@ -251,7 +247,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       return;
     }
 
-    centerOn(new ZonePoint(token.getX(), token.getY()));
+    viewModel.setZoneScale(
+        viewModel.getZoneScale().centeredOn(token.getX(), token.getY(), getSize()));
     setActiveLayer(token.getLayer());
     MapTool.getFrame()
         .getToolbox()
@@ -268,19 +265,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
   public boolean isPathShowing(Token token) {
     return showPathList.contains(token);
-  }
-
-  public Scale getZoneScale() {
-    return zoneScale;
-  }
-
-  public void setZoneScale(Scale scale) {
-    if (!zoneScale.equals(scale)) {
-      zoneScale = scale;
-      invalidateCurrentViewCache();
-      MapTool.getFrame().getZoomStatusBar().update();
-      repaintDebouncer.dispatch();
-    }
   }
 
   public void flushDrawableRenderer() {
@@ -529,25 +513,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     return viewModel.isTokenMoving(token.getId());
   }
 
-  protected void setViewOffset(int x, int y) {
-    setZoneScale(zoneScale.withOffset(x, y));
-  }
-
-  public void centerOn(ZonePoint point) {
-    int x = point.x;
-    int y = point.y;
-
-    x = getSize().width / 2 - (int) (x * getScale()) - 1;
-    y = getSize().height / 2 - (int) (y * getScale()) - 1;
-
-    setViewOffset(x, y);
-    repaintDebouncer.dispatch();
-  }
-
-  public void centerOn(CellPoint point) {
-    centerOn(zone.getGrid().convert(point));
-  }
-
   /**
    * Remove the token from: {@link #labelRenderingCache}. Set the {@link #visibleScreenArea} to
    * null. Flush the token from {@link #zoneView}.
@@ -622,32 +587,18 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     repaintDebouncer.dispatch();
   }
 
-  public void moveViewBy(int dx, int dy) {
-    setViewOffset(getViewOffsetX() + dx, getViewOffsetY() + dy);
-  }
-
   public void moveViewByCells(int dx, int dy) {
-    int gridSize = (int) (zone.getGrid().getSize() * getScale());
+    var zoneScale = viewModel.getZoneScale();
 
-    int rawXOffset = getViewOffsetX() + dx * gridSize;
-    int rawYOffset = getViewOffsetY() + dy * gridSize;
+    int gridSize = (int) (zone.getGrid().getSize() * zoneScale.getScale());
+
+    int rawXOffset = zoneScale.getOffsetX() + dx * gridSize;
+    int rawYOffset = zoneScale.getOffsetY() + dy * gridSize;
 
     int snappedXOffset = rawXOffset - rawXOffset % gridSize;
     int snappedYOffset = rawYOffset - rawYOffset % gridSize;
 
-    setViewOffset(snappedXOffset, snappedYOffset);
-  }
-
-  public void zoomReset(int x, int y) {
-    setZoneScale(zoneScale.withZoomReset(x, y));
-  }
-
-  public void zoomIn(int x, int y) {
-    setZoneScale(zoneScale.zoomedIn(x, y));
-  }
-
-  public void zoomOut(int x, int y) {
-    setZoneScale(zoneScale.zoomedOut(x, y));
+    viewModel.setZoneScale(zoneScale.withOffset(snappedXOffset, snappedYOffset));
   }
 
   public void enforceView(int x, int y, double scale, int gmWidth, int gmHeight) {
@@ -662,26 +613,32 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       scale = scale * height / gmHeight;
     }
 
-    previousScale = getScale();
+    previousScale = viewModel.getZoneScale().getScale();
     previousZonePoint = getCenterPoint();
 
-    setScale(scale);
-    centerOn(new ZonePoint(x, y));
+    viewModel.setZoneScale(
+        viewModel.getZoneScale().withCenteredScale(scale, getSize()).centeredOn(x, y, getSize()));
   }
 
   public void restoreView() {
-    log.info("Restoring view: " + previousZonePoint);
-    log.info("previousScale: " + previousScale);
-
-    centerOn(previousZonePoint);
-    setScale(previousScale);
+    viewModel.setZoneScale(
+        viewModel
+            .getZoneScale()
+            .withCenteredScale(previousScale, getSize())
+            .centeredOn(previousZonePoint.x, previousZonePoint.y, getSize()));
   }
 
   public void forcePlayersView() {
     ZonePoint zp =
         new ScreenPoint(getWidth() / 2d, getHeight() / 2d).convertToZone(viewModel.getZoneScale());
     MapTool.serverCommand()
-        .enforceZoneView(getZone().getId(), zp.x, zp.y, getScale(), getWidth(), getHeight());
+        .enforceZoneView(
+            getZone().getId(),
+            zp.x,
+            zp.y,
+            viewModel.getZoneScale().getScale(),
+            getWidth(),
+            getHeight());
   }
 
   public void maybeForcePlayersView() {
@@ -859,10 +816,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
       timer.start("createTransformedArea");
       if (!a.isEmpty()) {
-        AffineTransform af = new AffineTransform();
-        af.translate(zoneScale.getOffsetX(), zoneScale.getOffsetY());
-        af.scale(getScale(), getScale());
-        visibleScreenArea = a.createTransformedArea(af);
+        visibleScreenArea = a.createTransformedArea(viewModel.getZoneScale().toScreenTransform());
       }
       timer.stop("createTransformedArea");
     }
@@ -1083,11 +1037,12 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
   protected void renderDrawableOverlay(
       Graphics g, DrawableRenderer renderer, PlayerView view, List<DrawnElement> drawnElements) {
+    var zoneScale = viewModel.getZoneScale();
     Rectangle viewport =
         new Rectangle(
             zoneScale.getOffsetX(), zoneScale.getOffsetY(), getSize().width, getSize().height);
 
-    renderer.renderDrawables(g, drawnElements, viewport, getScale());
+    renderer.renderDrawables(g, drawnElements, viewport, viewModel.getZoneScale().getScale());
   }
 
   protected void renderBoard(Graphics2D g, PlayerView view) {
@@ -1098,10 +1053,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       backBuffer = new BufferedImage(size.width, size.height, Transparency.OPAQUE);
       drawBackground = true;
     }
-    Scale scale = getZoneScale();
-    if (scale.getOffsetX() != lastX
-        || scale.getOffsetY() != lastY
-        || scale.getScale() != lastScale) {
+    Scale scale = viewModel.getZoneScale();
+    if (!lastZoneScale.equals(scale)) {
       drawBackground = true;
     }
     if (zone.isBoardChanged()) {
@@ -1113,24 +1066,24 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       AppPreferences.renderQuality.get().setRenderingHints(bbg);
 
       // Background texture
-      Paint paint = zone.getBackgroundPaint().getPaint(zoneScale, this);
+      Paint paint = zone.getBackgroundPaint().getPaint(scale, this);
       bbg.setPaint(paint);
       bbg.fillRect(0, 0, size.width, size.height);
 
       // Only apply the noise if the feature is on and the background a textured paint
       if (bgTextureNoiseFilterOn && paint instanceof TexturePaint) {
-        bbg.setPaint(noise.getPaint(zoneScale));
+        bbg.setPaint(noise.getPaint(scale));
         bbg.fillRect(0, 0, size.width, size.height);
       }
 
       // Map
       if (zone.getMapAssetId() != null) {
         BufferedImage mapImage = ImageManager.getImage(zone.getMapAssetId(), this);
-        double scaleFactor = getScale();
+        double scaleFactor = viewModel.getZoneScale().getScale();
         bbg.drawImage(
             mapImage,
-            getViewOffsetX() + (int) (zone.getBoardX() * scaleFactor),
-            getViewOffsetY() + (int) (zone.getBoardY() * scaleFactor),
+            scale.getOffsetX() + (int) (zone.getBoardX() * scaleFactor),
+            scale.getOffsetY() + (int) (zone.getBoardY() * scaleFactor),
             (int) (mapImage.getWidth() * scaleFactor * zone.getImageScaleX()),
             (int) (mapImage.getHeight() * scaleFactor * zone.getImageScaleY()),
             null);
@@ -1138,9 +1091,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       bbg.dispose();
       drawBackground = false;
     }
-    lastX = scale.getOffsetX();
-    lastY = scale.getOffsetY();
-    lastScale = scale.getScale();
+    lastZoneScale = scale;
 
     g.drawImage(backBuffer, 0, 0, this);
   }
@@ -1181,11 +1132,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       }
 
       if (clearArea != null) {
-        AffineTransform af = new AffineTransform();
-        af.translate(zoneScale.getOffsetX(), zoneScale.getOffsetY());
-        af.scale(getScale(), getScale());
-        var clip = clearArea.createTransformedArea(af);
-
+        var clip = clearArea.createTransformedArea(viewModel.getZoneScale().toScreenTransform());
         g.clip(clip);
       }
     }
@@ -1259,7 +1206,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         if (token == keyToken
             && (AppUtil.playerOwns(token) || shouldShowMovementLabels(token, set, clearArea))
             && viewModel.getViewport().intersects(newPosition.footprintBounds())) {
-          var screenBounds = zoneScale.toScreenSpace(newPosition.footprintBounds());
+          var screenBounds = viewModel.getZoneScale().toScreenSpace(newPosition.footprintBounds());
 
           var labelY = (int) screenBounds.getMaxY() + 10;
           var labelX = (int) screenBounds.getCenterX();
@@ -1353,7 +1300,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     Grid grid = zone.getGrid();
-    double scale = getScale();
+    double scale = viewModel.getZoneScale().getScale();
 
     Rectangle footprintBounds = footprint.getBounds(grid);
     if (path.getCellPath().getFirst() instanceof CellPoint) {
@@ -1573,8 +1520,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     double resizeWidth = zone.getGrid().getCellWidth() / image.getWidth() * .25;
     double resizeHeight = zone.getGrid().getCellHeight() / image.getHeight() * .25;
 
-    double cWidth = image.getWidth() * getScale() * resizeWidth;
-    double cHeight = image.getHeight() * getScale() * resizeHeight;
+    double cWidth = image.getWidth() * viewModel.getZoneScale().getScale() * resizeWidth;
+    double cHeight = image.getHeight() * viewModel.getZoneScale().getScale() * resizeHeight;
 
     double iWidth = cWidth * size;
     double iHeight = cHeight * size;
@@ -1595,8 +1542,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
   public void highlightCell(Graphics2D g, ZonePoint point, BufferedImage image, float size) {
     Grid grid = zone.getGrid();
-    double cWidth = grid.getCellWidth() * getScale();
-    double cHeight = grid.getCellHeight() * getScale();
+    double cWidth = grid.getCellWidth() * viewModel.getZoneScale().getScale();
+    double cHeight = grid.getCellHeight() * viewModel.getZoneScale().getScale();
 
     double iWidth = cWidth * size;
     double iHeight = cHeight * size;
@@ -1619,8 +1566,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     }
 
     Grid grid = zone.getGrid();
-    double cWidth = grid.getCellWidth() * getScale();
-    double cHeight = grid.getCellHeight() * getScale();
+    double cWidth = grid.getCellWidth() * viewModel.getZoneScale().getScale();
+    double cHeight = grid.getCellHeight() * viewModel.getZoneScale().getScale();
 
     double iWidth = cWidth * size;
     double iHeight = cHeight * size;
@@ -1632,8 +1579,12 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
     // Draw distance for each cell
     double fontScale = (double) grid.getSize() / 50; // Font size of 12 at grid size 50 is default
-    int fontSize = (int) (getScale() * 12 * fontScale);
-    int textOffset = (int) (getScale() * 7 * fontScale); // 7 pixels at 100% zoom & grid size of 50
+    int fontSize = (int) (viewModel.getZoneScale().getScale() * 12 * fontScale);
+    int textOffset =
+        (int)
+            (viewModel.getZoneScale().getScale()
+                * 7
+                * fontScale); // 7 pixels at 100% zoom & grid size of 50
 
     String distanceText = NumberFormat.getInstance().format(distance);
     if (DeveloperOptions.Toggle.ShowAiDebugging.get()) {
@@ -1768,7 +1719,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
           Area cellVisibleArea = new Area(visibleScreenArea);
           Area cb =
               zone.getGrid()
-                  .getTokenCellArea(zoneScale.toScreenSpace(position.transformedBounds()));
+                  .getTokenCellArea(
+                      viewModel.getZoneScale().toScreenSpace(position.transformedBounds()));
           cellVisibleArea.intersect(cb);
           tokenG.clip(cellVisibleArea);
         }
@@ -1815,7 +1767,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
       timer.start("token-list-9");
       // Set up the graphics so that the overlay can just be painted.
-      Rectangle2D tokenBounds = zoneScale.toScreenSpace(position.transformedBounds().getBounds2D());
+      Rectangle2D tokenBounds =
+          viewModel.getZoneScale().toScreenSpace(position.transformedBounds().getBounds2D());
       Graphics2D locG =
           (Graphics2D)
               tokenG.create(
@@ -1952,7 +1905,10 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         }
         // Create LabelRenderer using cached label.
         Rectangle r =
-            zoneScale.toScreenSpace(position.transformedBounds().getBounds2D()).getBounds();
+            viewModel
+                .getZoneScale()
+                .toScreenSpace(position.transformedBounds().getBounds2D())
+                .getBounds();
         delayRendering(
             new LabelRenderer(
                 this,
@@ -1983,7 +1939,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
             continue;
           }
 
-          var bounds = zoneScale.toScreenSpace(position.transformedBounds().getBounds2D());
+          var bounds =
+              viewModel.getZoneScale().toScreenSpace(position.transformedBounds().getBounds2D());
 
           BufferedImage stackImage = RessourceManager.getImage(Images.ZONE_RENDERER_STACK_IMAGE);
           clippedG.drawImage(
@@ -2113,7 +2070,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
    * @return A list of token IDs for tokens whose footprint intersects with {@code screenRect}.
    */
   public List<GUID> getTokenIdsInBounds(Rectangle screenRect) {
-    var rect = zoneScale.toWorldSpace(screenRect);
+    var rect = viewModel.getZoneScale().toWorldSpace(screenRect);
 
     final var tokens = new ArrayList<GUID>();
     for (ZoneViewModel.TokenPosition position : getTokenPositions(getActiveLayer())) {
@@ -2233,14 +2190,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     return null;
   }
 
-  public int getViewOffsetX() {
-    return zoneScale.getOffsetX();
-  }
-
-  public int getViewOffsetY() {
-    return zoneScale.getOffsetY();
-  }
-
   /**
    * Since the map can be scaled, this is a convenience method to find out what cell is at this
    * location.
@@ -2266,17 +2215,9 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     return new ZonePoint((int) p2d.getX(), (int) p2d.getY());
   }
 
-  public void setScale(double scale) {
-    setZoneScale(zoneScale.withScale(scale, getWidth() / 2, getHeight() / 2));
-  }
-
-  public double getScale() {
-    return zoneScale.getScale();
-  }
-
   public double getScaledGridSize() {
     // Optimize: only need to calc this when grid size or scale changes
-    return getScale() * zone.getGrid().getSize();
+    return viewModel.getZoneScale().getScale() * zone.getGrid().getSize();
   }
 
   /** This makes sure that any image updates get refreshed. This could be a little smarter. */

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -42,6 +42,7 @@ import net.rptools.lib.CollectionUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.*;
+import net.rptools.maptool.client.events.RepaintZoneRequested;
 import net.rptools.maptool.client.functions.TokenMoveFunctions;
 import net.rptools.maptool.client.swing.GenericDialog;
 import net.rptools.maptool.client.swing.ImageLabel;
@@ -2536,6 +2537,15 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
    */
   @Override
   public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+  @Subscribe
+  private void onRepaintRequested(RepaintZoneRequested event) {
+    if (event.zone() != this.zone) {
+      return;
+    }
+
+    repaintDebouncer.dispatch();
+  }
 
   @Subscribe
   private void onSelectionChanged(SelectionModel.SelectionChanged event) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1113,14 +1113,13 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       AppPreferences.renderQuality.get().setRenderingHints(bbg);
 
       // Background texture
-      Paint paint =
-          zone.getBackgroundPaint().getPaint(getViewOffsetX(), getViewOffsetY(), getScale(), this);
+      Paint paint = zone.getBackgroundPaint().getPaint(zoneScale, this);
       bbg.setPaint(paint);
       bbg.fillRect(0, 0, size.width, size.height);
 
       // Only apply the noise if the feature is on and the background a textured paint
       if (bgTextureNoiseFilterOn && paint instanceof TexturePaint) {
-        bbg.setPaint(noise.getPaint(getViewOffsetX(), getViewOffsetY(), getScale()));
+        bbg.setPaint(noise.getPaint(zoneScale));
         bbg.fillRect(0, 0, size.width, size.height);
       }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -159,10 +159,10 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       throw new IllegalArgumentException("Zone cannot be null");
     }
     this.zone = zone;
-    selectionModel = new SelectionModel(zone);
-    zoneView = new ZoneView(zone);
+    this.zoneScale = new Scale();
+    this.selectionModel = new SelectionModel(zone);
+    this.zoneView = new ZoneView(zone);
     this.viewModel = new ZoneViewModel(zone, zoneView, selectionModel);
-    setZoneScale(new Scale());
 
     drawableRenderers =
         CollectionUtil.newFilledEnumMap(
@@ -275,17 +275,12 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public void setZoneScale(Scale scale) {
-    zoneScale = scale;
-    invalidateCurrentViewCache();
-
-    scale.addPropertyChangeListener(
-        evt -> {
-          if (Scale.PROPERTY_SCALE.equals(evt.getPropertyName())) {
-            clearZoomDependantCaches();
-          }
-          visibleScreenArea = null;
-          repaintDebouncer.dispatch();
-        });
+    if (!zoneScale.equals(scale)) {
+      zoneScale = scale;
+      invalidateCurrentViewCache();
+      MapTool.getFrame().getZoomStatusBar().update();
+      repaintDebouncer.dispatch();
+    }
   }
 
   public void flushDrawableRenderer() {
@@ -535,7 +530,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   protected void setViewOffset(int x, int y) {
-    zoneScale.setOffset(x, y);
+    setZoneScale(zoneScale.withOffset(x, y));
   }
 
   public void centerOn(ZonePoint point) {
@@ -644,18 +639,15 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public void zoomReset(int x, int y) {
-    zoneScale.zoomReset(x, y);
-    MapTool.getFrame().getZoomStatusBar().update();
+    setZoneScale(zoneScale.withZoomReset(x, y));
   }
 
   public void zoomIn(int x, int y) {
-    zoneScale.zoomIn(x, y);
-    MapTool.getFrame().getZoomStatusBar().update();
+    setZoneScale(zoneScale.zoomedIn(x, y));
   }
 
   public void zoomOut(int x, int y) {
-    zoneScale.zoomOut(x, y);
-    MapTool.getFrame().getZoomStatusBar().update();
+    setZoneScale(zoneScale.zoomedOut(x, y));
   }
 
   public void enforceView(int x, int y, double scale, int gmWidth, int gmHeight) {
@@ -2276,18 +2268,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public void setScale(double scale) {
-    if (zoneScale.getScale() != scale) {
-      /*
-       * MCL: I think it is correct to clear these caches (if not more).
-       */
-      clearZoomDependantCaches();
-      zoneScale.zoomScale(getWidth() / 2, getHeight() / 2, scale);
-      MapTool.getFrame().getZoomStatusBar().update();
-    }
-  }
-
-  private void clearZoomDependantCaches() {
-    invalidateCurrentViewCache();
+    setZoneScale(zoneScale.withScale(scale, getWidth() / 2, getHeight() / 2));
   }
 
   public double getScale() {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -262,7 +262,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public ZonePoint getCenterPoint() {
-    return new ScreenPoint(getSize().width / 2d, getSize().height / 2d).convertToZone(this);
+    return new ScreenPoint(getSize().width / 2d, getSize().height / 2d)
+        .convertToZone(viewModel.getZoneScale());
   }
 
   public boolean isPathShowing(Token token) {
@@ -685,7 +686,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public void forcePlayersView() {
-    ZonePoint zp = new ScreenPoint(getWidth() / 2d, getHeight() / 2d).convertToZone(this);
+    ZonePoint zp =
+        new ScreenPoint(getWidth() / 2d, getHeight() / 2d).convertToZone(viewModel.getZoneScale());
     MapTool.serverCommand()
         .enforceZoneView(getZone().getId(), zp.x, zp.y, getScale(), getWidth(), getHeight());
   }
@@ -1076,7 +1078,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         continue;
       }
       timer.start("labels-1.1");
-      ScreenPoint sp = ScreenPoint.fromZonePointRnd(this, zp.x, zp.y);
+      ScreenPoint sp = ScreenPoint.fromZonePointRnd(viewModel.getZoneScale(), zp.x, zp.y);
       var dim = fLabel.getDimensions(g, label.getLabel());
       Rectangle bounds =
           fLabel.render(
@@ -1443,8 +1445,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
             int dx = dzp.x;
             int dy = dzp.y;
 
-            ScreenPoint origin = ScreenPoint.fromZonePoint(this, ox, oy);
-            ScreenPoint destination = ScreenPoint.fromZonePoint(this, dx, dy);
+            ScreenPoint origin = viewModel.getZoneScale().toScreenSpace(ox, oy);
+            ScreenPoint destination = viewModel.getZoneScale().toScreenSpace(dx, dy);
 
             int halfX = (int) ((origin.x + destination.x) / 2);
             int halfY = (int) ((origin.y + destination.y) / 2);
@@ -1486,16 +1488,17 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         if (lastPoint == null) {
           lastPoint =
               ScreenPoint.fromZonePointRnd(
-                  this,
+                  viewModel.getZoneScale(),
                   zp.x + (footprintBounds.width / 2d) * footprint.getScale(),
                   zp.y + (footprintBounds.height / 2d) * footprint.getScale());
           continue;
         }
         ScreenPoint nextPoint =
-            ScreenPoint.fromZonePoint(
-                this,
-                zp.x + (footprintBounds.width / 2d) * footprint.getScale(),
-                zp.y + (footprintBounds.height / 2d) * footprint.getScale());
+            viewModel
+                .getZoneScale()
+                .toScreenSpace(
+                    zp.x + (footprintBounds.width / 2d) * footprint.getScale(),
+                    zp.y + (footprintBounds.height / 2d) * footprint.getScale());
 
         g.setColor(highlight);
         g.setStroke(highlightStroke);
@@ -1585,7 +1588,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     double iWidth = cWidth * size;
     double iHeight = cHeight * size;
 
-    ScreenPoint sp = ScreenPoint.fromZonePoint(this, point);
+    ScreenPoint sp = viewModel.getZoneScale().toScreenSpace(point.x, point.y);
 
     AffineTransform backup = g.getTransform();
 
@@ -1607,7 +1610,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     double iWidth = cWidth * size;
     double iHeight = cHeight * size;
 
-    ScreenPoint sp = ScreenPoint.fromZonePoint(this, point);
+    ScreenPoint sp = viewModel.getZoneScale().toScreenSpace(point.x, point.y);
 
     g.drawImage(
         image,
@@ -1631,7 +1634,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     double iWidth = cWidth * size;
     double iHeight = cHeight * size;
 
-    ScreenPoint sp = ScreenPoint.fromZonePoint(this, point);
+    ScreenPoint sp = viewModel.getZoneScale().toScreenSpace(point.x, point.y);
 
     int cellX = (int) (sp.x - iWidth / 2);
     int cellY = (int) (sp.y - iHeight / 2);
@@ -2181,7 +2184,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
    * @return the token
    */
   public @Nullable Token getTokenAt(int x, int y) {
-    var zonePoint = ScreenPoint.convertToZone2d(this, x, y);
+    var zonePoint = viewModel.getZoneScale().toWorldSpace(x, y);
 
     List<ZoneViewModel.TokenPosition> positionList =
         new ArrayList<>(getTokenPositions(getActiveLayer()));
@@ -2195,7 +2198,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public @Nullable Token getMarkerAt(int x, int y) {
-    var zonePoint = ScreenPoint.convertToZone2d(this, x, y);
+    var zonePoint = viewModel.getZoneScale().toWorldSpace(x, y);
 
     List<ZoneViewModel.TokenPosition> positionList =
         new ArrayList<>(viewModel.getMarkerPositions());
@@ -2255,7 +2258,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
    * @return The cell coordinates of the passed screen point.
    */
   public CellPoint getCellAt(ScreenPoint screenPoint) {
-    ZonePoint zp = screenPoint.convertToZone(this);
+    ZonePoint zp = screenPoint.convertToZone(viewModel.getZoneScale());
     return zone.getGrid().convert(zp);
   }
 
@@ -2343,7 +2346,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     List<String> failedPaste = new ArrayList<>(tokens.size());
     List<GUID> selectThese = new ArrayList<>(tokens.size());
 
-    ScreenPoint sp = ScreenPoint.fromZonePoint(this, zp);
+    ScreenPoint sp = viewModel.getZoneScale().toScreenSpace(zp.x, zp.y);
     Point dropPoint = new Point((int) sp.x, (int) sp.y);
     SwingUtilities.convertPointToScreen(dropPoint, this);
     int tokenIndex = 0;
@@ -2511,7 +2514,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     if (MapTool.getPlayer().isGM() || !MapTool.getServerPolicy().getDisablePlayerAssetPanel()) {
       ZonePoint zp =
           new ScreenPoint((int) dtde.getLocation().getX(), (int) dtde.getLocation().getY())
-              .convertToZone(this);
+              .convertToZone(viewModel.getZoneScale());
       TransferableHelper th = (TransferableHelper) getTransferHandler();
       List<Token> tokens = th.getTokens();
       if (tokens != null && !tokens.isEmpty()) {

--- a/src/main/java/net/rptools/maptool/model/CellPoint.java
+++ b/src/main/java/net/rptools/maptool/model/CellPoint.java
@@ -70,14 +70,15 @@ public final class CellPoint extends AbstractPoint {
    *     point.
    */
   public ScreenPoint convertToScreen(ZoneRenderer renderer) {
-    double scale = renderer.getScale();
+    var zoneScale = renderer.getViewModel().getZoneScale();
+    double scale = zoneScale.getScale();
     Zone zone = renderer.getZone();
 
     Grid grid = zone.getGrid();
     ZonePoint zp = grid.convert(this);
 
-    int sx = renderer.getViewOffsetX() + (int) (zp.x * scale);
-    int sy = renderer.getViewOffsetY() + (int) (zp.y * scale);
+    int sx = zoneScale.getOffsetX() + (int) (zp.x * scale);
+    int sy = zoneScale.getOffsetY() + (int) (zp.y * scale);
 
     return new ScreenPoint(sx, sy);
   }

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -22,6 +22,7 @@ import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.Dimension2D;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
@@ -29,6 +30,7 @@ import java.awt.image.BufferedImage;
 import java.util.function.BiConsumer;
 import net.rptools.maptool.client.AppState;
 import net.rptools.maptool.client.swing.SwingUtil;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.client.ui.theme.Images;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
 import net.rptools.maptool.client.ui.zone.renderer.GridRenderer;
@@ -341,24 +343,25 @@ public abstract class HexGrid extends Grid {
 
   protected abstract void setGridDrawTranslation(Graphics2D g, double u, double v);
 
-  public abstract double getRendererSizeU(ZoneRenderer renderer);
+  public abstract double getSizeU(Dimension2D size);
 
-  public abstract double getRendererSizeV(ZoneRenderer renderer);
+  public abstract double getSizeV(Dimension2D size);
 
-  public abstract int getOffV(ZoneRenderer renderer);
+  public abstract int getOffV(Scale scale);
 
-  public abstract int getOffU(ZoneRenderer renderer);
+  public abstract int getOffU(Scale scale);
 
   @Override
   public void draw(ZoneRenderer renderer, Graphics2D g, Rectangle bounds) {
-    var scale = renderer.getScale();
+    var zoneScale = renderer.getViewModel().getZoneScale();
+    var scale = zoneScale.getScale();
     var scaledMinorRadius = minorRadius * scale;
     var scaledEdgeLength = edgeLength * scale;
     var scaledEdgeProjection = edgeProjection * scale;
     var scaledHex = createHalfShape(scaledMinorRadius, scaledEdgeProjection, scaledEdgeLength);
 
-    int offU = getOffU(renderer);
-    int offV = getOffV(renderer);
+    int offU = getOffU(zoneScale);
+    int offV = getOffV(zoneScale);
     int count = 0;
 
     Object oldAntiAlias = SwingUtil.useAntiAliasing(g);
@@ -366,7 +369,7 @@ public abstract class HexGrid extends Grid {
     g.setStroke(new BasicStroke(AppState.getGridLineWeight()));
 
     for (double v = offV % (scaledMinorRadius * 2) - (scaledMinorRadius * 2);
-        v < getRendererSizeV(renderer);
+        v < getSizeV(renderer.getSize());
         v += scaledMinorRadius) {
       double offsetU = (int) ((count & 1) == 0 ? 0 : -(scaledEdgeProjection + scaledEdgeLength));
       count++;
@@ -374,7 +377,7 @@ public abstract class HexGrid extends Grid {
       double start =
           offU % (2 * scaledEdgeLength + 2 * scaledEdgeProjection)
               - (2 * scaledEdgeLength + 2 * scaledEdgeProjection);
-      double end = getRendererSizeU(renderer) + 2 * scaledEdgeLength + 2 * scaledEdgeProjection;
+      double end = getSizeU(renderer.getSize()) + 2 * scaledEdgeLength + 2 * scaledEdgeProjection;
       double incr = 2 * scaledEdgeLength + 2 * scaledEdgeProjection;
       for (double u = start; u < end; u += incr) {
         setGridDrawTranslation(g, u + offsetU, v);

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -20,6 +20,7 @@ import java.awt.Point;
 import java.awt.event.KeyEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.Dimension2D;
 import java.awt.geom.GeneralPath;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
@@ -30,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.Action;
 import javax.swing.KeyStroke;
 import net.rptools.maptool.client.tool.PointerTool;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.client.walker.astar.AStarHorizHexEuclideanWalker;
@@ -252,23 +253,23 @@ public class HexGridHorizontal extends HexGrid {
   }
 
   @Override
-  public double getRendererSizeV(ZoneRenderer renderer) {
-    return renderer.getSize().getWidth();
+  public double getSizeV(Dimension2D size) {
+    return size.getWidth();
   }
 
   @Override
-  public double getRendererSizeU(ZoneRenderer renderer) {
-    return renderer.getSize().getHeight();
+  public double getSizeU(Dimension2D size) {
+    return size.getHeight();
   }
 
   @Override
-  public int getOffV(ZoneRenderer renderer) {
-    return (int) (renderer.getViewOffsetX() + getOffsetX() * renderer.getScale());
+  public int getOffV(Scale scale) {
+    return (int) (scale.getOffsetX() + getOffsetX() * scale.getScale());
   }
 
   @Override
-  public int getOffU(ZoneRenderer renderer) {
-    return (int) (renderer.getViewOffsetY() + getOffsetY() * renderer.getScale());
+  public int getOffU(Scale scale) {
+    return (int) (scale.getOffsetY() + getOffsetY() * scale.getScale());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -21,6 +21,7 @@ import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.Dimension2D;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.List;
@@ -29,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.Action;
 import javax.swing.KeyStroke;
 import net.rptools.maptool.client.tool.PointerTool;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.client.walker.ZoneWalker;
 import net.rptools.maptool.client.walker.astar.AStarVertHexEuclideanWalker;
@@ -233,23 +234,23 @@ public class HexGridVertical extends HexGrid {
   }
 
   @Override
-  public double getRendererSizeV(ZoneRenderer renderer) {
-    return renderer.getSize().getHeight();
+  public double getSizeV(Dimension2D size) {
+    return size.getHeight();
   }
 
   @Override
-  public double getRendererSizeU(ZoneRenderer renderer) {
-    return renderer.getSize().getWidth();
+  public double getSizeU(Dimension2D size) {
+    return size.getWidth();
   }
 
   @Override
-  public int getOffV(ZoneRenderer renderer) {
-    return (int) (renderer.getViewOffsetY() + getOffsetY() * renderer.getScale());
+  public int getOffV(Scale scale) {
+    return (int) (scale.getOffsetY() + getOffsetY() * scale.getScale());
   }
 
   @Override
-  public int getOffU(ZoneRenderer renderer) {
-    return (int) (renderer.getViewOffsetX() + getOffsetX() * renderer.getScale());
+  public int getOffU(Scale scale) {
+    return (int) (scale.getOffsetX() + getOffsetX() * scale.getScale());
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -27,6 +27,7 @@ import javax.swing.KeyStroke;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.tool.PointerTool;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.client.ui.theme.Images;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
 import net.rptools.maptool.client.ui.zone.renderer.GridRenderer;
@@ -386,21 +387,22 @@ public class IsometricGrid extends Grid {
 
   @Override
   public void draw(ZoneRenderer renderer, Graphics2D g, Rectangle bounds) {
-    double scale = renderer.getScale();
+    var zoneScale = renderer.getViewModel().getZoneScale();
+    double scale = zoneScale.getScale();
     double gridSize = getSize() * scale;
     double isoHeight = getSize() * scale;
     double isoWidth = getSize() * 2 * scale;
     Path2D path = new Path2D.Double();
 
-    int offX = (int) (renderer.getViewOffsetX() % isoWidth + getOffsetX() * scale);
-    int offY = (int) (renderer.getViewOffsetY() % gridSize + getOffsetY() * scale);
+    int offX = (int) (zoneScale.getOffsetX() % isoWidth + getOffsetX() * scale);
+    int offY = (int) (zoneScale.getOffsetY() % gridSize + getOffsetY() * scale);
 
     int startCol = (int) ((int) (bounds.x / isoWidth) * isoWidth);
     int startRow = (int) ((int) (bounds.y / gridSize) * gridSize);
 
     for (double row = startRow; row < bounds.y + bounds.height + gridSize; row += gridSize) {
       for (double col = startCol; col < bounds.x + bounds.width + isoWidth; col += isoWidth) {
-        path.append(drawHatch(renderer, (int) (col + offX), (int) (row + offY)), false);
+        path.append(drawHatch(zoneScale, (int) (col + offX), (int) (row + offY)), false);
       }
     }
 
@@ -410,14 +412,14 @@ public class IsometricGrid extends Grid {
       for (double col = startCol - (isoWidth / 2);
           col < bounds.x + bounds.width + isoWidth;
           col += isoWidth) {
-        path.append(drawHatch(renderer, (int) (col + offX), (int) (row + offY)), false);
+        path.append(drawHatch(zoneScale, (int) (col + offX), (int) (row + offY)), false);
       }
     }
     GridRenderer.drawGridShape(g, path);
   }
 
-  private Shape drawHatch(ZoneRenderer renderer, int x, int y) {
-    double isoWidth = getSize() * renderer.getScale();
+  private Shape drawHatch(Scale zoneScale, int x, int y) {
+    double isoWidth = getSize() * zoneScale.getScale();
     int hatchSize = isoWidth > 10 ? (int) isoWidth / 8 : 2;
     Path2D path = new Path2D.Double();
     path.append(

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -232,8 +232,11 @@ public class SquareGrid extends Grid {
     FontMetrics fm = g.getFontMetrics();
 
     double cellSize = renderer.getScaledGridSize();
-    CellPoint topLeft = convert(new ScreenPoint(0, 0).convertToZone(renderer));
-    ScreenPoint sp = ScreenPoint.fromZonePoint(renderer, convert(topLeft));
+    CellPoint topLeft =
+        convert(new ScreenPoint(0, 0).convertToZone(renderer.getViewModel().getZoneScale()));
+    var topLeftZone = convert(topLeft);
+    ScreenPoint sp =
+        renderer.getViewModel().getZoneScale().toScreenSpace(topLeftZone.x, topLeftZone.y);
 
     Dimension size = renderer.getSize();
 

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -384,13 +384,14 @@ public class SquareGrid extends Grid {
 
   @Override
   public void draw(ZoneRenderer renderer, Graphics2D g, Rectangle bounds) {
-    double scale = renderer.getScale();
+    var zoneScale = renderer.getViewModel().getZoneScale();
+    double scale = zoneScale.getScale();
     double gridSize = getSize() * scale;
 
     g.setColor(new Color(getZone().getGridColor()));
 
-    int offX = (int) (renderer.getViewOffsetX() % gridSize + getOffsetX() * scale);
-    int offY = (int) (renderer.getViewOffsetY() % gridSize + getOffsetY() * scale);
+    int offX = (int) (zoneScale.getOffsetX() % gridSize + getOffsetX() * scale);
+    int offY = (int) (zoneScale.getOffsetY() % gridSize + getOffsetY() * scale);
 
     int startCol = (int) ((int) (bounds.x / gridSize) * gridSize);
     int startRow = (int) ((int) (bounds.y / gridSize) * gridSize);

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
@@ -18,6 +18,7 @@ import java.awt.Paint;
 import java.awt.Rectangle;
 import java.awt.TexturePaint;
 import java.awt.image.BufferedImage;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.noiselib.PerlinNoise;
 
 /**
@@ -160,6 +161,10 @@ public class DrawableNoise {
             offsetY + OFFFSET_Y_TWEAK,
             (int) (WIDTH * scale),
             (int) (HEIGHT * scale)));
+  }
+
+  public Paint getPaint(Scale scale) {
+    return getPaint(scale.getOffsetX(), scale.getOffsetY(), scale.getScale());
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawablePaint.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawablePaint.java
@@ -21,6 +21,7 @@ import java.awt.image.ImageObserver;
 import java.io.Serializable;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.ui.AssetPaint;
+import net.rptools.maptool.client.ui.Scale;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.server.proto.drawing.DrawablePaintDto;
 import org.apache.logging.log4j.LogManager;
@@ -33,6 +34,10 @@ public abstract class DrawablePaint implements Serializable {
 
   public abstract Paint getPaint(
       int offsetX, int offsetY, double scale, ImageObserver... observers);
+
+  public Paint getPaint(Scale scale, ImageObserver... observers) {
+    return getPaint(scale.getOffsetX(), scale.getOffsetY(), scale.getScale(), observers);
+  }
 
   public static DrawablePaint convertPaint(Paint paint) {
     if (paint == null) {

--- a/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
+++ b/src/main/java/net/rptools/maptool/util/PersistenceUtil.java
@@ -407,7 +407,7 @@ public class PersistenceUtil {
             ZoneRenderer currentZoneRenderer = MapTool.getFrame().getCurrentZoneRenderer();
             if (currentZoneRenderer != null) {
               persistedCampaign.currentZoneId = currentZoneRenderer.getZone().getId();
-              persistedCampaign.currentView = currentZoneRenderer.getZoneScale();
+              persistedCampaign.currentView = currentZoneRenderer.getViewModel().getZoneScale();
             }
             // Save all assets in active use (consolidate duplicates between maps)
             saveTimer.start("Collect all assets");

--- a/src/test/java/net/rptools/maptool/model/TestScreenPoint.java
+++ b/src/test/java/net/rptools/maptool/model/TestScreenPoint.java
@@ -16,9 +16,7 @@ package net.rptools.maptool.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import net.rptools.maptool.client.ScreenPoint;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
-import net.rptools.maptool.client.ui.zone.renderer.ZoneRendererFactory;
+import net.rptools.maptool.client.ui.Scale;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +24,14 @@ class TestScreenPoint {
 
   @Test
   @DisplayName("Test Conversion of Screen Points")
-  void testConversion() throws Exception {
-    ZoneRenderer renderer = ZoneRendererFactory.newRenderer(new Zone());
-    renderer.moveViewBy(-100, -100);
+  void testConversion() {
+    var scale = new Scale();
+    scale.setOffset(-100, -100);
 
     for (int i = -10; i < 10; i++) {
       for (int j = -10; j < 10; j++) {
         ZonePoint zp = new ZonePoint(i, j);
-        assertEquals(zp, ScreenPoint.fromZonePoint(renderer, zp).convertToZone(renderer));
+        assertEquals(zp, scale.toScreenSpace(zp.x, zp.y).convertToZone(scale));
       }
     }
   }

--- a/src/test/java/net/rptools/maptool/model/TestScreenPoint.java
+++ b/src/test/java/net/rptools/maptool/model/TestScreenPoint.java
@@ -25,8 +25,7 @@ class TestScreenPoint {
   @Test
   @DisplayName("Test Conversion of Screen Points")
   void testConversion() {
-    var scale = new Scale();
-    scale.setOffset(-100, -100);
+    var scale = new Scale(0, -100, -100);
 
     for (int i = -10; i < 10; i++) {
       for (int j = -10; j < 10; j++) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5849

### Description of the Change

Changes the interface of `Scale` so its properties can no longer be modified. The fields are not `final` so that serialization continues to work, but they are effectively immutable. As a proper value type, `Scale` now has `#equals(Object)` and `#hashCode()` methods. This also means `Scale` is no longer reponsible for pumping events when modified, so the `PropertyChangeSupport` has been removed.

`Scale` is now the only place that defines transformations between world and screen space. It provides general `AffineTransform`s in both directions via `#toWorldTransform()` and `#toScreenTransform()`. Also, most conversion methods on `ScreenPoint` have been removed in favour of using the `Scale` for conversions. Those conversion methods that remain in `ScreenPoint` are wrappers around the ones in `Scale` for specific circumstances, and they all accept a simple `Scale` rather than an entire `ZoneRenderer`.

The `ZoneViewModel` now manages the `Scale` for a `Zone` (used to be in `ZoneRenderer`). This is just one more step along the road of removing dependencies on `ZoneRenderer`, though for now most components still look up the view model from the renderer. `ZoneRenderer` now longer offers methods to directly change the current `Scale`, though it does offer a few convenience methods that may do so among other things.

A few `Scale`-related improvements as well:
- The new `RepaintZoneRequested` event gives a way for any component to trigger a repaint via the event bus. For now only `ZoneViewModel` uses it when the `Scale` is changed, but there are plenty of other places that will benefit from this as well.
- `HexGrid#getOffV(ZoneRenderer)` and `HexGrid#getOffU(ZoneRenderer)` now accept a `Scale` instead of a `ZoneRenderer`. Similarly, `HexGrid#getRendererSizeV(ZoneRenderer)` and `HexGrid#getRendererSizeU(ZoneRenderer)` are now `HexGrid#getSizeV(Dimension2D)` and `HexGrid#getSizeU(Dimension2D)`.
- `DrawablePaint` and `DrawableNoise` now accept a full `Scale` when getting the AWT paint. This isn't used much now, but will be more common with some upcoming rendering changes.

### Possible Drawbacks

Some scaling operations are more verbose to write now, though that will improve as `ZoneRenderer` is pushed out of the limelight.

### Documentation Notes

N/A

### Release Notes

- Refactored zone scale

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5851)
<!-- Reviewable:end -->
