### PR TITLE
Communicate map image changes to other clients

### DIFF
--- a/messages/src/main/proto/data_transfer_objects.proto
+++ b/messages/src/main/proto/data_transfer_objects.proto
@@ -651,7 +651,6 @@ message ZoneDto {
   google.protobuf.StringValue map_asset = 27;
   IntPointDto boardPosition = 28;
   bool draw_board = 29;
-  bool boardChanged = 30;
   string name = 31;
   google.protobuf.StringValue player_alias = 32;
   bool is_visible = 33;

--- a/messages/src/main/proto/data_transfer_objects.proto
+++ b/messages/src/main/proto/data_transfer_objects.proto
@@ -650,7 +650,6 @@ message ZoneDto {
   DrawablePaintDto background_paint = 26;
   google.protobuf.StringValue map_asset = 27;
   IntPointDto boardPosition = 28;
-  bool draw_board = 29;
   string name = 31;
   google.protobuf.StringValue player_alias = 32;
   bool is_visible = 33;

--- a/messages/src/main/proto/message_types.proto
+++ b/messages/src/main/proto/message_types.proto
@@ -206,7 +206,9 @@ message SendTokensToBackMsg {
 message SetBoardMsg {
   string zone_guid = 1;
   IntPointDto point = 2;
-  string asset_id = 3;
+  double scaleX = 3;
+  double scaleY = 4;
+  string asset_id = 5;
 }
 
 message SetCampaignMsg {

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -673,10 +673,13 @@ public class ClientMessageHandler implements MessageHandler {
         () -> {
           var zoneGUID = GUID.valueOf(msg.getZoneGuid());
           var zone = client.getCampaign().getZone(zoneGUID);
-
-          Point boardXY = Mapper.map(msg.getPoint());
-          var assetId = new MD5Key(msg.getAssetId());
-          zone.setBoard(boardXY, assetId);
+          if (zone != null) {
+            Point boardXY = Mapper.map(msg.getPoint());
+            var assetId = new MD5Key(msg.getAssetId());
+            zone.setBoard(boardXY, assetId);
+            zone.setImageScaleX((float) msg.getScaleX());
+            zone.setImageScaleY((float) msg.getScaleY());
+          }
         });
   }
 

--- a/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
+++ b/src/main/java/net/rptools/maptool/client/ClientMessageHandler.java
@@ -676,9 +676,7 @@ public class ClientMessageHandler implements MessageHandler {
           if (zone != null) {
             Point boardXY = Mapper.map(msg.getPoint());
             var assetId = new MD5Key(msg.getAssetId());
-            zone.setBoard(boardXY, assetId);
-            zone.setImageScaleX((float) msg.getScaleX());
-            zone.setImageScaleY((float) msg.getScaleY());
+            zone.setBoard(assetId, boardXY, (float) msg.getScaleX(), (float) msg.getScaleY());
           }
         });
   }

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -578,7 +578,7 @@ public class ServerCommandClientImpl implements ServerCommand {
         SetBoardMsg.newBuilder()
             .setZoneGuid(zoneGUID.toString())
             .setAssetId(mapAssetId.toString())
-            .setPoint(IntPointDto.newBuilder().setY(x).setY(y));
+            .setPoint(IntPointDto.newBuilder().setX(x).setY(y));
     makeServerCall(Message.newBuilder().setSetBoardMsg(msg).build());
   }
 

--- a/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
+++ b/src/main/java/net/rptools/maptool/client/ServerCommandClientImpl.java
@@ -566,19 +566,23 @@ public class ServerCommandClientImpl implements ServerCommand {
     }
   }
 
