### PR TITLE
Remove reduced alpha from default D20 light sources

### DIFF
--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -364,7 +364,7 @@ public class CampaignProperties implements Serializable {
                 radius * 2,
                 0,
                 360,
-                new DrawableColorPaint(new Color(0, 0, 0, 100)),
+                new DrawableColorPaint(Color.black),
                 100,
                 false,
                 false)));

--- a/src/main/java/net/rptools/maptool/model/Light.java
+++ b/src/main/java/net/rptools/maptool/model/Light.java
@@ -14,11 +14,13 @@
  */
 package net.rptools.maptool.model;
 
+import java.awt.Color;
 import java.awt.geom.Area;
 import java.io.Serial;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
 import net.rptools.maptool.server.proto.LightDto;
 import net.rptools.maptool.server.proto.ShapeTypeDto;
@@ -58,6 +60,15 @@ public final class Light implements Serializable {
   @SuppressWarnings("ConstantConditions")
   @Serial
   private @Nonnull Object readResolve() {
+    // Prior to 1.19, the default D20 light sources had an alpha value of 0x64 instead of 0xff,
+    // despite users not being able to specify alpha and not changing how they are rendered. This
+    // can cause trouble when trying to manipulate colors on lights loaded from old campaigns.
+    var newPaint = paint;
+    if (paint instanceof DrawableColorPaint colorPaint) {
+      var opaqueColor = new Color(colorPaint.getColor(), false);
+      newPaint = new DrawableColorPaint(opaqueColor);
+    }
+
     // Rather than modifying the current object, we'll create a replacement that is definitely
     // initialized properly.
     return new Light(
@@ -66,7 +77,7 @@ public final class Light implements Serializable {
         radius,
         width,
         arcAngle,
-        paint,
+        newPaint,
         lumens == 0 ? 100 : lumens,
         isGM,
         ownerOnly);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5852

### Description of the Change

In the default D20 light sources, the color is now `Color.black` to ensure the alpha is set to `0xff` instead of `0x64`.

When loading old lights, any reduced alpha value is replaced with `0xff`.

This does not affect any current behaviour as light alpha does not affect rendering, and users cannot supply their own alpha in light source definitions.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5863)
<!-- Reviewable:end -->
