### PR TITLE
Dispose "Assets in Transit dialog" on close requests

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/transferprogressdialog/TransferProgressDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/transferprogressdialog/TransferProgressDialog.java
@@ -50,6 +50,7 @@ public class TransferProgressDialog extends AbeillePanel<Token> implements Consu
                     .removeConsumerListener(TransferProgressDialog.this))
         .addButton(ButtonKind.CLOSE)
         .setDefaultButton(ButtonKind.CLOSE)
+        .setCloseOperation(GenericDialog.DISPOSE_ON_CLOSE)
         .display();
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5889

### Description of the Change

This fixes closing via the _Close_ button, hitting <kbd>Escape</kbd>, pressing <kbd>Alt+F4</kbd>, or pressing the OS's "x" button.

Tested on Linux Mint Cinnamon.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Fixed a bug where the asset transfer dialog could not be closed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5904)
<!-- Reviewable:end -->
