### PR TITLE
Clean up ExportDialog and support layer selection for current view

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -184,38 +184,51 @@ public class AppActions {
         }
       };
 
-  public static final ClientAction EXPORT_SCREENSHOT =
-      new ZoneClientAction("action.exportScreenShotAs") {
-        @Override
-        protected void executeAction(@Nonnull ZoneRenderer renderer) {
-          try {
-            ExportDialog d = MapTool.getCampaign().getExportDialog();
-            d.setVisible(true);
-            MapTool.getCampaign().setExportDialog(d);
-          } catch (Exception ex) {
-            MapTool.showError("Cannot create the ExportDialog object", ex);
-          }
-        }
-      };
+  // region Screenshot export
 
-  public static final Action EXPORT_SCREENSHOT_LAST_LOCATION =
-      new ZoneClientAction(
-          "action.exportScreenShot", withMenuShortcut(KeyStroke.getKeyStroke("shift S"))) {
-        @Override
-        protected void executeAction(@Nonnull ZoneRenderer renderer) {
-          ExportDialog d = MapTool.getCampaign().getExportDialog();
-          if (d == null || d.getExportLocation() == null || d.getExportSettings() == null) {
-            // Can't do a save.. so try "save as"
-            EXPORT_SCREENSHOT.executeAction();
-          } else {
-            try {
-              d.screenCapture();
-            } catch (Exception ex) {
-              MapTool.showError("msg.error.failedExportingImage", ex);
-            }
-          }
+  private static final class ExportScreenshotAction extends ZoneClientAction {
+    private final boolean forceSaveAs;
+
+    public ExportScreenshotAction(boolean forceSaveAs) {
+      super(forceSaveAs ? "action.exportScreenShotAs" : "action.exportScreenShot");
+      this.forceSaveAs = forceSaveAs;
+    }
+
+    @Override
+    protected void executeAction(@Nonnull ZoneRenderer renderer) {
+      var campaign = MapTool.getCampaign();
+      var exportLocation = campaign.getExportLocation();
+      var exportSettings = campaign.getExportSettings();
+
+      var doSaveAs = forceSaveAs || exportLocation == null || exportSettings == null;
+
+      var dialog = new ExportDialog(renderer);
+      dialog.setExportSettings(exportSettings);
+      dialog.setExportLocation(exportLocation);
+
+      if (doSaveAs) {
+        try {
+          dialog.setVisible(true);
+
+          // Save the new settings for future use comparison.
+          campaign.setExportLocation(dialog.getExportLocation());
+          campaign.setExportSettings(dialog.getExportSettings());
+        } catch (Exception ex) {
+          MapTool.showError("Cannot create the ExportDialog object", ex);
         }
-      };
+      } else {
+        try {
+          dialog.screenCapture();
+        } catch (Exception ex) {
+          MapTool.showError("msg.error.failedExportingImage", ex);
+        }
+      }
+    }
+  }
+
+  public static final ClientAction EXPORT_SCREENSHOT = new ExportScreenshotAction(true);
+
+  public static final Action EXPORT_SCREENSHOT_LAST_LOCATION = new ExportScreenshotAction(false);
 
   public static final Action EXPORT_CAMPAIGN_REPO =
       new TranslatedClientAction("admin.exportCampaignRepo") {

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -112,22 +112,8 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
   /** Only doing this because I don't expect more than one instance of this modal dialog */
   private static int instanceCount = 0;
 
-  //
-  // Vars for background rendering of the screenshot
-  //
-
   /** 0-100: percentage of pixels written to destination */
   private int renderPercent;
-
-  // 1. We shouldn't have to synchronize the names of variables manually
-  // 2. Specifying the name of a button in Abeille is the same as declaring a variable
-  // 3. This code is always the same for every form, aside from the var names
-  // 4. JAVA doesn't have a way to do abstract enumerated types, so we can't re-use the code except
-  // by copy/paste
-  // 5. Abeille seems to be abandonded at this point (July 2010). The owner replied as recently as
-  // July 2009, but
-  // seems not to have followed up.
-  //
 
   /**
    * This enum is for ALL the radio buttons in the dialog, regardless of their grouping.
@@ -622,47 +608,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
               postScreenshot();
               MapTool.getFrame()
                   .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaved"));
-            }
-          } else if (interactPanel.getRadioButton("METHOD_BACKGROUND").isSelected()) {
-            // We must call preScreenshot before creating the ZoneImageGenerator, because
-            // ZoneImageGenerator uses the ZoneRenderer's bounds to set itself up
-
-            MapTool.showError("This doesn't work! Try one of the other methods.", null);
-            if (false) {
-              //
-              // Note: this implementation is the obvious way, which doesn't work, since
-              // ZoneRenderer is part of the Swing component chain, and the threads get deadlocked.
-              //
-              // The suggested implementation by
-              // "Reiger" at http://ubuntuforums.org/archive/index.php/t-1455270.html
-              // might work... except that it would have to be part of ZoneRenderer
-              //
-              // The only way to make this really work is to pull the renderZone function
-              // out of ZoneRenderer into a new class: call it ZoneRasterizer. Then make
-              // ZoneRenderer create an instance of it, and patch up the code to make it
-              // compatible. Then we can create an instance of ZoneRasterizer, and run it
-              // in a separate thread, since it won't lock in any of the functions that
-              // Swing uses.
-              //
-              class backscreenRender implements Runnable {
-
-                public void run() {
-                  try {
-                    PlayerView view = preScreenshot();
-                    final ZoneImageGenerator zoneImageGenerator =
-                        new ZoneImageGenerator(renderer, view);
-                    final ImageWriter pngWriter = ImageIO.getImageWritersByFormatName("png").next();
-                    exportLocation.putContent(pngWriter, zoneImageGenerator);
-                    // postScreenshot is called by the callback imageComplete()
-                  } catch (Exception e) {
-                    assert false
-                        : "Unhandled Exception in renderOffScreen: '" + e.getMessage() + "'";
-                  }
-                }
-              }
-              backscreenRender p = new backscreenRender();
-              new Thread(p).start();
-              repaint();
             }
           } else {
             throw new Exception("Unknown rendering method!");

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -23,10 +23,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,13 +60,6 @@ import org.apache.logging.log4j.Logger;
  */
 public class ExportDialog extends JDialog {
 
-  public enum Status {
-    OK,
-    CANCEL
-  }
-
-  private ExportDialog.Status status;
-
   //
   // Dialog/ UI related vars
   //
@@ -82,19 +73,6 @@ public class ExportDialog extends JDialog {
 
   private final Zone zone;
   private final ZoneRenderer renderer;
-
-  // These are used to preserve zone settings because
-  // we'll change the Zone/ZoneRenderer temporarily to take the screenshot.
-
-  // Pseudo-layers
-  private Zone.VisionType savedVision;
-  private boolean savedFog;
-  // for ZoneRenderer preservation
-  private Rectangle origBounds;
-  private Scale origScale;
-
-  /** set by preScreenshot, cleared by postScreenshot */
-  private boolean waitingForPostScreenshot = false;
 
   /**
    * This enum is for ALL the radio buttons in the dialog, regardless of their grouping.
@@ -400,7 +378,7 @@ public class ExportDialog extends JDialog {
             "cancel",
             new AbstractAction() {
               public void actionPerformed(ActionEvent e) {
-                cancel();
+                dispose();
               }
             });
   }
@@ -415,17 +393,8 @@ public class ExportDialog extends JDialog {
       enforceButtonRules();
 
       SwingUtil.centerOver(this, MapTool.getFrame());
-    } else {
-      if (waitingForPostScreenshot) {
-        postScreenshot();
-      }
     }
     super.setVisible(b);
-  }
-
-  private void cancel() {
-    status = ExportDialog.Status.CANCEL;
-    setVisible(false);
   }
 
   private void exportButtonAction() {
@@ -501,80 +470,60 @@ public class ExportDialog extends JDialog {
     if (type == null) {
       throw new Exception(I18N.getString("dialog.screenshot.error.invalidDialogSettings"));
     }
-    Player.Role role;
     try {
-      switch (type) {
-        case TYPE_CURRENT_VIEW:
-          // This uses the original screenshot code: I didn't want to touch it, so I need
-          // to pass it the same parameter it took before.
-          role = ExportRadioButtons.VIEW_GM.isChecked() ? Player.Role.GM : Player.Role.PLAYER;
-          BufferedImage screenCap = MapTool.takeMapScreenShot(renderer.makePlayerView(role, true));
-          // since old screenshot code doesn't throw exceptions, look for null
-          if (screenCap == null) {
-            throw new Exception(I18N.getString("dialog.screenshot.error.failedImageGeneration"));
-          }
-          MapTool.getFrame()
-              .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotStreaming"));
-          try (ByteArrayOutputStream imageOut = new ByteArrayOutputStream()) {
-            ImageIO.write(screenCap, "png", imageOut);
-            screenCap = null; // Free up the memory as soon as possible
-            MapTool.getFrame()
-                .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaving"));
-            exportLocation.putContent(
-                new BufferedInputStream(new ByteArrayInputStream(imageOut.toByteArray())));
-          }
-          MapTool.getFrame()
-              .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaved"));
-          break;
-        case TYPE_ENTIRE_MAP:
-          switchToWaitPanel();
-          if (interactPanel.getRadioButton("METHOD_BUFFERED_IMAGE").isSelected()
-              || interactPanel.getRadioButton("METHOD_IMAGE_WRITER").isSelected()) {
-            // Using a buffer in memory for the whole image
-            try {
-              final PlayerView view = preScreenshot();
-              final ImageWriter pngWriter = ImageIO.getImageWritersByFormatName("png").next();
-              MapTool.getFrame()
-                  .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotStreaming"));
+      // Using a buffer in memory for the whole image
+      try (var resetView = restoreZoneState()) {
+        if (!interactPanel.getRadioButton("METHOD_BUFFERED_IMAGE").isSelected()
+            && !interactPanel.getRadioButton("METHOD_IMAGE_WRITER").isSelected()) {
+          throw new Exception("Unknown rendering method!");
+        }
 
-              BufferedImage image;
-              if (interactPanel.getRadioButton("METHOD_BUFFERED_IMAGE").isSelected()) {
-                image =
-                    new BufferedImage(
-                        renderer.getWidth(), renderer.getHeight(), Transparency.OPAQUE);
-                final Graphics2D g = image.createGraphics();
-                renderer.renderZone(g, view);
-                g.dispose();
-              } else {
-                image = new ZoneImageGenerator(renderer, view);
-              }
-              // putContent() can consume quite a bit of time; really should have a progress
-              // meter of some kind here.
-              exportLocation.putContent(pngWriter, image);
-              if (image instanceof ZoneImageGenerator) {
-                log.debug("ZoneImageGenerator() stats: " + image.toString());
-              }
-              MapTool.getFrame()
-                  .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaving"));
-            } catch (Exception e) {
-              MapTool.getFrame()
-                  .setStatusMessage(
-                      I18N.getString("dialog.screenshot.error.failedImageGeneration"));
-            } finally {
-              postScreenshot();
-              MapTool.getFrame()
-                  .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaved"));
-            }
-          } else {
-            throw new Exception("Unknown rendering method!");
-          }
-          break;
-        default:
-          throw new Exception(I18N.getString("dialog.screenshot.error.invalidDialogSettings"));
+        var playerView =
+            renderer.makePlayerView(
+                ExportRadioButtons.VIEW_PLAYER.isChecked() ? Player.Role.PLAYER : Player.Role.GM,
+                false);
+
+        switchToWaitPanel();
+        setupZoneLayers();
+
+        if (type == ExportRadioButtons.TYPE_ENTIRE_MAP) {
+          setRendererView(playerView);
+        }
+
+        doScreenshot(playerView);
+      } catch (Exception e) {
+        MapTool.getFrame()
+            .setStatusMessage(I18N.getString("dialog.screenshot.error.failedImageGeneration"));
+      } finally {
+        MapTool.getFrame()
+            .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaved"));
       }
     } catch (OutOfMemoryError e) {
       MapTool.showError("screenCapture() caught: Out Of Memory", e);
     }
+  }
+
+  private void doScreenshot(PlayerView view) throws IOException {
+    final ImageWriter pngWriter = ImageIO.getImageWritersByFormatName("png").next();
+    MapTool.getFrame()
+        .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotStreaming"));
+
+    BufferedImage image;
+    if (interactPanel.getRadioButton("METHOD_BUFFERED_IMAGE").isSelected()) {
+      image = new BufferedImage(renderer.getWidth(), renderer.getHeight(), Transparency.OPAQUE);
+      final Graphics2D g = image.createGraphics();
+      renderer.renderZone(g, view);
+      g.dispose();
+    } else {
+      image = new ZoneImageGenerator(renderer, view);
+    }
+    // putContent() can consume quite a bit of time; really should have a progress
+    // meter of some kind here.
+    exportLocation.putContent(pngWriter, image);
+    if (image instanceof ZoneImageGenerator) {
+      log.debug("ZoneImageGenerator() stats: " + image.toString());
+    }
+    MapTool.getFrame().setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaving"));
   }
 
   public Map<String, Boolean> getExportSettings() {
@@ -629,13 +578,6 @@ public class ExportDialog extends JDialog {
     final Zone zone = renderer.getZone();
 
     //
-    // Preserve settings
-    //
-    // pseudo-layers
-    savedVision = zone.getVisionType();
-    savedFog = zone.hasFog();
-
-    //
     // set according to dialog options
     //
     zone.setHasFog(ExportLayers.LAYER_FOG.isChecked());
@@ -653,11 +595,20 @@ public class ExportDialog extends JDialog {
     }
   }
 
-  /** This restores the layer settings on the Zone object. It should follow setupZoneLayers(). */
-  private void restoreZoneLayers() {
-    zone.setHasFog(savedFog);
-    zone.setVisionType(savedVision);
-    renderer.restoreLayers();
+  private AutoCloseable restoreZoneState() {
+    // Preserve settings of the zone and renderer.
+    Zone.VisionType savedVision = zone.getVisionType();
+    boolean savedFog = zone.hasFog();
+    var origBounds = renderer.getBounds();
+    var origScale = renderer.getViewModel().getZoneScale();
+
+    return () -> {
+      zone.setHasFog(savedFog);
+      zone.setVisionType(savedVision);
+      renderer.restoreLayers();
+      renderer.getViewModel().setZoneScale(origScale);
+      renderer.setBounds(origBounds);
+    };
   }
 
   /**
@@ -671,51 +622,33 @@ public class ExportDialog extends JDialog {
    * revealed fog-of-war.
    *
    * <p>Must be followed by postScreenshot at some point, or the Zone will be messed up.
-   *
-   * @return the image to be saved
    */
-  private PlayerView preScreenshot() throws Exception, OutOfMemoryError {
-    assert (!waitingForPostScreenshot) : "preScreenshot() called twice in a row!";
-
-    // Save the original state of the renderer to restore later.
+  private void setRendererView(PlayerView view) throws Exception {
     // Create a place to put the image, and
     // set up the renderer to encompass the whole extents of the map.
-
-    origBounds = renderer.getBounds();
-    origScale = renderer.getViewModel().getZoneScale();
-
-    setupZoneLayers();
-    boolean viewAsPlayer = ExportRadioButtons.VIEW_PLAYER.isChecked();
 
     // First, figure out the 'extents' of the canvas
     // This will be later modified by the fog (for players),
     // and by the tiling texture (for re-importing)
-    //
-    Player.Role viewRole = viewAsPlayer ? Player.Role.PLAYER : Player.Role.GM;
-    PlayerView view = renderer.makePlayerView(viewRole, false);
     Rectangle extents = zoneExtents(view);
     try {
       // Clip to what the players know about (if applicable).
       // This keeps the player from exporting the map to learn which
       // direction has more 'stuff' in it.
-      if (viewAsPlayer && renderer.getZone().hasFog()) {
+      if (!view.isGMView() && renderer.getZone().hasFog()) {
         Rectangle fogE = renderer.getZone().getExposedArea(view).getBounds();
         if ((fogE.width < 0) || (fogE.height < 0)) {
-          MapTool.showError(
-              I18N.getString("dialog.screenshot.error.negativeFogExtents")); // Image is not
-          // clipped to
-          // show only
-          // fog-revealed
-          // areas!"));
+          // Image is not clipped to show only fog-revealed areas!
+          MapTool.showError(I18N.getString("dialog.screenshot.error.negativeFogExtents"));
         } else {
           extents = extents.intersection(fogE);
         }
       }
     } catch (Exception ex) {
-      throw (new Exception(I18N.getString("dialog.screenshot.error.noArea"), ex));
+      throw new Exception(I18N.getString("dialog.screenshot.error.noArea"), ex);
     }
     if ((extents == null) || (extents.width == 0) || (extents.height == 0)) {
-      throw (new Exception(I18N.getString("dialog.screenshot.error.noArea")));
+      throw new Exception(I18N.getString("dialog.screenshot.error.noArea"));
     }
 
     // If output includes the tiling 'board' texture, move the upper-left corner
@@ -724,23 +657,17 @@ public class ExportDialog extends JDialog {
     // aligning on importing.
 
     boolean drawBoard = ExportLayers.LAYER_BOARD.isChecked();
-    if (drawBoard) {
-      DrawablePaint paint = renderer.getZone().getBackgroundPaint();
-      DrawableTexturePaint dummy = new DrawableTexturePaint();
-      int tileX = 0, tileY = 0;
-
-      if (paint.getClass() == dummy.getClass()) {
-        Image bgTexture =
-            ImageManager.getImage(((DrawableTexturePaint) paint).getAsset().getMD5Key());
-        tileX = bgTexture.getWidth(null);
-        tileY = bgTexture.getHeight(null);
-        int x = ((int) Math.floor((float) extents.x / tileX)) * tileX;
-        int y = ((int) Math.floor((float) extents.y / tileY)) * tileY;
-        extents.width = extents.width + (extents.x - x);
-        extents.height = extents.height + (extents.y - y);
-        extents.x = x;
-        extents.y = y;
-      }
+    if (drawBoard
+        && renderer.getZone().getBackgroundPaint() instanceof DrawableTexturePaint texturePaint) {
+      Image bgTexture = ImageManager.getImage(texturePaint.getAsset().getMD5Key());
+      int tileX = bgTexture.getWidth(null);
+      int tileY = bgTexture.getHeight(null);
+      int x = ((int) Math.floor((float) extents.x / tileX)) * tileX;
+      int y = ((int) Math.floor((float) extents.y / tileY)) * tileY;
+      extents.width = extents.width + (extents.x - x);
+      extents.height = extents.height + (extents.y - y);
+      extents.x = x;
+      extents.y = y;
     }
 
     // Rescale the bounds to match the view scale
@@ -753,9 +680,6 @@ public class ExportDialog extends JDialog {
     Scale s = originalZoneScale.withOffset(-extents.x, -extents.y);
     renderer.getViewModel().setZoneScale(s);
     renderer.setBounds(extents);
-
-    waitingForPostScreenshot = true;
-    return view;
   }
 
   public Rectangle fogExtents() {
@@ -867,15 +791,6 @@ public class ExportDialog extends JDialog {
       }
     }
     return extents;
-  }
-
-  private void postScreenshot() {
-    assert waitingForPostScreenshot : "postScrenshot called without preScreenshot";
-
-    renderer.setBounds(origBounds);
-    renderer.getViewModel().setZoneScale(origScale);
-    restoreZoneLayers();
-    waitingForPostScreenshot = false;
   }
 
   //

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -79,7 +79,7 @@ public class ExportDialog extends JDialog {
    *
    * <p>The names of the enums should be the same as the button names.
    */
-  public enum ExportRadioButtons {
+  private enum ExportRadioButtons {
     // Format of enum declaration:
     // [Abeille Forms Designer button name] (default checked, default enabled)
     // Button Group 1 (not that it matters for this controller)
@@ -303,7 +303,7 @@ public class ExportDialog extends JDialog {
    * should not have using the screenshot (such as revealing things under other things by disabling
    * layers). Players can basically only turn off tokens, to get an 'empty' version of the map.
    */
-  public static void enforceButtonRules() {
+  private static void enforceButtonRules() {
     if (!MapTool.getPlayer().isGM()) {
       ExportRadioButtons.VIEW_PLAYER.setChecked(true);
       ExportRadioButtons.VIEW_PLAYER.setEnabled(true);
@@ -445,7 +445,7 @@ public class ExportDialog extends JDialog {
     }
   }
 
-  public void browseButtonAction() {
+  private void browseButtonAction() {
     JFileChooser chooser = new JFileChooser();
     if (exportLocation instanceof LocalLocation) {
       chooser.setSelectedFile(((LocalLocation) exportLocation).getFile());
@@ -682,7 +682,7 @@ public class ExportDialog extends JDialog {
     renderer.setBounds(extents);
   }
 
-  public Rectangle fogExtents() {
+  private Rectangle fogExtents() {
     return zone.getExposedArea().getBounds();
   }
 
@@ -694,7 +694,7 @@ public class ExportDialog extends JDialog {
    * @param view the player view
    * @return a new Rectangle with the bounding box of all the elements in the Zone
    */
-  public Rectangle zoneExtents(PlayerView view) {
+  private Rectangle zoneExtents(PlayerView view) {
     // Can't initialize extents to any set x/y values, because
     // we don't know if the actual map contains that x/y.
     // So we need a flag to say extents is 'unset', and the best I

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -625,7 +625,7 @@ public class ExportDialog extends JDialog {
    * This is a preserves the layer settings on the Zone object. It should be followed by
    * restoreZone()
    */
-  private void setupZoneLayers() throws OutOfMemoryError {
+  private void setupZoneLayers() {
     final Zone zone = renderer.getZone();
 
     //

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -491,12 +491,12 @@ public class ExportDialog extends JDialog {
         }
 
         doScreenshot(playerView);
+
+        MapTool.getFrame()
+            .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaved"));
       } catch (Exception e) {
         MapTool.getFrame()
             .setStatusMessage(I18N.getString("dialog.screenshot.error.failedImageGeneration"));
-      } finally {
-        MapTool.getFrame()
-            .setStatusMessage(I18N.getString("dialog.screenshot.msg.screenshotSaved"));
       }
     } catch (OutOfMemoryError e) {
       MapTool.showError("screenCapture() caught: Out Of Memory", e);

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -74,39 +74,27 @@ public class ExportDialog extends JDialog {
   //
   private static final Logger log = LogManager.getLogger(ExportDialog.class);
 
-  private static final ExportDialog instance = new ExportDialog();
-
   /** the modal panel the user uses to select the screenshot options */
   private static AbeillePanel interactPanel;
 
   /** The place the image will be sent to (file/FTP) */
   private Location exportLocation;
 
-  // These are convenience variables, which should be set
-  // each time the dialog is shown. It is safe to
-  // cache them like this since the dialog is modal.
-  // If this dialog is ever not modal, these need to be
-  // factored out.
-  private static Zone zone;
-  private static ZoneRenderer renderer;
+  private final Zone zone;
+  private final ZoneRenderer renderer;
 
   // These are used to preserve zone settings because
   // we'll change the Zone/ZoneRenderer temporarily to take the screenshot.
-  // These are static because we don't expect more than
-  // a single ExportDialog to ever be instanced.
 
   // Pseudo-layers
-  private static Zone.VisionType savedVision;
-  private static boolean savedFog;
+  private Zone.VisionType savedVision;
+  private boolean savedFog;
   // for ZoneRenderer preservation
-  private static Rectangle origBounds;
-  private static Scale origScale;
+  private Rectangle origBounds;
+  private Scale origScale;
 
   /** set by preScreenshot, cleared by postScreenshot */
   private boolean waitingForPostScreenshot = false;
-
-  /** Only doing this because I don't expect more than one instance of this modal dialog */
-  private static int instanceCount = 0;
 
   /**
    * This enum is for ALL the radio buttons in the dialog, regardless of their grouping.
@@ -373,12 +361,11 @@ public class ExportDialog extends JDialog {
     }
   }
 
-  public static ExportDialog getInstance() {
-    return instance;
-  }
-
-  private ExportDialog() {
+  public ExportDialog(ZoneRenderer renderer) {
     super(MapTool.getFrame(), I18N.getText("action.exportScreenShot.title"), true);
+
+    this.renderer = renderer;
+    this.zone = renderer.getZone();
 
     // The window uses about 1MB. Disposing frees this, but repeated uses
     // will cause more memory fragmentation.
@@ -421,10 +408,6 @@ public class ExportDialog extends JDialog {
   @Override
   public void setVisible(boolean b) {
     if (b) {
-      // Always call this first, since other methods may rely on zone or renderer being set.
-      setZone(MapTool.getFrame().getCurrentZoneRenderer().getZone());
-      setZoneRenderer(MapTool.getFrame().getCurrentZoneRenderer());
-
       // Set to interactive mode
       switchToInteractPanel();
 
@@ -443,25 +426,6 @@ public class ExportDialog extends JDialog {
   private void cancel() {
     status = ExportDialog.Status.CANCEL;
     setVisible(false);
-  }
-
-  //
-  // These get/set the convenience variables zone and renderer
-  //
-  public static void setZone(Zone zone) {
-    ExportDialog.zone = zone;
-  }
-
-  public static ZoneRenderer getZoneRenderer() {
-    return renderer;
-  }
-
-  public static void setZoneRenderer(ZoneRenderer renderer) {
-    ExportDialog.renderer = renderer;
-  }
-
-  public static Zone getZone() {
-    return zone;
   }
 
   private void exportButtonAction() {
@@ -661,7 +625,7 @@ public class ExportDialog extends JDialog {
    * This is a preserves the layer settings on the Zone object. It should be followed by
    * restoreZone()
    */
-  private static void setupZoneLayers() throws OutOfMemoryError {
+  private void setupZoneLayers() throws OutOfMemoryError {
     final Zone zone = renderer.getZone();
 
     //
@@ -690,7 +654,7 @@ public class ExportDialog extends JDialog {
   }
 
   /** This restores the layer settings on the Zone object. It should follow setupZoneLayers(). */
-  private static void restoreZoneLayers() {
+  private void restoreZoneLayers() {
     zone.setHasFog(savedFog);
     zone.setVisionType(savedVision);
     renderer.restoreLayers();

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialog.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
-import javax.imageio.event.IIOWriteProgressListener;
 import javax.swing.*;
 import net.rptools.lib.net.FTPLocation;
 import net.rptools.lib.net.LocalLocation;
@@ -61,7 +60,7 @@ import org.apache.logging.log4j.Logger;
  * <p>This uses a modal dialog based on an Abeille form. It creates a PNG file at the resolution of
  * the 'board' image/tile. The file can be saved to disk or sent to an FTP location.
  */
-public class ExportDialog extends JDialog implements IIOWriteProgressListener {
+public class ExportDialog extends JDialog {
 
   public enum Status {
     OK,
@@ -79,9 +78,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
 
   /** the modal panel the user uses to select the screenshot options */
   private static AbeillePanel interactPanel;
-
-  /** The modal panel showing screenshot progress */
-  private static JLabel progressLabel;
 
   /** The place the image will be sent to (file/FTP) */
   private Location exportLocation;
@@ -111,9 +107,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
 
   /** Only doing this because I don't expect more than one instance of this modal dialog */
   private static int instanceCount = 0;
-
-  /** 0-100: percentage of pixels written to destination */
-  private int renderPercent;
 
   /**
    * This enum is for ALL the radio buttons in the dialog, regardless of their grouping.
@@ -397,7 +390,6 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
     //
     // Initialize the panel and button actions
     //
-    createWaitPanel();
     interactPanel = new AbeillePanel(new ExportDialogView().getRootComponent());
     setLayout(new GridLayout());
     add(interactPanel);
@@ -929,44 +921,4 @@ public class ExportDialog extends JDialog implements IIOWriteProgressListener {
   private void switchToWaitPanel() {}
 
   private void switchToInteractPanel() {}
-
-  private void createWaitPanel() {
-    progressLabel = new JLabel();
-    imageProgress(null, 0);
-  }
-
-  //
-  // IIOWriteProgressListener Interface
-  //
-
-  /** Setup the progress meter. */
-  public void imageStarted(ImageWriter source, int imageIndex) {
-    renderPercent = 0;
-    progressLabel.setText(I18N.getText("exportDialog.msg.renderingWait" + renderPercent + "%"));
-    repaint();
-  }
-
-  /** Update the progress meter. */
-  public void imageProgress(ImageWriter source, float percentageDone) {
-    int oldPercent = renderPercent;
-    renderPercent = (int) (percentageDone * 100);
-    if (renderPercent > oldPercent) {
-      progressLabel.setText(I18N.getText("exportDialog.msg.renderingWait" + renderPercent + "%"));
-      repaint();
-    }
-  }
-
-  /** Close this dialog box upon completion of background thread renderer. */
-  public void imageComplete(ImageWriter source) {
-    postScreenshot();
-    dispose();
-  }
-
-  public void thumbnailStarted(ImageWriter source, int imageIndex, int thumbnailIndex) {}
-
-  public void thumbnailProgress(ImageWriter source, float percentageDone) {}
-
-  public void thumbnailComplete(ImageWriter source) {}
-
-  public void writeAborted(ImageWriter source) {}
 }

--- a/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/exportdialog/ExportDialogView.form
@@ -3,7 +3,7 @@
   <grid id="ab115" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
-      <xy x="10" y="10" width="521" height="438"/>
+      <xy x="10" y="10" width="600" height="482"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -216,17 +216,6 @@
                   <name value="METHOD_IMAGE_WRITER"/>
                   <text resource-bundle="net/rptools/maptool/language/i18n" key="ExportScreenshot.method.iw"/>
                   <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="ExportScreenshot.method.iw.tooltip"/>
-                </properties>
-              </component>
-              <component id="da68b" class="javax.swing.JRadioButton">
-                <constraints>
-                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <actionCommand value="Background Thread"/>
-                  <name value="METHOD_BACKGROUND"/>
-                  <text resource-bundle="net/rptools/maptool/language/i18n" key="ExportScreenshot.method.bg"/>
-                  <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="ExportScreenshot.method.bg.tooltip"/>
                 </properties>
               </component>
               <component id="bacb0" class="javax.swing.JLabel">

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -26,7 +26,6 @@ import net.rptools.lib.MD5Key;
 import net.rptools.lib.net.Location;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.ui.ToolbarPanel;
-import net.rptools.maptool.client.ui.exportdialog.ExportDialog;
 import net.rptools.maptool.client.ui.macrobuttons.panels.AbstractMacroPanel;
 import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.client.ui.token.BooleanTokenOverlay;
@@ -54,16 +53,12 @@ public class Campaign implements Serializable {
 
   private String name; // the name of the campaign, to be displayed in the MapToolFrame title bar
 
-  private static ExportDialog exportDialog =
-      ExportDialog
-          .getInstance(); // this is the new export dialog (different name for upward compatibility)
-
   // Static data isn't written to the campaign file when saved; these two fields hold the output
   // location and type, and the
   // settings of all JToggleButton objects (JRadioButtons and JCheckBoxes).
   private Location exportLocation;
-  private Map<String, Boolean> exportSettings =
-      new HashMap<>(); // the state of each checkbox/radiobutton for the Export>ScreenshotAs dialog
+  // the state of each checkbox/radiobutton for the Export>ScreenshotAs dialog
+  private Map<String, Boolean> exportSettings = new HashMap<>();
 
   private @Nonnull CampaignProperties campaignProperties = new CampaignProperties();
   private transient boolean isBeingSerialized;
@@ -698,16 +693,21 @@ public class Campaign implements Serializable {
     return getCampaignProperties().getCharacterSheets();
   }
 
-  public ExportDialog getExportDialog() {
-    exportDialog.setExportSettings(exportSettings);
-    exportDialog.setExportLocation(exportLocation);
-    return exportDialog;
+  public Location getExportLocation() {
+    return exportLocation;
   }
 
-  public void setExportDialog(ExportDialog d) {
-    exportDialog = d;
-    exportSettings = d.getExportSettings();
-    exportLocation = d.getExportLocation();
+  public void setExportLocation(Location exportLocation) {
+    this.exportLocation = exportLocation;
+  }
+
+  public Map<String, Boolean> getExportSettings() {
+    return Collections.unmodifiableMap(exportSettings);
+  }
+
+  public void setExportSettings(Map<String, Boolean> exportSettings) {
+    this.exportSettings.clear();
+    this.exportSettings.putAll(exportSettings);
   }
 
   public void initDefault() {


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5898

### Description of the Change

#### ExportDialog refactoring

First, remove the unsupported option to run the screenshot in a background thread. Since `ExportDialog` is always blocking, also remove code related to tracking progress or checking state transitions has been removed.

Next, `ExportDialog` is no longer a singleton. It now only has instance state instead of a mix of instance and static state. The renderer is also injected via constructor instead of being looked up when the dialog is made visible.

`Campaign` is also no longer responsible for hanging onto an `ExportDialog`, but the screenshot actions now create one on demand. This fixes the lack of theming in the dialog since it is now only created after the application is initialized, including theme support.

The save/restore functionality required for map exports has been refactored so all the state can be local to the `screenCapture()` method.

#### Layer selection fixed

With the above refactoring in place, the fix was a matter of handling `TYPE_CURRENT_VIEW` exactly as `TYPE_ENTIRE_MAP`, except that the renderer bounds and scale are never modified.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed lack of theming in the Export Screenshot dialog.
- Fixed layer selection in the Export Screenshot dialog to work with the _Current View_ option.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5903)
<!-- Reviewable:end -->
