### PR TITLE
Replace deprecated function indentWithSpaces in gradle scripts

### DIFF
--- a/buildSrc/shared.gradle
+++ b/buildSrc/shared.gradle
@@ -30,7 +30,7 @@ spotless {
         // spotless has built-in rules for most basic formatting tasks
         trimTrailingWhitespace()
         // or spaces. Takes an integer argument if you don't like 4
-        indentWithSpaces(4)
+        leadingTabsToSpaces(4)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -221,4 +221,4 @@ javafx = { id = "org.openjfx.javafxplugin", version = "0.0.14" }
 jpackage-runtime = { id = "org.beryx.runtime", version = "1.13.1" }
 protobuf = { id = "com.google.protobuf", version = "0.9.5" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
-spotless = { id = "com.diffplug.spotless", version = "7.2.1" }
+spotless = { id = "com.diffplug.spotless", version = "8.0.0" }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5830

### Description of the Change

Change to the newer `leadingTabsToSpaces()` in spotless configuration.

Bump the spotless version up to 8.0.0 because why not.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5861)
<!-- Reviewable:end -->
