### PR TITLE
Fix null stat sheet location

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -481,9 +481,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     if (statSheetProperty == null) {
       id = ssManager.getDefaultStatSheetId();
       tokenTypeStatSheetMap.put(
-          propertyType,
-          new StatSheetProperties(
-              ssManager.getDefaultStatSheetId(), StatSheetLocation.BOTTOM_LEFT));
+          propertyType, new StatSheetProperties(ssManager.getDefaultStatSheetId(), null));
     } else {
       id = statSheetProperty.id();
     }

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -479,9 +479,8 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     var statSheetProperty = tokenTypeStatSheetMap.get(propertyType);
     String id;
     if (statSheetProperty == null) {
-      id = ssManager.getDefaultStatSheetId();
-      tokenTypeStatSheetMap.put(
-          propertyType, new StatSheetProperties(ssManager.getDefaultStatSheetId(), null));
+      id = StatSheetManager.LEGACY_STATSHEET.id();
+      tokenTypeStatSheetMap.put(propertyType, new StatSheetProperties(id, null));
     } else {
       id = statSheetProperty.id();
     }
@@ -514,7 +513,7 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
           if (getStatSheetComboBox().hasFocus()) { // Only if user has made change
             var tokenType = (String) getTokenTypeList().getSelectedValue();
             if (ss != null && tokenType != null) {
-              var id = new StatSheetManager().getId(ss);
+              var id = ss.id();
               var location = tokenTypeStatSheetMap.get(tokenType).location();
               tokenTypeStatSheetMap.put(tokenType, new StatSheetProperties(id, location));
               getStatSheetLocationComboBox().setSelectedItem(location);

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenPropertiesManagementPanel.java
@@ -481,7 +481,9 @@ public class TokenPropertiesManagementPanel extends AbeillePanel<CampaignPropert
     if (statSheetProperty == null) {
       id = ssManager.getDefaultStatSheetId();
       tokenTypeStatSheetMap.put(
-          propertyType, new StatSheetProperties(ssManager.getDefaultStatSheetId(), null));
+          propertyType,
+          new StatSheetProperties(
+              ssManager.getDefaultStatSheetId(), StatSheetLocation.BOTTOM_LEFT));
     } else {
       id = statSheetProperty.id();
     }

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
@@ -170,9 +170,6 @@ public class NewTokenDialog extends AbeillePanel<Token> {
     if (statSheet == null || (statSheet.name() == null && statSheet.namespace() == null)) {
       token.useDefaultStatSheet();
     } else {
-      if (location == null) {
-        location = StatSheetLocation.BOTTOM_LEFT;
-      }
       token.setStatSheet(new StatSheetProperties(ssManager.getId(statSheet), location));
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/create/NewTokenDialog.java
@@ -166,11 +166,10 @@ public class NewTokenDialog extends AbeillePanel<Token> {
 
     var statSheet = (StatSheet) getStatSheetComboBox().getSelectedItem();
     var location = (StatSheetLocation) getStatSheetLocationComboBox().getSelectedItem();
-    var ssManager = new StatSheetManager();
     if (statSheet == null || (statSheet.name() == null && statSheet.namespace() == null)) {
       token.useDefaultStatSheet();
     } else {
-      token.setStatSheet(new StatSheetProperties(ssManager.getId(statSheet), location));
+      token.setStatSheet(new StatSheetProperties(statSheet.id(), location));
     }
 
     return true;

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -910,9 +910,6 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     } else {
       var ssManager = new StatSheetManager();
       var location = (StatSheetLocation) getStatSheetLocationCombo().getSelectedItem();
-      if (location == null) {
-        location = StatSheetLocation.BOTTOM_LEFT;
-      }
       token.setStatSheet(new StatSheetProperties(ssManager.getId(ss), location));
     }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/dialog/edit/EditTokenDialog.java
@@ -908,9 +908,8 @@ public class EditTokenDialog extends AbeillePanel<Token> {
     if (ss == null || (ss.name() == null && ss.namespace() == null)) {
       token.useDefaultStatSheet();
     } else {
-      var ssManager = new StatSheetManager();
       var location = (StatSheetLocation) getStatSheetLocationCombo().getSelectedItem();
-      token.setStatSheet(new StatSheetProperties(ssManager.getId(ss), location));
+      token.setStatSheet(new StatSheetProperties(ss.id(), location));
     }
 
     /* Macros */

--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -50,7 +50,6 @@ import net.rptools.maptool.client.ui.token.XTokenOverlay;
 import net.rptools.maptool.client.ui.token.YieldTokenOverlay;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
-import net.rptools.maptool.model.sheet.stats.StatSheetLocation;
 import net.rptools.maptool.model.sheet.stats.StatSheetManager;
 import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
 import net.rptools.maptool.server.proto.CampaignPropertiesDto;
@@ -212,9 +211,7 @@ public class CampaignProperties implements Serializable {
    */
   public StatSheetProperties getTokenTypeDefaultStatSheet(String propertyType) {
     return tokenTypeStatSheetMap.getOrDefault(
-        propertyType,
-        new StatSheetProperties(
-            StatSheetManager.LEGACY_STATSHEET_ID, StatSheetLocation.BOTTOM_LEFT));
+        propertyType, new StatSheetProperties(StatSheetManager.LEGACY_STATSHEET_ID, null));
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheet.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheet.java
@@ -30,6 +30,10 @@ import java.util.Set;
  */
 public record StatSheet(
     String name, String description, URL entry, Set<String> propertyTypes, String namespace) {
+  public String id() {
+    return namespace + "." + name;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof StatSheet other)) {

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetManager.java
@@ -77,42 +77,6 @@ public class StatSheetManager {
   }
 
   /**
-   * Returns the default stat sheet.
-   *
-   * @return the default stat sheet.
-   */
-  public StatSheet getDefaultStatSheet() {
-    return LEGACY_STATSHEET;
-  }
-
-  /**
-   * Returns the id of the default stat sheet.
-   *
-   * @return the id of the default stat sheet.
-   */
-  public String getDefaultStatSheetId() {
-    return getId(LEGACY_STATSHEET);
-  }
-
-  /**
-   * Returns the "no" stat sheet.
-   *
-   * @return the "no" stat sheet.
-   */
-  public StatSheet getNoStatSheet() {
-    return NO_STATSHEET;
-  }
-
-  /**
-   * Returns the id of the "no" stat sheet.
-   *
-   * @return the id of the "no" stat sheet.
-   */
-  public String getNoStatSheetId() {
-    return getId(NO_STATSHEET);
-  }
-
-  /**
    * Returns the name and namespace of the stat sheet with the given id.
    *
    * @param id the id of the stat sheet.
@@ -199,17 +163,6 @@ public class StatSheetManager {
       return null;
     }
     return getStatSheet(name[0], name[1]);
-  }
-
-  /**
-   * Returns the id of the stat sheet with the given namespace and name.
-   *
-   * @param namespace the namespace of the stat sheet.
-   * @param name the name of the stat sheet.
-   * @return the id of the stat sheet with the given namespace and name.
-   */
-  public String getId(String namespace, String name) {
-    return namespace + "." + name;
   }
 
   /**
@@ -300,16 +253,6 @@ public class StatSheetManager {
       return null;
     }
     return getStatSheetContent(name[0], name[1]);
-  }
-
-  /**
-   * Returns the id of the stat sheet.
-   *
-   * @param ss the stat sheet.
-   * @return the id of the stat sheet.
-   */
-  public String getId(StatSheet ss) {
-    return getId(ss.namespace(), ss.name());
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetProperties.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetProperties.java
@@ -15,6 +15,7 @@
 package net.rptools.maptool.model.sheet.stats;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 import net.rptools.maptool.server.proto.StatSheetPropertiesDto;
 
 /**
@@ -33,11 +34,12 @@ public final class StatSheetProperties {
    * Creates a new instance of the class.
    *
    * @param id The id of the stat sheet.
-   * @param location The location of the stat sheet.
+   * @param location The location of the stat sheet, or {@code null} to use the default of {@link
+   *     StatSheetLocation#BOTTOM_LEFT}.
    */
-  public StatSheetProperties(String id, StatSheetLocation location) {
+  public StatSheetProperties(String id, @Nullable StatSheetLocation location) {
     this.id = id;
-    this.location = location;
+    this.location = Objects.requireNonNullElse(location, StatSheetLocation.BOTTOM_LEFT);
   }
 
   /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes NPE related to #5643

### Description of the Change

Changes the `StatSheetProperties` constructor to handle a `null` location and replace it with the default of `StatSheetLocation#BOTTOM_LEFT`. The various callers that did this same replacement have been updated to just pass `null`.

I also noticed that anywhere we need a `StatSheet`'s ID, we would conjure up a new `StatSheetManager` to build the ID. That seemed odd, so I also moved that responsibility to the `StatSheet` record itself, streamlining callers and eliminating a few redundant methods from `StatSheetManager`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5894)
<!-- Reviewable:end -->
