### PR TITLE
Replace String-based checks in GridFactory with GridType enum

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -20,7 +20,7 @@ import java.util.prefs.Preferences;
 import net.rptools.lib.image.RenderQuality;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.GridFactory;
+import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.Label;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.util.preferences.Preference;
@@ -615,7 +615,7 @@ public class AppPreferences {
 
   public static final Preference<String> defaultGridType =
       store
-          .defineString("defaultGridType", GridFactory.SQUARE)
+          .defineString("defaultGridType", Grid.GridType.Square.toString())
           .setLabel("Preferences.label.maps.grid")
           .setTooltip("Preferences.label.maps.grid.tooltip");
 

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -27,6 +27,7 @@ import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.GUID;
+import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.InvalidGUIDException;
 import net.rptools.maptool.model.Zone;
@@ -230,7 +231,7 @@ public class MapFunctions extends AbstractFunction {
             gridConfig.has("type")
                 ? gridConfig.getAsJsonPrimitive("type").getAsString()
                 : AppPreferences.defaultGridType.get();
-        final var grid = GridFactory.createGrid(gridType);
+        final var grid = GridFactory.createGrid(Grid.GridType.fromString(gridType));
 
         final var gridColor =
             gridConfig.has("color")

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -159,7 +159,7 @@ public class getInfoFunction extends AbstractFunction {
 
     JsonObject ginfo = new JsonObject();
     Grid grid = zone.getGrid();
-    ginfo.addProperty("type", GridFactory.getGridType(grid));
+    ginfo.addProperty("type", grid.getType().toString());
     ginfo.addProperty("color", String.format("%h", zone.getGridColor()));
     ginfo.addProperty("units per cell", zone.getUnitsPerCell());
     ginfo.addProperty("cell height", zone.getGrid().getCellHeight());

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
@@ -41,6 +41,7 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.Grid;
+import net.rptools.maptool.model.Grid.GridType;
 import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.GridlessGrid;
 import net.rptools.maptool.model.HexGridHorizontal;
@@ -112,17 +113,13 @@ public class MapPropertiesDialog extends JDialog {
     getMapButton().setEnabled(false);
   }
 
-  public void forceGridType(String gridType) {
-    if (GridFactory.isHexVertical(gridType)) {
-      getHexVerticalRadio().setSelected(true);
-    } else if (GridFactory.isHexHorizontal(gridType)) {
-      getHexHorizontalRadio().setSelected(true);
-    } else if (GridFactory.isIsometric(gridType)) {
-      getIsometricRadio().setSelected(true);
-    } else if (GridFactory.isSquare(gridType)) {
-      getSquareRadio().setSelected(true);
-    } else {
-      getNoGridRadio().setSelected(true);
+  public void forceGridType(GridType gridType) {
+    switch (gridType) {
+      case Square -> getSquareRadio().setSelected(true);
+      case Isometric -> getIsometricRadio().setSelected(true);
+      case HexVertical -> getHexVerticalRadio().setSelected(true);
+      case HexHorizontal -> getHexHorizontalRadio().setSelected(true);
+      case None -> getNoGridRadio().setSelected(true);
     }
     getHexVerticalRadio().setEnabled(false);
     getHexHorizontalRadio().setEnabled(false);
@@ -343,29 +340,35 @@ public class MapPropertiesDialog extends JDialog {
   }
 
   private void initIsometricRadio() {
-    getIsometricRadio().setSelected(GridFactory.isIsometric(AppPreferences.defaultGridType.get()));
+    getIsometricRadio()
+        .setSelected(
+            GridType.fromString(AppPreferences.defaultGridType.get()) == GridType.Isometric);
     getIsometricIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_ISOMETRIC));
   }
 
   private void initHexHoriRadio() {
     getHexHorizontalRadio()
-        .setSelected(GridFactory.isHexHorizontal(AppPreferences.defaultGridType.get()));
+        .setSelected(
+            GridType.fromString(AppPreferences.defaultGridType.get()) == GridType.HexHorizontal);
     getHexHorizontalIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_HEX_HORIZONTAL));
   }
 
   private void initHexVertRadio() {
     getHexVerticalRadio()
-        .setSelected(GridFactory.isHexVertical(AppPreferences.defaultGridType.get()));
+        .setSelected(
+            GridType.fromString(AppPreferences.defaultGridType.get()) == GridType.HexVertical);
     getHexVerticalIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_HEX_VERTICAL));
   }
 
   private void initSquareRadio() {
-    getSquareRadio().setSelected(GridFactory.isSquare(AppPreferences.defaultGridType.get()));
+    getSquareRadio()
+        .setSelected(GridType.fromString(AppPreferences.defaultGridType.get()) == GridType.Square);
     getSquareIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_SQUARE));
   }
 
   private void initNoGridRadio() {
-    getNoGridRadio().setSelected(GridFactory.isNone(AppPreferences.defaultGridType.get()));
+    getNoGridRadio()
+        .setSelected(GridType.fromString(AppPreferences.defaultGridType.get()) == GridType.None);
     getNoGridIcon().setIcon(RessourceManager.getSmallIcon(Icons.GRID_NONE));
   }
 
