### PR TITLE
Fix jumpy token drags

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/DefaultTool.java
@@ -170,7 +170,7 @@ public abstract class DefaultTool extends Tool
    * @param x the x coordinate of the drag start
    * @param y the y coordinate of the drag start
    */
-  public void setDragStart(int x, int y) {
+  private void setDragStart(int x, int y) {
     mapDragStart = new Point(x, y);
   }
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -204,12 +204,7 @@ public class PointerTool extends DefaultTool {
   }
 
   public void startTokenDrag(Token keyToken, Set<GUID> tokens) {
-    startTokenDrag(
-        keyToken,
-        tokens,
-        new ScreenPoint(dragStartX, dragStartY)
-            .convertToZone(renderer.getViewModel().getZoneScale()),
-        false);
+    startTokenDrag(keyToken, tokens, keyToken.getDragAnchor(renderer.getZone()), false);
   }
 
   private void startTokenDrag(

--- a/src/main/java/net/rptools/maptool/client/tool/StampTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/StampTool.java
@@ -132,12 +132,7 @@ public class StampTool extends DefaultTool implements ZoneOverlay {
   }
 
   public void startTokenDrag(Token keyToken, Set<GUID> tokens) {
-    startTokenDrag(
-        keyToken,
-        tokens,
-        new ScreenPoint(dragStartX, dragStartY)
-            .convertToZone(renderer.getViewModel().getZoneScale()),
-        false);
+    startTokenDrag(keyToken, tokens, keyToken.getDragAnchor(renderer.getZone()), false);
   }
 
   private void startTokenDrag(

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -34,8 +34,6 @@ import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.events.OverlayVisibilityChanged;
 import net.rptools.maptool.client.swing.SwingUtil;
-import net.rptools.maptool.client.tool.DefaultTool;
-import net.rptools.maptool.client.tool.Tool;
 import net.rptools.maptool.client.ui.AppMenuBar;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.Token;
@@ -388,7 +386,6 @@ public class HTMLOverlayPanel extends JFXPanel {
 
           @Override
           public void mousePressed(MouseEvent e) {
-            maySetMapDragStart(e); // may set map dragstart x and y, even if on overlay
             mayPassClick(e);
             e.consume(); // workaround for java bug JDK-8200224
           }
@@ -435,22 +432,6 @@ public class HTMLOverlayPanel extends JFXPanel {
     Component c = MapTool.getFrame().getCurrentZoneRenderer();
     if (c != null) {
       c.dispatchEvent(SwingUtilities.convertMouseEvent(e.getComponent(), e, c));
-    }
-  }
-
-  /**
-   * Sets up the initial drag start. If the mouse press is a right click and the tool could be
-   * dragging the map, sets up the initial drag start. This is required or the map will "jump" if
-   * performing a right click on the overlay followed by a drag.
-   *
-   * @param e the mouse press event
-   */
-  private void maySetMapDragStart(MouseEvent e) {
-    if (SwingUtilities.isRightMouseButton(e)) {
-      Tool tool = MapTool.getFrame().getToolbox().getSelectedTool();
-      if (tool instanceof DefaultTool) {
-        ((DefaultTool) tool).setDragStart(e.getX(), e.getY());
-      }
     }
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/htmlframe/HTMLOverlayPanel.java
@@ -314,7 +314,7 @@ public class HTMLOverlayPanel extends JFXPanel {
             SwingUtilities.invokeLater(
                 () -> {
                   if (result == mousePassResult.PASS || !isOpaque(e.getX(), e.getY())) {
-                    passMouseEvent(e);
+                    passMouseEventImmediately(e);
                   }
                 });
           }
@@ -415,7 +415,23 @@ public class HTMLOverlayPanel extends JFXPanel {
    *
    * @param e the mouse event to forward
    */
-  void passMouseEvent(MouseEvent e) {
+  private void passMouseEvent(MouseEvent e) {
+    /*
+     * Important: because mayPassClick() first goes to Platform.runLater(), then
+     * `SwingUtilities.invokeLater()` if permitted, we need to do the same here. Otherwise, events
+     * can end up out of order.
+     */
+
+    Platform.runLater(
+        () -> {
+          SwingUtilities.invokeLater(
+              () -> {
+                passMouseEventImmediately(e);
+              });
+        });
+  }
+
+  private void passMouseEventImmediately(MouseEvent e) {
     Component c = MapTool.getFrame().getCurrentZoneRenderer();
     if (c != null) {
       c.dispatchEvent(SwingUtilities.convertMouseEvent(e.getComponent(), e, c));


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5901

### Description of the Change

Fixes the underlying problem with mouse event delivery from overlays so that mouse events are delivered in the same order they were received. For those events that don't require hit detection, we still send them through the JavaFX thread and back to the Swing thread to preserve the timing. With this fixed, there is no more need for the workaround regarding map dragging introduced back in 9f454c3ea1, so `HTMLOverlayPanel#mayStartMapDrag()` has been removed.

A minor related issue in `PointerTool` and `StampTool` changes the context-menu's Move action to follow the token drag anchor rather than whatever point happened to be last pressed before the context menu opened.

### Possible Drawbacks

`PointerTool` and `StampTool` still have weakness in terms of `mousePressed()` vs `mouseDragged()` event ordering. But, by a stroke of luck, it doesn't seem possible or at least easy to run afoul of these weaknesses, at least not without the significantly delayed `mousePressed()` events fixed in this PR. These tools ought to still be refactored in a future change so that they rely less on share state directly between `mousePressed()` and `mouseDragged()`.

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where having an overlay open would often cause tokens to jump randomly at the start of drags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5902)
<!-- Reviewable:end -->
