### PR TITLE
Remove JIDE's banner from JOptionPane

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1268,26 +1268,16 @@ public class MapTool {
           ThemePainter painter = (ThemePainter) UIDefaultsLookup.get("Theme.painter");
           defaults.put("OptionPaneUI", "com.jidesoft.plaf.basic.BasicJideOptionPaneUI");
 
-          defaults.put("OptionPane.showBanner", Boolean.TRUE); // show banner or not. default
-          // is true
+          // show banner or not. default is true
+          defaults.put("OptionPane.showBanner", Boolean.FALSE);
           defaults.put("OptionPane.bannerIcon", RessourceManager.getSmallIcon(Icons.MAPTOOL));
           defaults.put("OptionPane.bannerFontSize", 13);
           defaults.put("OptionPane.bannerFontStyle", Font.BOLD);
           defaults.put("OptionPane.bannerMaxCharsPerLine", 60);
+          // you should adjust this if banner background is not the default gradient paint
           defaults.put(
               "OptionPane.bannerForeground",
-              painter != null ? painter.getOptionPaneBannerForeground() : null); // you
-          // should
-          // adjust
-          // this
-          // if
-          // banner
-          // background
-          // is
-          // not
-          // the
-          // default
-          // gradient paint
+              painter != null ? painter.getOptionPaneBannerForeground() : null);
           defaults.put("OptionPane.bannerBorder", null); // use default border
 
           // set both bannerBackgroundDk and bannerBackgroundLt to null if you don't want
@@ -1298,8 +1288,8 @@ public class MapTool {
           defaults.put(
               "OptionPane.bannerBackgroundLt",
               painter != null ? painter.getOptionPaneBannerLt() : null);
-          defaults.put("OptionPane.bannerBackgroundDirection", Boolean.TRUE); // default is
-          // true
+          // default is true
+          defaults.put("OptionPane.bannerBackgroundDirection", Boolean.TRUE);
 
           // optionally, you can set a Paint object for BannerPanel. If so, the three
           // UIDefaults

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -70,7 +70,7 @@ public class MapToolEventQueue extends EventQueue {
       jta.setWrapStyleWord(true);
       jta.setMargin(new Insets(5, 10, 10, 10));
       optionPane.setDetails(jta);
-      displayPopup();
+      displayPopup(optionPane);
       reportToSentryIO(soe);
     } catch (Throwable t) {
       log.error(t, t);
@@ -78,7 +78,7 @@ public class MapToolEventQueue extends EventQueue {
       optionPane.setTitle(I18N.getString("MapToolEventQueue.unexpectedError")); // $NON-NLS-1$
       optionPane.setDetails(toString(t));
       try {
-        displayPopup();
+        displayPopup(optionPane);
         reportToSentryIO(t);
       } catch (Throwable thrown) {
         // Displaying the error message using the JideOptionPane has just failed. Fallback to
@@ -109,11 +109,9 @@ public class MapToolEventQueue extends EventQueue {
     return optionPane;
   }
 
-  private static void displayPopup() {
+  private static void displayPopup(JideOptionPane optionPane) {
     optionPane.setDetailsVisible(true);
-    JDialog dialog =
-        optionPane.createDialog(
-            MapTool.getFrame(), I18N.getString("MapToolEventQueue.warning.title")); // $NON-NLS-1$
+    JDialog dialog = optionPane.createDialog(MapTool.getFrame(), optionPane.getTitle().toString());
     dialog.setResizable(true);
     dialog.pack();
     dialog.setVisible(true);


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5876

### Description of the Change

Changes JIDE's `OptionPaneUI` settings to disable the banner.

For the one dialog that used it ("unexpected error"), the banner text is now used as the dialog title.

### Possible Drawbacks

Less flashy appearance

### Documentation Notes

N/A

### Release Notes

- Removed the blue banner present in several dialogs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5881)
<!-- Reviewable:end -->
