### PR TITLE
Add table lines to Edit Token dialog's speech table

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1319,6 +1319,9 @@ public class MapTool {
         BorderFactory.createLineBorder(UIManager.getColor("Panel.background")));
     defaults.put("DockableFrameTitlePane.showIcon", true);
     // endregion
+
+    defaults.put("Table.showHorizontalLines", Boolean.TRUE);
+    defaults.put("Table.showVerticalLines", Boolean.TRUE);
   }
 
   private static void postInitialize() {

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -14,7 +14,6 @@
  */
 package net.rptools.maptool.client;
 
-import com.jidesoft.plaf.LookAndFeelFactory;
 import com.jidesoft.plaf.UIDefaultsLookup;
 import com.jidesoft.plaf.basic.ThemePainter;
 import io.sentry.EventProcessor;
@@ -1266,62 +1265,60 @@ public class MapTool {
     return clientFrame;
   }
 
-  private static void configureJide() {
-    LookAndFeelFactory.UIDefaultsCustomizer uiDefaultsCustomizer =
-        defaults -> {
-          ThemePainter painter = (ThemePainter) UIDefaultsLookup.get("Theme.painter");
-          defaults.put("OptionPaneUI", "com.jidesoft.plaf.basic.BasicJideOptionPaneUI");
+  private static void configureLaf() {
+    final var defaults = UIManager.getDefaults();
 
-          // show banner or not. default is true
-          defaults.put("OptionPane.showBanner", Boolean.FALSE);
-          defaults.put("OptionPane.bannerIcon", RessourceManager.getSmallIcon(Icons.MAPTOOL));
-          defaults.put("OptionPane.bannerFontSize", 13);
-          defaults.put("OptionPane.bannerFontStyle", Font.BOLD);
-          defaults.put("OptionPane.bannerMaxCharsPerLine", 60);
-          // you should adjust this if banner background is not the default gradient paint
-          defaults.put(
-              "OptionPane.bannerForeground",
-              painter != null ? painter.getOptionPaneBannerForeground() : null);
-          defaults.put("OptionPane.bannerBorder", null); // use default border
+    // region JIDE LAF
+    ThemePainter painter = (ThemePainter) UIDefaultsLookup.get("Theme.painter");
+    defaults.put("OptionPaneUI", "com.jidesoft.plaf.basic.BasicJideOptionPaneUI");
 
-          // set both bannerBackgroundDk and bannerBackgroundLt to null if you don't want
-          // gradient
-          defaults.put(
-              "OptionPane.bannerBackgroundDk",
-              painter != null ? painter.getOptionPaneBannerDk() : null);
-          defaults.put(
-              "OptionPane.bannerBackgroundLt",
-              painter != null ? painter.getOptionPaneBannerLt() : null);
-          // default is true
-          defaults.put("OptionPane.bannerBackgroundDirection", Boolean.TRUE);
+    // show banner or not. default is true
+    defaults.put("OptionPane.showBanner", Boolean.FALSE);
+    defaults.put("OptionPane.bannerIcon", RessourceManager.getSmallIcon(Icons.MAPTOOL));
+    defaults.put("OptionPane.bannerFontSize", 13);
+    defaults.put("OptionPane.bannerFontStyle", Font.BOLD);
+    defaults.put("OptionPane.bannerMaxCharsPerLine", 60);
+    // you should adjust this if banner background is not the default gradient paint
+    defaults.put(
+        "OptionPane.bannerForeground",
+        painter != null ? painter.getOptionPaneBannerForeground() : null);
+    defaults.put("OptionPane.bannerBorder", null); // use default border
 
-          // optionally, you can set a Paint object for BannerPanel. If so, the three
-          // UIDefaults
-          // related to banner background above will be ignored.
-          defaults.put("OptionPane.bannerBackgroundPaint", null);
+    // set both bannerBackgroundDk and bannerBackgroundLt to null if you don't want
+    // gradient
+    defaults.put(
+        "OptionPane.bannerBackgroundDk", painter != null ? painter.getOptionPaneBannerDk() : null);
+    defaults.put(
+        "OptionPane.bannerBackgroundLt", painter != null ? painter.getOptionPaneBannerLt() : null);
+    // default is true
+    defaults.put("OptionPane.bannerBackgroundDirection", Boolean.TRUE);
 
-          defaults.put("OptionPane.buttonAreaBorder", BorderFactory.createEmptyBorder(6, 6, 6, 6));
-          defaults.put("OptionPane.buttonOrientation", SwingConstants.RIGHT);
+    // optionally, you can set a Paint object for BannerPanel. If so, the three
+    // UIDefaults
+    // related to banner background above will be ignored.
+    defaults.put("OptionPane.bannerBackgroundPaint", null);
 
-          defaults.put(
-              "DockableFrame.inactiveTitleBackground",
-              UIManager.getColor("InternalFrame.inactiveTitleBackground"));
-          defaults.put(
-              "DockableFrame.inactiveTitleForeground",
-              UIManager.getColor("InternalFrame.inactiveTitleForeground"));
-          defaults.put(
-              "DockableFrame.activeTitleBackground",
-              UIManager.getColor("InternalFrame.activeTitleBackground"));
-          defaults.put(
-              "DockableFrame.activeTitleForeground",
-              UIManager.getColor("InternalFrame.activeTitleForeground"));
-          defaults.put("DockableFrame.background", UIManager.getColor("Panel.background"));
-          defaults.put(
-              "DockableFrame.border",
-              BorderFactory.createLineBorder(UIManager.getColor("Panel.background")));
-          defaults.put("DockableFrameTitlePane.showIcon", true);
-        };
-    uiDefaultsCustomizer.customize(UIManager.getDefaults());
+    defaults.put("OptionPane.buttonAreaBorder", BorderFactory.createEmptyBorder(6, 6, 6, 6));
+    defaults.put("OptionPane.buttonOrientation", SwingConstants.RIGHT);
+
+    defaults.put(
+        "DockableFrame.inactiveTitleBackground",
+        UIManager.getColor("InternalFrame.inactiveTitleBackground"));
+    defaults.put(
+        "DockableFrame.inactiveTitleForeground",
+        UIManager.getColor("InternalFrame.inactiveTitleForeground"));
+    defaults.put(
+        "DockableFrame.activeTitleBackground",
+        UIManager.getColor("InternalFrame.activeTitleBackground"));
+    defaults.put(
+        "DockableFrame.activeTitleForeground",
+        UIManager.getColor("InternalFrame.activeTitleForeground"));
+    defaults.put("DockableFrame.background", UIManager.getColor("Panel.background"));
+    defaults.put(
+        "DockableFrame.border",
+        BorderFactory.createLineBorder(UIManager.getColor("Panel.background")));
+    defaults.put("DockableFrameTitlePane.showIcon", true);
+    // endregion
   }
 
   private static void postInitialize() {
@@ -1731,7 +1728,7 @@ public class MapTool {
       com.jidesoft.utils.Lm.verifyLicense(
           "Trevor Croft", "rptools", "5MfIVe:WXJBDrToeLWPhMv3kI2s3VFo");
 
-      configureJide();
+      configureLaf();
     } catch (Exception e) {
       MapTool.showError("msg.error.lafSetup", e);
       System.exit(1);

--- a/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/addon/AddOnLibrariesDialogView.form
@@ -63,7 +63,10 @@
                         <children>
                           <component id="7b8c5" class="javax.swing.JTable" binding="addOnLibraryTable">
                             <constraints/>
-                            <properties/>
+                            <properties>
+                              <showHorizontalLines value="false"/>
+                              <showVerticalLines value="false"/>
+                            </properties>
                           </component>
                         </children>
                       </scrollpane>

--- a/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/addresource/AddResourceDialogView.form
@@ -201,6 +201,8 @@
                     <properties>
                       <autoCreateRowSorter value="true"/>
                       <name value="libraryTable"/>
+                      <showHorizontalLines value="false"/>
+                      <showVerticalLines value="false"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/net/rptools/maptool/client/ui/connecttoserverdialog/ConnectToServerDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/connecttoserverdialog/ConnectToServerDialogView.form
@@ -99,6 +99,8 @@
                     <constraints/>
                     <properties>
                       <name value="aliasTable"/>
+                      <showHorizontalLines value="false"/>
+                      <showVerticalLines value="false"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/net/rptools/maptool/client/ui/lookuptable/EditLookupTablePanelView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/lookuptable/EditLookupTablePanelView.form
@@ -21,6 +21,7 @@
             <constraints/>
             <properties>
               <preferredScrollableViewportSize width="450" height="150"/>
+              <rowSelectionAllowed value="false"/>
             </properties>
           </component>
         </children>

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/TokenPropertiesDialog.form
@@ -97,6 +97,7 @@
                             <constraints/>
                             <properties>
                               <name value="speechTable"/>
+                              <rowSelectionAllowed value="false"/>
                             </properties>
                           </component>
                         </children>

--- a/src/main/java/net/rptools/maptool/client/ui/transferprogressdialog/TransferProgressDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/transferprogressdialog/TransferProgressDialogView.form
@@ -27,6 +27,8 @@
             <constraints/>
             <properties>
               <name value="transferTable"/>
+              <showHorizontalLines value="false"/>
+              <showVerticalLines value="false"/>
             </properties>
           </component>
         </children>


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5814

### Description of the Change

This enables both horizontal and vertical lines for `JTable` at the look-and-feel level. Individual tables can then decide whether to display the lines using their `showHorizontalLines` and `showVerticalLines` properties. Most tables leave these properties disabled, but these editable tables enable the lines:
1. The Speech table in the **Edit Token** dialog.
2. The table in the **Edit Table** dialog.

The inclusion of lines makes these tables easier to use as the user is now aware that extra blank rows exist at the end of the table for them to extend the table. To further improve the UX for these tables, the row selection highlight has also been disabled so that the current cell's highlight is visible without having to strain the eyes.

_There are some other editable tables, but they are more specialized and do not use a default JTable. E.g., the token properties in **Edit Token**. Such tables do not have the same usability issues, or already do not follow the table L&F on this point, so they have not been changed._

### Possible Drawbacks

Should not be any.

### Documentation Notes

Editing the Speech table in the **Edit Token** should be clearer in 1.19 compared to 1.18 and earlier. Old (top right cell selected for editing):
<img width="556" height="187" alt="image" src="https://github.com/user-attachments/assets/963eae52-9652-49e1-9b1f-157c1b007e77" />
The same situation now looks like:
<img width="572" height="182" alt="image" src="https://github.com/user-attachments/assets/e73297dd-29f8-4faf-aefd-dcc1abcaf1f3" />

And similarly in the **Edit Table** dialog:
<img width="512" height="413" alt="image" src="https://github.com/user-attachments/assets/b190d67f-0950-4e1a-b95a-c2315237e57e" />
is now:
<img width="499" height="458" alt="image" src="https://github.com/user-attachments/assets/acb1c87f-f609-4d59-894d-7fe230355ee5" />

### Release Notes

- Added lines to the Speech table of the Edit Token dialog, and the main table of the Edit Table dialog, and remove the row selection highlight leaving only the cell selection highlight.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5890)
<!-- Reviewable:end -->
