### PR TITLE
Fix Discord invite for "Submit a Question" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-a-question.yml
+++ b/.github/ISSUE_TEMPLATE/submit-a-question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         *This should NOT be used for general questions on use of MapTool*
-        For user support, please post your question on the Forums: http://forums.rptools.net
+        For user support, please post your question on the Forums: https://forums.rptools.net
         Or on our Discord server: [Invite Link](https://discord.gg/dZy7HeYYVY)
         Or on Reddit: [r/MapTool](https://www.reddit.com/r/MapTool/)
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/submit-a-question.yml
+++ b/.github/ISSUE_TEMPLATE/submit-a-question.yml
@@ -8,7 +8,7 @@ body:
       value: |
         *This should NOT be used for general questions on use of MapTool*
         For user support, please post your question on the Forums: http://forums.rptools.net
-        Or on our Discord channel: [Invite Link](https://discord.gg/2FCwhZ9)
+        Or on our Discord server: [Invite Link](https://discord.gg/dZy7HeYYVY)
         Or on Reddit: [r/MapTool](https://www.reddit.com/r/MapTool/)
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/submit-a-question.yml
+++ b/.github/ISSUE_TEMPLATE/submit-a-question.yml
@@ -6,10 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        *This should NOT be used for general questions on use of MapTool*
-        For user support, please post your question on the Forums: https://forums.rptools.net
-        Or on our Discord server: [Invite Link](https://discord.gg/dZy7HeYYVY)
-        Or on Reddit: [r/MapTool](https://www.reddit.com/r/MapTool/)
+        > [!IMPORTANT]
+        > *This should NOT be used for general questions on use of MapTool*
+        >
+        > For user support, please post your question in one of these places:
+        > - [RPTools.net forums](https://forums.rptools.net)
+        > - [MapTool Discord server](https://discord.gg/dZy7HeYYVY)
+        > - [r/MapTool subreddit](https://www.reddit.com/r/MapTool/)
   - type: textarea
     attributes:
       label: Your Question


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5859

### Description of the Change

Changes the Discord invite to `dZy7HeYYVY` as is done everywhere else in this repo, and changes the forums link from `http` to `https`.

I also reworked the text to make it stand out more and have more consistent flow between the different linked resources.

Current:
<img width="599" height="173" alt="image" src="https://github.com/user-attachments/assets/7416132e-226c-4ff4-b92b-e3813c6e0ccf" />

New:
<img width="530" height="284" alt="image" src="https://github.com/user-attachments/assets/02e42b6a-456f-40e3-8a1e-596e3b7cbb5d" />

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5860)
<!-- Reviewable:end -->