-  public void setBoard(GUID zoneGUID, MD5Key mapAssetId, int x, int y) {
+  public void setBoard(
+      GUID zoneGUID, MD5Key mapAssetId, int x, int y, double scaleX, double scaleY) {
     // First, ensure that the possibly new map texture is available on the client
     // note: This may not be the optimal solution... can't tell from available documentation.
     // it may send a texture that is already sent
     // it might be better to do it in the background(?)
     // there seem to be other ways to upload textures (?) (e.g. in MapToolUtil)
     putAsset(AssetManager.getAsset(mapAssetId));
+
     // Second, tell the client to change the zone's board info
     var msg =
         SetBoardMsg.newBuilder()
             .setZoneGuid(zoneGUID.toString())
             .setAssetId(mapAssetId.toString())
-            .setPoint(IntPointDto.newBuilder().setX(x).setY(y));
+            .setPoint(IntPointDto.newBuilder().setX(x).setY(y))
+            .setScaleX(scaleX)
+            .setScaleY(scaleY);
     makeServerCall(Message.newBuilder().setSetBoardMsg(msg).build());
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MapFunctions.java
@@ -292,7 +292,7 @@ public class MapFunctions extends AbstractFunction {
           }
         }
 
-        newMap.setMapAsset(mapAssetKey);
+        newMap.setMapAssetId(mapAssetKey);
       }
 
       MapTool.addZone(newMap, false);

--- a/src/main/java/net/rptools/maptool/client/tool/boardtool/BoardTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/boardtool/BoardTool.java
@@ -199,9 +199,8 @@ public class BoardTool extends DefaultTool {
   private void copyControlPanelToBoard() {
     boardPosition.x = (int) boardPositionXSpinner.getModel().getValue();
     boardPosition.y = (int) boardPositionYSpinner.getModel().getValue();
-    zone.setImageScaleX((float) boardScale.getX());
-    zone.setImageScaleY((float) boardScale.getY());
-    zone.setBoard(boardPosition);
+    zone.setBoard(
+        zone.getMapAssetId(), boardPosition, (float) boardScale.getX(), (float) boardScale.getY());
   }
 
   @Override
@@ -303,7 +302,7 @@ public class BoardTool extends DefaultTool {
       boardPosition.y = boardStart.y + dragOffset.height;
       snapBoard();
       updateGUI();
-      zone.setBoard(boardPosition);
+      zone.setBoardPosition(boardPosition);
     } else {
       super.mouseDragged(e);
     }
@@ -342,7 +341,7 @@ public class BoardTool extends DefaultTool {
           break;
       }
       updateGUI();
-      zone.setBoard(boardPosition);
+      zone.setBoardPosition(boardPosition);
     }
   }
 
@@ -380,7 +379,7 @@ public class BoardTool extends DefaultTool {
       setSnap(1, 1);
     }
     updateGUI();
