### PR TITLE
Avoid NPE with ZoneRenderer#lastZoneScale

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1054,7 +1054,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       drawBackground = true;
     }
     Scale scale = viewModel.getZoneScale();
-    if (!lastZoneScale.equals(scale)) {
+    if (!Objects.equals(lastZoneScale, scale)) {
       drawBackground = true;
     }
     if (zone.isBoardChanged()) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes critical issue with PR #5851

### Description of the Change

Performs a null-safe check for against the previous scale when deciding whether to render the board.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5853)
<!-- Reviewable:end -->
