### PR TITLE
Fix noise seed

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -1063,6 +1063,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     }
     if (drawBackground) {
       Graphics2D bbg = backBuffer.createGraphics();
+      bbg.setComposite(AlphaComposite.SrcOver);
       AppPreferences.renderQuality.get().setRenderingHints(bbg);
 
       // Background texture
@@ -1072,8 +1073,14 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
 
       // Only apply the noise if the feature is on and the background a textured paint
       if (bgTextureNoiseFilterOn && paint instanceof TexturePaint) {
-        bbg.setPaint(noise.getPaint(scale));
-        bbg.fillRect(0, 0, size.width, size.height);
+        var noiseG = (Graphics2D) bbg.create();
+        try {
+          noiseG.setComposite(AlphaComposite.SrcOver.derive(noise.getNoiseAlpha()));
+          noiseG.setPaint(noise.getPaint(scale));
+          noiseG.fillRect(0, 0, size.width, size.height);
+        } finally {
+          noiseG.dispose();
+        }
       }
 
       // Map

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
@@ -76,12 +76,11 @@ public class DrawableNoise {
   private void recalc() {
     needsRecalc = false;
     int[] array = new int[WIDTH * HEIGHT];
-    int alpha = (int) (noiseAlpha * 255) << 24;
     for (int x = 0; x < WIDTH; x++) {
       for (int y = 0; y < HEIGHT; y++) {
         double noiseVal = perlinNoise.noise(x / WIDTH_DIVISOR, y / HEIGHT_DIVISOR);
         int colVal = (int) (255 * noiseVal);
-        array[y * WIDTH + x] = colVal | (colVal << 8) | (colVal << 16) | alpha;
+        array[y * WIDTH + x] = colVal | (colVal << 8) | (colVal << 16) | (0xFF << 24);
       }
     }
     noiseImage.setRGB(0, 0, WIDTH, HEIGHT, array, 0, WIDTH);
@@ -115,34 +114,12 @@ public class DrawableNoise {
   }
 
   /**
-   * Sets the alpha level that is used to apply the noise.
-   *
-   * @param alpha the alpha level that is used to apply the noise.
-   */
-  public void setNoiseAlpha(float alpha) {
-    noiseAlpha = alpha;
-    needsRecalc = true;
-    recalc();
-  }
-
-  /**
    * Returns the seed used to generate the noise..
    *
    * @return The seed used to generate the noise.
    */
   public long getNoiseSeed() {
     return noiseSeed;
-  }
-
-  /**
-   * Sets the seed that is used to generate the noise.
-   *
-   * @param seed the seed that is used to generate the noise.
-   */
-  public void setNoiseSeed(long seed) {
-    noiseSeed = seed;
-    perlinNoise = new PerlinNoise(seed);
-    recalc();
   }
 
   /**
@@ -174,7 +151,7 @@ public class DrawableNoise {
    * @param alpha The alpha used to apply the noise.
    */
   public void setNoiseValues(long seed, float alpha) {
-    if (seed != noiseSeed || alpha != noiseAlpha) {
+    if (seed != noiseSeed) {
       needsRecalc = true;
     }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
@@ -151,14 +151,11 @@ public class DrawableNoise {
    * @param alpha The alpha used to apply the noise.
    */
   public void setNoiseValues(long seed, float alpha) {
-    if (seed != noiseSeed) {
-      needsRecalc = true;
-    }
-
-    noiseSeed = seed;
     noiseAlpha = alpha;
 
-    if (needsRecalc) {
+    if (seed != noiseSeed) {
+      noiseSeed = seed;
+      perlinNoise = new PerlinNoise(noiseSeed);
       recalc();
     }
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/DrawableNoise.java
@@ -22,7 +22,7 @@ import net.rptools.maptool.client.ui.Scale;
 import net.rptools.noiselib.PerlinNoise;
 
 /**
- * This class is used to generate a image from a noise function that can be used to break up
+ * This class is used to generate an image from a noise function that can be used to break up
  * repeating patterns in other images.
  */
 public class DrawableNoise {
@@ -63,9 +63,6 @@ public class DrawableNoise {
   /** The alpha used to apply this noise to other images. */
   private float noiseAlpha;
 
-  /** Flags if the noise "image" needs recalculation or not. */
-  private boolean needsRecalc = true;
-
   /** The seed used to generate the noise. */
   private long noiseSeed;
 
@@ -74,7 +71,6 @@ public class DrawableNoise {
 
   /** Recalculate the noise image. */
   private void recalc() {
-    needsRecalc = false;
     int[] array = new int[WIDTH * HEIGHT];
     for (int x = 0; x < WIDTH; x++) {
       for (int y = 0; y < HEIGHT; y++) {
@@ -114,7 +110,7 @@ public class DrawableNoise {
   }
 
   /**
-   * Returns the seed used to generate the noise..
+   * Returns the seed used to generate the noise.
    *
    * @return The seed used to generate the noise.
    */


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5895

### Description of the Change

Changes `DrawableNoise` to create a new `PerlinNoise` when the seed is changed.

Also, don't incorporate the alpha into the noise image, since that can be done by changing the alpha composite during rendering. This avoids recalcs when only the alpha is changed.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed `/texturenoise` to use the supplied seed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5896)
<!-- Reviewable:end -->