@@ -573,19 +576,19 @@ public class MapPropertiesDialog extends JDialog {
   private Grid createZoneGrid() {
     Grid grid = null;
     if (getHexHorizontalRadio().isSelected()) {
-      grid = GridFactory.createGrid(GridFactory.HEX_HORI);
+      grid = GridFactory.createGrid(GridType.HexHorizontal);
     }
     if (getHexVerticalRadio().isSelected()) {
-      grid = GridFactory.createGrid(GridFactory.HEX_VERT);
+      grid = GridFactory.createGrid(GridType.HexVertical);
     }
     if (getSquareRadio().isSelected()) {
-      grid = GridFactory.createGrid(GridFactory.SQUARE);
+      grid = GridFactory.createGrid(GridType.Square);
     }
     if (getIsometricRadio().isSelected()) {
-      grid = GridFactory.createGrid(GridFactory.ISOMETRIC);
+      grid = GridFactory.createGrid(GridType.Isometric);
     }
     if (getNoGridRadio().isSelected()) {
-      grid = GridFactory.createGrid(GridFactory.NONE);
+      grid = GridFactory.createGrid(GridType.None);
     }
     grid.setSize(StringUtil.parseInteger(getPixelsPerCellTextField().getText(), grid.getSize()));
 

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -55,7 +55,7 @@ import net.rptools.maptool.client.ui.theme.ThemeSupport.ThemeDetails;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.GridFactory;
+import net.rptools.maptool.model.Grid.GridType;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.util.UserJvmOptions;
@@ -534,11 +534,12 @@ public class PreferencesDialog extends AbeillePanel {
    * Each item in the array consists of a grid type and its corresponding localized display name.
    */
   private static final LocalizedComboItem[] defaultGridTypeComboItems = {
-    new LocalizedComboItem(GridFactory.SQUARE, "Preferences.combo.maps.grid.square"),
-    new LocalizedComboItem(GridFactory.HEX_HORI, "Preferences.combo.maps.grid.hexHori"),
-    new LocalizedComboItem(GridFactory.HEX_VERT, "Preferences.combo.maps.grid.hexVert"),
-    new LocalizedComboItem(GridFactory.ISOMETRIC, "Preferences.combo.maps.grid.isometric"),
-    new LocalizedComboItem(GridFactory.NONE, "MapPropertiesDialog.image.nogrid")
+    new LocalizedComboItem(GridType.Square.toString(), "Preferences.combo.maps.grid.square"),
+    new LocalizedComboItem(
+        GridType.HexHorizontal.toString(), "Preferences.combo.maps.grid.hexHori"),
+    new LocalizedComboItem(GridType.HexVertical.toString(), "Preferences.combo.maps.grid.hexVert"),
+    new LocalizedComboItem(GridType.Isometric.toString(), "Preferences.combo.maps.grid.isometric"),
+    new LocalizedComboItem(GridType.None.toString(), "MapPropertiesDialog.image.nogrid")
   };
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenLayoutPanelHelper.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenLayoutPanelHelper.java
@@ -107,7 +107,7 @@ class TokenLayoutPanelHelper {
   private static final UIDefaults UI_DEFAULTS = UIManager.getDefaults();
   private static final double DEFAULT_FONT_SIZE = UI_DEFAULTS.getFont("defaultFont").getSize2D();
   protected Grid grid = MapTool.getFrame().getCurrentZoneRenderer().getZone().getGrid();
-  private boolean noGrid = GridFactory.getGridType(grid).equals(GridFactory.NONE);
+  private boolean noGrid = grid.getType().isNone();
   private int gridSize = grid.getSize();
   private double cellHeight = grid.getCellHeight();
   private double cellWidth = grid.getCellWidth();
@@ -387,8 +387,8 @@ class TokenLayoutPanelHelper {
 
   protected void setToken(Token token, boolean useDefaults) {
     grid = MapTool.getFrame().getCurrentZoneRenderer().getZone().getGrid();
-    boolean isoGrid = grid.isIsometric();
-    noGrid = GridFactory.getGridType(grid).equals(GridFactory.NONE);
+    boolean isoGrid = grid.getType().isIsometric();
+    noGrid = grid.getType().isNone();
     renderBits = new RenderBits();
     gridSize = grid.getSize();
     cellHeight = grid.getCellHeight();
@@ -855,8 +855,7 @@ class TokenLayoutPanelHelper {
     }
 
     private Shape createGridShape(boolean trueSize) {
-      return Grid.createGridShape(
-          GridFactory.getGridType(grid), (trueSize ? grid.getSize() : grid.getSize() - 8));
+      return Grid.createGridShape(grid.getType(), (trueSize ? grid.getSize() : grid.getSize() - 8));
     }
 
     /** Itty bitty cross to show the dead-centre of the footprint */

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -324,9 +324,7 @@ public class HaloRenderer {
            * CIRCLE previously. */
           case TOKEN -> null;
           case HaloPart.HaloShapeType.FOOTPRINT -> // tokens on gridless maps do not have footprints
-              GridFactory.getGridType(grid).equals(GridFactory.NONE)
-                  ? null
-                  : getHaloFootprintShape(token, grid, concentricOffset);
+              grid.getType().isNone() ? null : getHaloFootprintShape(token, grid, concentricOffset);
           case HaloPart.HaloShapeType.OUTLINE -> getHaloOutlineShape(token);
           case HaloPart.HaloShapeType.MBL ->
               token.getTransformedMaskTopology(zone, Zone.TopologyType.MBL);
@@ -405,9 +403,7 @@ public class HaloRenderer {
     double scaleY;
     double footprintScaleX = position.footprintBounds().getWidth() + concentricAdjustment;
     double footprintScaleY = position.footprintBounds().getHeight() + concentricAdjustment;
-    if (GridFactory.getGridType(grid).equals(GridFactory.ISOMETRIC)
-        || GridFactory.getGridType(grid).equals(GridFactory.HEX_HORI)
-        || GridFactory.getGridType(grid).equals(GridFactory.HEX_VERT)) {
+    if (grid.getType().isIsometric() || grid.getType().isHex()) {
       scaleX = haloPart.getScaleX() * Math.min(footprintScaleX, footprintScaleY);
       scaleY = haloPart.getScaleY() * Math.min(footprintScaleX, footprintScaleY);
     } else {
@@ -599,9 +595,7 @@ public class HaloRenderer {
         (position.footprintBounds().getWidth() + concentricAdjustment) / grid.getSize();
     double footprintScaleY =
         (position.footprintBounds().getHeight() + concentricAdjustment) / grid.getSize();
-    if (GridFactory.getGridType(grid).equals(GridFactory.ISOMETRIC)
-        || GridFactory.getGridType(grid).equals(GridFactory.HEX_HORI)
-        || GridFactory.getGridType(grid).equals(GridFactory.HEX_VERT)) {
+    if (grid.getType().isIsometric() || grid.getType().isHex()) {
       scaleX = Math.min(footprintScaleX, footprintScaleY);
       scaleY = Math.min(footprintScaleX, footprintScaleY);
     } else {
@@ -817,7 +811,7 @@ public class HaloRenderer {
     timer.start("HaloRenderer-getHaloGridShape");
 
     if (haloGridShapeCache == null) {
-      if (GridFactory.getGridType(grid).equals(GridFactory.NONE)) {
+      if (grid.getType().isNone()) {
         double r = grid.getSize() / 2d;
         haloGridShapeCache = new Ellipse2D.Double(-r, -r, 2 * r, 2 * r);
       } else {
@@ -834,9 +828,7 @@ public class HaloRenderer {
     double scaleY =
         (position.footprintBounds().getHeight() + concentricAdjustment) / grid.getSize();
     double scale;
-    if (GridFactory.getGridType(grid).equals(GridFactory.ISOMETRIC)
-        || GridFactory.getGridType(grid).equals(GridFactory.HEX_HORI)
-        || GridFactory.getGridType(grid).equals(GridFactory.HEX_VERT)) {
+    if (grid.getType().isIsometric() || grid.getType().isHex()) {
       scale = Math.min(scaleX, scaleY);
     } else {
       scale = Math.max(scaleX, scaleY);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1340,7 +1340,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
         highlightCell(g, zp, grid.getCellHighlight(), 1.0f);
       }
       if (AppState.getShowMovementMeasurements()) {
-        double cellAdj = grid.isHex() ? 2.5 : 2;
+        double cellAdj = grid.getType().isHex() ? 2.5 : 2;
         for (CellPoint p : cellPath) {
           ZonePoint zp = grid.convert(p);
           zp.x += (int) (grid.getCellWidth() / cellAdj + cellOffset.width);
@@ -1358,7 +1358,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       // Line path
       if (grid.getCapabilities().isPathLineSupported()) {
         ZonePoint lineOffset;
-        if (grid.isHex()) {
+        if (grid.getType().isHex()) {
           lineOffset = new ZonePoint(0, 0);
         } else {
           lineOffset =
@@ -1743,7 +1743,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
       timer.stop("token-list-1b");
 
       timer.start("token-list-5a");
-      if (token.getIsFlippedIso() && getZone().getGrid().isIsometric()) {
+      if (token.getIsFlippedIso() && getZone().getGrid().getType().isIsometric()) {
         int newSize = (image.getWidth() + image.getHeight());
         token.setWidth(newSize);
         token.setHeight(newSize / 2);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/tokenRender/FacingArrowRenderer.java
@@ -106,7 +106,7 @@ public class FacingArrowRenderer {
     var timer = CodeTimer.get();
     timer.start("FacingArrowRenderer-paintArrow");
     try {
-      final var isIsometric = zone.getGrid().isIsometric();
+      final var isIsometric = zone.getGrid().getType().isIsometric();
 
       timer.start("FacingArrowRenderer-calculateTransform");
       int angle = Math.floorMod(facing + (isIsometric ? 45 : 0), 360);

--- a/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
+++ b/src/main/java/net/rptools/maptool/client/utilities/DungeonDraftImporter.java
@@ -44,7 +44,7 @@ import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.Asset;
 import net.rptools.maptool.model.AssetManager;
 import net.rptools.maptool.model.GUID;
-import net.rptools.maptool.model.GridFactory;
+import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.Light;
 import net.rptools.maptool.model.LightSource;
 import net.rptools.maptool.model.ShapeType;
@@ -183,7 +183,7 @@ public class DungeonDraftImporter {
         MapPropertiesDialog.createMapPropertiesImportDialog(MapTool.getFrame());
     dialog.setZone(zone);
     dialog.forcePixelsPerCell(pixelsPerCell);
-    dialog.forceGridType(GridFactory.SQUARE);
+    dialog.forceGridType(Grid.GridType.Square);
     dialog.forceMap(asset);
     dialog.setVisible(true);
     if (dialog.getStatus() != MapPropertiesDialog.Status.OK) {

--- a/src/main/java/net/rptools/maptool/model/Grid.java
+++ b/src/main/java/net/rptools/maptool/model/Grid.java
@@ -47,6 +47,48 @@ import org.apache.logging.log4j.Logger;
  * @author trevor
  */
 public abstract class Grid implements Cloneable {
+  public enum GridType {
+    Square,
+    Isometric,
+    HexVertical,
+    HexHorizontal,
+    None;
+
+    public boolean isHex() {
+      return this == HexVertical || this == HexHorizontal;
+    }
+
+    public boolean isIsometric() {
+      return this == Isometric;
+    }
+
+    public boolean isNone() {
+      return this == None;
+    }
+
+    public String toString() {
+      return switch (this) {
+        case Square -> "Square";
+        case Isometric -> "Isometric";
+        case HexVertical -> "Vertical Hex";
+        case HexHorizontal -> "Horizontal Hex";
+        case None -> "None";
+      };
+    }
+
+    public static GridType fromString(String string) {
+      return switch (string) {
+        case "Square" -> Square;
+        case "Isometric" -> Isometric;
+        case "Vertical Hex" -> HexVertical;
+        case "Horizontal Hex" -> HexHorizontal;
+        case "None" -> None;
+        default ->
+            throw new IllegalArgumentException(
+                String.format("\"%s\" is not a valid grid type", string));
+      };
+    }
+  }
 
   /**
    * The minimum grid size (minimum on any dimension). The default value is 9 because the algorithm
@@ -81,7 +123,7 @@ public abstract class Grid implements Cloneable {
     setOffset(grid.offsetX, grid.offsetY);
   }
 
-  public static Shape createGridShape(String gridType, double size) {
+  public static Shape createGridShape(GridType gridType, double size) {
     final Shape gridShape;
     int sides = 0;
     double startAngle = 0;
@@ -92,29 +134,23 @@ public abstract class Grid implements Cloneable {
     final double root2 = Math.sqrt(2d);
     final double root3 = Math.sqrt(3d);
     switch (gridType) {
-      case GridFactory.HEX_HORI -> {
+      case HexHorizontal -> {
         sides = 6;
         startAngle = Math.TAU / 12;
         hScale = vScale = root3 / 3d;
       }
-      case GridFactory.HEX_VERT -> {
+      case HexVertical -> {
         sides = 6;
         hScale = vScale = root3 / 3d;
       }
-      case GridFactory.ISOMETRIC -> {
+      case Isometric -> {
         sides = 4;
         vScale = 0.5;
       }
-      case GridFactory.ISOMETRIC_HEX -> {
-        sides = 6;
-        startAngle = Math.TAU / 24;
-        hScale = vScale = root3 / 3d;
-        skew = Math.toRadians(30d);
-      }
-      case GridFactory.NONE -> {
+      case None -> {
         return new Ellipse2D.Double(-size / 2d, -size / 2d, size, size);
       }
-      case GridFactory.SQUARE -> {
+      case Square -> {
         sides = 4;
         hScale = vScale = root2 / 2d;
         startAngle = Math.TAU / 8d;
@@ -141,6 +177,8 @@ public abstract class Grid implements Cloneable {
     cellShape = createCellShape();
     return this;
   }
+
+  public abstract GridType getType();
 
   protected synchronized Map<Integer, Area> getGridShapeCache() {
     return gridShapeCache;
@@ -272,16 +310,8 @@ public abstract class Grid implements Cloneable {
     return footprintList;
   }
 
-  public boolean isIsometric() {
-    return false;
-  }
-
   public boolean useMetric() {
     return false; // only square & iso use metrics
-  }
-
-  public boolean isHex() {
-    return false;
   }
 
   @Override
@@ -476,10 +506,10 @@ public abstract class Grid implements Cloneable {
    * <p>This is used to rotate cones and beams according to the on-grid angle. The result is the
    * number of clockwise degrees measured from the positive x-axis of the grid.
    *
-   * <p>This method exists because {@link net.rptools.maptool.model.Token#getFacing()} is a measure
-   * of the on-screen angle of the token's facing, i.e., how many degrees from the positive x-axis
-   * of the screen. For most grids this is the same as measuring the number of degress from the
-   * positive x-axis of the grid, which is what is should be.
+   * <p>This method exists because {@link Token#getFacing()} is a measure of the on-screen angle of
+   * the token's facing, i.e., how many degrees from the positive x-axis of the screen. For most
+   * grids this is the same as measuring the number of degress from the positive x-axis of the grid,
+   * which is what is should be.
    *
    * <p>Things are different for isometric grids. Since they are rotated, the on-screen facing does
    * not agree with the on-grid facing - there is a 45° offset. When building shapes, we need the
@@ -499,10 +529,9 @@ public abstract class Grid implements Cloneable {
    *
    * <p>This method expressly does not add in the footprint bit that cone lights are expected to
    * have. This part cannot be freely transformed, so it is done separately in {@link
-   * #getFootprintShapedAreaForCone(java.awt.Rectangle)}.
+   * #getFootprintShapedAreaForCone(Rectangle)}.
    *
-   * @param shape The shape. Can be any shape except {@link
-   *     net.rptools.maptool.model.ShapeType#GRID}.
+   * @param shape The shape. Can be any shape except {@link ShapeType#GRID}.
    * @param tokenFacingAngle The angle on-screen that the token is facing. Used for cones and beams
    *     to provide the main axis of the shape.
    * @param visionRange The range to which the token can see. Determines the size of the shape.
@@ -586,7 +615,7 @@ public abstract class Grid implements Cloneable {
   /**
    * Called by SightType and Light class to return a vision area based upon a specified distance
    *
-   * @param shape The shape of the light. Can be any {@link net.rptools.maptool.model.ShapeType}
+   * @param shape The shape of the light. Can be any {@link ShapeType}
    * @param token Used to position the shape and to provide footprint
    * @param range How far the shape should extends from the origin. If {@code 0}, the zone's vision
    *     range is used.

--- a/src/main/java/net/rptools/maptool/model/GridFactory.java
+++ b/src/main/java/net/rptools/maptool/model/GridFactory.java
@@ -14,80 +14,17 @@
  */
 package net.rptools.maptool.model;
 
-/**
- * Given a string describing the type of desired grid, this factory creates and returns an object of
- * the appropriate type.
- *
- * <p>(Ugh. This really should use an SPI-like factory interface.)
- */
+import net.rptools.maptool.model.Grid.GridType;
+
+/** Creates {@link Grid} instances from a given {@link GridType}. */
 public class GridFactory {
-  public static final String HEX_VERT = "Vertical Hex";
-  public static final String HEX_HORI = "Horizontal Hex";
-  public static final String SQUARE = "Square";
-  public static final String ISOMETRIC = "Isometric";
-  public static final String ISOMETRIC_HEX = "Isometric Hex";
-  public static final String NONE = "None";
-
-  public static Grid createGrid(String type) {
-    if (isHexVertical(type)) {
-      return new HexGridVertical();
-    }
-    if (isHexHorizontal(type)) {
-      return new HexGridHorizontal();
-    }
-    if (isSquare(type)) {
-      return new SquareGrid();
-    }
-    if (isIsometric(type)) {
-      return new IsometricGrid();
-    }
-    if (isNone(type)) {
-      return new GridlessGrid();
-    }
-    throw new IllegalArgumentException("Unknown grid type: " + type);
-  }
-
-  public static String getGridType(Grid grid) {
-    if (grid instanceof HexGridVertical) {
-      if (grid.isIsometric()) return ISOMETRIC_HEX;
-      return HEX_VERT;
-    }
-    if (grid instanceof HexGridHorizontal) {
-      return HEX_HORI;
-    }
-    if (grid instanceof SquareGrid) {
-      return SQUARE;
-    }
-    if (grid instanceof IsometricGrid) {
-      return ISOMETRIC;
-    }
-    if (grid instanceof GridlessGrid) {
-      return NONE;
-    }
-    throw new IllegalArgumentException("Don't know type of grid: " + grid.getClass().getName());
-  }
-
-  public static boolean isSquare(String gridType) {
-    return SQUARE.equals(gridType);
-  }
-
-  public static boolean isNone(String gridType) {
-    return NONE.equals(gridType);
-  }
-
-  public static boolean isHexVertical(String gridType) {
-    return HEX_VERT.equals(gridType);
-  }
-
-  public static boolean isHexHorizontal(String gridType) {
-    return HEX_HORI.equals(gridType);
-  }
-
-  public static boolean isIsometric(String gridType) {
-    return ISOMETRIC.equals(gridType);
-  }
-
-  public static boolean isIsometricHex(String gridType) {
-    return ISOMETRIC_HEX.equals(gridType);
+  public static Grid createGrid(GridType type) {
+    return switch (type) {
+      case Square -> new SquareGrid();
+      case Isometric -> new IsometricGrid();
+      case HexVertical -> new HexGridVertical();
+      case HexHorizontal -> new HexGridHorizontal();
+      case None -> new GridlessGrid();
+    };
   }
 }

--- a/src/main/java/net/rptools/maptool/model/GridlessGrid.java
+++ b/src/main/java/net/rptools/maptool/model/GridlessGrid.java
@@ -54,6 +54,11 @@ public class GridlessGrid extends Grid {
       };
 
   @Override
+  public GridType getType() {
+    return GridType.None;
+  }
+
+  @Override
   protected List<TokenFootprint> createFootprints() {
     return List.of(
         new TokenFootprint(new GUID("C0A80F0EBEFED0A20100000080800E0E"), "-11", false, 0.086),

--- a/src/main/java/net/rptools/maptool/model/HexGrid.java
+++ b/src/main/java/net/rptools/maptool/model/HexGrid.java
@@ -120,13 +120,8 @@ public abstract class HexGrid extends Grid {
     return edgeLength;
   }
 
-  @Override
-  public boolean isHex() {
-    return true;
-  }
-
-  public boolean isHexHorizontal() {
-    return false;
+  private boolean isHexHorizontal() {
+    return getType() == GridType.HexHorizontal;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridHorizontal.java
@@ -59,8 +59,8 @@ public class HexGridHorizontal extends HexGrid {
   private static final Map<Integer, Area> gridShapeCache = new ConcurrentHashMap<>();
 
   @Override
-  public boolean isHexHorizontal() {
-    return true;
+  public GridType getType() {
+    return GridType.HexHorizontal;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/HexGridVertical.java
+++ b/src/main/java/net/rptools/maptool/model/HexGridVertical.java
@@ -59,6 +59,11 @@ public class HexGridVertical extends HexGrid {
   private static final Map<Integer, Area> gridShapeCache = new ConcurrentHashMap<>();
 
   @Override
+  public GridType getType() {
+    return GridType.HexVertical;
+  }
+
+  @Override
   protected List<TokenFootprint> createFootprints() {
     return List.of(
         new TokenFootprint(new GUID("C0A80F0E0CB9FB560100000040A8090C"), "1/6", false, .408),

--- a/src/main/java/net/rptools/maptool/model/IsometricGrid.java
+++ b/src/main/java/net/rptools/maptool/model/IsometricGrid.java
@@ -43,8 +43,9 @@ public class IsometricGrid extends Grid {
   private static final BufferedImage pathHighlight =
       RessourceManager.getImage(Images.GRID_BORDER_ISOMETRIC);
 
-  public boolean isIsometric() {
-    return true;
+  @Override
+  public GridType getType() {
+    return GridType.Isometric;
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/model/SquareGrid.java
+++ b/src/main/java/net/rptools/maptool/model/SquareGrid.java
@@ -79,6 +79,11 @@ public class SquareGrid extends Grid {
       };
 
   @Override
+  public GridType getType() {
+    return GridType.Square;
+  }
+
+  @Override
   protected List<TokenFootprint> createFootprints() {
     return List.of(
         new TokenFootprint(

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -1573,7 +1573,7 @@ public class Token implements Cloneable {
     if (!isSnapToScale()) {
       w = getWidth() * scaleX;
       h = getHeight() * scaleY;
-      if (grid.isIsometric() && getShape() == Token.TokenShape.FIGURE) {
+      if (grid.getType().isIsometric() && getShape() == Token.TokenShape.FIGURE) {
         // Native size figure tokens need to follow iso rules
         h = (w / 2);
       }
@@ -1611,7 +1611,7 @@ public class Token implements Cloneable {
     if (!isSnapToScale()) {
       w = getWidth() * scaleX;
       h = getHeight() * scaleY;
-      if (grid.isIsometric() && getShape() == Token.TokenShape.FIGURE) {
+      if (grid.getType().isIsometric() && getShape() == Token.TokenShape.FIGURE) {
         // Native size figure tokens need to follow iso rules
         h = (w / 2);
       }
@@ -1751,7 +1751,7 @@ public class Token implements Cloneable {
 
         offsetX = footprintOffsetX / 2.0 - cellOffset.width * cellsX;
         offsetY = footprintOffsetY / 2.0 - cellOffset.height * cellsY;
-        if (grid.isHex() && "large".equalsIgnoreCase(footprint.getName())) {
+        if (grid.getType().isHex() && "large".equalsIgnoreCase(footprint.getName())) {
           // Merudo: not sure why this special case is needed.
           offsetX = offsetX - Math.min(grid.getCellWidth(), grid.getCellHeight()) / 2;
           offsetY = offsetY - Math.min(grid.getCellWidth(), grid.getCellHeight()) / 2;

--- a/src/main/java/net/rptools/maptool/model/ZoneFactory.java
+++ b/src/main/java/net/rptools/maptool/model/ZoneFactory.java
@@ -84,7 +84,8 @@ public class ZoneFactory {
     zone.setTokenVisionDistance(AppPreferences.defaultVisionDistance.get());
     zone.setVisionType(AppPreferences.defaultVisionType.get());
 
-    zone.setGrid(GridFactory.createGrid(AppPreferences.defaultGridType.get()));
+    zone.setGrid(
+        GridFactory.createGrid(Grid.GridType.fromString(AppPreferences.defaultGridType.get())));
     zone.setGridColor(AppPreferences.defaultGridColor.get().getRGB());
     zone.getGrid().setSize(AppPreferences.defaultGridSize.get());
     zone.getGrid().setOffset(0, 0);

--- a/src/main/java/net/rptools/maptool/util/ImageSupport.java
+++ b/src/main/java/net/rptools/maptool/util/ImageSupport.java
@@ -23,7 +23,6 @@ import net.rptools.lib.image.ImageUtil;
 import net.rptools.lib.image.RenderQuality;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.model.Grid;
-import net.rptools.maptool.model.GridFactory;
 import net.rptools.maptool.model.LookupTable;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.TokenFootprint;
@@ -102,7 +101,7 @@ public class ImageSupport {
       double fpW, fpH;
       // size:  multiply by zoom level to prevent multiple scaling ops which lose definition, i.e.
       // scale once
-      if (GridFactory.getGridType(grid).equals(GridFactory.NONE)) {
+      if (grid.getType().isNone()) {
         fpW = fpH = grid.getSize() * fpS * zoom; // all gridless are relative to the grid size
       } else {
         fpW = footprintBounds.getWidth() * fpS * zoom;
@@ -114,7 +113,7 @@ public class ImageSupport {
       // scale to fit image inside footprint bounds using the dimension that needs the most scaling,
       // i.e. lowest ratio
       double imageFootprintRatio;
-      if (token.getShape() == Token.TokenShape.FIGURE && grid.isIsometric()) {
+      if (token.getShape() == Token.TokenShape.FIGURE && grid.getType().isIsometric()) {
         imageFootprintRatio = fpW / imgW;
       } else {
         imageFootprintRatio = Math.min(fpW / imgW, fpH / imgH);

--- a/src/main/java/net/rptools/maptool/util/TokenUtil.java
+++ b/src/main/java/net/rptools/maptool/util/TokenUtil.java
@@ -43,7 +43,7 @@ public class TokenUtil {
   public static AffineTransform getRenderTransform(
       Zone zone, Token token, Dimension imageSize, Rectangle2D footprintBounds) {
     var isoFigure =
-        zone.getGrid().isIsometric()
+        zone.getGrid().getType().isIsometric()
             && !token.getIsFlippedIso()
             && token.getShape() == Token.TokenShape.FIGURE;
 
@@ -92,7 +92,7 @@ public class TokenUtil {
       }
 
       // Iso flip
-      if (token.getIsFlippedIso() && zone.getGrid().isIsometric()) {
+      if (token.getIsFlippedIso() && zone.getGrid().getType().isIsometric()) {
         imageTransform.scale(Math.sqrt(2), 1 / Math.sqrt(2));
         imageTransform.rotate(Math.toRadians(45));
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5857

### Description of the Change

Adds a new enum `GridType` that describe the kind of `Grid`. This makes a more convenient value type of communicating between different components, compared to the `String` constants that used to be used via `GridFactory`. The new `GridType` also has `#isHex()`, `#isIsometric()` and `#isNone()` to keep these common checks terse.

Despite being in the model package, there is no change to serialization.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Consolidated various internal checks for grid types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5858)
<!-- Reviewable:end -->
