### PR TITLE
Fix priority when multiple table entries match

### DIFF
--- a/src/main/java/net/rptools/maptool/model/LookupTable.java
+++ b/src/main/java/net/rptools/maptool/model/LookupTable.java
@@ -106,7 +106,7 @@ public class LookupTable {
   public @Nullable LookupEntry getEntryByRollResult(int rollResult) {
     // For now this is a linear scan. In the future hopefully we can use some kind of accelerated
     // search.
-    for (var entry : entryList) {
+    for (var entry : entryList.reversed()) {
       if (entry.min <= rollResult && rollResult <= entry.max) {
         return entry;
       }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes new bug introduced by #5822 for #4769

### Description of the Change

Up until MapTool 1.18, when multiple table entries match a roll, the last one would be returned despite the list being iterated front to back. My recent change inverted this so that the first match would be returned.

This PR brings back the original behaviour by iterating the list in reverse while keeping the early exit once a match is found.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5875)
<!-- Reviewable:end -->
