### PR TITLE
Fix resource library double install

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/AbeillePanel.java
+++ b/src/main/java/net/rptools/maptool/client/swing/AbeillePanel.java
@@ -169,10 +169,8 @@ public class AbeillePanel<T> extends JPanel {
    */
   public void bind(T model) {
     if (this.model != null) {
-      // Jamz: Don't like this; the bind/unbind on open/close tracking. Binding can get locked on an
-      // exception rendering the dialog in a broken state.
+      log.error("Panel is already bound. Unbinding the old model.");
       unbind();
-      throw new IllegalStateException("Already bound exception");
     }
     this.model = model;
     Binder.bindContainer(model.getClass(), panel, UpdateTime.NEVER);

--- a/src/main/java/net/rptools/maptool/client/swing/GenericDialog.java
+++ b/src/main/java/net/rptools/maptool/client/swing/GenericDialog.java
@@ -19,8 +19,6 @@ import com.jidesoft.swing.*;
 import com.jidesoft.utils.PortingUtils;
 import java.awt.*;
 import java.awt.event.*;
-import java.util.ArrayList;
-import java.util.List;
 import javax.swing.*;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.language.I18N;
@@ -28,15 +26,13 @@ import net.rptools.maptool.language.I18N;
 public class GenericDialog extends JDialog {
   public static final String AFFIRM = ButtonPanel.AFFIRMATIVE_BUTTON;
   public static final String DENY = ButtonPanel.CANCEL_BUTTON;
-  private Dimension _preferredSize = null;
   private boolean hasBeenShown;
   private String _dialogResult = ButtonPanel.CANCEL_BUTTON;
-  protected final Resizable _resizable;
+  private final Resizable _resizable;
   private final JComponent _contentPane = new JPanel();
   private JComponent _content = new JPanel();
   private final JScrollPane _scrollPane = new JScrollPane();
   private ScrollableButtonPanel _buttonPanel;
-  private boolean _usingAbeillePanel = false;
   private ActionListener _onCloseAction;
   private ActionListener _onShowAction;
 
@@ -227,7 +223,6 @@ public class GenericDialog extends JDialog {
 
   public void setContent(JComponent content) {
     this._content = content;
-    this._usingAbeillePanel = content instanceof AbeillePanel;
     this._scrollPane.setViewportView(content);
   }
 
@@ -259,24 +254,8 @@ public class GenericDialog extends JDialog {
         bounds.width - insets.left - insets.right, bounds.height - insets.top - insets.bottom);
   }
 
-  private List<Component> getAllComponents(Container c) {
-    List<Component> listOut = new ArrayList<>();
-    Component[] components = c.getComponents();
-    for (Component _c : components) {
-      listOut.add(_c);
-      if (_c instanceof Container c_) {
-        listOut.addAll(getAllComponents(c_));
-      }
-    }
-    return listOut;
-  }
-
   @Override
   public Dimension getPreferredSize() {
-    //    for (Component c : getAllComponents(this)) {
-    //      System.out.println(c.getName() + c.getPreferredSize());
-    //    }
-
     int scrollBarSize = UIManager.getDefaults().getInt("ScrollBar.width");
     Dimension frameSize = MapTool.getFrame().getSize();
     Dimension superPref = super.getPreferredSize();
@@ -355,12 +334,12 @@ public class GenericDialog extends JDialog {
   }
 
   public void closeDialog() {
-    if (this._usingAbeillePanel && ((AbeillePanel<?>) this._content).getModel() != null) {
+    if (this._content instanceof AbeillePanel<?> abeillePanel && abeillePanel.getModel() != null) {
       // wrap up any AbeillePanel commits and unbinding
       if (this.getDialogResult().equals(AFFIRM)) {
-        ((AbeillePanel<?>) _content).commit();
+        abeillePanel.commit();
       }
-      ((AbeillePanel<?>) _content).unbind();
+      abeillePanel.unbind();
     }
     // set off the onCloseAction if present
     if (this._onCloseAction != null) {

--- a/src/main/java/net/rptools/maptool/client/swing/GenericDialogFactory.java
+++ b/src/main/java/net/rptools/maptool/client/swing/GenericDialogFactory.java
@@ -19,23 +19,21 @@ import java.awt.event.ActionListener;
 import javax.swing.*;
 
 public class GenericDialogFactory {
-  GenericDialog delegate;
-
-  public GenericDialog getDialog() {
-    return delegate;
-  }
+  private final GenericDialog delegate;
 
   public GenericDialogFactory() {
     delegate = new GenericDialog();
   }
 
-  @SuppressWarnings("UnusedReturnValue")
+  public GenericDialog getDialog() {
+    return delegate;
+  }
+
   public GenericDialogFactory setDefaultButton(ButtonKind buttonKind) {
     delegate.setDefaultButton(buttonKind);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addButton(
       AbstractButton b, ActionListener l, Object constraints, int index) {
     b.addActionListener(l);
@@ -43,38 +41,31 @@ public class GenericDialogFactory {
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addButton(AbstractButton b, ActionListener l, Object constraints) {
     return addButton(b, l, constraints, -1);
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addNonButton(Component c, Object constraints, int index) {
     delegate.addNonButton(c, constraints, index);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addNonButton(Component c, Object constraints) {
     return addNonButton(c, constraints, -1);
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addButton(ButtonKind buttonKind) {
     return addButton(buttonKind, null, null);
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addButton(ButtonKind buttonKind, Action action) {
     return addButton(buttonKind, action, null);
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addButton(ButtonKind buttonKind, ActionListener listener) {
     return addButton(buttonKind, null, listener);
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory addButton(
       ButtonKind buttonKind, Action action, ActionListener listener) {
     delegate.addButton(buttonKind, action, listener);
@@ -89,67 +80,56 @@ public class GenericDialogFactory {
     return delegate.getButtonPanel().getOppositeButtonOrder();
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory setButtonOrder(String buttonOrder) {
     delegate.setButtonOrder(buttonOrder);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory setOppositeButtonOrder(String buttonOrder) {
     delegate.setOppositeButtonOrder(buttonOrder);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory makeModal(boolean modal) {
     delegate.setModal(modal);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory setCloseOperation(int closeOperation) {
     delegate.setDefaultCloseOperation(closeOperation);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory createOkCancelButtons() {
     delegate.createOkCancelButtons();
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory onBeforeShow(ActionListener listener) {
     delegate.onBeforeShow(listener);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory onBeforeClose(ActionListener listener) {
     delegate.onBeforeClose(listener);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory setDialogTitle(String title) {
     delegate.setTitle(title);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory setContent(JComponent content) {
     delegate.setContent(content);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory setDialogResult(String string) {
     delegate.setDialogResult(string);
     return this;
   }
 
-  @SuppressWarnings("UnusedReturnValue")
   public GenericDialogFactory display() {
     delegate.showDialog();
     return this;

--- a/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialog.java
@@ -48,8 +48,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
-  private static final long serialVersionUID = -1709712124453405062L;
-
   private static final Logger log = LogManager.getLogger(AddResourceDialog.class);
 
   private static final String LIBRARY_URL = "http://library.rptools.net/1.3";
@@ -66,10 +64,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
           .setDialogTitle(I18N.getText("action.addIconSelector"))
           .addButton(ButtonKind.CANCEL)
           .setCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-  private Model model;
   private boolean downloadLibraryListInitiated;
-
-  private boolean install = false;
 
   public AddResourceDialog() {
     super(new AddRessourcesDialogView().getRootComponent());
@@ -77,30 +72,13 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
     panelInit();
     dialogFactory
         .setContent(this)
-        .addButton(
-            ButtonKind.INSTALL,
-            e -> {
-              install = true;
-              if (commit()) {
-                dialogFactory.getDialog().closeDialog();
-              }
-            })
+        .addButton(ButtonKind.INSTALL)
         .setDefaultButton(ButtonKind.INSTALL);
   }
 
-  public boolean getInstall() {
-    return install;
-  }
-
   public void showDialog() {
-    model = new Model();
-    bind(model);
+    bind(new Model());
     dialogFactory.display();
-  }
-
-  @Override
-  public Model getModel() {
-    return model;
   }
 
   public JTextField getBrowseTextField() {
@@ -132,6 +110,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
         .addChangeListener(
             e -> {
               // Hmmm, this is fragile (breaks if the order changes) rethink this later
+              var model = getModel();
               switch (tabPane.getSelectedIndex()) {
                 case 0 -> model.tab = Tab.LOCAL;
                 case 1 -> model.tab = Tab.WEB;
@@ -196,6 +175,7 @@ public class AddResourceDialog extends AbeillePanel<AddResourceDialog.Model> {
     // Add the resource
     final List<LibraryRow> rowList = new ArrayList<>();
 
+    var model = getModel();
     switch (model.getTab()) {
       case LOCAL -> {
         if (StringUtils.isEmpty(model.getLocalDirectory())) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5865

### Description of the Change

Removes the `ButtonKind.INSTALL` listener from `AddResourceDialog` since its `GenericDialog` will automatically call `commit()` for us when the dialog is approvingly closed. Doing so in a listener as well causes the redundant installation.

Also did some minor clean up in `GenericDialog` and `GenericDialogFactory` to remove unused code and improve encapsulation.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where MapTool would try to install resource libraries twice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5866)
<!-- Reviewable:end -->