-    zone.setBoard(boardPosition);
+    zone.setBoardPosition(boardPosition);
   }
 
   private class spinnerListener implements ChangeListener {

--- a/src/main/java/net/rptools/maptool/client/tool/boardtool/BoardTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/boardtool/BoardTool.java
@@ -260,7 +260,13 @@ public class BoardTool extends DefaultTool {
   protected void detachFrom(ZoneRenderer renderer) {
     MapTool.getFrame().removeControlPanel();
     MapTool.serverCommand()
-        .setBoard(zone.getId(), zone.getMapAssetId(), zone.getBoardX(), zone.getBoardY());
+        .setBoard(
+            zone.getId(),
+            zone.getMapAssetId(),
+            zone.getBoardX(),
+            zone.getBoardY(),
+            zone.getImageScaleX(),
+            zone.getImageScaleY());
     AppState.setShowGrid(oldShowGrid);
     super.detachFrom(renderer);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1490,7 +1490,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
               zone.setBackgroundPaint(new DrawableTexturePaint(asset));
               zone.setBackgroundAsset(asset.getMD5Key());
             } else {
-              zone.setMapAsset(asset.getMD5Key());
+              zone.setMapAssetId(asset.getMD5Key());
               zone.setBackgroundPaint(new DrawableColorPaint(Color.black));
               zone.setBackgroundAsset(asset.getMD5Key());
             }

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -102,7 +102,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
   // Pseudo-layers
   private static Zone.VisionType savedVision;
   private static boolean savedFog;
-  private static boolean savedBoard;
   // for ZoneRenderer preservation
   private static Rectangle origBounds;
   private static Scale origScale;
@@ -734,7 +733,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     // pseudo-layers
     savedVision = zone.getVisionType();
     savedFog = zone.hasFog();
-    savedBoard = zone.drawBoard();
 
     //
     // set according to dialog options
@@ -743,8 +741,10 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     if (!ExportLayers.LAYER_VISIBILITY.isChecked()) {
       zone.setVisionType(Zone.VisionType.OFF);
     }
-    zone.setDrawBoard(ExportLayers.LAYER_BOARD.isChecked());
 
+    if (!ExportLayers.LAYER_BOARD.isChecked()) {
+      renderer.disableBoard();
+    }
     for (ExportLayers exportLayer : ExportLayers.values()) {
       if (exportLayer.associatedZoneLayer != null && !exportLayer.isChecked()) {
         renderer.disableLayer(exportLayer.associatedZoneLayer);
@@ -756,7 +756,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
   private static void restoreZoneLayers() {
     zone.setHasFog(savedFog);
     zone.setVisionType(savedVision);
-    zone.setDrawBoard(savedBoard);
     renderer.restoreLayers();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/mappropertiesdialog/MapPropertiesDialog.java
@@ -328,7 +328,7 @@ public class MapPropertiesDialog extends JDialog {
 
     zone.setFogPaint(fogPaint);
     zone.setBackgroundPaint(backgroundPaint);
-    zone.setMapAsset(mapAsset != null ? mapAsset.getMD5Key() : null);
+    zone.setMapAssetId(mapAsset != null ? mapAsset.getMD5Key() : null);
 
     var campaign = MapTool.getClient().getCampaign();
     if (getIsLandingMapCheckBox().isSelected()) {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -117,6 +117,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   private BufferedImage miniImage;
   private BufferedImage backBuffer;
   private boolean drawBackground = true;
+  private boolean boardChanged = true;
   private Scale lastZoneScale;
   private Area visibleScreenArea;
   private final List<ItemRenderer> itemRenderList = new LinkedList<>();
@@ -1057,9 +1058,9 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     if (!Objects.equals(lastZoneScale, scale)) {
       drawBackground = true;
     }
-    if (zone.isBoardChanged()) {
+    if (boardChanged) {
       drawBackground = true;
-      zone.setBoardChanged(false);
+      boardChanged = false;
     }
     if (drawBackground) {
       Graphics2D bbg = backBuffer.createGraphics();
@@ -2583,6 +2584,8 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     if (event.zone() != this.zone) {
       return;
     }
+
+    this.boardChanged = true;
     repaintDebouncer.dispatch();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -118,6 +118,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   private BufferedImage backBuffer;
   private boolean drawBackground = true;
   private boolean boardChanged = true;
+  private boolean boardEnabled = true;
   private Scale lastZoneScale;
   private Area visibleScreenArea;
   private final List<ItemRenderer> itemRenderList = new LinkedList<>();
@@ -733,7 +734,15 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
   }
 
   public void restoreLayers() {
+    boardEnabled = true;
+    boardChanged = true;
+
     disabledLayers.clear();
+  }
+
+  public void disableBoard() {
+    boardEnabled = false;
+    boardChanged = true;
   }
 
   public void disableLayer(Layer layer) {
@@ -825,7 +834,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     timer.stop("calcs-1");
 
     // Rendering pipeline
-    if (zone.drawBoard()) {
+    if (boardEnabled) {
       timer.start("board");
       renderBoard(g2d, view);
       timer.stop("board");

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -400,7 +400,11 @@ public class Zone {
   private DrawablePaint backgroundPaint;
   private MD5Key mapAsset;
   private Point boardPosition = new Point(0, 0);
-  private boolean drawBoard = true;
+
+  /**
+   * @deprecated This is a rendering concern and so has been removed from the model.
+   */
+  @Deprecated private boolean drawBoard = true;
 
   /**
    * @deprecated This is a rendering concern and so has been removed from the model.
@@ -783,14 +787,6 @@ public class Zone {
 
   public float getImageScaleY() {
     return imageScaleY;
-  }
-
-  public boolean drawBoard() {
-    return drawBoard;
-  }
-
-  public void setDrawBoard(boolean draw) {
-    drawBoard = draw;
   }
 
   // endregion
@@ -2071,11 +2067,6 @@ public class Zone {
       exposedAreaMeta = new HashMap<GUID, ExposedAreaMetaData>();
     }
     // 1.3b70 -> 1.3b71
-    // These two variables were added
-    if (drawBoard == false) {
-      // this should check the file version, not the value
-      drawBoard = true;
-    }
     if (boardPosition == null) {
       boardPosition = new Point(0, 0);
     }
@@ -2273,7 +2264,6 @@ public class Zone {
     zone.mapAsset = dto.hasMapAsset() ? new MD5Key(dto.getMapAsset().getValue()) : null;
     zone.boardPosition.x = dto.getBoardPosition().getX();
     zone.boardPosition.y = dto.getBoardPosition().getY();
-    zone.drawBoard = dto.getDrawBoard();
     zone.name = dto.getName();
     zone.playerAlias = dto.hasPlayerAlias() ? dto.getPlayerAlias().getValue() : null;
     zone.isVisible = dto.getIsVisible();
@@ -2338,7 +2328,6 @@ public class Zone {
       dto.setMapAsset(StringValue.of(mapAsset.toString()));
     }
     dto.setBoardPosition(Mapper.map(boardPosition));
-    dto.setDrawBoard(drawBoard);
     dto.setIsVisible(isVisible);
     dto.setVisionType(ZoneDto.VisionTypeDto.valueOf(visionType.name()));
     dto.setLightingStyle(ZoneDto.LightingStyleDto.valueOf(lightingStyle.name()));

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -401,7 +401,11 @@ public class Zone {
   private MD5Key mapAsset;
   private Point boardPosition = new Point(0, 0);
   private boolean drawBoard = true;
-  private boolean boardChanged = false;
+
+  /**
+   * @deprecated This is a rendering concern and so has been removed from the model.
+   */
+  @Deprecated private boolean boardChanged = false;
 
   // Lee: adding extra property to determine FoW exposure method
   // Jamz: Changed to transient to allow backwards compatibility of campaign
@@ -445,11 +449,6 @@ public class Zone {
 
   public MD5Key getBackgroundAsset() {
     return ((DrawableTexturePaint) getBackgroundPaint()).getAssetId();
-  }
-
-  public void setMapAsset(MD5Key id) {
-    mapAsset = id;
-    boardChanged = true;
   }
 
   public void setTokenVisionDistance(int units) {
@@ -535,10 +534,6 @@ public class Zone {
     } else {
       return playerAlias + " (" + name + ")";
     }
-  }
-
-  public MD5Key getMapAssetId() {
-    return mapAsset;
   }
 
   public DrawablePaint getBackgroundPaint() {
@@ -742,30 +737,28 @@ public class Zone {
     gridColor = color;
   }
 
-  /**
-   * Board pseudo-object. Not making full object since this will change when new layer model is
-   * created
-   *
-   * @return has the board changed?
-   */
-  public boolean isBoardChanged() {
-    return boardChanged;
+  // region Map image
+
+  private void boardChanged() {
+    new MapToolEventBus()
+        .getMainEventBus()
+        .post(new BoardChanged(this, mapAsset, boardPosition, imageScaleX, imageScaleY));
   }
 
-  public void setBoardChanged(boolean set) {
-    boardChanged = set;
+  public void setBoard(MD5Key asset, Point position, float scaleX, float scaleY) {
+    mapAsset = asset;
+    boardPosition.setLocation(position);
+    this.imageScaleX = scaleX;
+    this.imageScaleY = scaleY;
+    boardChanged();
   }
 
-  public void setBoard(Point position) {
-    boardPosition.x = position.x;
-    boardPosition.y = position.y;
-    setBoardChanged(true);
-    new MapToolEventBus().getMainEventBus().post(new BoardChanged(this, mapAsset, boardPosition));
+  public MD5Key getMapAssetId() {
+    return mapAsset;
   }
 
-  public void setBoard(Point position, MD5Key asset) {
-    this.setMapAsset(asset);
-    this.setBoard(position);
+  public void setMapAssetId(MD5Key id) {
+    setBoard(id, boardPosition, imageScaleX, imageScaleY);
   }
 
   public int getBoardX() {
@@ -776,6 +769,22 @@ public class Zone {
     return boardPosition.y;
   }
 
+  public void setBoardPosition(Point position) {
+    setBoard(mapAsset, position, imageScaleX, imageScaleY);
+  }
+
+  public float getImageScaleX() {
+    return imageScaleX;
+  }
+
+  public void setImageScale(float scaleX, float scaleY) {
+    setBoard(mapAsset, boardPosition, scaleX, scaleY);
+  }
+
+  public float getImageScaleY() {
+    return imageScaleY;
+  }
+
   public boolean drawBoard() {
     return drawBoard;
   }
@@ -784,25 +793,7 @@ public class Zone {
     drawBoard = draw;
   }
 
-  //
-  // Misc Scale methods
-  //
-
-  public float getImageScaleX() {
-    return imageScaleX;
-  }
-
-  public void setImageScaleX(float imageScaleX) {
-    this.imageScaleX = imageScaleX;
-  }
-
-  public float getImageScaleY() {
-    return imageScaleY;
-  }
-
-  public void setImageScaleY(float imageScaleY) {
-    this.imageScaleY = imageScaleY;
-  }
+  // endregion
 
   //
   // Fog
@@ -2283,7 +2274,6 @@ public class Zone {
     zone.boardPosition.x = dto.getBoardPosition().getX();
     zone.boardPosition.y = dto.getBoardPosition().getY();
     zone.drawBoard = dto.getDrawBoard();
-    zone.boardChanged = dto.getBoardChanged();
     zone.name = dto.getName();
     zone.playerAlias = dto.hasPlayerAlias() ? dto.getPlayerAlias().getValue() : null;
     zone.isVisible = dto.getIsVisible();
@@ -2349,7 +2339,6 @@ public class Zone {
     }
     dto.setBoardPosition(Mapper.map(boardPosition));
     dto.setDrawBoard(drawBoard);
-    dto.setBoardChanged(boardChanged);
     dto.setIsVisible(isVisible);
     dto.setVisionType(ZoneDto.VisionTypeDto.valueOf(visionType.name()));
     dto.setLightingStyle(ZoneDto.LightingStyleDto.valueOf(lightingStyle.name()));

--- a/src/main/java/net/rptools/maptool/model/Zone.java
+++ b/src/main/java/net/rptools/maptool/model/Zone.java
@@ -763,13 +763,6 @@ public class Zone {
     new MapToolEventBus().getMainEventBus().post(new BoardChanged(this, mapAsset, boardPosition));
   }
 
-  public void setBoard(int newX, int newY) {
-    boardPosition.x = newX;
-    boardPosition.y = newY;
-    setBoardChanged(true);
-    new MapToolEventBus().getMainEventBus().post(new BoardChanged(this, mapAsset, boardPosition));
-  }
-
   public void setBoard(Point position, MD5Key asset) {
     this.setMapAsset(asset);
     this.setBoard(position);

--- a/src/main/java/net/rptools/maptool/model/zones/BoardChanged.java
+++ b/src/main/java/net/rptools/maptool/model/zones/BoardChanged.java
@@ -18,4 +18,4 @@ import java.awt.*;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Zone;
 
-public record BoardChanged(Zone zone, MD5Key asset, Point position) {}
+public record BoardChanged(Zone zone, MD5Key asset, Point position, double scaleX, double scaleY) {}

--- a/src/main/java/net/rptools/maptool/server/ServerCommand.java
+++ b/src/main/java/net/rptools/maptool/server/ServerCommand.java
@@ -161,7 +161,7 @@ public interface ServerCommand {
 
   void updateGmMacros(List<MacroButtonProperties> properties);
 
-  void setBoard(GUID zoneGUID, MD5Key mapAsset, int X, int Y);
+  void setBoard(GUID zoneGUID, MD5Key mapAsset, int x, int y, double scalex, double scaleY);
 
   void setLiveTypingLabel(String name, boolean show);
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5897

### Description of the Change

First, modified `ServerCommandClientImpl#setBoard()` to set the x coordinate as the x coordinate, not the y coordinate.

Next, include the image scale as part of the board properties, including being part of the `SetBoardMsg` DTO and `BoardChanged` events.

Finally, move `drawBoard` and `boardChanged` out of `Zone` and into `ZoneRenderer` as these are purely rendering concerns. Because these fields were never marked as `transient`, they are part of campaign files, and so they have not been removed but only marked as `@Deprecated`.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where _Map_ > _Adjust Map Board_ would not propertly update connected clients.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5900)
<!-- Reviewable:end -->
