### PR TITLE
Fix order of renderHalos() parameters

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -176,8 +176,8 @@ public class HaloRenderer {
                       halo,
                       hp,
                       shapeType,
-                      width,
                       haloFacingAngle,
+                      width,
                       concentricOffset,
                       haloScaleFactor));
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes PR #5855

### Description of the Change

I mixed up two neighbouring `int` parameters in my previous change, causing mini shape halos to use the token facing as the line width and vice versa.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5856)
<!-- Reviewable:end -->
