### PR TITLE
Further Drawing/Template improvements and new MTScript functions

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolExpressionParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolExpressionParser.java
@@ -98,6 +98,7 @@ public class MapToolExpressionParser extends ExpressionParser {
               DrawingSetterFunctions.getInstance(),
               DrawingMiscFunctions.getInstance(),
               ShapeFunctions.getInstance(),
+              TemplateFunctions.getInstance(),
               ExportDataFunctions.getInstance(),
               RESTfulFunctions.getInstance(),
               HeroLabFunctions.getInstance(),

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -20,23 +20,15 @@ import java.awt.Point;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.PathIterator;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.tool.drawing.DrawingPointerTool;
+import net.rptools.maptool.client.tool.drawing.TemplatePointerTool;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.GUID;
-import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.Zone.Layer;
-import net.rptools.maptool.model.drawing.AbstractDrawing;
-import net.rptools.maptool.model.drawing.AbstractTemplate;
-import net.rptools.maptool.model.drawing.Drawable;
-import net.rptools.maptool.model.drawing.DrawableColorPaint;
-import net.rptools.maptool.model.drawing.DrawablePaint;
-import net.rptools.maptool.model.drawing.DrawableTexturePaint;
-import net.rptools.maptool.model.drawing.DrawablesGroup;
-import net.rptools.maptool.model.drawing.DrawnElement;
-import net.rptools.maptool.model.drawing.LineSegment;
-import net.rptools.maptool.model.drawing.Pen;
-import net.rptools.maptool.model.drawing.ShapeDrawable;
+import net.rptools.maptool.model.drawing.*;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -47,6 +39,67 @@ public class DrawingFunctions extends AbstractFunction {
 
   public DrawingFunctions(int minParameters, int maxParameters, String... aliases) {
     super(minParameters, maxParameters, aliases);
+  }
+
+  /**
+   * DrawableUnit enumeration, including an <code>index</code> property based on the "units" boolean
+   * argument found in certain MTScript functions, but as a tri-state with <code>CELLS</code>,
+   * <code>DISTANCE</code>, and <code>PIXELS</code> options. For template radii the units used
+   * typically will be <code>DISTANCE</code>.
+   */
+  protected enum DrawableUnit {
+    CELLS(0),
+    DISTANCE(1),
+    PIXELS(2);
+
+    DrawableUnit(int index) {
+      this.index = index;
+    }
+
+    private final int index;
+
+    public static DrawableUnit valueOfIndex(int index) {
+      for (DrawableUnit drawableUnit : values()) {
+        if (drawableUnit.index == index) {
+          return drawableUnit;
+        }
+      }
+      return null;
+    }
+
+    public static int convert(Zone zone, int value, DrawableUnit fromUnit, DrawableUnit toUnit) {
+      double fromConversion = getConversionFactor(zone, fromUnit);
+      double toConversion = getConversionFactor(zone, toUnit);
+      return (int) (value * toConversion / fromConversion);
+    }
+
+    public static int convertToCells(Zone zone, int value, DrawableUnit fromUnit) {
+      return convert(zone, value, fromUnit, DrawableUnit.CELLS);
+    }
+
+    public static double getConversionFactor(Zone zone, DrawableUnit drawableUnit) {
+      return switch (drawableUnit) {
+        case CELLS -> 1d;
+        case DISTANCE -> zone.getUnitsPerCell();
+        case PIXELS -> zone.getGrid().getSize();
+      };
+    }
+
+    public static int getIndex(DrawableUnit drawableUnit) {
+      return drawableUnit.index;
+    }
+
+    public static int getCellsIndex() {
+      return DrawableUnit.CELLS.index;
+    }
+
+    public static int getDistanceIndex() {
+      return DrawableUnit.DISTANCE.index;
+    }
+
+    public static int getPixelsIndex() {
+      return DrawableUnit.PIXELS.index;
+    }
   }
 
   @Override
@@ -124,8 +177,47 @@ public class DrawingFunctions extends AbstractFunction {
     DrawnElement drawnElement = findDrawnElement(map.getAllDrawnElements(), guid);
     if (drawnElement != null) return drawnElement;
     throw new ParserException(
-        I18N.getText(
-            "macro.function.drawingFunction.unknownDrawing", functionName, guid.toString()));
+        I18N.getText("macro.function.drawable.unknownDrawable", functionName, guid.toString()));
+  }
+
+  /**
+   * Try and find a drawn element, using its {@link Drawable}'s {@link GUID} or case-insensitive
+   * <code>name</code>.
+   *
+   * <p>Warning: If name is used, and there are multiple drawables with the same name on the same
+   * map, only the first one encountered will be returned
+   *
+   * @param functionName this is used in the exception message
+   * @param zone the map to search for the template
+   * @param drawnElementRef either the name, or the id
+   * @return the template's drawn element, or null if not found
+   */
+  public static DrawnElement findDrawnElement(
+      String functionName, Zone zone, String drawnElementRef) throws ParserException {
+
+    DrawnElement drawnElement = null;
+
+    GUID guid = null;
+    try {
+      guid = GUID.valueOf(drawnElementRef);
+    } catch (Exception e) {
+      // wasn't a GUID after all, OK to ignore
+    }
+
+    for (DrawnElement de : zone.getAllDrawnElements()) {
+      AbstractDrawing d = (AbstractDrawing) de.getDrawable();
+      if (d.getId().equals(guid)) {
+        drawnElement = de;
+        break;
+      } else if (drawnElementRef.equalsIgnoreCase(d.getName())) {
+        drawnElement = de;
+        break;
+      }
+    }
+
+    if (drawnElement != null) return drawnElement;
+    throw new ParserException(
+        I18N.getText("macro.function.drawable.unknownDrawable", functionName, drawnElementRef));
   }
 
   private DrawnElement findDrawnElement(List<DrawnElement> drawableList, GUID guid) {
@@ -236,6 +328,22 @@ public class DrawingFunctions extends AbstractFunction {
   }
 
   /**
+   * Get the name of the drawing (if it has one).
+   *
+   * @param functionName this is used in the exception message
+   * @param zone the zone that should contain the drawing
+   * @param guid the id of the drawing
+   * @return the drawing name
+   * @throws ParserException the exception
+   */
+  protected String getDrawingName(String functionName, Zone zone, GUID guid)
+      throws ParserException {
+    DrawnElement de = getDrawnElement(functionName, zone, guid);
+    AbstractDrawing ad = (AbstractDrawing) de.getDrawable();
+    return ad.getName() == null ? "" : ad.getName();
+  }
+
+  /**
    * Converts the selected drawing element into a JSON string.
    *
    * @param functionName this is used in the exception message
@@ -260,8 +368,59 @@ public class DrawingFunctions extends AbstractFunction {
     dinfo.addProperty("isEraser", el.getPen().isEraser() ? BigDecimal.ONE : BigDecimal.ZERO);
     dinfo.addProperty("penWidth", el.getPen().getThickness());
     dinfo.add("path", pathToJSON(d));
-    if (el.getDrawable() instanceof AbstractTemplate t) {
-      dinfo.addProperty("templateSize", t.getRadius());
+    dinfo.addProperty(
+        "isTemplate",
+        el.getDrawable() instanceof AbstractTemplate ? BigDecimal.ONE : BigDecimal.ZERO);
+    if (el.getDrawable() instanceof AbstractTemplate at) {
+      JsonObject template = new JsonObject();
+      template.addProperty("radius", at.getRadius());
+      JsonObject vertex = new JsonObject();
+      vertex.addProperty("x", at.getVertex().x);
+      vertex.addProperty("y", at.getVertex().y);
+      template.add("vertex", vertex);
+
+      // order is important here as some templates extend others, so do them first.
+      switch (at) {
+        case BlastTemplate bt -> {
+          template.addProperty("direction", bt.getDirection().toString());
+          JsonObject controlOffset = new JsonObject();
+          controlOffset.addProperty("x", bt.getOffsetX());
+          controlOffset.addProperty("y", bt.getOffsetY());
+          template.add("controlOffset", controlOffset);
+        }
+        case ConeTemplate ct -> template.addProperty("direction", ct.getDirection().toString());
+        case WallTemplate wt -> {
+          if (wt.getPath() != null) {
+            JsonArray pathInfo = new JsonArray();
+            for (CellPoint cp : wt.getPath()) {
+              ZonePoint zp = map.getGrid().convert(cp);
+              JsonObject pointInfo = new JsonObject();
+              pointInfo.addProperty("x", zp.x);
+              pointInfo.addProperty("y", zp.y);
+              pathInfo.add(pointInfo);
+            }
+            template.add("wallPath", pathInfo);
+          } else {
+            template.addProperty("wallPath", "null");
+          }
+        }
+        case LineTemplate lt -> {
+          JsonObject pathVertex = new JsonObject();
+          pathVertex.addProperty("x", lt.getPathVertex().x);
+          pathVertex.addProperty("y", lt.getPathVertex().y);
+          template.add("pathVertex", pathVertex);
+        }
+        case LineCellTemplate lct -> {
+          JsonObject pathVertex = new JsonObject();
+          pathVertex.addProperty("x", lct.getPathVertex().x);
+          pathVertex.addProperty("y", lct.getPathVertex().y);
+          template.add("pathVertex", pathVertex);
+        }
+        default -> {}
+      }
+      if (!template.isEmpty()) {
+        dinfo.add("template", template);
+      }
     }
 
     return dinfo;
@@ -269,10 +428,18 @@ public class DrawingFunctions extends AbstractFunction {
 
   private JsonObject boundsToJSON(Zone map, AbstractDrawing d) {
     JsonObject binfo = new JsonObject();
-    binfo.addProperty("x", d.getBounds(map).x);
-    binfo.addProperty("y", d.getBounds(map).y);
-    binfo.addProperty("width", d.getBounds(map).width);
-    binfo.addProperty("height", d.getBounds(map).height);
+    // templates have a BOUNDS_PADDING so use the area bounds instead for those
+    if (d instanceof AbstractTemplate) {
+      binfo.addProperty("x", d.getArea(map).getBounds().x);
+      binfo.addProperty("y", d.getArea(map).getBounds().y);
+      binfo.addProperty("width", d.getArea(map).getBounds().width);
+      binfo.addProperty("height", d.getArea(map).getBounds().height);
+    } else {
+      binfo.addProperty("x", d.getBounds(map).x);
+      binfo.addProperty("y", d.getBounds(map).y);
+      binfo.addProperty("width", d.getBounds(map).width);
+      binfo.addProperty("height", d.getBounds(map).height);
+    }
     return binfo;
   }
 
@@ -315,8 +482,8 @@ public class DrawingFunctions extends AbstractFunction {
         while (!pathIter.isDone()) {
           pathIter.currentSegment(coords);
           JsonObject info = new JsonObject();
-          info.addProperty("x", coords[0]);
-          info.addProperty("y", coords[1]);
+          info.addProperty("x", (int) coords[0]);
+          info.addProperty("y", (int) coords[1]);
           if (!info.equals(lastinfo)) {
             pinfo.add(info);
           }
@@ -394,8 +561,9 @@ public class DrawingFunctions extends AbstractFunction {
     }
   }
 
-  protected void setDrawingName(Zone map, GUID guid, String name) throws ParserException {
-    DrawnElement de = getDrawnElement("setDrawingName", map, guid);
+  protected void setDrawingName(String functionName, Zone map, GUID guid, String name)
+      throws ParserException {
+    DrawnElement de = getDrawnElement(functionName, map, guid);
     AbstractDrawing ad = (AbstractDrawing) de.getDrawable();
 
     if (name != null) {
@@ -423,7 +591,64 @@ public class DrawingFunctions extends AbstractFunction {
       return;
     }
     throw new ParserException(
-        I18N.getText(
-            "macro.function.drawingFunction.unknownDrawing", functionName, guid.toString()));
+        I18N.getText("macro.function.drawable.unknownDrawable", functionName, guid.toString()));
+  }
+
+  /**
+   * Get the bounds of the drawing / template.
+   *
+   * <p>See {@link AbstractTemplate} for details about <code>BOUNDS_PADDING</code> and why it should
+   * be ignored here.
+   *
+   * @param functionName this is used in the exception message
+   * @param guid the guid of the drawn element
+   * @return the bounds
+   * @see AbstractTemplate
+   */
+  protected java.awt.Rectangle getDrawingBounds(String functionName, Zone zone, GUID guid)
+      throws ParserException {
+
+    DrawnElement de = getDrawnElement(functionName, zone, guid);
+
+    Drawable d = de.getDrawable();
+    if (d instanceof AbstractTemplate) {
+      // AbstractTemplates have BOUNDS_PADDING applied to the drawable so use area bounds instead
+      return d.getArea(zone).getBounds();
+    } else {
+      return d.getBounds(zone);
+    }
+  }
+
+  /**
+   * Get a single selected drawing or template relevant to the respective {@link DrawingPointerTool}
+   * or {@link TemplatePointerTool}.
+   *
+   * @param functionName this is used in the exception message
+   * @param zone the map
+   * @return the selected drawn element
+   */
+  public DrawnElement getSingleSelectedDrawnElement(String functionName, Zone zone)
+      throws ParserException {
+
+    List<GUID> selectedDrawables = new ArrayList<>();
+
+    // get a list of selected drawings depending on the selected tool
+    Object selectedTool = MapTool.getFrame().getToolbox().getSelectedTool().getClass();
+    if (selectedTool.equals(TemplatePointerTool.class)) {
+      selectedDrawables = TemplatePointerTool.getSelectedDrawables();
+    } else if (selectedTool.equals(DrawingPointerTool.class)) {
+      selectedDrawables = DrawingPointerTool.getSelectedDrawables();
+    }
+
+    // if only one is selected, return that
+    if (selectedDrawables.size() == 1) {
+      return zone.getDrawnElement(selectedDrawables.getFirst());
+    } else if (selectedDrawables.size() > 1) {
+      throw new ParserException(
+          I18N.getText("macro.function.drawable.noSingleSelectedDrawable", functionName));
+    } else {
+      throw new ParserException(
+          I18N.getText("macro.function.drawable.noSelectedDrawable", functionName));
+    }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingFunctions.java
@@ -371,9 +371,13 @@ public class DrawingFunctions extends AbstractFunction {
     dinfo.addProperty(
         "isTemplate",
         el.getDrawable() instanceof AbstractTemplate ? BigDecimal.ONE : BigDecimal.ZERO);
+
     if (el.getDrawable() instanceof AbstractTemplate at) {
+      dinfo.addProperty("templateSize", at.getRadius());
       JsonObject template = new JsonObject();
-      template.addProperty("radius", at.getRadius());
+      if (!(el.getDrawable() instanceof WallTemplate)) {
+        template.addProperty("radius", at.getRadius());
+      }
       JsonObject vertex = new JsonObject();
       vertex.addProperty("x", at.getVertex().x);
       vertex.addProperty("y", at.getVertex().y);
@@ -390,19 +394,14 @@ public class DrawingFunctions extends AbstractFunction {
         }
         case ConeTemplate ct -> template.addProperty("direction", ct.getDirection().toString());
         case WallTemplate wt -> {
-          if (wt.getPath() != null) {
-            JsonArray pathInfo = new JsonArray();
-            for (CellPoint cp : wt.getPath()) {
-              ZonePoint zp = map.getGrid().convert(cp);
-              JsonObject pointInfo = new JsonObject();
-              pointInfo.addProperty("x", zp.x);
-              pointInfo.addProperty("y", zp.y);
-              pathInfo.add(pointInfo);
-            }
-            template.add("wallPath", pathInfo);
-          } else {
-            template.addProperty("wallPath", "null");
+          JsonArray pathInfo = new JsonArray();
+          for (CellPoint cp : wt.getPath()) {
+            JsonObject pointInfo = new JsonObject();
+            pointInfo.addProperty("x", cp.x);
+            pointInfo.addProperty("y", cp.y);
+            pathInfo.add(pointInfo);
           }
+          template.add("wallPath", pathInfo);
         }
         case LineTemplate lt -> {
           JsonObject pathVertex = new JsonObject();
@@ -482,8 +481,8 @@ public class DrawingFunctions extends AbstractFunction {
         while (!pathIter.isDone()) {
           pathIter.currentSegment(coords);
           JsonObject info = new JsonObject();
-          info.addProperty("x", (int) coords[0]);
-          info.addProperty("y", (int) coords[1]);
+          info.addProperty("x", coords[0]);
+          info.addProperty("y", coords[1]);
           if (!info.equals(lastinfo)) {
             pinfo.add(info);
           }

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingGetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingGetterFunctions.java
@@ -14,23 +14,18 @@
  */
 package net.rptools.maptool.client.functions;
 
+import java.awt.*;
 import java.math.BigDecimal;
 import java.util.List;
+import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
+import net.rptools.maptool.model.drawing.DrawnElement;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
 
-/*
- * This software Copyright by the RPTools.net development team, and licensed under the Affero GPL Version 3 or, at your option, any later version.
- *
- * MapTool Source Code is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *
- * You should have received a copy of the GNU Affero General Public License * along with this source Code. If not, please visit <http://www.gnu.org/licenses/> and specifically the Affero license text
- * at <http://www.gnu.org/licenses/agpl.html>.
- */
 public class DrawingGetterFunctions extends DrawingFunctions {
   private static final DrawingGetterFunctions instance = new DrawingGetterFunctions();
 
@@ -38,10 +33,22 @@ public class DrawingGetterFunctions extends DrawingFunctions {
     return instance;
   }
 
+  private static final String FUNC_GET_DRAWABLE_INFO = "getDrawableInfo";
+  private static final String FUNC_GET_DRAWABLE_LAYER = "getDrawableLayer";
+  private static final String FUNC_GET_DRAWABLE_NAME = "getDrawableName";
+  private static final String FUNC_GET_DRAWABLE_X = "getDrawableX";
+  private static final String FUNC_GET_DRAWABLE_Y = "getDrawableY";
+  private static final String FUNC_GET_DRAWABLE_CENTER_X = "getDrawableCenterX";
+  private static final String FUNC_GET_DRAWABLE_CENTER_Y = "getDrawableCenterY";
+  private static final String FUNC_GET_DRAWABLE_MAX_X = "getDrawableMaxX";
+  private static final String FUNC_GET_DRAWABLE_MAX_Y = "getDrawableMaxY";
+  private static final String FUNC_GET_DRAWABLE_HEIGHT = "getDrawableHeight";
+  private static final String FUNC_GET_DRAWABLE_WIDTH = "getDrawableWidth";
+
   private DrawingGetterFunctions() {
     super(
-        2,
-        2,
+        0,
+        3,
         "getDrawingLayer",
         "getDrawingOpacity",
         "getDrawingProperties",
@@ -50,7 +57,18 @@ public class DrawingGetterFunctions extends DrawingFunctions {
         "getDrawingEraser",
         "getPenWidth",
         "getLineCap",
-        "getDrawingInfo");
+        "getDrawingInfo",
+        FUNC_GET_DRAWABLE_INFO,
+        FUNC_GET_DRAWABLE_LAYER,
+        FUNC_GET_DRAWABLE_NAME,
+        FUNC_GET_DRAWABLE_X,
+        FUNC_GET_DRAWABLE_Y,
+        FUNC_GET_DRAWABLE_CENTER_X,
+        FUNC_GET_DRAWABLE_CENTER_Y,
+        FUNC_GET_DRAWABLE_MAX_X,
+        FUNC_GET_DRAWABLE_MAX_Y,
+        FUNC_GET_DRAWABLE_HEIGHT,
+        FUNC_GET_DRAWABLE_WIDTH);
   }
 
   @Override
@@ -58,32 +76,113 @@ public class DrawingGetterFunctions extends DrawingFunctions {
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
     checkTrusted(functionName);
-    FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
-    String mapName = parameters.get(0).toString();
-    String id = parameters.get(1).toString();
-    Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
-    GUID guid = getGUID(functionName, id);
-    if ("getDrawingLayer".equalsIgnoreCase(functionName)) {
-      return getDrawable(functionName, map, guid).getLayer().name();
-    } else if ("getDrawingOpacity".equalsIgnoreCase(functionName)) {
-      return getPen(functionName, map, guid).getOpacity();
-    } else if ("getDrawingProperties".equalsIgnoreCase(functionName)) {
-      return getPen(functionName, map, guid);
-    } else if ("getPenColor".equalsIgnoreCase(functionName)) {
-      String result = paintToString(getPen(functionName, map, guid).getPaint());
-      return result;
-    } else if ("getFillColor".equalsIgnoreCase(functionName)) {
-      String result = paintToString(getPen(functionName, map, guid).getBackgroundPaint());
-      return result;
-    } else if ("getDrawingEraser".equalsIgnoreCase(functionName)) {
-      return getPen(functionName, map, guid).isEraser() ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else if ("getPenWidth".equalsIgnoreCase(functionName)) {
-      return getPen(functionName, map, guid).getThickness();
-    } else if ("getLineCap".equalsIgnoreCase(functionName)) {
-      return getPen(functionName, map, guid).getSquareCap() ? BigDecimal.ONE : BigDecimal.ZERO;
-    } else if ("getDrawingInfo".equalsIgnoreCase(functionName)) {
-      return getDrawingJSONInfo(functionName, map, guid);
+
+    if (FUNC_GET_DRAWABLE_INFO.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_LAYER.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_NAME.equalsIgnoreCase(functionName)) {
+      // [drawingRef [, mapRef]]
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 2);
+
+      // mapRef - defaults to current zone/map
+      Zone zone = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 1).getZone();
+
+      // drawableRef - defaults to the drawable selected by the respective pointer tool
+      DrawnElement de =
+          !parameters.isEmpty()
+              ? findDrawnElement(functionName, zone, parameters.getFirst().toString())
+              : getSingleSelectedDrawnElement(functionName, zone);
+
+      if (FUNC_GET_DRAWABLE_INFO.equalsIgnoreCase(functionName)) {
+        return getDrawingJSONInfo(FUNC_GET_DRAWABLE_INFO, zone, de.getDrawable().getId());
+      } else if (FUNC_GET_DRAWABLE_LAYER.equalsIgnoreCase(functionName)) {
+        return getDrawable(FUNC_GET_DRAWABLE_LAYER, zone, de.getDrawable().getId())
+            .getLayer()
+            .name();
+      } else if (FUNC_GET_DRAWABLE_NAME.equalsIgnoreCase(functionName)) {
+        return getDrawingName(FUNC_GET_DRAWABLE_NAME, zone, de.getDrawable().getId());
+      } else {
+        return null;
+      }
+
+    } else if (FUNC_GET_DRAWABLE_X.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_Y.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_CENTER_X.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_CENTER_Y.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_MAX_X.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_MAX_Y.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_HEIGHT.equalsIgnoreCase(functionName)
+        || FUNC_GET_DRAWABLE_WIDTH.equalsIgnoreCase(functionName)) {
+      // [units [, drawingRef [, mapRef]]]
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
+
+      // units - defaults to PIXELS
+      int units =
+          !parameters.isEmpty()
+              ? FunctionUtil.paramAsInteger(functionName, parameters, 0, false)
+              : DrawableUnit.getPixelsIndex();
+      DrawableUnit drawableUnit = DrawableUnit.valueOfIndex(units);
+      if (drawableUnit == null) {
+        throw new ParserException(
+            I18N.getText("macro.function.drawable.unknownDrawableUnits", functionName, units));
+      }
+
+      // mapRef - defaults to current zone/map
+      Zone zone = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 2).getZone();
+
+      // drawableRef - defaults to the drawable selected by the respective pointer tool
+      DrawnElement de =
+          parameters.size() > 1
+              ? findDrawnElement(functionName, zone, parameters.get(1).toString())
+              : getSingleSelectedDrawnElement(functionName, zone);
+
+      Rectangle bounds = getDrawingBounds(functionName, zone, de.getDrawable().getId());
+      int dimension = 0;
+      if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_X)) {
+        dimension = bounds.x;
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_Y)) {
+        dimension = bounds.y;
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_CENTER_X)) {
+        dimension = (int) bounds.getCenterX();
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_CENTER_Y)) {
+        dimension = (int) bounds.getCenterY();
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_MAX_X)) {
+        dimension = (int) bounds.getMaxX();
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_MAX_Y)) {
+        dimension = (int) bounds.getMaxY();
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_HEIGHT)) {
+        dimension = bounds.height;
+      } else if (functionName.equalsIgnoreCase(FUNC_GET_DRAWABLE_WIDTH)) {
+        dimension = bounds.width;
+      }
+      return BigDecimal.valueOf(
+          DrawableUnit.convert(zone, dimension, DrawableUnit.PIXELS, drawableUnit));
+
+    } else {
+      FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
+      String mapName = parameters.get(0).toString();
+      String id = parameters.get(1).toString();
+      Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
+      GUID guid = getGUID(functionName, id);
+      if ("getDrawingLayer".equalsIgnoreCase(functionName)) {
+        return getDrawable(functionName, map, guid).getLayer().name();
+      } else if ("getDrawingOpacity".equalsIgnoreCase(functionName)) {
+        return getPen(functionName, map, guid).getOpacity();
+      } else if ("getDrawingProperties".equalsIgnoreCase(functionName)) {
+        return getPen(functionName, map, guid);
+      } else if ("getPenColor".equalsIgnoreCase(functionName)) {
+        return paintToString(getPen(functionName, map, guid).getPaint());
+      } else if ("getFillColor".equalsIgnoreCase(functionName)) {
+        return paintToString(getPen(functionName, map, guid).getBackgroundPaint());
+      } else if ("getDrawingEraser".equalsIgnoreCase(functionName)) {
+        return getPen(functionName, map, guid).isEraser() ? BigDecimal.ONE : BigDecimal.ZERO;
+      } else if ("getPenWidth".equalsIgnoreCase(functionName)) {
+        return getPen(functionName, map, guid).getThickness();
+      } else if ("getLineCap".equalsIgnoreCase(functionName)) {
+        return getPen(functionName, map, guid).getSquareCap() ? BigDecimal.ONE : BigDecimal.ZERO;
+      } else if ("getDrawingInfo".equalsIgnoreCase(functionName)) {
+        return getDrawingJSONInfo(functionName, map, guid);
+      }
+      return null;
     }
-    return null;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingMiscFunctions.java
@@ -17,26 +17,26 @@ package net.rptools.maptool.client.functions;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.awt.BasicStroke;
-import java.awt.Point;
-import java.awt.geom.Area;
-import java.awt.geom.Line2D;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
+import java.awt.*;
+import java.awt.Rectangle;
+import java.awt.geom.*;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
-import net.rptools.maptool.model.GUID;
-import net.rptools.maptool.model.Zone;
-import net.rptools.maptool.model.drawing.AbstractDrawing;
-import net.rptools.maptool.model.drawing.DrawablesGroup;
-import net.rptools.maptool.model.drawing.DrawnElement;
+import net.rptools.maptool.client.tool.drawing.DrawingPointerTool;
+import net.rptools.maptool.client.tool.drawing.TemplatePointerTool;
+import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.*;
+import net.rptools.maptool.model.drawing.*;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.VariableResolver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DrawingMiscFunctions extends DrawingFunctions {
   private static final DrawingMiscFunctions instance = new DrawingMiscFunctions();
@@ -45,16 +45,29 @@ public class DrawingMiscFunctions extends DrawingFunctions {
     return instance;
   }
 
+  private static final String FUNC_DUPLICATE_DRAWABLE = "duplicateDrawable";
+  private static final String FUNC_GET_SELECTED_DRAWABLES = "getSelectedDrawables";
+  private static final String FUNC_GET_DRAWABLES_UNDER_TOKEN = "getDrawablesUnderToken";
+  private static final String FUNC_GET_TOKENS_OVER_DRAWABLE = "getTokensOverDrawable";
+  private static final String FUNC_MOVE_DRAWABLE = "moveDrawable";
+
+  private final Logger log = LogManager.getLogger(DrawingMiscFunctions.class);
+
   private DrawingMiscFunctions() {
     super(
-        2,
-        3,
+        0,
+        5,
         "findDrawings",
         "refreshDrawing",
         "bringDrawingToFront",
         "sendDrawingToBack",
         "movedOverDrawing",
-        "removeDrawing");
+        "removeDrawing",
+        FUNC_DUPLICATE_DRAWABLE,
+        FUNC_GET_SELECTED_DRAWABLES,
+        FUNC_GET_DRAWABLES_UNDER_TOKEN,
+        FUNC_GET_TOKENS_OVER_DRAWABLE,
+        FUNC_MOVE_DRAWABLE);
   }
 
   @Override
@@ -62,49 +75,166 @@ public class DrawingMiscFunctions extends DrawingFunctions {
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
     checkTrusted(functionName);
-    String mapName = parameters.get(0).toString();
-    String drawing = parameters.get(1).toString();
-    Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
-    if ("movedOverDrawing".equalsIgnoreCase(functionName)) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
-      String jsonPath = parameters.get(2).toString();
-      GUID guid = getGUID(functionName, drawing);
-      DrawnElement de = getDrawnElement(functionName, map, guid);
-      return getCrossedPoints(map, de, jsonPath);
-    } else if ("findDrawings".equalsIgnoreCase(functionName)) {
-      FunctionUtil.checkNumberParam(functionName, parameters, 2, 3);
-      List<DrawnElement> drawableList = map.getAllDrawnElements();
-      List<String> drawingList = findDrawings(drawableList, drawing);
-      String delim = parameters.size() > 2 ? parameters.get(2).toString() : ",";
-      if ("json".equalsIgnoreCase(delim)) {
-        JsonArray json = new JsonArray();
-        for (String val : drawingList) {
-          json.add(val);
+
+    if (FUNC_DUPLICATE_DRAWABLE.equalsIgnoreCase(functionName)) {
+      // [drawingRef [, mapRef]]
+      FunctionUtil.checkNumberParam(FUNC_DUPLICATE_DRAWABLE, parameters, 0, 2);
+
+      ZoneRenderer renderer =
+          FunctionUtil.getZoneRendererFromParam(FUNC_DUPLICATE_DRAWABLE, parameters, 1);
+      Zone zone = renderer.getZone();
+      DrawnElement de =
+          !parameters.isEmpty()
+              ? findDrawnElement(FUNC_DUPLICATE_DRAWABLE, zone, parameters.getFirst().toString())
+              : getSingleSelectedDrawnElement(FUNC_DUPLICATE_DRAWABLE, zone);
+      return duplicateDrawnElement(renderer, de);
+
+    } else if (FUNC_GET_SELECTED_DRAWABLES.equalsIgnoreCase(functionName)) {
+      // [delim]
+      FunctionUtil.checkNumberParam(FUNC_GET_SELECTED_DRAWABLES, parameters, 0, 1);
+
+      String delim = !parameters.isEmpty() ? parameters.getFirst().toString() : ",";
+      return getSelectedDrawables(delim);
+
+    } else if (FUNC_GET_DRAWABLES_UNDER_TOKEN.equalsIgnoreCase(functionName)
+        || FUNC_GET_TOKENS_OVER_DRAWABLE.equalsIgnoreCase(functionName)) {
+      // get drawables -> [verbose [, threshold [, drawablesOnLayer [,tokenRef [, mapRef]]]]]
+      // get tokens -> [verbose [, threshold [, tokensOnLayer [ ,drawingRef [, mapRef ]]]]]
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 5);
+
+      // (optional) verbose - defaults to false, i.e. return just an array of ids
+      boolean verbose =
+          !parameters.isEmpty()
+              ? FunctionUtil.paramAsBoolean(functionName, parameters, 0, false)
+              : false;
+
+      // (optional) threshold - defaults to 0, i.e. any overlap
+      double threshold =
+          parameters.size() > 1
+              ? FunctionUtil.paramAsDouble(functionName, parameters, 1, false)
+              : 0;
+
+      // (optional) layer, defaults to null, i.e. all layers
+      Zone.Layer layer = null;
+      if (parameters.size() > 2) {
+        String argLayer = parameters.get(2).toString().toUpperCase();
+        if (!argLayer.equals("*")) {
+          // getByName also handles turning HIDDEN -> GM
+          layer = Zone.Layer.getByName(argLayer);
         }
-        return json;
-      } else return StringFunctions.getInstance().join(drawingList, delim);
-    } else {
-      FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
-      GUID guid = getGUID(functionName, drawing);
-      if ("refreshDrawing".equalsIgnoreCase(functionName)) {
-        DrawnElement de = getDrawnElement(functionName, map, guid);
-        MapTool.getFrame().updateDrawTree();
-        MapTool.serverCommand().updateDrawing(map.getId(), de.getPen(), de);
-        return "";
-      } else if ("bringDrawingToFront".equalsIgnoreCase(functionName)) {
-        bringToFront(map, guid);
-        return "";
-      } else if ("sendDrawingToBack".equalsIgnoreCase(functionName)) {
-        sendToBack(map, guid);
-        return "";
-      } else if ("removeDrawing".equalsIgnoreCase(functionName)) {
-        MapTool.serverCommand().undoDraw(map.getId(), guid);
-        return "";
       }
+
+      // (optional) mapRef - defaults to current zone/map
+      Zone zone = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 4).getZone();
+
+      if (FUNC_GET_DRAWABLES_UNDER_TOKEN.equalsIgnoreCase(functionName)) {
+        // (optional) tokenRef - defaults to current token
+        Token token =
+            FunctionUtil.getTokenFromParam(
+                resolver, FUNC_GET_DRAWABLES_UNDER_TOKEN, parameters, 3, 4);
+        return getDrawablesUnderToken(zone, verbose, threshold, layer, token);
+
+      } else if (FUNC_GET_TOKENS_OVER_DRAWABLE.equalsIgnoreCase(functionName)) {
+        // (optional) drawableRef - defaults to the drawable selected by the respective pointer tool
+        DrawnElement de =
+            parameters.size() > 3
+                ? findDrawnElement(
+                    FUNC_GET_TOKENS_OVER_DRAWABLE, zone, parameters.get(3).toString())
+                : getSingleSelectedDrawnElement(FUNC_GET_TOKENS_OVER_DRAWABLE, zone);
+        return getTokensOverDrawable(zone, verbose, threshold, layer, de);
+
+      } else {
+        // should not get here but this branch is needed otherwise IDE moans
+        return null;
+      }
+
+    } else if (FUNC_MOVE_DRAWABLE.equalsIgnoreCase(functionName)) {
+      // x, y, [, units [, drawingRef [, mapRef]]]
+      FunctionUtil.checkNumberParam(FUNC_MOVE_DRAWABLE, parameters, 2, 5);
+
+      // x & y
+      int x = FunctionUtil.paramAsInteger(FUNC_MOVE_DRAWABLE, parameters, 0, false);
+      int y = FunctionUtil.paramAsInteger(FUNC_MOVE_DRAWABLE, parameters, 1, false);
+
+      // (optional) units - defaults to PIXELS
+      int units =
+          parameters.size() > 2
+              ? FunctionUtil.paramAsInteger(functionName, parameters, 2, false)
+              : DrawableUnit.getPixelsIndex();
+      DrawableUnit drawableUnit = DrawableUnit.valueOfIndex(units);
+      if (drawableUnit == null && parameters.size() > 2) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.drawable.unknownDrawableUnits", functionName, parameters.get(2)));
+      }
+
+      // (optional) renderer & zone/map - defaults to the current
+      ZoneRenderer renderer =
+          FunctionUtil.getZoneRendererFromParam(FUNC_MOVE_DRAWABLE, parameters, 4);
+      Zone zone = renderer.getZone();
+
+      // (optional) drawn element - defaults to the drawable selected by the respective pointer tool
+      DrawnElement de =
+          parameters.size() > 3
+              ? findDrawnElement(FUNC_MOVE_DRAWABLE, zone, parameters.get(3).toString())
+              : getSingleSelectedDrawnElement(FUNC_MOVE_DRAWABLE, zone);
+
+      moveDrawable(renderer, de, x, y, drawableUnit);
+      return "";
+
+    } else {
+      String mapName = parameters.get(0).toString();
+      String drawing = parameters.get(1).toString();
+      Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
+      if ("movedOverDrawing".equalsIgnoreCase(functionName)) {
+        FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
+        String jsonPath = parameters.get(2).toString();
+        GUID guid = getGUID(functionName, drawing);
+        DrawnElement de = getDrawnElement(functionName, map, guid);
+        return getCrossedPoints(map, de, jsonPath);
+      } else if ("findDrawings".equalsIgnoreCase(functionName)) {
+        FunctionUtil.checkNumberParam(functionName, parameters, 2, 3);
+        List<DrawnElement> drawableList = map.getAllDrawnElements();
+        List<String> drawingList = findDrawings(drawableList, drawing);
+        String delim = parameters.size() > 2 ? parameters.get(2).toString() : ",";
+        if ("json".equalsIgnoreCase(delim)) {
+          JsonArray json = new JsonArray();
+          for (String val : drawingList) {
+            json.add(val);
+          }
+          return json;
+        } else return StringFunctions.getInstance().join(drawingList, delim);
+      } else {
+        FunctionUtil.checkNumberParam(functionName, parameters, 2, 2);
+        GUID guid = getGUID(functionName, drawing);
+        if ("refreshDrawing".equalsIgnoreCase(functionName)) {
+          DrawnElement de = getDrawnElement(functionName, map, guid);
+          MapTool.getFrame().updateDrawTree();
+          MapTool.serverCommand().updateDrawing(map.getId(), de.getPen(), de);
+          return "";
+        } else if ("bringDrawingToFront".equalsIgnoreCase(functionName)) {
+          bringToFront(map, guid);
+          return "";
+        } else if ("sendDrawingToBack".equalsIgnoreCase(functionName)) {
+          sendToBack(map, guid);
+          return "";
+        } else if ("removeDrawing".equalsIgnoreCase(functionName)) {
+          MapTool.serverCommand().undoDraw(map.getId(), guid);
+          return "";
+        }
+      }
+      return null;
     }
-    return null;
   }
 
+  /**
+   * Check if a given path has crossed through a specified drawing or template.
+   *
+   * @param map the map
+   * @param de the drawn element
+   * @param pathStr the path as a string
+   * @return a json array or all points crossed
+   */
   private JsonArray getCrossedPoints(final Zone map, final DrawnElement de, final String pathStr) {
     List<Map<String, Integer>> pathPoints = convertJSONStringToList(pathStr);
     JsonArray returnPoints = new JsonArray();
@@ -135,6 +265,12 @@ public class DrawingMiscFunctions extends DrawingFunctions {
     return returnPoints;
   }
 
+  /**
+   * Create a list of path points
+   *
+   * @param pointsString a string of points
+   * @return a list of the path points
+   */
   private List<Map<String, Integer>> convertJSONStringToList(final String pointsString) {
 
     JsonElement json = null;
@@ -178,5 +314,380 @@ public class DrawingMiscFunctions extends DrawingFunctions {
       }
     }
     return drawingList;
+  }
+
+  /**
+   * Duplicates a drawing or template in place.
+   *
+   * @param renderer where to draw
+   * @param de the drawn element to duplicate
+   * @return the id of the new duplicate drawn element
+   */
+  public GUID duplicateDrawnElement(ZoneRenderer renderer, DrawnElement de) {
+    Drawable d = de.getDrawable();
+    AbstractDrawing ad = (AbstractDrawing) d.copy();
+    ad.setId(new GUID());
+    // Draw it
+    MapTool.serverCommand().draw(renderer.getZone().getId(), de.getPen(), ad);
+    // Allow it to be undone
+    renderer.getZone().addDrawable(de.getPen(), ad);
+    renderer.repaint();
+    MapTool.getFrame().updateDrawTree();
+    MapTool.getFrame().refresh();
+    return ad.getId();
+  }
+
+  /**
+   * Move a drawable to position x, y on a map
+   *
+   * @param renderer where to draw
+   * @param de the drawn element to move
+   * @param x where to move to on the x-axis
+   * @param y where to move to on the y-axis
+   * @param drawableUnit CELLS, DISTANCE, or PIXELS
+   */
+  private void moveDrawable(
+      ZoneRenderer renderer, DrawnElement de, int x, int y, DrawableUnit drawableUnit) {
+
+    Zone zone = renderer.getZone();
+
+    // determine the drawable type and hand off moving it
+    switch (de.getDrawable()) {
+      case DrawablesGroup dg2 -> {
+        moveDrawable(zone, dg2, x, y, drawableUnit);
+        MapTool.serverCommand().updateDrawing(zone.getId(), de.getPen(), de);
+        zone.updateDrawable(de, de.getPen());
+      }
+      case LineSegment ls -> {
+        moveDrawable(zone, ls, x, y, drawableUnit);
+        MapTool.serverCommand().updateDrawing(zone.getId(), de.getPen(), de);
+        zone.updateDrawable(de, de.getPen());
+      }
+      case ShapeDrawable sd -> {
+        moveDrawable(zone, sd, x, y, drawableUnit);
+        MapTool.serverCommand().updateDrawing(zone.getId(), de.getPen(), de);
+        zone.updateDrawable(de, de.getPen());
+      }
+      case AbstractTemplate at -> moveDrawable(zone, at, de, x, y, drawableUnit);
+      case null, default -> {
+        // drawn element is not of a type currently moveable by this method
+      }
+    }
+
+    MapTool.serverCommand().updateDrawing(zone.getId(), de.getPen(), de);
+    zone.updateDrawable(de, de.getPen());
+    renderer.repaint();
+    MapTool.getFrame().updateDrawTree();
+    MapTool.getFrame().refresh();
+  }
+
+  /**
+   * Move a {@link DrawablesGroup} and its nested contents to position x, y on a map. Note that
+   * <code>DrawablesGroup</code>s cannot currently contain templates.
+   *
+   * @param zone where to draw
+   * @param dg the drawables group to move
+   * @param x where to move to on the x-axis
+   * @param y where to move to on the y-axis
+   * @param drawableUnit whether x & y are given in CELLS, DISTANCE, or PIXELS
+   */
+  private void moveDrawable(Zone zone, DrawablesGroup dg, int x, int y, DrawableUnit drawableUnit) {
+    for (DrawnElement de : dg.getDrawableList()) {
+      if (de.getDrawable() instanceof DrawablesGroup dg2) {
+        moveDrawable(zone, dg2, x, y, drawableUnit);
+      } else if (de.getDrawable() instanceof LineSegment ls) {
+        moveDrawable(zone, ls, x, y, drawableUnit);
+      } else if (de.getDrawable() instanceof ShapeDrawable sd) {
+        moveDrawable(zone, sd, x, y, drawableUnit);
+      }
+      MapTool.serverCommand().updateDrawing(zone.getId(), de.getPen(), de);
+      zone.updateDrawable(de, de.getPen());
+    }
+  }
+
+  /**
+   * Move a {@link LineSegment} to position x, y on a map
+   *
+   * @param zone where to draw
+   * @param ls the line segment to move
+   * @param x where to move on the x-axis
+   * @param y where to move on the y-axis
+   * @param drawableUnit whether x & y are given in CELLS, DISTANCE, or PIXELS
+   */
+  private void moveDrawable(Zone zone, LineSegment ls, int x, int y, DrawableUnit drawableUnit) {
+
+    ZonePoint zp = null;
+    switch (drawableUnit) {
+      case CELLS -> zp = zone.getGrid().convert(new CellPoint(x, y));
+      case DISTANCE ->
+          zp =
+              zone.getGrid()
+                  .convert(
+                      new CellPoint(
+                          DrawableUnit.convert(zone, x, drawableUnit, DrawableUnit.CELLS),
+                          DrawableUnit.convert(zone, y, drawableUnit, DrawableUnit.CELLS)));
+      case PIXELS -> zp = new ZonePoint(x, y);
+      case null, default -> {
+        // as PIXELS
+        zp = new ZonePoint(x, y);
+      }
+    }
+
+    ls.translate(zp.x - ls.getBounds(zone).x, zp.y - ls.getBounds(zone).y);
+  }
+
+  /**
+   * Move a {@link ShapeDrawable} to position x, y on a map
+   *
+   * @param zone where to draw
+   * @param sd the shape drawable to move
+   * @param x where to move to on the x-axis
+   * @param y where to move to on the y-axis
+   * @param drawableUnit whether x & y are given in CELLS, DISTANCE, or PIXELS
+   */
+  private void moveDrawable(Zone zone, ShapeDrawable sd, int x, int y, DrawableUnit drawableUnit) {
+
+    ZonePoint zp = null;
+    switch (drawableUnit) {
+      case CELLS -> zp = zone.getGrid().convert(new CellPoint(x, y));
+      case DISTANCE ->
+          zp =
+              zone.getGrid()
+                  .convert(
+                      new CellPoint(
+                          DrawableUnit.convert(zone, x, drawableUnit, DrawableUnit.CELLS),
+                          DrawableUnit.convert(zone, y, drawableUnit, DrawableUnit.CELLS)));
+      case PIXELS -> zp = new ZonePoint(x, y);
+      case null, default -> {
+        // as PIXELS
+        zp = new ZonePoint(x, y);
+      }
+    }
+
+    if (sd.getShape() instanceof RectangularShape rs) {
+      rs.setFrame(zp.x, zp.y, rs.getWidth(), rs.getHeight());
+    } else if (sd.getShape() instanceof Polygon p) {
+      p.translate(zp.x - p.getBounds().x, zp.y - p.getBounds().y);
+    }
+  }
+
+  /**
+   * Moves an {@link AbstractTemplate}'s bounds to position x, y on a map, and if applicable the
+   * pathVertex to a related position.
+   *
+   * @param zone where to draw
+   * @param at the abstract template to move
+   * @param de the drawn element
+   * @param x where to move to on the x-axis
+   * @param y where to move to on the y-axis
+   * @param drawableUnit whether x & y are given in CELLS, DISTANCE, or PIXELS
+   */
+  private void moveDrawable(
+      Zone zone, AbstractTemplate at, DrawnElement de, int x, int y, DrawableUnit drawableUnit) {
+
+    Rectangle bounds = at.getArea(zone).getBounds();
+    ZonePoint vertex = at.getVertex();
+    ZonePoint diff = new ZonePoint(vertex.x - bounds.x, vertex.y - bounds.y);
+
+    CellPoint cp;
+    switch (drawableUnit) {
+      case CELLS -> cp = new CellPoint(x, y);
+      case DISTANCE ->
+          cp =
+              new CellPoint(
+                  DrawableUnit.convert(zone, x, drawableUnit, DrawableUnit.CELLS),
+                  DrawableUnit.convert(zone, y, drawableUnit, DrawableUnit.CELLS));
+      case PIXELS -> cp = zone.getGrid().convert(new ZonePoint(x, y));
+      case null, default -> {
+        // as CELLS
+        cp = new CellPoint(x, y);
+      }
+    }
+    ZonePoint zp0 = zone.getGrid().convert(cp);
+    ZonePoint zp = new ZonePoint(zp0.x + diff.x, zp0.y + diff.y);
+
+    if (at instanceof LineTemplate lt && !(at instanceof WallTemplate)) {
+      // While WallTemplate extends LineTemplate, changing a WallTemplate's path vertex breaks
+      // getBounds(), so don't change it for WallTemplates!
+      ZonePoint pathVertexMove =
+          new ZonePoint(
+              zp.x + lt.getPathVertex().x - lt.getVertex().x,
+              zp.y + lt.getPathVertex().y - lt.getVertex().y);
+      lt.setPathVertex(pathVertexMove);
+    }
+    if (at instanceof LineCellTemplate lct) {
+      ZonePoint pathVertexMove =
+          new ZonePoint(
+              zp.x + lct.getPathVertex().x - lct.getVertex().x,
+              zp.y + lct.getPathVertex().y - lct.getVertex().y);
+      lct.setPathVertex(pathVertexMove);
+    }
+    at.setVertex(zp);
+    de.setDrawable(at);
+  }
+
+  /**
+   * Get selected drawings or templates relevant to the respective {@link DrawingPointerTool} or
+   * {@link TemplatePointerTool}.
+   *
+   * @param delim the delimiter to use for the selected drawings output
+   * @return the selected drawables
+   */
+  public String getSelectedDrawables(String delim) {
+
+    List<GUID> selectedDrawables = new ArrayList<>();
+
+    // get a list of selected drawings depending on the selected tool
+    Object selectedTool = MapTool.getFrame().getToolbox().getSelectedTool().getClass();
+    if (selectedTool.equals(TemplatePointerTool.class)) {
+      selectedDrawables = TemplatePointerTool.getSelectedDrawables();
+    } else if (selectedTool.equals(DrawingPointerTool.class)) {
+      selectedDrawables = DrawingPointerTool.getSelectedDrawables();
+    }
+
+    // output the list using the desired delimiter
+    if (delim.equalsIgnoreCase("json")) {
+      JsonArray selectedDrawablesJsonArray = new JsonArray();
+      for (GUID selectedDrawing : selectedDrawables) {
+        selectedDrawablesJsonArray.add(selectedDrawing.toString());
+      }
+      return selectedDrawablesJsonArray.toString();
+    } else {
+      return selectedDrawables.stream().map(GUID::toString).collect(Collectors.joining(delim));
+    }
+  }
+
+  /**
+   * For a specified drawing/template, get any tokens that overlap by an amount.
+   *
+   * @param zone the map
+   * @param verbose whether to show the amount of the overlap in the results
+   * @param threshold the minimum amount of overlap between the tokens and the drawing
+   * @param layer if supplied, only check tokens on this layer otherwise all layers
+   * @param drawnElement the drawing/template
+   * @return drawings under the token with their % overlap
+   */
+  private String getTokensOverDrawable(
+      Zone zone, boolean verbose, double threshold, Zone.Layer layer, DrawnElement drawnElement) {
+
+    JsonArray tokensOverDrawable = new JsonArray();
+
+    List<Token> tokens;
+    if (layer != null) {
+      tokens = zone.getTokensOnLayer(layer);
+    } else {
+      tokens = zone.getAllTokens();
+    }
+
+    for (Token token : tokens) {
+      double overlap = calculateOverlap(zone, token, drawnElement);
+      if (overlap > 0 && overlap >= threshold) {
+        String id = token.getId().toString();
+        if (verbose) {
+          JsonObject tokenWithOverlap = new JsonObject();
+          tokenWithOverlap.addProperty("tokenId", id);
+          tokenWithOverlap.addProperty("overlap", overlap);
+          tokensOverDrawable.add(tokenWithOverlap);
+        } else {
+          tokensOverDrawable.add(id);
+        }
+      }
+    }
+
+    return tokensOverDrawable.toString();
+  }
+
+  /**
+   * For a specified token, get any drawings/templates that are under it by an amount.
+   *
+   * @param zone the map
+   * @param verbose whether to show the amount of the overlap in the results
+   * @param threshold the minimum amount of overlap between the token and the drawings
+   * @param layer if supplied, only check drawings/templates on this layer otherwise all layers
+   * @param token the token
+   * @return drawings under the token with their % overlap
+   */
+  private String getDrawablesUnderToken(
+      Zone zone, boolean verbose, double threshold, Zone.Layer layer, Token token) {
+
+    JsonArray drawablesUnderToken = new JsonArray();
+
+    List<DrawnElement> drawnElements;
+    if (layer != null) {
+      drawnElements = zone.getDrawnElements(layer);
+    } else {
+      drawnElements = zone.getAllDrawnElements();
+    }
+
+    for (DrawnElement drawnElement : drawnElements) {
+      double overlap = calculateOverlap(zone, token, drawnElement);
+      if (overlap > 0 && overlap >= threshold) {
+        String id = drawnElement.getDrawable().getId().toString();
+        if (verbose) {
+          JsonObject drawableWithOverlap = new JsonObject();
+          drawableWithOverlap.addProperty("drawableId", id);
+          drawableWithOverlap.addProperty("overlap", overlap);
+          drawablesUnderToken.add(drawableWithOverlap);
+        } else {
+          drawablesUnderToken.add(id);
+        }
+      }
+    }
+
+    return drawablesUnderToken.toString();
+  }
+
+  /**
+   * For a given token, break down its rectangle bounds into a mini-grid of smaller rectangles and
+   * count the number of these rectangle centers that are within the {@link Drawable}'s {@link
+   * Area}.
+   *
+   * <p>Limitations/areas for improvement:
+   *
+   * <ul>
+   *   <li>the number of mini-rectangles checked is the same regardless of token size
+   *   <li>does not account for different grid type shapes (so iso and hex grid threshold may be
+   *       incorrect)
+   *   <li>is not based on a token's occupied cells
+   *
+   * @param zone the map
+   * @param token the token
+   * @param drawnElement the drawn element
+   * @return % of token bounds that overlaps with drawing
+   */
+  private double calculateOverlap(Zone zone, Token token, DrawnElement drawnElement) {
+
+    Grid grid = zone.getGrid();
+
+    Rectangle tokenFootprintBounds =
+        token
+            .getFootprint(grid)
+            .getBounds(grid, grid.convert(new ZonePoint(token.getX(), token.getY())));
+    Rectangle tokenImageBounds = token.getImageBounds(zone);
+    Rectangle tokenBounds = token.isSnapToGrid() ? tokenFootprintBounds : tokenImageBounds;
+
+    Area drawingArea = drawnElement.getDrawable().getArea(zone);
+
+    int countOverlap = 0;
+
+    // first do inexpensive check if bounds overlap, we can ignore those which don't overlap
+    if (tokenBounds.intersects(drawingArea.getBounds())) {
+
+      // set x & y dimensions to increment by
+      double incX = tokenBounds.width / grid.getCellWidth();
+      double incY = tokenBounds.height / grid.getCellHeight();
+
+      // starting at token left iterate to token right
+      for (double x = tokenBounds.x; x < (tokenBounds.x + tokenBounds.width); x = x + incX) {
+        // starting at token top iterate to token bottom
+        for (double y = tokenBounds.y; y < (tokenBounds.y + tokenBounds.height); y = y + incY) {
+          // check if the middle of each square is within the drawing area
+          if (drawingArea.contains((int) (x + incX / 2), (int) (y + incY / 2))) {
+            countOverlap++;
+          }
+        }
+      }
+    }
+    return countOverlap / (grid.getCellWidth() * grid.getCellHeight());
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/DrawingSetterFunctions.java
@@ -15,9 +15,11 @@
 package net.rptools.maptool.client.functions;
 
 import java.util.List;
+import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.Zone.Layer;
+import net.rptools.maptool.model.drawing.DrawnElement;
 import net.rptools.maptool.model.drawing.Pen;
 import net.rptools.maptool.util.FunctionUtil;
 import net.rptools.parser.Parser;
@@ -31,9 +33,12 @@ public class DrawingSetterFunctions extends DrawingFunctions {
     return instance;
   }
 
+  private static final String FUNC_SET_DRAWABLE_LAYER = "setDrawableLayer";
+  private static final String FUNC_SET_DRAWABLE_NAME = "setDrawableName";
+
   private DrawingSetterFunctions() {
     super(
-        3,
+        1,
         3,
         "setDrawingLayer",
         "setDrawingOpacity",
@@ -43,7 +48,9 @@ public class DrawingSetterFunctions extends DrawingFunctions {
         "setDrawingEraser",
         "setPenWidth",
         "setLineCap",
-        "setDrawingName");
+        "setDrawingName",
+        FUNC_SET_DRAWABLE_LAYER,
+        FUNC_SET_DRAWABLE_NAME);
   }
 
   @Override
@@ -51,59 +58,90 @@ public class DrawingSetterFunctions extends DrawingFunctions {
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
     checkTrusted(functionName);
-    FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
-    String mapName = parameters.get(0).toString();
-    String id = parameters.get(1).toString();
-    Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
-    GUID guid = getGUID(functionName, id);
-    if ("setDrawingLayer".equalsIgnoreCase(functionName)) {
-      Layer layer = getLayer(parameters.get(2).toString());
-      return changeLayer(map, layer, guid).name();
-    } else if ("setDrawingOpacity".equalsIgnoreCase(functionName)) {
-      String opacity = parameters.get(2).toString();
-      float op = getFloatPercent(functionName, opacity);
-      setDrawingOpacity(functionName, map, guid, op);
+
+    if (FUNC_SET_DRAWABLE_LAYER.equalsIgnoreCase(functionName)) {
+      // layer, [drawingRef [, mapRef]]
+      FunctionUtil.checkNumberParam(FUNC_SET_DRAWABLE_LAYER, parameters, 1, 3);
+      Layer layer = getLayer(parameters.getFirst().toString());
+      ZoneRenderer renderer =
+          FunctionUtil.getZoneRendererFromParam(FUNC_SET_DRAWABLE_LAYER, parameters, 2);
+      Zone zone = renderer.getZone();
+      DrawnElement de =
+          parameters.size() < 2
+              ? getSingleSelectedDrawnElement(FUNC_SET_DRAWABLE_LAYER, zone)
+              : findDrawnElement(FUNC_SET_DRAWABLE_LAYER, zone, parameters.get(1).toString());
+      return changeLayer(zone, layer, de.getDrawable().getId()).name();
+
+    } else if (FUNC_SET_DRAWABLE_NAME.equalsIgnoreCase(functionName)) {
+      // name, [drawingRef [, mapRef]]
+      FunctionUtil.checkNumberParam(FUNC_SET_DRAWABLE_NAME, parameters, 1, 3);
+      String name = parameters.getFirst().toString();
+      ZoneRenderer renderer =
+          FunctionUtil.getZoneRendererFromParam(FUNC_SET_DRAWABLE_NAME, parameters, 2);
+      Zone zone = renderer.getZone();
+      DrawnElement de =
+          parameters.size() < 2
+              ? getSingleSelectedDrawnElement(FUNC_SET_DRAWABLE_NAME, zone)
+              : findDrawnElement(FUNC_SET_DRAWABLE_NAME, zone, parameters.get(1).toString());
+      setDrawingName(FUNC_SET_DRAWABLE_NAME, zone, de.getDrawable().getId(), name);
       return "";
-    } else if ("setDrawingProperties".equalsIgnoreCase(functionName)) {
-      Pen pen = (Pen) parameters.get(2);
-      setPen(functionName, map, guid, pen);
-      return "";
-    } else if ("setPenColor".equalsIgnoreCase(functionName)) {
-      String paint = parameters.get(2).toString();
-      if ("".equalsIgnoreCase(paint)) {
-        getPen(functionName, map, guid).setPaint(null);
-      } else {
-        getPen(functionName, map, guid).setPaint(FunctionUtil.getPaintFromString(paint));
+
+    } else {
+      FunctionUtil.checkNumberParam(functionName, parameters, 3, 3);
+      String mapName = parameters.get(0).toString();
+      String id = parameters.get(1).toString();
+      Zone map = FunctionUtil.getZoneRenderer(functionName, mapName).getZone();
+      GUID guid = getGUID(functionName, id);
+      if ("setDrawingLayer".equalsIgnoreCase(functionName)) {
+        Layer layer = getLayer(parameters.get(2).toString());
+        return changeLayer(map, layer, guid).name();
+      } else if ("setDrawingOpacity".equalsIgnoreCase(functionName)) {
+        String opacity = parameters.get(2).toString();
+        float op = getFloatPercent(functionName, opacity);
+        setDrawingOpacity(functionName, map, guid, op);
+        return "";
+      } else if ("setDrawingProperties".equalsIgnoreCase(functionName)) {
+        Pen pen = (Pen) parameters.get(2);
+        setPen(functionName, map, guid, pen);
+        return "";
+      } else if ("setPenColor".equalsIgnoreCase(functionName)) {
+        String paint = parameters.get(2).toString();
+        if ("".equalsIgnoreCase(paint)) {
+          getPen(functionName, map, guid).setPaint(null);
+        } else {
+          getPen(functionName, map, guid).setPaint(FunctionUtil.getPaintFromString(paint));
+        }
+        return "";
+      } else if ("setFillColor".equalsIgnoreCase(functionName)) {
+        String paint = parameters.get(2).toString();
+        if ("".equalsIgnoreCase(paint)) {
+          getPen(functionName, map, guid).setBackgroundPaint(null);
+        } else {
+          getPen(functionName, map, guid)
+              .setBackgroundPaint(FunctionUtil.getPaintFromString(paint));
+        }
+        return "";
+      } else if ("setDrawingEraser".equalsIgnoreCase(functionName)) {
+        boolean eraser = parseBoolean(functionName, parameters, 2);
+        Pen p = getPen(functionName, map, guid);
+        p.setEraser(eraser);
+        return "";
+      } else if ("setPenWidth".equalsIgnoreCase(functionName)) {
+        String penWidth = parameters.get(2).toString();
+        float pw = getFloat(functionName, penWidth);
+        getPen(functionName, map, guid).setThickness(pw);
+        return "";
+      } else if ("setLineCap".equalsIgnoreCase(functionName)) {
+        boolean squareCap = parseBoolean(functionName, parameters, 2);
+        Pen p = getPen(functionName, map, guid);
+        p.setSquareCap(squareCap);
+        return "";
+      } else if ("setDrawingName".equalsIgnoreCase(functionName)) {
+        String name = parameters.get(2).toString();
+        setDrawingName(functionName, map, guid, name);
+        return "";
       }
-      return "";
-    } else if ("setFillColor".equalsIgnoreCase(functionName)) {
-      String paint = parameters.get(2).toString();
-      if ("".equalsIgnoreCase(paint)) {
-        getPen(functionName, map, guid).setBackgroundPaint(null);
-      } else {
-        getPen(functionName, map, guid).setBackgroundPaint(FunctionUtil.getPaintFromString(paint));
-      }
-      return "";
-    } else if ("setDrawingEraser".equalsIgnoreCase(functionName)) {
-      boolean eraser = parseBoolean(functionName, parameters, 2);
-      Pen p = getPen(functionName, map, guid);
-      p.setEraser(eraser);
-      return "";
-    } else if ("setPenWidth".equalsIgnoreCase(functionName)) {
-      String penWidth = parameters.get(2).toString();
-      float pw = getFloat(functionName, penWidth);
-      getPen(functionName, map, guid).setThickness(pw);
-      return "";
-    } else if ("setLineCap".equalsIgnoreCase(functionName)) {
-      boolean squareCap = parseBoolean(functionName, parameters, 2);
-      Pen p = getPen(functionName, map, guid);
-      p.setSquareCap(squareCap);
-      return "";
-    } else if ("setDrawingName".equalsIgnoreCase(functionName)) {
-      String name = parameters.get(2).toString();
-      setDrawingName(map, guid, name);
-      return "";
+      return null;
     }
-    return null;
   }
 }

--- a/src/main/java/net/rptools/maptool/client/functions/TemplateFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TemplateFunctions.java
@@ -63,84 +63,62 @@ public class TemplateFunctions extends DrawingFunctions {
   }
 
   /**
-   * TemplateType Enumeration, including:
-   *
-   * <ul>
-   *   <li><code>alias</code> property for matching template type by an alias
-   *   <li><code>template</code> method to return the appropriate template class
+   * TemplateType Enumeration, including <code>template</code> method to return the appropriate
+   * template class.
    */
   private enum TemplateType {
-    BlastTemplate("Blast") {
+    BLAST() {
       @Override
       public AbstractTemplate template() {
         return new BlastTemplate();
       }
     },
-    BurstTemplate("Burst") {
+    BURST() {
       @Override
       public AbstractTemplate template() {
         return new BurstTemplate();
       }
     },
-    ConeTemplate("Cone") {
+    CONE() {
       @Override
       public AbstractTemplate template() {
         return new ConeTemplate();
       }
     },
-    LineTemplate("Line") {
+    LINE() {
       @Override
       public AbstractTemplate template() {
         return new LineTemplate();
       }
     },
-    LineCellTemplate("LineCell") {
+    LINECELL() {
       @Override
       public AbstractTemplate template() {
         return new LineCellTemplate();
       }
     },
-    RadiusTemplate("Radius") {
+    RADIUS() {
       @Override
       public AbstractTemplate template() {
         return new RadiusTemplate();
       }
     },
-    RadiusCellTemplate("RadiusCell") {
+    RADIUSCELL() {
       @Override
       public AbstractTemplate template() {
         return new RadiusCellTemplate();
       }
     },
-    WallTemplate("Wall") {
+    WALL() {
       @Override
       public AbstractTemplate template() {
         return new WallTemplate();
       }
     };
 
-    TemplateType(String alias) {
-      this.alias = alias;
-    }
+    TemplateType() {}
 
-    public AbstractTemplate template() {
-      return null;
-    }
-
-    private final String alias;
-
-    public String getAlias() {
-      return alias;
-    }
-
-    public static TemplateType valueOfAlias(String alias) {
-      for (TemplateType tt : values()) {
-        if (tt.alias.equalsIgnoreCase(alias)) {
-          return tt;
-        }
-      }
-      return null;
-    }
+    public abstract AbstractTemplate template();
   }
 
   /** Evaluate the function(s) */
@@ -154,19 +132,15 @@ public class TemplateFunctions extends DrawingFunctions {
       // templateType, radius/wallPath [, units, [, options [, delim [, mapRef ]]]]
       FunctionUtil.checkNumberParam(FUNC_CREATE_TEMPLATE, parameters, 2, 6);
 
-      // template type, determine first by alias, then name (i.e. enum value)
+      // template type, determine by name (i.e. enum value)
       String templateType = parameters.getFirst().toString().toUpperCase().trim();
-      TemplateType tt = TemplateType.valueOfAlias(templateType);
-      if (tt == null) {
-        try {
-          tt = TemplateType.valueOf(templateType);
-        } catch (IllegalArgumentException iae) {
-          throw new ParserException(
-              I18N.getText(
-                  "macro.function.template.unknownTemplateType",
-                  FUNC_CREATE_TEMPLATE,
-                  templateType));
-        }
+      TemplateType tt;
+      try {
+        tt = TemplateType.valueOf(templateType);
+      } catch (IllegalArgumentException iae) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.template.unknownTemplateType", FUNC_CREATE_TEMPLATE, templateType));
       }
       AbstractTemplate abstractTemplate = tt.template();
 
@@ -244,10 +218,19 @@ public class TemplateFunctions extends DrawingFunctions {
           parameters.size() < 2
               ? getSingleSelectedDrawnElement(FUNC_GET_TEMPLATE_RADIUS, zone)
               : findDrawnElement(FUNC_GET_TEMPLATE_RADIUS, zone, parameters.get(1).toString());
+
       if (!(de.getDrawable() instanceof AbstractTemplate)) {
         throw new ParserException(
             I18N.getText(
                 "macro.function.template.unknownTemplate", functionName, de.getDrawable().getId()));
+      }
+
+      if (de.getDrawable() instanceof WallTemplate) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.template.invalidRadius",
+                functionName,
+                de.getDrawable().getClass().getSimpleName()));
       }
 
       return BigDecimal.valueOf(

--- a/src/main/java/net/rptools/maptool/client/functions/TemplateFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TemplateFunctions.java
@@ -1,0 +1,782 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import com.google.gson.JsonObject;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.model.*;
+import net.rptools.maptool.model.drawing.*;
+import net.rptools.maptool.util.FunctionUtil;
+import net.rptools.parser.Parser;
+import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TemplateFunctions extends DrawingFunctions {
+  private static final TemplateFunctions instance = new TemplateFunctions();
+
+  public static TemplateFunctions getInstance() {
+    return instance;
+  }
+
+  private static final String FUNC_CREATE_TEMPLATE = "createTemplate";
+  private static final String FUNC_GET_TEMPLATE_RADIUS = "getTemplateRadius";
+  private static final String FUNC_GET_TEMPLATE_X = "getTemplateX";
+  private static final String FUNC_GET_TEMPLATE_Y = "getTemplateY";
+  private static final String FUNC_MOVE_TEMPLATE = "moveTemplate";
+
+  private final Logger log = LogManager.getLogger(TemplateFunctions.class);
+
+  /** The minimum radius value allowed. */
+  private final int MIN_RADIUS = AbstractTemplate.MIN_RADIUS;
+
+  private TemplateFunctions() {
+    super(
+        0,
+        5,
+        FUNC_CREATE_TEMPLATE,
+        FUNC_GET_TEMPLATE_RADIUS,
+        FUNC_GET_TEMPLATE_X,
+        FUNC_GET_TEMPLATE_Y,
+        FUNC_MOVE_TEMPLATE);
+  }
+
+  /**
+   * TemplateType Enumeration, including:
+   *
+   * <ul>
+   *   <li><code>alias</code> property for matching template type by an alias
+   *   <li><code>template</code> method to return the appropriate template class
+   */
+  private enum TemplateType {
+    BlastTemplate("Blast") {
+      @Override
+      public AbstractTemplate template() {
+        return new BlastTemplate();
+      }
+    },
+    BurstTemplate("Burst") {
+      @Override
+      public AbstractTemplate template() {
+        return new BurstTemplate();
+      }
+    },
+    ConeTemplate("Cone") {
+      @Override
+      public AbstractTemplate template() {
+        return new ConeTemplate();
+      }
+    },
+    LineTemplate("Line") {
+      @Override
+      public AbstractTemplate template() {
+        return new LineTemplate();
+      }
+    },
+    LineCellTemplate("LineCell") {
+      @Override
+      public AbstractTemplate template() {
+        return new LineCellTemplate();
+      }
+    },
+    RadiusTemplate("Radius") {
+      @Override
+      public AbstractTemplate template() {
+        return new RadiusTemplate();
+      }
+    },
+    RadiusCellTemplate("RadiusCell") {
+      @Override
+      public AbstractTemplate template() {
+        return new RadiusCellTemplate();
+      }
+    },
+    WallTemplate("Wall") {
+      @Override
+      public AbstractTemplate template() {
+        return new WallTemplate();
+      }
+    };
+
+    TemplateType(String alias) {
+      this.alias = alias;
+    }
+
+    public AbstractTemplate template() {
+      return null;
+    }
+
+    private final String alias;
+
+    public String getAlias() {
+      return alias;
+    }
+
+    public static TemplateType valueOfAlias(String alias) {
+      for (TemplateType tt : values()) {
+        if (tt.alias.equalsIgnoreCase(alias)) {
+          return tt;
+        }
+      }
+      return null;
+    }
+  }
+
+  /** Evaluate the function(s) */
+  @Override
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
+      throws ParserException {
+    FunctionUtil.blockUntrustedMacro(functionName);
+
+    if (FUNC_CREATE_TEMPLATE.equalsIgnoreCase(functionName)) {
+      // templateType, radius/wallPath [, units, [, options [, delim [, mapRef ]]]]
+      FunctionUtil.checkNumberParam(FUNC_CREATE_TEMPLATE, parameters, 2, 6);
+
+      // template type, determine first by alias, then name (i.e. enum value)
+      String templateType = parameters.getFirst().toString().toUpperCase().trim();
+      TemplateType tt = TemplateType.valueOfAlias(templateType);
+      if (tt == null) {
+        try {
+          tt = TemplateType.valueOf(templateType);
+        } catch (IllegalArgumentException iae) {
+          throw new ParserException(
+              I18N.getText(
+                  "macro.function.template.unknownTemplateType",
+                  FUNC_CREATE_TEMPLATE,
+                  templateType));
+        }
+      }
+      AbstractTemplate abstractTemplate = tt.template();
+
+      // radius, for non wall templates
+      // or wall path, for wall templates
+      int radius =
+          !(abstractTemplate instanceof WallTemplate)
+              ? FunctionUtil.paramAsInteger(FUNC_CREATE_TEMPLATE, parameters, 1, false)
+              : 0;
+      String wallPath =
+          (abstractTemplate instanceof WallTemplate) ? parameters.get(1).toString().trim() : "";
+
+      // (optional) units - defaults to DISTANCE
+      int units =
+          parameters.size() > 2
+              ? FunctionUtil.paramAsInteger(functionName, parameters, 2, false)
+              : DrawableUnit.getDistanceIndex();
+      DrawableUnit drawableUnit = DrawableUnit.valueOfIndex(units);
+      if (drawableUnit == null && parameters.size() > 2) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.drawable.unknownDrawableUnits", functionName, parameters.get(2)));
+      }
+
+      // (optional) template/pen options
+      // (optional) delimiter for template/pen options, defaulting to a comma
+      String delimiter =
+          parameters.size() > 4
+              ? FunctionUtil.paramAsString(FUNC_CREATE_TEMPLATE, parameters, 4, false)
+              : ",";
+      JsonObject options =
+          parameters.size() > 3
+              ? FunctionUtil.jsonWithLowerCaseKeys(
+                  FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                      FUNC_CREATE_TEMPLATE, parameters, 3, delimiter))
+              : new JsonObject();
+
+      // (optional) mapRef, defaulting to the current map
+      ZoneRenderer zoneRenderer =
+          FunctionUtil.getZoneRendererFromParam(FUNC_CREATE_TEMPLATE, parameters, 5);
+
+      return createTemplate(
+          FUNC_CREATE_TEMPLATE,
+          abstractTemplate,
+          radius,
+          wallPath,
+          drawableUnit,
+          options,
+          zoneRenderer);
+
+    } else if (FUNC_GET_TEMPLATE_RADIUS.equalsIgnoreCase(functionName)) {
+      // [units, [templateRef [, mapRef]]]
+      FunctionUtil.checkNumberParam(FUNC_GET_TEMPLATE_RADIUS, parameters, 0, 3);
+
+      // (optional) units - defaults to DISTANCE
+      int units =
+          !parameters.isEmpty()
+              ? FunctionUtil.paramAsInteger(FUNC_GET_TEMPLATE_RADIUS, parameters, 0, false)
+              : DrawableUnit.getDistanceIndex();
+      DrawableUnit drawableUnit = DrawableUnit.valueOfIndex(units);
+      if (drawableUnit == null && !parameters.isEmpty()) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.drawable.unknownDrawableUnits",
+                functionName,
+                parameters.getFirst()));
+      }
+
+      // (optional) mapRef, defaulting to the current map
+      Zone zone =
+          FunctionUtil.getZoneRendererFromParam(FUNC_GET_TEMPLATE_RADIUS, parameters, 2).getZone();
+
+      // (optional) templateRef - defaults to the drawable selected by the respective pointer tool
+      DrawnElement de =
+          parameters.size() < 2
+              ? getSingleSelectedDrawnElement(FUNC_GET_TEMPLATE_RADIUS, zone)
+              : findDrawnElement(FUNC_GET_TEMPLATE_RADIUS, zone, parameters.get(1).toString());
+      if (!(de.getDrawable() instanceof AbstractTemplate)) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.template.unknownTemplate", functionName, de.getDrawable().getId()));
+      }
+
+      return BigDecimal.valueOf(
+          getTemplateRadius(FUNC_GET_TEMPLATE_RADIUS, zone, de, drawableUnit));
+
+    } else if (FUNC_GET_TEMPLATE_X.equalsIgnoreCase(functionName)
+        || FUNC_GET_TEMPLATE_Y.equalsIgnoreCase(functionName)) {
+      // [units [,templateRef [, mapRef]]]
+      FunctionUtil.checkNumberParam(functionName, parameters, 0, 3);
+
+      // (optional) units - defaults to PIXELS
+      int units =
+          !parameters.isEmpty()
+              ? FunctionUtil.paramAsInteger(functionName, parameters, 0, false)
+              : DrawableUnit.getPixelsIndex();
+      DrawableUnit drawableUnit = DrawableUnit.valueOfIndex(units);
+      if (drawableUnit == null && !parameters.isEmpty()) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.drawable.unknownDrawableUnits",
+                functionName,
+                parameters.getFirst()));
+      }
+
+      // zone/map
+      Zone zone = FunctionUtil.getZoneRendererFromParam(functionName, parameters, 2).getZone();
+
+      // (optional) templateRef - defaults to the drawable selected by the respective pointer tool
+      DrawnElement de =
+          parameters.size() < 2
+              ? getSingleSelectedDrawnElement(functionName, zone)
+              : findDrawnElement(functionName, zone, parameters.get(1).toString());
+      if (!(de.getDrawable() instanceof AbstractTemplate)) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.template.unknownTemplate", functionName, de.getDrawable().getId()));
+      }
+
+      ZonePoint zp = getTemplateVertex(functionName, de);
+      CellPoint cp = zone.getGrid().convert(zp);
+
+      double dimension = 0;
+      if (zp != null) {
+        if (functionName.equalsIgnoreCase(FUNC_GET_TEMPLATE_X)) {
+          switch (drawableUnit) {
+            case CELLS -> dimension = cp.x;
+            case DISTANCE ->
+                dimension = DrawableUnit.convert(zone, cp.x, DrawableUnit.CELLS, drawableUnit);
+            case PIXELS -> dimension = zp.x;
+            default -> dimension = 0;
+          }
+        } else if (functionName.equalsIgnoreCase(FUNC_GET_TEMPLATE_Y)) {
+          switch (drawableUnit) {
+            case CELLS -> dimension = cp.y;
+            case DISTANCE ->
+                dimension = DrawableUnit.convert(zone, cp.y, DrawableUnit.CELLS, drawableUnit);
+            case PIXELS -> dimension = zp.y;
+            default -> dimension = 0;
+          }
+        }
+        return BigDecimal.valueOf((int) dimension);
+      }
+      return null;
+
+    } else if (FUNC_MOVE_TEMPLATE.equalsIgnoreCase(functionName)) {
+      // x, y, [, units [, templateRef [, mapRef]]]
+      FunctionUtil.checkNumberParam(FUNC_MOVE_TEMPLATE, parameters, 2, 5);
+
+      // x & y
+      int x = FunctionUtil.paramAsInteger(FUNC_MOVE_TEMPLATE, parameters, 0, false);
+      int y = FunctionUtil.paramAsInteger(FUNC_MOVE_TEMPLATE, parameters, 1, false);
+
+      // (optional) units - defaults to PIXELS
+      int units =
+          parameters.size() > 2
+              ? FunctionUtil.paramAsInteger(functionName, parameters, 2, false)
+              : DrawableUnit.getPixelsIndex();
+      DrawableUnit drawableUnit = DrawableUnit.valueOfIndex(units);
+      if (drawableUnit == null && parameters.size() > 2) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.drawable.unknownDrawableUnits", functionName, parameters.get(2)));
+      }
+
+      // (optional) renderer & zone/map - defaults to the current
+      ZoneRenderer renderer =
+          FunctionUtil.getZoneRendererFromParam(FUNC_MOVE_TEMPLATE, parameters, 4);
+      Zone zone = renderer.getZone();
+
+      // (optional) drawn element - defaults to the drawable selected by the respective pointer tool
+      DrawnElement de =
+          parameters.size() > 3
+              ? findDrawnElement(FUNC_MOVE_TEMPLATE, zone, parameters.get(3).toString())
+              : getSingleSelectedDrawnElement(FUNC_MOVE_TEMPLATE, zone);
+      if (!(de.getDrawable() instanceof AbstractTemplate)) {
+        throw new ParserException(
+            I18N.getText(
+                "macro.function.template.unknownTemplate", functionName, de.getDrawable().getId()));
+      }
+
+      moveTemplate(renderer, de, x, y, drawableUnit);
+      return "";
+    }
+
+    return null;
+  }
+
+  /*
+   * METHODS
+   */
+
+  /**
+   * Create a template.
+   *
+   * @param functionName this is used in exception messages
+   * @param abstractTemplate a typed template
+   * @param radius n radius/size for non-wall templates
+   * @param wallPath XnYnZnNnEnSnWn path notation for wall templates
+   * @param drawableUnit which drawableUnits to use
+   * @param options template and pen options as a JsonObject
+   * @param renderer the zone renderer
+   * @return the drawingId of the created template
+   * @throws ParserException parser exception
+   */
+  private GUID createTemplate(
+      String functionName,
+      AbstractTemplate abstractTemplate,
+      int radius,
+      String wallPath,
+      DrawableUnit drawableUnit,
+      JsonObject options,
+      ZoneRenderer renderer)
+      throws ParserException {
+
+    Zone zone = renderer.getZone();
+
+    // template radius to be in CELLS
+    int convertedRadius =
+        drawableUnit == DrawableUnit.CELLS || radius == 0
+            ? radius
+            : DrawableUnit.convert(zone, radius, drawableUnit, DrawableUnit.CELLS);
+    int templateRadius = Math.max(MIN_RADIUS, convertedRadius);
+    abstractTemplate.setRadius(templateRadius);
+
+    // name of the template
+    String name = options.has("name") ? options.get("name").getAsString() : "";
+    abstractTemplate.setName(name);
+
+    // layer to draw the template on, defaults to token layer for a player or the active layer for
+    // the GM
+    String layer = options.has("layer") ? options.get("layer").getAsString().toUpperCase() : "";
+    Zone.Layer zoneLayer;
+    if (layer.isEmpty()) {
+      if (MapTool.getPlayer().isGM()) {
+        zoneLayer = renderer.getActiveLayer();
+      } else {
+        zoneLayer = Zone.Layer.getDefaultPlayerLayer();
+      }
+    } else {
+      zoneLayer = Zone.Layer.getByName(layer);
+    }
+    abstractTemplate.setLayer(zoneLayer);
+
+    // x and y are for the where the position the template vertex in CELLS
+    int x =
+        options.has("x")
+            ? DrawableUnit.convert(
+                zone, options.get("x").getAsInt(), drawableUnit, DrawableUnit.CELLS)
+            : 0;
+    int y =
+        options.has("y")
+            ? DrawableUnit.convert(
+                zone, options.get("y").getAsInt(), drawableUnit, DrawableUnit.CELLS)
+            : 0;
+
+    // pathx and path are used to set the pathVertex for Line and LineCell templates
+    int pathX =
+        options.has("pathx")
+            ? DrawableUnit.convert(
+                zone, options.get("pathx").getAsInt(), drawableUnit, DrawableUnit.CELLS)
+            : 0;
+    int pathY =
+        options.has("pathy")
+            ? DrawableUnit.convert(
+                zone, options.get("pathy").getAsInt(), drawableUnit, DrawableUnit.CELLS)
+            : 0;
+
+    // prevent creating a pathVertex at the same position as the vertex
+    if (x == x + pathX && y == y + pathY) {
+      pathX = pathX + 1;
+    }
+
+    // initial placement of templates on the map, which may be adjusted by supplied options
+    // note that not all shapes have a path vertex, but easier to set here along with the vertex
+    ZonePoint zpVertex = zone.getGrid().convert(new CellPoint(x, y));
+    ZonePoint zpPathVertex = zone.getGrid().convert(new CellPoint(x + pathX, y + pathY));
+
+    // region set special properties for specific template types
+    // due to template classes extending others, do the most extended first
+    switch (abstractTemplate) {
+      case BlastTemplate bt -> {
+        // blast direction & placement around vertex
+        String optionDirection =
+            options.has("direction") ? options.get("direction").getAsString().toUpperCase() : "";
+        if (!Objects.equals(optionDirection, "")) {
+          try {
+            BlastTemplate.Direction direction = BlastTemplate.Direction.valueOf(optionDirection);
+            bt.setDirectionControlCellOffset(direction);
+          } catch (IllegalArgumentException iae) {
+            throw new ParserException(
+                I18N.getText(
+                    "macro.function.template.unknownDirection", functionName, optionDirection));
+          }
+        } else {
+          bt.setDirectionControlCellOffset(AbstractTemplate.Direction.SOUTH_EAST);
+        }
+      }
+
+      case ConeTemplate ct -> {
+        // direction & placement around vertex
+        String optionDirection =
+            options.has("direction") ? options.get("direction").getAsString().toUpperCase() : "";
+        ConeTemplate.Direction direction;
+        if (!Objects.equals(optionDirection, "")) {
+          try {
+            direction = ConeTemplate.Direction.valueOf(optionDirection);
+          } catch (IllegalArgumentException iae) {
+            throw new ParserException(
+                I18N.getText(
+                    "macro.function.template.unknownDirection", functionName, optionDirection));
+          }
+        } else {
+          direction =
+              ConeTemplate.Direction.findDirection(
+                  zpPathVertex.x, zpPathVertex.y, zpVertex.x, zpVertex.y);
+        }
+        ct.setDirection(direction);
+      }
+      case WallTemplate wt -> {
+        // a path vertex is required by wt's super for rendering correctly
+        zpPathVertex = new ZonePoint(0, 0);
+        wt.setPathVertex(zpPathVertex);
+
+        // walls are constructed from a path of individual cells
+        wt.setPath(generateWallPath(functionName, zone, wt, wallPath, drawableUnit));
+      }
+      case LineTemplate lt -> lt.setPathVertex(zpPathVertex);
+      case LineCellTemplate lct -> lct.setPathVertex(zpPathVertex);
+      default -> {}
+    }
+    // endregion
+
+    // region set other common template properties and set any pen options
+    abstractTemplate.setVertex(zpVertex);
+    boolean isEraser = options.has("eraser") && options.get("eraser").getAsBoolean();
+    Pen colorPickerPen = MapTool.getFrame().getPen(isEraser);
+    Pen templatePen = generatePenFromOptions(colorPickerPen, options);
+    // endregion
+
+    // draw the template
+    MapTool.serverCommand().draw(zone.getId(), templatePen, abstractTemplate);
+    // allow it to be undone
+    zone.addDrawable(templatePen, abstractTemplate);
+    MapTool.getFrame().updateDrawTree();
+    MapTool.getFrame().refresh();
+
+    return abstractTemplate.getId();
+  }
+
+  /**
+   * Apply pen options to a copy of another pen
+   *
+   * @param basePen the pen which to apply options onto
+   * @param options a json object containing pen options
+   * @return pen
+   */
+  private Pen generatePenFromOptions(Pen basePen, JsonObject options) {
+
+    Pen pen = new Pen(basePen);
+
+    // foreground (color or asset)
+    if (options.has("foreground")) {
+      String fg = options.get("foreground").getAsString();
+      if (fg.equalsIgnoreCase("transparent") || fg.isEmpty()) {
+        pen.setPaint(null);
+      } else {
+        pen.setPaint(FunctionUtil.getPaintFromString(fg));
+      }
+    }
+
+    // background (color or asset)
+    if (options.has("background")) {
+      String bg = options.get("background").getAsString();
+      if (bg.equalsIgnoreCase("transparent") || bg.isEmpty()) {
+        pen.setBackgroundPaint(null);
+      } else {
+        pen.setBackgroundPaint(FunctionUtil.getPaintFromString(bg));
+      }
+    }
+
+    // line thickness
+    if (options.has("width")) {
+      pen.setThickness(options.get("width").getAsFloat());
+    }
+
+    // square cap
+    if (options.has("squarecap")) {
+      pen.setSquareCap(options.get("squarecap").getAsBoolean());
+    }
+
+    // opacity
+    if (options.has("opacity")) {
+      float opacity = options.get("opacity").getAsFloat();
+      if (opacity <= 1f) {
+        pen.setOpacity(opacity);
+      } else if (opacity <= 255f) {
+        pen.setOpacity(opacity / 255f);
+      }
+    }
+
+    // cut/eraser
+    if (options.has("eraser")) {
+      pen.setEraser(options.get("eraser").getAsBoolean());
+    }
+
+    return pen;
+  }
+
+  /**
+   * From the given wall path notation, generate a list of cell points for the wall path.
+   *
+   * @param functionName this is used in the exception message
+   * @param zone the map
+   * @param wallTemplate the wall template
+   * @param wallPath the wall path notation
+   * @param drawableUnit the drawableUnits to use
+   * @return a list of cell points for the wall path
+   * @throws ParserException parser exception
+   */
+  private List<CellPoint> generateWallPath(
+      String functionName,
+      Zone zone,
+      WallTemplate wallTemplate,
+      String wallPath,
+      DrawableUnit drawableUnit)
+      throws ParserException {
+
+    // a wall path *must* start off at the pathVertex (otherwise getPath() == null in
+    // WallTemplate.toDto())
+    int wallCellX = zone.getGrid().convert(wallTemplate.getPathVertex()).x;
+    int wallCellY = zone.getGrid().convert(wallTemplate.getPathVertex()).y;
+
+    List<CellPoint> wallPathList = new ArrayList<>();
+    CellPoint wallCell = new CellPoint(wallCellX, wallCellY);
+    wallPathList.add(wallCell);
+
+    // e.g. for CELL based drawableUnits (& unitConversion == 1)
+    //   y4x3 or s4e3 will create an 'L' shape to the south-east of the starting point
+    //   x-3y-4 or w3n4 will create an 'L' shape to the north-west of the starting point
+    //   z5 will create a wall stacked '5' high
+    Pattern p = Pattern.compile("([xyznsew])(-?\\d+)", Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher(wallPath);
+
+    while (m.find()) {
+      String wallDirection = m.group(1).toLowerCase();
+      int wallDistance =
+          DrawableUnit.convert(
+              zone, Integer.parseInt(m.group(2)), drawableUnit, DrawableUnit.CELLS);
+
+      if (wallDistance != 0) {
+        // loop through and construct path from individual cell points
+        for (int i = 1; i <= Math.abs(wallDistance); i++) {
+          switch (wallDirection) {
+            case "x", "e":
+              {
+                wallCellX = wallDistance > 0 ? ++wallCellX : --wallCellX;
+                break;
+              }
+            case "w":
+              {
+                wallCellX = wallDistance > 0 ? --wallCellX : ++wallCellX;
+                break;
+              }
+            case "y", "s":
+              {
+                wallCellY = wallDistance > 0 ? ++wallCellY : --wallCellY;
+                break;
+              }
+            case "n":
+              {
+                wallCellY = wallDistance > 0 ? --wallCellY : ++wallCellY;
+                break;
+              }
+            case "z":
+              {
+                // just 'stack' the wall at the previous wallCellX or wallCellY
+                break;
+              }
+            default:
+              {
+              }
+          }
+          wallCell = new CellPoint(wallCellX, wallCellY);
+          wallPathList.add(wallCell);
+        }
+      }
+    }
+
+    if (wallPathList.isEmpty()) {
+      throw new ParserException(
+          I18N.getText("macro.function.template.unknownWallPath", functionName, wallPath));
+    }
+
+    // arbitrary wall length limit
+    int wallPathLengthLimit = 9999;
+
+    if (wallPathList.size() > wallPathLengthLimit) {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.template.exceededWallLengthLimit",
+              functionName,
+              wallPath,
+              wallPathLengthLimit));
+    }
+
+    return wallPathList;
+  }
+
+  /**
+   * Get the template's radius.
+   *
+   * @param functionName this is used in the exception message
+   * @param drawnElement the guid of the drawn element
+   * @param drawableUnit the units
+   * @return the radius in the units
+   * @throws ParserException parser exception
+   */
+  private int getTemplateRadius(
+      String functionName, Zone zone, DrawnElement drawnElement, DrawableUnit drawableUnit)
+      throws ParserException {
+
+    if (drawnElement.getDrawable() instanceof AbstractTemplate at) {
+      return DrawableUnit.convert(zone, at.getRadius(), DrawableUnit.CELLS, drawableUnit);
+    } else {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.template.unknownTemplate",
+              functionName,
+              drawnElement.getDrawable().getId()));
+    }
+  }
+
+  /**
+   * Get the template's vertex.
+   *
+   * @param functionName this is used in the exception message
+   * @param drawnElement the guid of the drawn element
+   * @return the zone co-ordinates of the template vertex
+   * @throws ParserException parser exception
+   */
+  private ZonePoint getTemplateVertex(String functionName, DrawnElement drawnElement)
+      throws ParserException {
+
+    if (drawnElement.getDrawable() instanceof AbstractTemplate at) {
+      return at.getVertex();
+    } else {
+      throw new ParserException(
+          I18N.getText(
+              "macro.function.template.unknownTemplate",
+              functionName,
+              drawnElement.getDrawable().getId()));
+    }
+  }
+
+  /**
+   * Moves an {@link AbstractTemplate}'s vertex to position x, y on a map, and if applicable the
+   * pathVertex to a related position.
+   *
+   * @param renderer where to draw
+   * @param de the drawn element
+   * @param x where to move to on the x-axis
+   * @param y where to move to on the y-axis
+   * @param drawableUnit whether x & y are given in CELLS, DISTANCE, or PIXELS
+   */
+  private void moveTemplate(
+      ZoneRenderer renderer, DrawnElement de, int x, int y, DrawableUnit drawableUnit) {
+
+    Zone zone = renderer.getZone();
+    AbstractTemplate at = (AbstractTemplate) de.getDrawable();
+
+    CellPoint cp;
+    switch (drawableUnit) {
+      case CELLS -> cp = new CellPoint(x, y);
+      case DISTANCE ->
+          cp =
+              new CellPoint(
+                  DrawableUnit.convert(zone, x, drawableUnit, DrawableUnit.CELLS),
+                  DrawableUnit.convert(zone, y, drawableUnit, DrawableUnit.CELLS));
+      case PIXELS -> cp = zone.getGrid().convert(new ZonePoint(x, y));
+      case null, default -> {
+        // as CELLS
+        cp = new CellPoint(x, y);
+      }
+    }
+    ZonePoint zp = zone.getGrid().convert(cp);
+
+    if (at instanceof LineTemplate lt && !(at instanceof WallTemplate)) {
+      // While WallTemplate extends LineTemplate, changing a WallTemplate's path vertex breaks
+      // getBounds(), so don't change it for WallTemplates!
+      ZonePoint pathVertexMove =
+          new ZonePoint(
+              zp.x + lt.getPathVertex().x - lt.getVertex().x,
+              zp.y + lt.getPathVertex().y - lt.getVertex().y);
+      lt.setPathVertex(pathVertexMove);
+    }
+    if (at instanceof LineCellTemplate lct) {
+      ZonePoint pathVertexMove =
+          new ZonePoint(
+              zp.x + lct.getPathVertex().x - lct.getVertex().x,
+              zp.y + lct.getPathVertex().y - lct.getVertex().y);
+      lct.setPathVertex(pathVertexMove);
+    }
+    at.setVertex(zp);
+    de.setDrawable(at);
+
+    MapTool.serverCommand().updateDrawing(zone.getId(), de.getPen(), de);
+    zone.updateDrawable(de, de.getPen());
+    renderer.repaint();
+    MapTool.getFrame().updateDrawTree();
+    MapTool.getFrame().refresh();
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/drawing/DrawingPointerTool.java
@@ -815,7 +815,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
 
   /**
    * Helper method to get the path vertex for the template (for known template types that have
-   * them). *
+   * them).
    *
    * @param at The template.
    * @return The zone point for the path vertex, or <code>null</code>.
@@ -1147,7 +1147,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
       int startY = startVertex.y + offsetXY;
       int endX = endVertex.x + offsetXY;
       int endY = endVertex.y + offsetXY;
-      float[] dashingPattern = {9f, 3f};
+      float[] dashingPattern = {pen.getThickness() * 9, pen.getThickness() * 3};
 
       Composite composite = g.getComposite();
       Paint paint;
@@ -1169,7 +1169,7 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
               BasicStroke.JOIN_MITER,
               1.0f,
               dashingPattern,
-              2.0f));
+              0));
       g.drawLine(startX, startY, endX, endY);
       g.setComposite(composite);
     }
@@ -1397,26 +1397,27 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
       // Resize the Template Radius
       CellPoint workingCell = getZone().getGrid().convert(getCellAtMouse(e));
       CellPoint vertexCell = getZone().getGrid().convert(vertex);
-      int x = Math.abs(workingCell.x - vertexCell.x);
-      int y = Math.abs(workingCell.y - vertexCell.y);
-      int dragRadius = at.getDistance(x, y);
+      int x = workingCell.x - vertexCell.x;
+      int y = workingCell.y - vertexCell.y;
+      int dragRadius = at.getDistance(Math.abs(x), Math.abs(y));
       at.setRadius(dragRadius);
 
-      // Move the Template around the Vertex (if applicable)
+      // Move the BlastTemplate around the Vertex
       if (templateType.equals("BlastTemplate")) {
-        ((BlastTemplate) at)
-            .setControlCellRelative(workingCell.x - vertexCell.x, workingCell.y - vertexCell.y);
+        ((BlastTemplate) at).setControlCellRelative(x, y);
       }
-      if (templateType.equals("ConeTemplate")) {
+
+      // Change ConeTemplate direction
+      if (templateType.equals("ConeTemplate") && at instanceof ConeTemplate ct) {
         ZonePoint mouse =
             new ScreenPoint(e.getX(), e.getY())
                 .convertToZone(renderer.getViewModel().getZoneScale());
-        ((ConeTemplate) at)
-            .setDirection(
-                RadiusTemplate.Direction.findDirection(mouse.x, mouse.y, vertex.x, vertex.y));
+        ct.setDirection(
+            RadiusTemplate.Direction.findDirection(mouse.x, mouse.y, vertex.x, vertex.y));
       }
 
-      // ALT -> Change the Path Vertex if only one drawing selected
+      // ALT ->  If only one template selected change the Path Vertex (Line/LineCell), Control
+      // Offset (Blast), or Direction (Cone)
     } else if (selectedDrawableIdSet.size() == 1 && e.isAltDown()) {
 
       // Move just pathVertex (if applicable)
@@ -1425,6 +1426,34 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
         pathVertex.x = pathVertex.x - dragCellOffset.x;
         pathVertex.y = pathVertex.y - dragCellOffset.y;
         setTemplatePathVertex(at, pathVertex);
+      }
+
+      // Move the BlastTemplate about the Vertex (i.e. without changing the radius)
+      // N.B. this ALT behaviour is not available in the BlastTemplateTool
+      if (templateType.equals("BlastTemplate") && at instanceof BlastTemplate bt) {
+        int blastRadius = bt.getRadius();
+        int ox = bt.getOffsetX();
+        int oy = bt.getOffsetY();
+        CellPoint dragCell = getZone().getGrid().convert(dragCellOffset);
+
+        if (dragCell.y != 0 && (ox == -blastRadius || ox == 1)) {
+          // blast is to the left or right of the vertex, so only move up or down
+          oy = Math.min(1, Math.max(-blastRadius, oy - dragCell.y));
+        } else if (dragCell.x != 0 && (oy == -blastRadius || oy == 1)) {
+          // blast is above or below the vertex, so only move left or right
+          ox = Math.min(1, Math.max(-blastRadius, ox - dragCell.x));
+        }
+        bt.setControlCellOffset(ox, oy);
+      }
+
+      // Rotate the ConeTemplate about the Vertex (i.e. change direction without changing the
+      // radius)
+      // N.B. this ALT behaviour is not available in the ConeTemplateTool
+      if (templateType.equals("ConeTemplate") && at instanceof ConeTemplate ct) {
+        ZonePoint mouse =
+            new ScreenPoint(e.getX(), e.getY())
+                .convertToZone(renderer.getViewModel().getZoneScale());
+        ct.setDirection(ConeTemplate.Direction.findDirection(mouse.x, mouse.y, vertex.x, vertex.y));
       }
 
     } else {
@@ -1471,5 +1500,15 @@ public class DrawingPointerTool extends DefaultTool implements ZoneOverlay, Mous
     } // end for
     draggedDrawnElementSet.clear();
     renderer.repaint();
+  }
+
+  /**
+   * Get an unmodifiable {@link List} of {@link GUID}s for each {@link Drawable} selected by this
+   * tool.
+   *
+   * @return a list of selected drawable guids
+   */
+  public static List<GUID> getSelectedDrawables() {
+    return selectedDrawableIdSet.stream().toList();
   }
 }

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -20,6 +20,7 @@ import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.geom.Area;
 import javax.annotation.Nonnull;
