### PR TITLE
Fix for partial commits in Edit Table

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/GenericDialog.java
+++ b/src/main/java/net/rptools/maptool/client/swing/GenericDialog.java
@@ -337,7 +337,10 @@ public class GenericDialog extends JDialog {
     if (this._content instanceof AbeillePanel<?> abeillePanel && abeillePanel.getModel() != null) {
       // wrap up any AbeillePanel commits and unbinding
       if (this.getDialogResult().equals(AFFIRM)) {
-        abeillePanel.commit();
+        if (!abeillePanel.commit()) {
+          // Do not close the dialog since validation failed.
+          return;
+        }
       }
       abeillePanel.unbind();
     }

--- a/src/main/java/net/rptools/maptool/client/ui/lookuptable/EditLookupTablePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/lookuptable/EditLookupTablePanel.java
@@ -222,52 +222,64 @@ public class EditLookupTablePanel extends AbeillePanel<LookupTable> {
       MapTool.showError(I18N.getText("EditLookupTablePanel.error.invalidSize", name));
       return false;
     }
+    var isPickOnce = view.getPickOnce().isSelected();
+
+    // Before modifying the table, parse and validate all the entries to avoid partial modification
+    // in case of error.
+    var entries = new ArrayList<LookupTable.LookupEntry>();
+    for (int i = 0; i < tableModel.getRowCount(); i++) {
+      var row = tableModel.getRowAt(i);
+      if (row.range.isEmpty()) {
+        continue;
+      }
+
+      int min;
+      int max;
+      // Allow negative numbers
+      int split = row.range.indexOf('-', row.range.charAt(0) == '-' ? 1 : 0);
+      try {
+        if (split < 0) {
+          min = Integer.parseInt(row.range);
+          max = min;
+        } else {
+          min = Integer.parseInt(row.range.substring(0, split).trim());
+          max = Integer.parseInt(row.range.substring(split + 1).trim());
+        }
+      } catch (NumberFormatException nfe) {
+        MapTool.showError(I18N.getText("EditLookupTablePanel.error.badRange", name, row.range, i));
+        return false;
+      }
+
+      MD5Key image = null;
+      if (row.imageId != null && !row.imageId.isEmpty()) {
+        image = new MD5Key(row.imageId);
+        MapToolUtil.uploadAsset(AssetManager.getAsset(image));
+      }
+
+      var entry = new LookupEntry(min, max, row.value, image);
+      if (isPickOnce) {
+        entry.setPicked(row.picked);
+      }
+      entries.add(entry);
+    }
 
     // save existing name for later removal from LookupTableMap
     String origname = lookupTable.getName();
     lookupTable.setName(name);
-    lookupTable.setPickOnce(view.getPickOnce().isSelected());
-    lookupTable.setRoll(lookupTable.getPickOnce() ? null : view.getDefaultTableRoll().getText());
+    lookupTable.setPickOnce(isPickOnce);
+    lookupTable.setRoll(isPickOnce ? null : view.getDefaultTableRoll().getText());
     lookupTable.setTableImage(tableImageAssetPanel.getImageId());
     lookupTable.setVisible(view.getIsVisible().isSelected());
     lookupTable.setAllowLookup(view.getAllowLookup().isSelected());
+
     lookupTable.clearEntries();
-    for (int i = 0; i < tableModel.getRowCount(); i++) {
-      var row = tableModel.getRowAt(i);
-
-      String range = row.range;
-      if (range.isEmpty()) {
-        continue;
-      }
-      String value = row.value;
-      String imageId = row.imageId;
-      boolean picked = row.picked;
-
-      int min;
-      int max;
-      int split = range.indexOf('-', range.charAt(0) == '-' ? 1 : 0); // Allow negative numbers
-      try {
-        if (split < 0) {
-          min = Integer.parseInt(range);
-          max = min;
-        } else {
-          min = Integer.parseInt(range.substring(0, split).trim());
-          max = Integer.parseInt(range.substring(split + 1).trim());
-        }
-      } catch (NumberFormatException nfe) {
-        MapTool.showError(I18N.getText("EditLookupTablePanel.error.badRange", name, range, i));
-        return false;
-      }
-      MD5Key image = null;
-      if (imageId != null && !imageId.isEmpty()) {
-        image = new MD5Key(imageId);
-        MapToolUtil.uploadAsset(AssetManager.getAsset(image));
-      }
-      var entry = lookupTable.addEntry(min, max, value, image);
-      if (lookupTable.getPickOnce()) {
-        entry.setPicked(picked);
-      }
+    for (var entry : entries) {
+      var copy =
+          lookupTable.addEntry(
+              entry.getMin(), entry.getMax(), entry.getValue(), entry.getImageId());
+      copy.setPicked(entry.getPicked());
     }
+
     if (!name.equals(origname)) {
       // New name is not the same as the existing name
       MapTool.getCampaign().getLookupTableMap().remove(origname);


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5869

### Description of the Change

Changes how the **New Table** / **Edit Table** commits the entries to a `LookupTable`. All entries are now parsed prior to any modification of the `LookupTable`, stored in a list for later consumption. Only once all validations are completed are any table properties modified or entries added.

Also fixes an issue where `GenericDialog` would ignore the result of `AbeillePanel#commit()`. This caused a problem where dialogs with validation errors would close themselves after the user dismissed the validation error modal. So far this has only affected the **Edit Token** and **Add Resource** dialogs in development builds. Other dialogs do not yet take full advantage of `GenericDialog` and have to handle the commit failures explicitly, so they do not have this issue.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where canceling the Edit Token dialog after a validation error would result in table data being lost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5874)
<!-- Reviewable:end -->
