### PR TITLE
Add "Check for Updates" help menu item

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -30,6 +30,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
@@ -41,7 +43,9 @@ import javax.swing.*;
 import javax.swing.text.BadLocationException;
 import net.rptools.lib.FileUtil;
 import net.rptools.lib.MD5Key;
+import net.rptools.lib.ModelVersionManager;
 import net.rptools.lib.OsDetection;
+import net.rptools.maptool.client.AppUpdate.ReleaseInfo;
 import net.rptools.maptool.client.swing.GenericDialog;
 import net.rptools.maptool.client.swing.SwingUtil;
 import net.rptools.maptool.client.tool.FacingTool;
@@ -86,6 +90,7 @@ import net.rptools.maptool.util.*;
 import net.rptools.maptool.util.PersistenceUtil.PersistedCampaign;
 import net.rptools.maptool.util.PersistenceUtil.PersistedMap;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -3241,6 +3246,79 @@ public class AppActions {
     @Override
     protected void executeAction() {
       MapTool.showDocument(url);
+    }
+  }
+
+  public static class CheckForUpdatesAction extends TranslatedClientAction {
+    public CheckForUpdatesAction() {
+      super("action.helpurl.checkForUpdates");
+    }
+
+    @Override
+    protected void executeAction() {
+      Object[] options = {I18N.getText("Button.cancel")};
+      var optionPane =
+          new JOptionPane(
+              I18N.getText("Update.checking.message"),
+              JOptionPane.PLAIN_MESSAGE,
+              JOptionPane.DEFAULT_OPTION,
+              null,
+              options,
+              options[0]);
+      var dialog =
+          optionPane.createDialog(MapTool.getFrame(), I18N.getText("Update.checking.title"));
+      dialog.pack();
+
+      var worker =
+          AppUpdate.getLatestRelease()
+              .thenApplyAsync(
+                  r -> {
+                    dialog.setVisible(false);
+                    dialog.dispose();
+                    return r;
+                  },
+                  SwingUtilities::invokeLater)
+              .toCompletableFuture();
+
+      // Blocks
+      dialog.setVisible(true);
+      // In case it is still running.
+      worker.cancel(true);
+
+      if (!optionPane.getValue().equals(JOptionPane.UNINITIALIZED_VALUE)) {
+        // The user canceled rather than the worker closing the dialog.
+        return;
+      }
+
+      Optional<ReleaseInfo> release;
+      try {
+        release = worker.get();
+      } catch (CancellationException | InterruptedException e) {
+        log.info("Cancelled update check", e);
+        release = Optional.empty();
+      } catch (ExecutionException e) {
+        log.warn("Failed to find latest release", e);
+        release = Optional.empty();
+      }
+
+      release
+          .filter(
+              r -> {
+                String runningVersion = AppUpdate.getImplementationVersion();
+                // If we can't find a current version, give the user a chance to install
+                // anyways. Only skip if the latest version is not newer than the current.
+                return StringUtils.isBlank(runningVersion)
+                    || ModelVersionManager.isBefore(runningVersion, r.version());
+              })
+          .ifPresentOrElse(
+              r -> {
+                if (AppUpdate.confirmUpdate(r, false)) {
+                  AppUpdate.downloadFile(r.assetUrl(), r.assetSize());
+                }
+              },
+              () ->
+                  JOptionPane.showMessageDialog(
+                      MapTool.getFrame(), I18N.getText("Update.noNewerRelease")));
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -19,10 +19,8 @@ import java.io.*;
 import java.net.*;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.*;
@@ -115,66 +113,50 @@ public class AppUpdate {
 
   /**
    * Look for a newer version of MapTool. If a newer release is found and the AppPreferences tell us
-   * the update should not be ignored, give a prompt to update.
+   * the update should not be ignored, return the information for the release.
    *
-   * @return has an update been made
+   * @return The release information for the latest release, if it is newer. If there is no newer
+   *     release, {@code Optional.empty()}.
    */
-  public static boolean gitHubReleases() {
-    if (MapTool.isDevelopment() || AppPreferences.skipAutoUpdate.get()) {
-      return false;
+  public static CompletionStage<Optional<ReleaseInfo>> autoUpdateCheck() {
+    if (MapTool.isDevelopment()) {
+      log.info("Development build. Skipping update check");
+      return CompletableFuture.completedStage(Optional.empty());
+    }
+    if (AppPreferences.skipAutoUpdate.get()) {
+      log.info("Automatic updates have been disabled via preferences. Skipping update check");
+      return CompletableFuture.completedStage(Optional.empty());
     }
 
     String runningVersion = getImplementationVersion();
     if (StringUtils.isBlank(runningVersion)) {
       log.info("Blank implementation version detected, not checking for updates.");
-      return false;
+      return CompletableFuture.completedStage(Optional.empty());
     }
 
-    var future =
-        getLatestRelease()
-            .thenApply(
-                latestReleaseOptional -> {
-                  if (latestReleaseOptional.isEmpty()) {
-                    log.info("Did not find a latest release asset");
-                    return Optional.<ReleaseInfo>empty();
-                  }
+    return getLatestRelease()
+        .thenApply(
+            latestReleaseOptional -> {
+              if (latestReleaseOptional.isEmpty()) {
+                log.info("Did not find a latest release asset");
+                return Optional.empty();
+              }
 
-                  var latestRelease = latestReleaseOptional.get();
-                  if (AppPreferences.skipAutoUpdateRelease.get().equals(latestRelease.id())) {
-                    log.info("Release {} skipped by user request", latestRelease.version());
-                    return Optional.<ReleaseInfo>empty();
-                  }
-                  if (!ModelVersionManager.isBefore(runningVersion, latestRelease.version())) {
-                    log.info(
-                        "Skipping release {} as it is not newer than the current version {}",
-                        latestRelease.version(),
-                        runningVersion);
-                    return Optional.<ReleaseInfo>empty();
-                  }
+              var latestRelease = latestReleaseOptional.get();
+              if (AppPreferences.skipAutoUpdateRelease.get().equals(latestRelease.id())) {
+                log.info("Release {} skipped by user request", latestRelease.version());
+                return Optional.empty();
+              }
+              if (!ModelVersionManager.isBefore(runningVersion, latestRelease.version())) {
+                log.info(
+                    "Skipping release {} as it is not newer than the current version {}",
+                    latestRelease.version(),
+                    runningVersion);
+                return Optional.empty();
+              }
 
-                  return latestReleaseOptional;
-                })
-            .toCompletableFuture();
-
-    try {
-      var optional = future.get();
-      if (optional.isPresent()) {
-        // Ask the user if we should download it.
-        var latestRelease = optional.get();
-        if (confirmUpdate(optional.get(), true)) {
-          downloadFile(latestRelease.assetUrl(), latestRelease.assetSize());
-        }
-        return true;
-      } else {
-        return false;
-      }
-    } catch (CancellationException | InterruptedException e) {
-      log.info("Cancelled update check", e);
-      return false;
-    } catch (ExecutionException e) {
-      log.warn("Failed to find latest release", e);
-      return false;
-    }
+              return latestReleaseOptional;
+            });
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -19,6 +19,12 @@ import java.io.*;
 import java.net.*;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.*;
 import javax.swing.*;
 import net.rptools.lib.ModelVersionManager;
@@ -37,6 +43,76 @@ public class AppUpdate {
 
   private static final String GIT_HUB_LATEST_RELEASE = "github.api.releases.latest";
 
+  public record ReleaseInfo(String id, String version, URL assetUrl, long assetSize) {}
+
+  public static CompletionStage<Optional<ReleaseInfo>> getLatestRelease() {
+    return getLatestReleaseJson()
+        .thenApply(
+            latestRelease -> {
+              if (!latestRelease.has("id") || !latestRelease.has("tag_name")) {
+                throw new RuntimeException(
+                    "Github payload missing required fields. Aborting update check.");
+              }
+
+              String latestReleaseId = latestRelease.get("id").getAsString();
+              String latestReleaseVersion = latestRelease.get("tag_name").getAsString();
+              if (StringUtils.isBlank(latestReleaseVersion)) {
+                throw new RuntimeException(
+                    "Unable to detect latest version from GitHub payload. Aborting comparison.");
+              }
+
+              // Look for the default extension for each platform.
+              // Ideally, we could even detect the current installation method and find a matching
+              // asset, but for now we just hardcode one option for each platform.
+              String downloadExtension;
+              if (OsDetection.WINDOWS) {
+                downloadExtension = ".exe";
+              } else if (OsDetection.MAC_OS_X) {
+                downloadExtension = ".pkg";
+              } else {
+                downloadExtension = ".deb";
+              }
+
+              JsonArray releaseAssets = latestRelease.get("assets").getAsJsonArray();
+              for (JsonElement elem : releaseAssets) {
+                JsonObject asset = elem.getAsJsonObject();
+                if (!asset.has("name")) {
+                  continue;
+                }
+
+                String assetName = asset.get("name").getAsString();
+                log.info("Asset: {}", assetName);
+
+                if (!assetName.toLowerCase().endsWith(downloadExtension)) {
+                  continue;
+                }
+
+                JsonElement assetDownloadElem = asset.get("browser_download_url");
+                JsonElement assetSizeElem = asset.get("size");
+                if (assetDownloadElem == null || assetSizeElem == null) {
+                  continue;
+                }
+
+                String assetDownloadURL = assetDownloadElem.getAsString();
+                final long assetDownloadSize = assetSizeElem.getAsLong();
+                log.info("Download URL: {}", assetDownloadURL);
+
+                URL url;
+                try {
+                  url = new URI(assetDownloadURL).toURL();
+                } catch (URISyntaxException | MalformedURLException e) {
+                  log.warn("Invalid asset download URL.", e);
+                  continue;
+                }
+
+                return Optional.of(
+                    new ReleaseInfo(latestReleaseId, latestReleaseVersion, url, assetDownloadSize));
+              }
+
+              return Optional.empty();
+            });
+  }
+
   /**
    * Look for a newer version of MapTool. If a newer release is found and the AppPreferences tell us
    * the update should not be ignored, give a prompt to update.
@@ -48,121 +124,96 @@ public class AppUpdate {
       return false;
     }
 
-    // Default for Linux?
-    String DOWNLOAD_EXTENSION = ".deb";
-
-    if (OsDetection.WINDOWS) DOWNLOAD_EXTENSION = ".exe";
-    else if (OsDetection.MAC_OS_X) DOWNLOAD_EXTENSION = ".pkg"; // Better default than .dmg?
-
     String runningVersion = getImplementationVersion();
     if (StringUtils.isBlank(runningVersion)) {
       log.info("Blank implementation version detected, not checking for updates.");
       return false;
     }
 
-    Optional<JsonObject> latestReleaseOpt = getLatestReleaseInfo();
-    if (latestReleaseOpt.isEmpty()) return false;
-    JsonObject latestRelease = latestReleaseOpt.get();
-    if (!latestRelease.has("id") || !latestRelease.has("tag_name")) {
-      log.info("Github payload missing required fields??? Aborting update check.");
-      return false;
-    }
-    String latestReleaseId = latestRelease.get("id").getAsString();
-    String latestReleaseVersion = latestRelease.get("tag_name").getAsString();
-    if (StringUtils.isBlank(latestReleaseVersion)) {
-      log.info("Unable to detect latest version from GitHub payload, aborting comparison.");
-      return false;
-    }
+    var future =
+        getLatestRelease()
+            .thenApply(
+                latestReleaseOptional -> {
+                  if (latestReleaseOptional.isEmpty()) {
+                    log.info("Did not find a latest release asset");
+                    return Optional.<ReleaseInfo>empty();
+                  }
 
-    if (!AppPreferences.skipAutoUpdateRelease.get().equals(latestReleaseId)
-        && ModelVersionManager.isBefore(runningVersion, latestReleaseVersion)) {
-      JsonArray releaseAssets = latestRelease.get("assets").getAsJsonArray();
+                  var latestRelease = latestReleaseOptional.get();
+                  if (AppPreferences.skipAutoUpdateRelease.get().equals(latestRelease.id())) {
+                    log.info("Release {} skipped by user request", latestRelease.version());
+                    return Optional.<ReleaseInfo>empty();
+                  }
+                  if (!ModelVersionManager.isBefore(runningVersion, latestRelease.version())) {
+                    log.info(
+                        "Skipping release {} as it is not newer than the current version {}",
+                        latestRelease.version(),
+                        runningVersion);
+                    return Optional.<ReleaseInfo>empty();
+                  }
 
-      for (JsonElement elem : releaseAssets) {
-        JsonObject asset = elem.getAsJsonObject();
-        String assetName = asset.get("name").getAsString();
-        log.info("Asset: {}", assetName);
+                  return latestReleaseOptional;
+                })
+            .toCompletableFuture();
 
-        if (assetName.toLowerCase().endsWith(DOWNLOAD_EXTENSION)) {
-          JsonElement assetDownloadElem = asset.get("browser_download_url");
-          JsonElement assetSizeElem = asset.get("size");
-          if (assetDownloadElem != null && assetSizeElem != null) {
-            String assetDownloadURL = assetDownloadElem.getAsString();
-            final long assetDownloadSize = assetSizeElem.getAsLong();
-            log.info("Download URL: {}", assetDownloadURL);
-            try {
-              URL url = new URL(assetDownloadURL);
-              SwingUtilities.invokeLater(
-                  () -> {
-                    if (showMessage(latestReleaseId, latestReleaseVersion))
-                      downloadFile(url, assetDownloadSize);
-                  });
-            } catch (MalformedURLException e) {
-              log.error("Error with download URL.", e);
-            }
-            return true;
-          }
+    try {
+      var optional = future.get();
+      if (optional.isPresent()) {
+        // Ask the user if we should download it.
+        var latestRelease = optional.get();
+        if (confirmUpdate(optional.get(), true)) {
+          downloadFile(latestRelease.assetUrl(), latestRelease.assetSize());
         }
+        return true;
+      } else {
+        return false;
       }
+    } catch (CancellationException | InterruptedException e) {
+      log.info("Cancelled update check", e);
+      return false;
+    } catch (ExecutionException e) {
+      log.warn("Failed to find latest release", e);
+      return false;
     }
-
-    return false;
   }
 
   /**
-   * Get the release info from the GitHub /releases/latest endpoint. The GitHub API docs define
-   * "latest" as:
+   * Get the release info from the GitHub {@code /releases/latest} endpoint. The GitHub API docs
+   * define "latest" as:
    *
    * <blockquote>
    *
-   * ...the most recent non-prerelease, no-draft release, sorted by the `created_at` attribute. The
-   * `created_at` attribute is the date of the commit used for the release, and not the date when
-   * the release was drafted or published.
+   * … the most recent non-prerelease, non-draft release, sorted by the {@code created_at}
+   * attribute. The {@code created_at} attribute is the date of the commit used for the release, and
+   * not the date when the release was drafted or published.
    *
    * </blockquote>
    *
    * @return a JsonObject representing the latest release, if one could be retrieved
    */
-  private static Optional<JsonObject> getLatestReleaseInfo() {
-    String strURL = getProperty(GIT_HUB_LATEST_RELEASE);
-    try {
-      Request request = new Request.Builder().url(strURL).build();
-      Response response = new OkHttpClient().newCall(request).execute();
-      String bodyStr = response.body().string();
-      return Optional.of(JsonParser.parseString(bodyStr).getAsJsonObject());
-    } catch (IOException e) {
-      log.error("Unable to reach {}: {}", strURL, e.getLocalizedMessage());
-      return Optional.empty();
-    } catch (IllegalStateException e1) {
-      log.error("Error parsing JSON response from releases/latest.", e1);
-      return Optional.empty();
-    }
-  }
-
-  /**
-   * Get the latest commit SHA from MANIFEST.MF
-   *
-   * @return the String of the commit SHA, or null if IOException
-   */
-  @Deprecated
-  public static String getCommitSHA() {
-    String jarCommit = "";
-
-    ClassLoader cl = MapTool.class.getClassLoader();
-
-    try {
-      URL url = cl.getResource("META-INF/MANIFEST.MF");
-      Manifest manifest = new Manifest(url.openStream());
-
-      Attributes attr = manifest.getMainAttributes();
-      jarCommit = attr.getValue("Git-Commit-SHA");
-      log.info("Git-Commit-SHA from Manifest: " + jarCommit);
-    } catch (IOException e) {
-      log.error("No Git-Commit-SHA attribute found in MANIFEST.MF, skip looking for updates...", e);
-      return null;
-    }
-
-    return jarCommit;
+  private static CompletionStage<JsonObject> getLatestReleaseJson() {
+    var future = new CompletableFuture<JsonObject>();
+    ForkJoinPool.commonPool()
+        .submit(
+            () -> {
+              String strURL = getProperty(GIT_HUB_LATEST_RELEASE);
+              try {
+                Request request = new Request.Builder().url(strURL).build();
+                Response response = new OkHttpClient().newCall(request).execute();
+                String bodyStr = response.body().string();
+                future.complete(JsonParser.parseString(bodyStr).getAsJsonObject());
+              } catch (IOException e) {
+                log.error("Unable to reach {}", strURL, e);
+                future.completeExceptionally(e);
+              } catch (IllegalStateException e) {
+                log.error("Error parsing JSON response from releases/latest.", e);
+                future.completeExceptionally(e);
+              } catch (Throwable e) {
+                log.error("Unexpected error while getting release info", e);
+                future.completeExceptionally(e);
+              }
+            });
+    return future.orTimeout(5, TimeUnit.SECONDS);
   }
 
   /**
@@ -193,18 +244,28 @@ public class AppUpdate {
     return version;
   }
 
-  private static boolean showMessage(String releaseId, String tagName) {
-    JCheckBox dontAskCheckbox = new JCheckBox(I18N.getText("Update.chkbox"));
+  public static boolean confirmUpdate(ReleaseInfo releaseInfo, boolean showSkipOptions) {
+    String releaseId = releaseInfo.id();
+    String tagName = releaseInfo.version();
 
     String title = I18N.getText("Update.title");
     String msg1 = I18N.getText("Update.msg1");
     String msg2 = I18N.getText("Update.msg2", tagName);
-    String blankLine = " ";
 
-    Object[] msgContent = {msg1, msg2, blankLine, dontAskCheckbox};
-    Object[] options = {
-      I18N.getText("Button.yes"), I18N.getText("Button.no"), I18N.getText("Update.button")
-    };
+    JCheckBox dontAskCheckbox = new JCheckBox(I18N.getText("Update.chkbox"));
+
+    Object[] msgContent, options;
+    if (showSkipOptions) {
+      msgContent = new Object[] {msg1, msg2, "", dontAskCheckbox};
+      options =
+          new Object[] {
+            I18N.getText("Button.yes"), I18N.getText("Button.no"), I18N.getText("Update.button")
+          };
+    } else {
+      msgContent = new Object[] {msg1, msg2, ""};
+      options = new Object[] {I18N.getText("Button.yes"), I18N.getText("Button.no")};
+    }
+
     int result =
         JOptionPane.showOptionDialog(
             MapTool.getFrame(),
@@ -217,16 +278,19 @@ public class AppUpdate {
             options[1]);
     boolean dontAsk = dontAskCheckbox.isSelected();
 
-    if (dontAsk) {
-      AppPreferences.skipAutoUpdate.set(true);
+    if (showSkipOptions) {
+      if (dontAsk) {
+        AppPreferences.skipAutoUpdate.set(true);
+      }
+      if (result == JOptionPane.CANCEL_OPTION) {
+        AppPreferences.skipAutoUpdateRelease.set(releaseId);
+      }
     }
-
-    if (result == JOptionPane.CANCEL_OPTION) AppPreferences.skipAutoUpdateRelease.set(releaseId);
 
     return (result == JOptionPane.YES_OPTION);
   }
 
-  private static void downloadFile(URL assetDownloadURL, long assetDownloadSize) {
+  public static void downloadFile(URL assetDownloadURL, long assetDownloadSize) {
     final JFileChooser chooser = MapTool.getFrame().getSaveFileChooser();
     chooser.setSelectedFile(new File(assetDownloadURL.getFile()));
 
@@ -253,12 +317,13 @@ public class AppUpdate {
     }
     final File saveLocation = chooser.getSelectedFile();
 
-    log.info("URL: " + assetDownloadURL.toString());
-    log.info("assetDownloadSize: " + assetDownloadSize);
+    log.info("URL: {}", assetDownloadURL);
+    log.info("assetDownloadSize: {}", assetDownloadSize);
 
     Runnable updatethread =
         () -> {
           try (InputStream stream = assetDownloadURL.openStream()) {
+            // TODO I18N
             ProgressMonitorInputStream pmis =
                 new ProgressMonitorInputStream(MapTool.getFrame(), "Downloading...\n", stream);
             UIManager.put("ProgressMonitor.progressText", "New Update");

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.*;
 import javax.swing.*;
+import net.rptools.lib.FileUtil;
 import net.rptools.lib.ModelVersionManager;
 import net.rptools.lib.OsDetection;
 import net.rptools.maptool.language.I18N;
@@ -297,7 +298,7 @@ public class AppUpdate {
         chosenLocation = null;
       }
     }
-    final File saveLocation = chooser.getSelectedFile();
+    final File saveLocation = chosenLocation;
 
     log.info("URL: {}", assetDownloadURL);
     log.info("assetDownloadSize: {}", assetDownloadSize);
@@ -318,7 +319,14 @@ public class AppUpdate {
             pm.setMaximum((int) assetDownloadSize);
 
             FileUtils.copyInputStreamToFile(pmis, saveLocation);
+          } catch (InterruptedIOException e) {
+            // Progress monitor was canceled. This is not an error, unlike other IOExceptions, so
+            // ignore it.
+            // Don't leave partial files around.
+            FileUtil.delete(saveLocation);
           } catch (IOException ioe) {
+            // Don't leave potential broken files around..
+            FileUtil.delete(saveLocation);
             MapTool.showError("msg.error.failedSavingNewVersion", ioe);
           }
         };

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -306,10 +306,10 @@ public class AppUpdate {
     Runnable updatethread =
         () -> {
           try (InputStream stream = assetDownloadURL.openStream()) {
-            // TODO I18N
             ProgressMonitorInputStream pmis =
-                new ProgressMonitorInputStream(MapTool.getFrame(), "Downloading...\n", stream);
-            UIManager.put("ProgressMonitor.progressText", "New Update");
+                new ProgressMonitorInputStream(
+                    MapTool.getFrame(), I18N.getText("Update.downloading"), stream);
+            UIManager.put("ProgressMonitor.progressText", I18N.getText("Update.downloadingTitle"));
 
             ProgressMonitor pm = pmis.getProgressMonitor();
             pm.setMillisToDecideToPopup(500);

--- a/src/main/java/net/rptools/maptool/client/AppUpdate.java
+++ b/src/main/java/net/rptools/maptool/client/AppUpdate.java
@@ -44,7 +44,7 @@ public class AppUpdate {
    * @return has an update been made
    */
   public static boolean gitHubReleases() {
-    if (AppPreferences.skipAutoUpdate.get()) {
+    if (MapTool.isDevelopment() || AppPreferences.skipAutoUpdate.get()) {
       return false;
     }
 

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -56,9 +56,7 @@ public class LaunchInstructions {
 
       MapTool.main(args);
 
-      if (!MapTool.isDevelopment()) {
-        AppUpdate.gitHubReleases();
-      }
+      AppUpdate.gitHubReleases();
     } catch (Throwable e) {
       // IMPORTANT: don't move this logger init to class-level because we need AppUtil.initLogging()
       // to run before any loggers are initialized. Yes, it's brittle, but c'est la vie.

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -55,8 +55,6 @@ public class LaunchInstructions {
       }
 
       MapTool.main(args);
-
-      AppUpdate.gitHubReleases();
     } catch (Throwable e) {
       // IMPORTANT: don't move this logger init to class-level because we need AppUtil.initLogging()
       // to run before any loggers are initialized. Yes, it's brittle, but c'est la vie.

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -44,6 +44,9 @@ import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import javafx.application.Platform;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -63,6 +66,7 @@ import net.rptools.lib.image.ThumbnailManager;
 import net.rptools.lib.net.RPTURLStreamHandlerFactory;
 import net.rptools.lib.net.SyrinscapeURLStreamHandler;
 import net.rptools.lib.sound.SoundManager;
+import net.rptools.maptool.client.AppUpdate.ReleaseInfo;
 import net.rptools.maptool.client.MapToolConnection.HandshakeCompletionObserver;
 import net.rptools.maptool.client.events.ChatMessageAdded;
 import net.rptools.maptool.client.events.ServerDisconnected;
@@ -1527,6 +1531,19 @@ public class MapTool {
     }
   }
 
+  private static Optional<ReleaseInfo> waitForUpdateInfo(
+      CompletionStage<Optional<ReleaseInfo>> updateFuture) {
+    try {
+      return updateFuture.toCompletableFuture().get();
+    } catch (CancellationException | InterruptedException e) {
+      log.info("Cancelled update check", e);
+      return Optional.empty();
+    } catch (ExecutionException e) {
+      log.warn("Failed to find latest release", e);
+      return Optional.empty();
+    }
+  }
+
   public static void main(String[] args) {
     log.info("********************************************************************************");
     log.info("**                                                                            **");
@@ -1534,6 +1551,9 @@ public class MapTool {
     log.info("**                                                                            **");
     log.info("********************************************************************************");
     log.info("Logging to: " + getLoggerFileName());
+
+    // Start the update check early. Will be handled after the splash screen goes away.
+    var updateFuture = AppUpdate.autoUpdateCheck();
 
     String versionImplementation = version;
     String versionOverride = version;
@@ -1785,10 +1805,24 @@ public class MapTool {
 
           EventQueue.invokeLater(
               () -> {
+                // Wait for the release information before transitioning away from the splash.
+                final Optional<ReleaseInfo> release = waitForUpdateInfo(updateFuture);
+
                 clientFrame.setVisible(true);
                 splash.setVisible(false);
                 splash.dispose();
-                EventQueue.invokeLater(MapTool::postInitialize);
+
+                EventQueue.invokeLater(
+                    () -> {
+                      release.ifPresent(
+                          r -> {
+                            if (AppUpdate.confirmUpdate(r, true)) {
+                              AppUpdate.downloadFile(r.assetUrl(), r.assetSize());
+                            }
+                          });
+
+                      MapTool.postInitialize();
+                    });
               });
         });
   }

--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -26,6 +26,7 @@ import javax.swing.*;
 import net.rptools.lib.FileUtil;
 import net.rptools.lib.OsDetection;
 import net.rptools.maptool.client.*;
+import net.rptools.maptool.client.AppActions.CheckForUpdatesAction;
 import net.rptools.maptool.client.AppActions.OpenUrlAction;
 import net.rptools.maptool.client.ui.MapToolFrame.MTFrame;
 import net.rptools.maptool.client.ui.htmlframe.HTMLOverlayManager;
@@ -402,6 +403,10 @@ public class AppMenuBar extends JMenuBar {
                 "action.helpurl.06",
                 "https://wiki.rptools.info/index.php/Frameworks",
                 Icons.MENU_FRAMEWORKS)));
+
+    menu.addSeparator();
+
+    menu.add(new JMenuItem(new CheckForUpdatesAction()));
 
     menu.addSeparator();
 

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -504,6 +504,9 @@ public class PreferencesDialog extends AbeillePanel {
   // ** Checkbox for loading the most recently used campaign on startup */
   private final JCheckBox loadMRUcheckbox = getCheckBox("loadMRU");
 
+  // ** Checkbox for loading the most recently used campaign on startup */
+  private final JCheckBox checkUpdatesCheckbox = getCheckBox("checkUpdatesAtStartup");
+
   /** status bar scrolling checkbox */
   private final JCheckBox statusScrollEnable = getCheckBox("statusScrollEnable");
 
@@ -1048,6 +1051,8 @@ public class PreferencesDialog extends AbeillePanel {
 
     loadMRUcheckbox.addActionListener(
         e -> AppPreferences.loadMruCampaignAtStart.set(loadMRUcheckbox.isSelected()));
+    checkUpdatesCheckbox.addActionListener(
+        e -> AppPreferences.skipAutoUpdate.set(!checkUpdatesCheckbox.isSelected()));
     allowExternalMacroAccessCheckBox.addActionListener(
         e ->
             AppPreferences.allowExternalMacroAccess.set(
@@ -1668,6 +1673,7 @@ public class PreferencesDialog extends AbeillePanel {
     defaultUsername.setText(AppPreferences.defaultUserName.get());
     autoSaveSpinner.setValue(AppPreferences.autoSaveIncrement.get());
     loadMRUcheckbox.setSelected(AppPreferences.loadMruCampaignAtStart.get());
+    checkUpdatesCheckbox.setSelected(!AppPreferences.skipAutoUpdate.get());
     newMapsHaveFOWCheckBox.setSelected(AppPreferences.newMapsHaveFow.get());
     tokensPopupWarningWhenDeletedCheckBox.setSelected(AppPreferences.tokensWarnWhenDeleted.get());
     tokensStartSnapToGridCheckBox.setSelected(AppPreferences.tokensStartSnapToGrid.get());

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -1894,7 +1894,7 @@
                   </grid>
                 </children>
               </grid>
-              <grid id="b7224" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="b7224" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -2056,9 +2056,44 @@
                   </grid>
                   <vspacer id="66fca">
                     <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                     </constraints>
                   </vspacer>
+                  <grid id="60c82" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none" title-resource-bundle="net/rptools/maptool/language/i18n" title-key="Button.update">
+                      <font name="Dialog" size="12" style="1"/>
+                      <title-color color="-13538620"/>
+                      <color color="-6710887"/>
+                    </border>
+                    <children>
+                      <component id="28956" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <name value="checkForUpdates"/>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.update.checkForUpdates"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.update.checkForUpdates.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="33d28" class="javax.swing.JCheckBox" default-binding="true">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <label value=""/>
+                          <name value="checkUpdatesAtStartup"/>
+                          <text value=""/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.update.checkForUpdates.tooltip"/>
+                        </properties>
+                      </component>
+                    </children>
+                  </grid>
                 </children>
               </grid>
               <hspacer id="1a503">

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -855,6 +855,8 @@ Preferences.colorwell.access.drawableLabel.templateForeground.tooltip = Set the 
 Preferences.colorwell.access.drawableLabel.templateBorder.tooltip     = Set the border color for template name labels.
 Preferences.label.access.tokenLabel.borderArc         = Border Arc
 Preferences.label.access.tokenLabel.borderSize        = Border Size
+Preferences.label.update.checkForUpdates = Check for updates at startup
+Preferences.label.update.checkForUpdates.tooltip = Check for newer releases when MapTool starts
 
 StatusBar.button.toggleAutoScroll.tooltip         = Toggle the automatic scrolling of over-sized messages.
 StatusBar.helpText                                = This area can scroll long messages. You can click on it to pause and resume automatic scrolling, drag the text from side to side, or use the mouse-wheel to scroll the text.

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -633,6 +633,9 @@ Update.msg1   = A new version of MapTool is available!
 Update.msg2   = Would you like to download {0}?
 Update.button = Skip this Version
 Update.chkbox  = Never check for updates again!
+Update.checking.title = Checking for updates
+Update.checking.message = Checking GitHub for the latest release ...
+Update.noNewerRelease = No newer release is available
 
 ExportCampaign.desc = Export campaign to a previous version
 
@@ -1511,6 +1514,8 @@ action.helpurl.03                             = Forums
 action.helpurl.04                             = Networking Setup (forum thread)
 action.helpurl.05                             = Macro Scripting
 action.helpurl.06                             = Frameworks
+action.helpurl.checkForUpdates                = Check for Updates ...
+action.helpurl.checkForUpdates.description    = Check if a newer version of MapTool is available.
 action.toggleLandingMap                       = &Landing map
 action.toggleLandingMap.description           = Make this map the first one that players see when they connect.
 action.hideMap                                = &Player Visible

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -636,6 +636,8 @@ Update.chkbox  = Never check for updates again!
 Update.checking.title = Checking for updates
 Update.checking.message = Checking GitHub for the latest release ...
 Update.noNewerRelease = No newer release is available
+Update.downloading = Downloading...
+Update.downloadingTitle = New Update
 
 ExportCampaign.desc = Export campaign to a previous version
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #999
Fixes #5872

### Description of the Change

Improves update checks in a few ways.

#### New UI for `skipAutoUpdate` preference 

This preference is the one that gets set if the user selects "Never check for updates again!" from the **Update Available** dialog. Previously, there was no user-friendly way to turn this off again, but now the choice can be reverted in the **Preferences** dialog via the new _Check for updates at startup_ option. This also lets users set this preference immediately on new installations without having to wait for an update first.

The wording and checkbox are inverted from the preference as that felt more natural to me.

#### Consistent timing for _Update Available_ dialog

The existing startup check for updates in `AppUpdate#gitHubReleases()` was not able to properly integrate into the startup sequence, and so could end up showing the **Update Available** dialog at just about any point after the splash screen gets hidden, even if other stuff is already going on.

This has been replaced by `AppUpdate#autoUpdateCheck()`, which does similar work but is explicitly async. This gets called early in `MapTool.main()` so the work can run in parallel with other startup tasks. The results are consumed in the EDT just before the splash screen is hidden. If an update is available, the **Update Available** dialog will then be displayed right after the main UI comes up, before the auto-save check and the developer options warning.

The download of the latest release info is given a timeout of five seconds so it doesn't block startup indefinitely in case of a slow network connection.

Two other bits of clean up here:
- Added some i18n keys for previously untranslated strings
- Handle the case where a user cancels of the release asset download. They are no longer greeted with an error dialog in that case. Also, whether the user canceled or the download failed, the partial asset is deleted instead of being left around in the file system.

#### _Check for Updates_ help menu item

This new menu item allows a user to explicitly check for a new update, regardless of whether they have previously set the `skipAuotUpdate` preference, and without having to restart MapTool. This lets them have all the convenience of the built-in download functionality, even if they don't want to be bothered about it every time they open MT.

While checking for a release, a temporary dialog is shown to the user so they know it's actually working. If no update is found, another dialog will inform the user of this fact.

If an update is available, a dialog will be shown to the user similar to the dialog shown for the startup update check. But because `skipAutoUpdate` is not respected, there is no option to skip the specific update or modify the `skipAutoUpdate` preference. Instead, the user can simply cancel the dialog.

### Possible Drawbacks

On slow networks, start up can be slower since the update check is blocking now. On the other hand, it has a timeout, so the **Update Available** modal won't randomly show up much later in such cases.

### Documentation Notes

New menu item to explicitly check for updates:
<img width="267" height="369" alt="image" src="https://github.com/user-attachments/assets/ba927028-b188-4b58-bbc0-e4a4ff90aadb" />

New preference UI:
<img width="1193" height="680" alt="image" src="https://github.com/user-attachments/assets/f67c5a5a-d8e0-420c-bcc3-27a40f001bcc" />


### Release Notes

- Added a "Check for Updates" menu item
- Added a preference to enable checking for updates at startup, in case it was previous disabled.
- Change startup sequence so the **Update Available** dialog is shown right away and won't overlap with other dialogs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5882)
<!-- Reviewable:end -->