+import net.rptools.maptool.client.tool.drawing.BlastTemplateTool;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
 import net.rptools.maptool.model.ZonePoint;
@@ -53,6 +54,7 @@ public class BlastTemplate extends ConeTemplate {
     super(other);
     this.offsetX = other.offsetX;
     this.offsetY = other.offsetY;
+    this.direction = other.direction;
   }
 
   /*---------------------------------------------------------------------------------------------
@@ -125,6 +127,7 @@ public class BlastTemplate extends ConeTemplate {
       }
       offsetX = centerOffset + Math.min(Math.max(lowerBound, relX), upperBound);
     }
+    setDirection(findDirection());
   }
 
   /**
@@ -135,6 +138,77 @@ public class BlastTemplate extends ConeTemplate {
   public void setControlCellOffset(int controlCellOffsetX, int controlCellOffsetY) {
     offsetX = controlCellOffsetX;
     offsetY = controlCellOffsetY;
+    setDirection(findDirection());
+  }
+
+  /**
+   * Determine the {@link net.rptools.maptool.model.drawing.AbstractTemplate.Direction} of the
+   * {@link BlastTemplate} using its radius and offsets. NW/NE/SE/SW need to be exactly at the
+   * extremes, otherwise generalised to N/E/S/W.
+   *
+   * @return the direction of the blast from the center vertex.
+   */
+  public Direction findDirection() {
+
+    Direction direction;
+    int radius = getRadius();
+
+    if (offsetY == -radius) {
+      // Blast is above the vertex
+      if (offsetX == -radius) {
+        direction = Direction.NORTH_WEST;
+      } else if (offsetX == 1) {
+        direction = Direction.NORTH_EAST;
+      } else {
+        direction = Direction.NORTH;
+      }
+    } else if (offsetY == 1) {
+      // Blast is below the vertex
+      if (offsetX == -radius) {
+        direction = Direction.SOUTH_WEST;
+      } else if (offsetX == 1) {
+        direction = Direction.SOUTH_EAST;
+      } else {
+        direction = Direction.SOUTH;
+      }
+    } else if (offsetX == -radius) {
+      // Blast is left of the vertex
+      direction = Direction.WEST;
+    } else if (offsetX == 1) {
+      // Blast is right of the vertex
+      direction = Direction.EAST;
+    } else {
+      // should not get here
+      return null;
+    }
+
+    return direction;
+  }
+
+  /**
+   * Set the {@link BlastTemplate}'s {@link Direction} and then set the control offsets for that
+   * direction. While this is coarser than setting the control offsets explicitly, it provides an
+   * alternative and user-friendly way of setting the control offsets when not using the {@link
+   * BlastTemplateTool}.
+   *
+   * @param direction The direction to draw the blast from the center vertex.
+   */
+  public void setDirectionControlCellOffset(Direction direction) {
+    if (direction != null) {
+      this.direction = direction.name();
+      int radius = getRadius();
+      switch (direction) {
+        case Direction.NORTH_WEST -> setControlCellOffset(-radius, -radius);
+        case Direction.NORTH -> setControlCellOffset(-radius / 2, -radius);
+        case Direction.NORTH_EAST -> setControlCellOffset(1, -radius);
+        case Direction.EAST -> setControlCellOffset(1, -radius / 2);
+        case Direction.SOUTH_EAST -> setControlCellOffset(1, 1);
+        case Direction.SOUTH -> setControlCellOffset(-radius / 2, 1);
+        case Direction.SOUTH_WEST -> setControlCellOffset(-radius, 1);
+        case Direction.WEST -> setControlCellOffset(-radius, -radius / 2);
+        default -> setControlCellOffset(1, 1);
+      }
+    }
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/BlastTemplate.java
@@ -54,7 +54,6 @@ public class BlastTemplate extends ConeTemplate {
     super(other);
     this.offsetX = other.offsetX;
     this.offsetY = other.offsetY;
-    this.direction = other.direction;
   }
 
   /*---------------------------------------------------------------------------------------------
@@ -195,7 +194,7 @@ public class BlastTemplate extends ConeTemplate {
    */
   public void setDirectionControlCellOffset(Direction direction) {
     if (direction != null) {
-      this.direction = direction.name();
+      setDirection(direction);
       int radius = getRadius();
       switch (direction) {
         case Direction.NORTH_WEST -> setControlCellOffset(-radius, -radius);

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -38,7 +38,7 @@ public class ConeTemplate extends RadiusTemplate {
    * of the selected vertex. Saved as a string as a hack to get around the hessian library's problem
    * w/ serializing enumerations.
    */
-  protected String direction = Direction.SOUTH_EAST.name();
+  private String direction = Direction.SOUTH_EAST.name();
 
   public ConeTemplate() {}
 

--- a/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ConeTemplate.java
@@ -38,7 +38,7 @@ public class ConeTemplate extends RadiusTemplate {
    * of the selected vertex. Saved as a string as a hack to get around the hessian library's problem
    * w/ serializing enumerations.
    */
-  private String direction = Direction.SOUTH_EAST.name();
+  protected String direction = Direction.SOUTH_EAST.name();
 
   public ConeTemplate() {}
 

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2214,6 +2214,16 @@ macro.function.strPropFromVar.wrongArgs            = strPropFromVars second para
 macro.function.sound.illegalargument               = Error executing "{0}", parameter "{1}" is invalid: {2}
 macro.function.sound.mediaexception                = Error executing "{0}" with media "{1}"
 macro.function.syrinscape.inactive                 = This client has not enabled Syrinscape integration in preference.
+# DrawableFunctions
+macro.function.drawable.unknownDrawable            = Error executing "{0}", the template or drawing "{1}" is unknown.
+macro.function.drawable.noSelectedDrawable         = Error executing "{0}", there is no drawable selected.
+macro.function.drawable.noSingleSelectedDrawable   = Error executing "{0}", there is no single drawable selected.
+macro.function.drawable.unknownDrawableUnits       = Error executing "{0}", the drawable unit "{1}" is unknown.
+# TemplateFunctions
+macro.function.template.unknownTemplate            = Error executing "{0}", the template name or id "{1}" is unknown.
+macro.function.template.unknownTemplateType        = Error executing "{0}", the template type "{1}" is unknown.
+macro.function.template.unknownDirection           = Error executing "{0}", the direction "{1}" is unknown.
+macro.function.template.exceededWallLengthLimit    = Error executing "{0}", the wall path "{1}" has exceeded the wall length limit of "{2}".
 # TokenLightFunctions
 macro.function.tokenLight.unknownLightType         = Unknown light type "{1}" in function "{0}".
 # name setting functions

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2224,6 +2224,7 @@ macro.function.template.unknownTemplate            = Error executing "{0}", the 
 macro.function.template.unknownTemplateType        = Error executing "{0}", the template type "{1}" is unknown.
 macro.function.template.unknownDirection           = Error executing "{0}", the direction "{1}" is unknown.
 macro.function.template.exceededWallLengthLimit    = Error executing "{0}", the wall path "{1}" has exceeded the wall length limit of "{2}".
+macro.function.template.invalidRadius              = Error executing "{0}", "{1}s" do not have a radius.
 # TokenLightFunctions
 macro.function.tokenLight.unknownLightType         = Unknown light type "{1}" in function "{0}".
 # name setting functions


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement

closes #2743

### Description of the Change
Lots of new template and drawable MTScript functions and some new tool features.  Drawables selected via the appropriate tool are now accessible to Drawable (i.e. drawing and template) and template-only functions.

**DrawingPointerTool**
now exposes tool selected drawings/templates to new `getSelectedDrawings()` MTScript function, and also to the helper function `getSingleSelectedDrawnElement()`.
- Slight change to movement line dash pattern when dragging templates
- New ALT drag feature on Blast templates now allows moving the template around the vertex without resizing it.
- New ALT drag feature on Cone templates now allows rotating the template around the vertex without resizing it.

** ConeTemplate**

- Change direction to be protected so is accessible from extending classes (i.e. the BlastTemplate)

** BlastTemplate**

- Now get/sets direction property based on where the blast template is placed

**DrawingFunctions**
 new/updated MapTool methods to support the new MTScript functions
- enum `DrawableUnit` to facilitate cells, distance, or (zone) pixels units for creating templates, moving drawables/templates , or getting info on dimensions about them
- `getDrawingJSONInfo()` -> expose more information on templates
- `boundsToJSON()` -> corrected for templates which previously had a padding applied and was incorrect
- `getDrawingBounds()` -> helper method used in the new `DrawingGetterFunctions`
- `findDrawnElement()` -> used by MT script template/drawable functions to find drawings and templates using the name or id
- `getSingleSelectedDrawnElement()` -> used in MT script template/drawable functions to find a drawable selected by the Drawing/Template pointer tools.

**TemplateFunctions**
new class with new MTScript functions just for templates:
- `createTemplate()` can create any type of template
- `getTemplateX()` gets a template's vertex x position
- `getTemplateY()` gets a template's vertex y position
- `getTemplateRadius()` gets a template's radius
- `moveTemplate()` move a template's vertex position

**DrawingMiscFunctions**
new MTScript functions (and supporting methods):

- `duplicateDrawable()`
- `getSelectedDrawables()`
- `getDrawablesUnderToken()`
- `getTokensOverDrawable()`
- `moveDrawable()`

**DrawingGetterFunctions**
new MTScript functions that expand on existing drawing functions and makes getting some drawable properties easier, such as they also work with drawables selected via the respective tool, and take the units parameter.

- `getDrawableInfo()`
- `getDrawableLayer()`
- `getDrawableName()`
- `getDrawableX()`
- `getDrawableY()`
- `getDrawableCenterX()`
- `getDrawableCenterY()`
- `getDrawableMaxX()`
- `getDrawableMaxY()`
- `getDrawableHeight()`
- `getDrawableWidth()`

**DrawingSetterFunctions**

- `setDrawableLayer()`
- `setDrawableName()`

### Possible Drawbacks

Over use of templates in games ;)
I have not java coded things in the best way.

### Documentation Notes
t.b.c.

### Release Notes
Added new MTScript functions for templates and drawables, inc. `createTemplate()`, `moveTemplate()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5891)
<!-- Reviewable:end -->
