### PR TITLE
Clip long names in initiative window

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativeListCellRenderer.java
@@ -14,21 +14,34 @@
  */
 package net.rptools.maptool.client.ui.tokenpanel;
 
-import java.awt.*;
-import java.awt.geom.Rectangle2D;
+import com.intellij.uiDesigner.core.GridConstraints;
+import com.intellij.uiDesigner.core.GridLayoutManager;
+import com.intellij.uiDesigner.core.Spacer;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.Stroke;
 import java.awt.image.BufferedImage;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 import javax.swing.SwingConstants;
 import javax.swing.border.Border;
-import net.miginfocom.swing.MigLayout;
 import net.rptools.lib.AwtUtil;
-import net.rptools.lib.image.ImageUtil;
+import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.label.FlatImageLabel;
@@ -54,17 +67,33 @@ public class InitiativeListCellRenderer extends JPanel
    * Instance Variables
    *-------------------------------------------------------------------------------------------*/
 
-  /** The label used to display the current item indicator. */
-  private final JLabel currentIndicator;
-
-  /** The label used to display the item's name and icon. */
-  private final JLabel name;
-
   /** This is the panel showing initiative. It contains the state for display. */
-  private final InitiativePanel panel;
+  private final InitiativePanel initiativePanel;
+
+  /** The label used to display the current item indicator. */
+  private final JLabel currentIndicatorLabel;
+
+  // region Column 2: the token label
+
+  /** Contains the token image, name, and initiative, styled like a token label. */
+  private final JPanel labelPanel;
+
+  /**
+   * Shows the token image, optionally with states. Shown on the right of {@link #textPanelTwoLines}
+   * when the token is holding, otherwise on the left.
+   */
+  private final TokenImagePanel tokenImagePanel;
+
+  /** Shows the textual parts of the label (name, GM name, initiative). */
+  private final TextPanel textPanelTwoLines;
+
+  /** Same as {@link #textPanelTwoLines} but shows information on one line. */
+  private final TextPanel textPanelOneLine;
 
   /** Used to draw the background of the item. */
   private FlatImageLabel backgroundFlatImageLabel;
+
+  // endregion
 
   /**
    * The text height for the background image label. Only the text is painted inside, the token
@@ -94,9 +123,6 @@ public class InitiativeListCellRenderer extends JPanel
           RessourceManager.getBorder(Borders.RED).getBottomMargin(),
           RessourceManager.getBorder(Borders.RED).getRightMargin());
 
-  /** Border used for name plate */
-  public static final Border NAME_BORDER = BorderFactory.createEmptyBorder(2, 4, 3, 4);
-
   /** The size of the ICON shown in the list renderer */
   public static final int ICON_SIZE = 50;
 
@@ -112,25 +138,154 @@ public class InitiativeListCellRenderer extends JPanel
   public InitiativeListCellRenderer(InitiativePanel aPanel) {
 
     // Set up the panel
-    panel = aPanel;
-    setLayout(new MigLayout("", "[][grow]"));
-    //    setBorder(SELECTED_BORDER);
-    //    setBackground(Color.WHITE);
+    initiativePanel = aPanel;
+
+    /*
+     * The main layout is two columns: one to hold the current initiative indicator, the other to
+     * hold the "label" (which includes the token image, name, initiative, etc., all on a label
+     * background).
+     *
+     * The label is itself made of _three_ columns, though at any point in time only two are used.
+     * The first column shows the token image in a non-holding state. The second holds the textual
+     * bits (name, GM name, initiative), possibly as two lines. The third holds the token image in a
+     * holding state.
+     */
+
+    setLayout(new GridLayoutManager(1, 2, new Insets(6, 6, 9, 6), 7, 0, false, false));
 
     // The current indicator
-    currentIndicator = new JLabel();
-    currentIndicator.setPreferredSize(INDICATOR_SIZE);
-    currentIndicator.setHorizontalAlignment(SwingConstants.CENTER);
-    currentIndicator.setVerticalAlignment(SwingConstants.CENTER);
-    add(currentIndicator);
+    currentIndicatorLabel = new JLabel();
+    currentIndicatorLabel.setBorder(BorderFactory.createEmptyBorder(4, 0, 0, 0));
+    currentIndicatorLabel.setPreferredSize(INDICATOR_SIZE);
+    currentIndicatorLabel.setHorizontalAlignment(SwingConstants.CENTER);
+    currentIndicatorLabel.setVerticalAlignment(SwingConstants.CENTER);
+    add(
+        currentIndicatorLabel,
+        new GridConstraints(
+            0,
+            0,
+            1,
+            1,
+            GridConstraints.ANCHOR_CENTER,
+            GridConstraints.FILL_BOTH,
+            GridConstraints.SIZEPOLICY_FIXED,
+            GridConstraints.SIZEPOLICY_FIXED,
+            INDICATOR_SIZE,
+            INDICATOR_SIZE,
+            INDICATOR_SIZE,
+            0,
+            false));
 
-    // And the name
-    name = new NameLabel();
-    name.setText("Ty");
-    name.setBorder(NAME_BORDER);
-    name.setFont(getFont().deriveFont(Font.BOLD));
+    labelPanel = new JPanel();
+    labelPanel.setOpaque(false);
+    labelPanel.setLayout(new GridLayoutManager(3, 3, new Insets(2, 3, 0, 4), 4, 0, false, false));
+    add(
+        labelPanel,
+        new GridConstraints(
+            0,
+            1,
+            1,
+            1,
+            GridConstraints.ANCHOR_WEST,
+            GridConstraints.FILL_VERTICAL,
+            GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+            GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+            null,
+            null,
+            null,
+            0,
+            false));
+
+    textPanelTwoLines = new TextPanel(true);
+    labelPanel.add(
+        textPanelTwoLines,
+        new GridConstraints(
+            1,
+            1,
+            1,
+            1,
+            GridConstraints.ANCHOR_WEST,
+            GridConstraints.FILL_VERTICAL,
+            GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+            GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+            null,
+            null,
+            null,
+            0,
+            false));
+    textPanelOneLine = new TextPanel(false);
+    labelPanel.add(
+        textPanelOneLine,
+        new GridConstraints(
+            1,
+            1,
+            1,
+            1,
+            GridConstraints.ANCHOR_WEST,
+            GridConstraints.FILL_VERTICAL,
+            GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+            GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+            null,
+            null,
+            null,
+            0,
+            false));
+
     textHeight = getFontMetrics(getFont()).getHeight();
-    add(name);
+
+    tokenImagePanel = new TokenImagePanel();
+    tokenImagePanel.putClientProperty("html.disable", true);
+    var iconSize = new Dimension(ICON_SIZE, ICON_SIZE);
+    labelPanel.add(
+        tokenImagePanel,
+        new GridConstraints(
+            0,
+            0,
+            3,
+            1,
+            GridConstraints.ANCHOR_CENTER,
+            GridConstraints.FILL_BOTH,
+            GridConstraints.SIZEPOLICY_FIXED,
+            GridConstraints.SIZEPOLICY_FIXED,
+            iconSize,
+            iconSize,
+            iconSize,
+            0,
+            false));
+
+    labelPanel.add(
+        new Spacer(),
+        new GridConstraints(
+            0,
+            1,
+            1,
+            1,
+            GridConstraints.ANCHOR_CENTER,
+            GridConstraints.FILL_VERTICAL,
+            GridConstraints.SIZEPOLICY_FIXED,
+            GridConstraints.SIZEPOLICY_WANT_GROW,
+            null,
+            null,
+            null,
+            0,
+            false));
+    labelPanel.add(
+        new Spacer(),
+        new GridConstraints(
+            2,
+            1,
+            1,
+            1,
+            GridConstraints.ANCHOR_CENTER,
+            GridConstraints.FILL_VERTICAL,
+            GridConstraints.SIZEPOLICY_FIXED,
+            GridConstraints.SIZEPOLICY_WANT_GROW,
+            null,
+            null,
+            null,
+            0,
+            false));
+
     validate();
   }
 
@@ -138,265 +293,302 @@ public class InitiativeListCellRenderer extends JPanel
    * ListCellRenderer Interface Methods
    *-------------------------------------------------------------------------------------------*/
 
-  /**
-   * @see javax.swing.ListCellRenderer#getListCellRendererComponent(javax.swing.JList,
-   *     java.lang.Object, int, boolean, boolean)
-   */
   @Override
   public Component getListCellRendererComponent(
-      JList list, TokenInitiative ti, int index, boolean isSelected, boolean cellHasFocus) {
-
+      JList<? extends TokenInitiative> list,
+      TokenInitiative ti,
+      int index,
+      boolean isSelected,
+      boolean cellHasFocus) {
     setOpaque(false);
 
-    // Set the background by type
-    Token token = null;
-    if (ti != null) token = ti.getToken();
-    if (token == null) { // Can happen when deleting a token before all events have propagated
-      currentIndicator.setIcon(null);
-      name.setText(null);
-      name.setIcon(null);
+    TextPanel textPanel =
+        initiativePanel.isInitStateSecondLine() && initiativePanel.isShowInitState()
+            ? textPanelTwoLines
+            : textPanelOneLine;
+    textPanelTwoLines.setVisible(textPanel == textPanelTwoLines);
+    textPanelOneLine.setVisible(textPanel == textPanelOneLine);
+
+    Token token;
+    if (ti == null || (token = ti.getToken()) == null) {
+      // Can happen when deleting a token before all events have propagated
+      currentIndicatorLabel.setIcon(null);
+      textPanel.setName(null);
+      textPanel.setInitiative(null);
       setBorder(UNSELECTED_BORDER);
       return this;
-    } // endif
+    }
 
     var labelRenderFactory = new FlatImageLabelFactory();
     backgroundFlatImageLabel = labelRenderFactory.getMapImageLabel(token);
 
-    // We still use the UI text so use the map label color preferences
-    if (!token.isVisible()) {
-      name.setForeground(AppPreferences.nonVisibleTokenMapLabelForeground.get());
-    } else if (token.getType() == Token.Type.NPC) {
-      name.setForeground(AppPreferences.npcMapLabelForeground.get());
-    } else {
-      name.setForeground(AppPreferences.pcMapLabelForeground.get());
-    }
-    name.setFont(name.getFont().deriveFont(token.isVisible() ? Font.PLAIN : Font.ITALIC));
+    textPanel.setTokenIsVisible(token.isVisible());
+    textPanel.setTokenIsNpc(token.getType() == Token.Type.NPC);
 
     // Show the indicator?
-    int currentIndex = panel.getList().getCurrent();
-    if (currentIndex >= 0 && ti == panel.getList().getTokenInitiative(currentIndex)) {
-      currentIndicator.setIcon(CURRENT_INDICATOR_ICON);
-    } else {
-      currentIndicator.setIcon(null);
-    } // endif
+    var isCurrent = ti == initiativePanel.getList().getCurrentTokenInitiative();
+    currentIndicatorLabel.setIcon(isCurrent ? CURRENT_INDICATOR_ICON : null);
 
-    // Get the name string, add the state if displayed, then get the icon if needed
-    boolean initStateSecondLine = panel.isInitStateSecondLine() && panel.isShowInitState();
-    String sName = (initStateSecondLine ? "<html>" : "") + ti.getToken().getName();
-    if (MapTool.getFrame().getInitiativePanel().hasGMPermission()
-        && token.getGMName() != null
-        && token.getGMName().trim().length() != 0) sName += " (" + token.getGMName().trim() + ")";
-    if (panel.isShowInitState() && ti.getState() != null)
-      sName += (initStateSecondLine ? "<br>" : " = ") + ti.getState();
-    if (initStateSecondLine) sName += "</html>";
-    Icon icon = null;
-    if (panel.isShowTokens()) {
-      icon = ti.getDisplayIcon();
-      if (icon == null || ti.wasTokenVisibleWhenIconUpdated() != token.isVisible()) {
-        icon = new InitiativeListIcon(ti);
-        ti.setDisplayIcon(icon);
-        ti.setTokenVisibleWhenIconUpdated(token.isVisible());
-      } // endif
-    } // endif
-    name.setText(sName);
-    name.setIcon(icon);
+    var nameText = new StringBuilder(token.getName());
+    if (MapTool.getFrame().getInitiativePanel().hasGMPermission()) {
+      var gmName = token.getGMName();
+      if (!StringUtil.isEmpty(gmName)) {
+        nameText.append(" (").append(gmName.trim()).append(")");
+      }
+    }
+    textPanel.setName(nameText.toString());
 
-    // Align it properly
-    var alignment = ti.isHolding() ? SwingConstants.LEFT : SwingConstants.RIGHT;
-    name.setHorizontalTextPosition(alignment);
-    MigLayout layout = (MigLayout) getLayout();
-    //
-    if (alignment == SwingConstants.RIGHT) {
-      layout.setComponentConstraints(name, "align left");
+    textPanel.setInitiative(initiativePanel.isShowInitState() ? ti.getState() : null);
+
+    var layout = (GridLayoutManager) getLayout();
+    layout
+        .getConstraintsForComponent(labelPanel)
+        .setAnchor(ti.isHolding() ? GridConstraints.ANCHOR_EAST : GridConstraints.ANCHOR_WEST);
+
+    // Arrange the panel depending on whether the token is holding.
+    var labelPanelLayout = (GridLayoutManager) labelPanel.getLayout();
+
+    if (initiativePanel.isShowTokens()) {
+      tokenImagePanel.setVisible(true);
+      tokenImagePanel.setModel(token, initiativePanel.isShowTokenStates());
+
+      var iconConstraints = labelPanelLayout.getConstraintsForComponent(tokenImagePanel);
+      iconConstraints.setColumn(ti.isHolding() ? 2 : 0);
+      int iconSize = initiativePanel.isShowTokenStates() ? ICON_SIZE : Math.max(textHeight + 4, 16);
+      iconConstraints.myMinimumSize.setSize(iconSize, iconSize);
+      iconConstraints.myMaximumSize.setSize(iconSize, iconSize);
+      iconConstraints.myPreferredSize.setSize(iconSize, iconSize);
     } else {
-      layout.setComponentConstraints(name, "align right");
-    } // endif
+      tokenImagePanel.setVisible(false);
+    }
 
     // Selected?
     if (isSelected) {
       setBorder(SELECTED_BORDER);
     } else {
       setBorder(UNSELECTED_BORDER);
-    } // endif
+    }
+
     return this;
   }
 
-  /*---------------------------------------------------------------------------------------------
-   * NameLabel Inner Class
-   *-------------------------------------------------------------------------------------------*/
+  @Override
+  protected void paintComponent(Graphics g) {
+    var labelPanelBounds = labelPanel.getBounds();
+    var textBounds =
+        textPanelTwoLines.isVisible()
+            ? textPanelTwoLines.getBounds()
+            : textPanelOneLine.getBounds();
 
-  /**
-   * This label contains the sized background image for the name component.
-   *
-   * @author Jay
-   */
-  public class NameLabel extends JLabel {
+    // Horizontally, we want to paint around everything (image and text).
+    // Vertically, we want to fit tightly to just the text, even if the image is larger.
+    var bounds =
+        new Rectangle(
+            labelPanelBounds.x,
+            labelPanelBounds.y + textBounds.y,
+            labelPanelBounds.width,
+            textBounds.height);
 
-    /**
-     * @see javax.swing.JComponent#paintComponent(java.awt.Graphics)
-     */
-    @Override
-    protected void paintComponent(Graphics g) {
-      boolean initStateSecondLine = panel.isInitStateSecondLine() && panel.isShowInitState();
-      Dimension s = name.getSize();
-      int th = (textHeight + 2) * (initStateSecondLine ? 2 : 1);
-      // render an image label with set dimensions and without text
-      backgroundFlatImageLabel.render((Graphics2D) g, 0, (s.height - th) / 2, s.width, th, "");
-      super.paintComponent(g);
+    // Render an image label with set dimensions and without text.
+    backgroundFlatImageLabel.render(
+        (Graphics2D) g, bounds.x, bounds.y, bounds.width, bounds.height, "");
+
+    super.paintComponent(g);
+  }
+
+  private static final class TextPanel extends JPanel {
+    private final JLabel nameLabel;
+    private final JLabel initLabel;
+    private final Function<String, String> initiativeFormatter;
+    private boolean tokenIsVisible;
+    private boolean tokenIsNpc;
+
+    public TextPanel(boolean initiativeOnSecondLine) {
+      super(
+          new GridLayoutManager(
+              initiativeOnSecondLine ? 2 : 1,
+              initiativeOnSecondLine ? 1 : 2,
+              new Insets(3, 0, 1, 0),
+              initiativeOnSecondLine ? 0 : 10,
+              0,
+              false,
+              true));
+      setOpaque(false);
+
+      nameLabel = new JLabel();
+      nameLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+      nameLabel.putClientProperty("html.disable", true);
+      nameLabel.setText("Ty");
+      nameLabel.setBorder(BorderFactory.createEmptyBorder());
+      nameLabel.setFont(getFont());
+      nameLabel.setBackground(Color.blue);
+      add(
+          nameLabel,
+          new GridConstraints(
+              0,
+              0,
+              1,
+              1,
+              GridConstraints.ANCHOR_CENTER,
+              GridConstraints.FILL_BOTH,
+              GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+              GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+              new Dimension(0, 0),
+              null,
+              null,
+              0,
+              false));
+
+      initLabel = new JLabel();
+      initLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+      initLabel.putClientProperty("html.disable", true);
+      initLabel.setText("Ty");
+      initLabel.setBorder(BorderFactory.createEmptyBorder());
+      initLabel.setFont(getFont());
+      initLabel.setBackground(Color.red);
+      add(
+          initLabel,
+          new GridConstraints(
+              initiativeOnSecondLine ? 1 : 0,
+              initiativeOnSecondLine ? 0 : 1,
+              1,
+              1,
+              GridConstraints.ANCHOR_CENTER,
+              GridConstraints.FILL_BOTH,
+              GridConstraints.SIZEPOLICY_FIXED,
+              GridConstraints.SIZEPOLICY_CAN_GROW | GridConstraints.SIZEPOLICY_CAN_SHRINK,
+              null,
+              null,
+              null,
+              0,
+              false));
+
+      initiativeFormatter =
+          initiativeOnSecondLine
+              ? Function.identity()
+              : init -> init.isEmpty() ? init : "= " + init;
     }
 
-    /**
-     * @see javax.swing.JComponent#getPreferredSize()
-     */
-    @Override
-    public Dimension getPreferredSize() {
-      boolean initStateSecondLine = panel.isInitStateSecondLine() && panel.isShowInitState();
-      Dimension s = super.getPreferredSize();
-      int th = textHeight * (initStateSecondLine ? 2 : 1);
-      Insets insets = getInsets();
-      if (getIcon() != null) th = Math.max(th, getIcon().getIconHeight());
-      s.height = th + insets.top + insets.bottom;
-      return s;
+    public void setName(@Nullable String name) {
+      name = Objects.requireNonNullElse(name, "");
+
+      nameLabel.setText(name);
+    }
+
+    public void setInitiative(@Nullable String init) {
+      init = initiativeFormatter.apply(Objects.requireNonNullElse(init, ""));
+
+      initLabel.setText(init);
+      // Don't allocate spacing for the label if there is no initiative state.
+      initLabel.setVisible(!init.isEmpty());
+    }
+
+    public void setTokenIsVisible(boolean tokenIsVisible) {
+      this.tokenIsVisible = tokenIsVisible;
+      updateStyle();
+    }
+
+    public void setTokenIsNpc(boolean tokenIsNpc) {
+      this.tokenIsNpc = tokenIsNpc;
+      updateStyle();
+    }
+
+    private void updateStyle() {
+      // We still use the UI text so use the map label color preferences
+      if (!tokenIsVisible) {
+        nameLabel.setForeground(AppPreferences.nonVisibleTokenMapLabelForeground.get());
+      } else if (tokenIsNpc) {
+        nameLabel.setForeground(AppPreferences.npcMapLabelForeground.get());
+      } else {
+        nameLabel.setForeground(AppPreferences.pcMapLabelForeground.get());
+      }
+      nameLabel.setFont(getFont().deriveFont(tokenIsVisible ? Font.PLAIN : Font.ITALIC));
     }
   }
 
-  /*---------------------------------------------------------------------------------------------
-   * InitiativeListIcon Inner Class
-   *-------------------------------------------------------------------------------------------*/
-
-  /**
-   * An icon that will show a token image and all of the states as needed.
-   *
-   * @author Jay
-   */
-  public class InitiativeListIcon extends ImageIcon {
-
-    /** Bounds sent to the token state */
-    private final Rectangle bounds = new Rectangle(0, 0, ICON_SIZE, ICON_SIZE);
+  /** An icon that will show a token image and all of the states as needed. */
+  private static final class TokenImagePanel extends JPanel {
 
     /** The token painted by this icon */
-    private final TokenInitiative tokenInitiative;
+    private Token token;
 
-    /** The image that is displayed when states are not being shown. */
-    private Image textTokenImage;
+    private boolean showTokenStates;
 
-    /** The image that is displayed when states are being shown. */
-    private Image stateTokenImage;
-
-    /** Size of the text only token */
-    private final int textTokenSize = Math.max(textHeight + 4, 16);
-
-    /**
-     * Create the image from the token and then build an icon suitable for displaying state.
-     *
-     * @param aTokenInitiative The initiative item being rendered
-     */
-    public InitiativeListIcon(TokenInitiative aTokenInitiative) {
-      tokenInitiative = aTokenInitiative;
-      if (panel.isShowTokenStates()) {
-        stateTokenImage = scaleImage();
-      } else {
-        textTokenImage = scaleImage();
-      } // endif
+    /** Create the image from the token and then build an icon suitable for displaying state. */
+    public TokenImagePanel() {
+      setOpaque(false);
     }
 
     /**
-     * Scale the token's image to fit in the allotted space for text or state painting.
-     *
-     * @return The properly scaled image.
+     * @param token The token being rendererd.
+     * @param showTokenStates Whether to render the token's states as part of the image.
      */
-    public Image scaleImage() {
-      Image image = ImageManager.getImageAndWait(tokenInitiative.getToken().getImageAssetId());
-      BufferedImage bi =
-          ImageUtil.createCompatibleImage(
-              getIconWidth(), getIconHeight(), Transparency.TRANSLUCENT);
-      Dimension d = new Dimension(image.getWidth(null), image.getHeight(null));
-      AwtUtil.constrainTo(d, getIconWidth(), getIconHeight());
-      Graphics2D g = bi.createGraphics();
-      g.setComposite(
-          AlphaComposite.getInstance(
-              AlphaComposite.SRC_OVER, tokenInitiative.getToken().isVisible() ? 1.0F : 0.5F));
-      g.drawImage(
-          image,
-          (getIconWidth() - d.width) / 2,
-          (getIconHeight() - d.height) / 2,
-          d.width,
-          d.height,
-          null);
-      setImage(bi);
-      return bi;
+    public void setModel(Token token, boolean showTokenStates) {
+      this.token = token;
+      this.showTokenStates = showTokenStates;
+      invalidate();
     }
 
-    /**
-     * @see javax.swing.ImageIcon#getIconHeight()
-     */
     @Override
-    public int getIconHeight() {
-      return panel.isShowTokenStates() ? ICON_SIZE : textTokenSize;
-    }
+    protected void paintComponent(Graphics g) {
+      if (this.token == null) {
+        return;
+      }
 
-    /**
-     * @see javax.swing.ImageIcon#getIconWidth()
-     */
-    @Override
-    public int getIconWidth() {
-      return panel.isShowTokenStates() ? ICON_SIZE : textTokenSize;
-    }
-
-    /**
-     * Paint the icon and then the image.
-     *
-     * @see javax.swing.ImageIcon#paintIcon(java.awt.Component, java.awt.Graphics, int, int)
-     */
-    @Override
-    public void paintIcon(Component c, Graphics g, int x, int y) {
+      var bounds = new Rectangle(0, 0, getWidth(), getHeight());
 
       // Paint the halo if needed
-      Token token = tokenInitiative.getToken();
       Color haloColor = token.getHaloColor();
-      if (panel.isShowTokenStates() && haloColor != null) {
+      if (showTokenStates && haloColor != null) {
         Graphics2D g2d = (Graphics2D) g;
         Stroke oldStroke = g2d.getStroke();
         Color oldColor = g.getColor();
         g2d.setStroke(new BasicStroke(AppPreferences.haloLineWidth.get()));
         g.setColor(haloColor);
-        g2d.draw(new Rectangle2D.Double(x, y, ICON_SIZE, ICON_SIZE));
+        g2d.draw(bounds);
         g2d.setStroke(oldStroke);
         g.setColor(oldColor);
-      } // endif
+      }
 
-      // Paint the icon, is that all that's needed?
-      if (panel.isShowTokenStates() && getImage() != stateTokenImage) {
-        if (stateTokenImage == null) stateTokenImage = scaleImage();
-        setImage(stateTokenImage);
-      } else if (!panel.isShowTokenStates() && getImage() != textTokenImage) {
-        if (textTokenImage == null) textTokenImage = scaleImage();
-        setImage(textTokenImage);
-      } // endif
-      super.paintIcon(c, g, x, y);
-      if (!panel.isShowTokenStates()) return;
+      {
+        // Paint the icon, is that all that's needed?
+        BufferedImage image = ImageManager.getImageAndWait(token.getImageAssetId());
+        Dimension imageSize = new Dimension(image.getWidth(), image.getHeight());
+        AwtUtil.constrainTo(imageSize, bounds.width, bounds.height);
+        g.drawImage(
+            image,
+            (bounds.width - imageSize.width) / 2,
+            (bounds.height - imageSize.height) / 2,
+            imageSize.width,
+            imageSize.height,
+            this);
+      }
 
-      // Paint all the states
-      g.translate(x, y);
-      Shape old = g.getClip();
-      g.setClip(bounds.intersection(old.getBounds()));
-      for (String state : MapTool.getCampaign().getTokenStatesMap().keySet()) {
-        Object stateSet = token.getState(state);
-        AbstractTokenOverlay overlay = MapTool.getCampaign().getTokenStatesMap().get(state);
-        if (stateSet instanceof AbstractTokenOverlay
-            || overlay == null
-            || !overlay.showPlayer(token, MapTool.getPlayer())
-            || overlay.isMouseover()) continue;
-        overlay.paintOverlay((Graphics2D) g, token, bounds, stateSet);
-      } // endfor
-      for (String bar : MapTool.getCampaign().getTokenBarsMap().keySet()) {
-        Object barSet = token.getState(bar);
-        BarTokenOverlay overlay = MapTool.getCampaign().getTokenBarsMap().get(bar);
-        if (overlay == null || !overlay.showPlayer(token, MapTool.getPlayer())) continue;
-        overlay.paintOverlay((Graphics2D) g, token, bounds, barSet);
-      } // endfor
-      g.setClip(old);
-      g.translate(-x, -y);
+      if (showTokenStates) {
+        // Paint all the states
+        Shape old = g.getClip();
+        g.setClip(bounds.intersection(old.getBounds()));
+        for (String state : MapTool.getCampaign().getTokenStatesMap().keySet()) {
+          Object stateSet = token.getState(state);
+          AbstractTokenOverlay overlay = MapTool.getCampaign().getTokenStatesMap().get(state);
+          if (stateSet instanceof AbstractTokenOverlay
+              || overlay == null
+              || !overlay.showPlayer(token, MapTool.getPlayer())
+              || overlay.isMouseover()) {
+            continue;
+          }
+          overlay.paintOverlay((Graphics2D) g, token, bounds, stateSet);
+        }
+        for (String bar : MapTool.getCampaign().getTokenBarsMap().keySet()) {
+          Object barSet = token.getState(bar);
+          BarTokenOverlay overlay = MapTool.getCampaign().getTokenBarsMap().get(bar);
+          if (overlay == null || !overlay.showPlayer(token, MapTool.getPlayer())) {
+            continue;
+          }
+          overlay.paintOverlay((Graphics2D) g, token, bounds, barSet);
+        }
+        g.setClip(old);
+      }
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/tokenpanel/InitiativePanel.java
@@ -177,7 +177,16 @@ public class InitiativePanel extends JPanel
     initPanelButtonsDisabled = MapTool.getCampaign().isInitiativePanelButtonsDisabled();
 
     // Set up the list with an empty model
-    displayList = new JList<TokenInitiative>();
+    displayList =
+        new JList<TokenInitiative>() {
+          @Override
+          public boolean getScrollableTracksViewportWidth() {
+            // Make sure the width of the list always tracks with the width of the panel. Without
+            // this, the scroll pane won't shrink the JList past a certain point depending on its
+            // content's preferred size, which is not what we want.
+            return true;
+          }
+        };
     model = new InitiativeListModel();
     displayList.setModel(model);
     setList(new InitiativeList(null));
@@ -188,7 +197,13 @@ public class InitiativePanel extends JPanel
     displayList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     displayList.addListSelectionListener(this);
     displayList.addMouseListener(new MouseHandler());
-    add(new JScrollPane(displayList), BorderLayout.CENTER);
+
+    var scrollPane =
+        new JScrollPane(
+            displayList,
+            ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+    add(scrollPane, BorderLayout.CENTER);
 
     // Set the keyboard mapping
     InputMap imap = displayList.getInputMap();

--- a/src/main/java/net/rptools/maptool/model/InitiativeList.java
+++ b/src/main/java/net/rptools/maptool/model/InitiativeList.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.swing.Icon;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.language.I18N;
@@ -821,15 +820,6 @@ public class InitiativeList implements Serializable {
     /** Optional state that can be displayed in the initiative panel. */
     private String state;
 
-    /** Save off the icon so that it can be displayed as needed. */
-    private transient Icon displayIcon;
-
-    /**
-     * Need to remember whether the displayIcon was shaded (to indicate a hidden token) so we can
-     * update when needed
-     */
-    private transient boolean tokenVisibleWhenIconUpdated = false;
-
     /*---------------------------------------------------------------------------------------------
      * Constructors
      *-------------------------------------------------------------------------------------------*/
@@ -910,43 +900,6 @@ public class InitiativeList implements Serializable {
       state = aState;
       getPCS().fireIndexedPropertyChange(TOKENS_PROP, tokens.indexOf(this), old, aState);
       finishUnitOfWork(this);
-    }
-
-    /**
-     * @return Getter for displayIcon
-     */
-    public Icon getDisplayIcon() {
-      return displayIcon;
-    }
-
-    /**
-     * NOTE: Be sure to also call {@link#setTokenVisibleWhenIconUpdated(boolean)}
-     *
-     * @param displayIcon Setter for the displayIcon to set.
-     */
-    public void setDisplayIcon(Icon displayIcon) {
-      this.displayIcon = displayIcon;
-    }
-
-    /**
-     * Checks whether the cached icon for this {@link TokenInitiative} was generated with the alpha
-     * shading - indicating whether the token was visible when the icon was last refreshed.
-     *
-     * @return true if the token was visible (and the icon was therefore opaque), false otherwise
-     */
-    public boolean wasTokenVisibleWhenIconUpdated() {
-      return tokenVisibleWhenIconUpdated;
-    }
-
-    /**
-     * Remember whether the generated icon was shaded (to indicate a non-visible token), so it can
-     * be refreshed if needed.
-     *
-     * @param tokenVisibleWhenIconUpdated true to indicate that the token was visible, false
-     *     otherwise
-     */
-    public void setTokenVisibleWhenIconUpdated(boolean tokenVisibleWhenIconUpdated) {
-      this.tokenVisibleWhenIconUpdated = tokenVisibleWhenIconUpdated;
     }
 
     /**


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5905

### Description of the Change

Reimplements `InitiativeListCellRenderer` so that the list items are not wider than the initiative list itself. When token names are too long to fit, they overflow with ellipsis. Too accomplish this, these main steps are taken:
- Change the layout from `MigLayout` to `GridLayoutManager` so we can explicitly modify which rows and columns elements are in (useful for holding, "Initiative on Line 2", etc).
- Split the initiative state into its own label rather than being incorporated into the name label.
- Remove HTML support in the name label (allows text to overflow properly, avoids embedded HTML in token names from controlling formatting).

Details follow...

The token image is no longer a customized `ImageIcon` set on a `JLabel`, but is now a custom `JPanel` (`TokenImagePanel`) that directly draws itself via `paintComponent()`. With this approach, we don't need to modify the component while rendering it, nor do we need to produce a separate, scaled `BufferedImage` (drawing is pretty lightweight here, so this doesn't hurt). It also means we don't have to cache this scaled image anywhere, especially not in the model (`InitiativeList.TokenInitiative`), which further avoids a bug where the initiative panel would not reflect changes to the token image.

The token name and initiative state are now in separate `JLabel`s. These are packed into a new `TextPanel` that can either be laid out on one line or two. The two-line version is used when "Initaitive on Line 2" is enabled, and the one-line version is used otherwise. The initiative state is always shown in its full width, under the assumption that this will tend to be relatively short (although it's not under any such restriction). The name label, by contrast, can shrink depending on the text and the panel width, and allows the text to overflow. If it does overflow, ellipsis will be shown to indicate that the name is too long. In order to support this overflow, HTML is no longer supported in the name label in any case, with any embedded HTML being shown verbatim instead of controlling the label formatting. This is done implicitly by removing the `<html>` tags, and explicitly by setting the "html.disable" client property.

The `TokenImagePanel` and the `TextPanel` are packed into another `JPanel` called the `labelPanel` which changes its layout depending on whether the token is holding. If the token is holding, the `labelPanel` is aligned right with the text panel in the first column and the image panel in the second column. If the token is not holding, the `labelPanel` is aligned left with the image panel in the first column and the text panel in the second column. _Technically this is accomplished by moving the image panel between the first and third columns, but from the user's perspective the result is as just described._

The cell as a whole is still a two-column `JPanel`, with the first column optionally holding the current initiative icon, and the second column containing the `labelPanel`.

### Possible Drawbacks

Anyone abusing the HTML support when "Initiative on Line 2" is set will be surprised.

Unlike before, when "Initiative on Line 2" is set but the token does not have an initiative set, the name will still be aligned to the top of the label rather than being vertically centered as it used to be.

The new layout is more verbose than the previous implementation, so potentially higher maintenance burder.

### Documentation Notes

This is the same narrow initiative list, presented on 1.18.6, on `develop` prior to this PR, and after this PR:
<img width="215" height="567" alt="image" src="https://github.com/user-attachments/assets/b6b9b98b-ecd3-4d88-8b67-f5b0b8407f5a" /> <img width="217" height="569" alt="image" src="https://github.com/user-attachments/assets/8b52c439-1890-44dd-bc4c-f986fe86c553" /> <img width="215" height="570" alt="image" src="https://github.com/user-attachments/assets/392538e9-654c-46c0-bfef-d87161e328bf" />

And the same thing, but with "Initiative on Line 2" enabled:
<img width="213" height="564" alt="image" src="https://github.com/user-attachments/assets/69e11406-34da-4eff-a175-a6bbcc29225d" /> <img width="218" height="569" alt="image" src="https://github.com/user-attachments/assets/f1b28411-bf77-4354-8f50-c1eec5dcf843" /> <img width="216" height="568" alt="image" src="https://github.com/user-attachments/assets/42db83ad-9e48-454f-9f5b-f5b6e1b18d9c" />


### Release Notes

- Modified the Initiative window so that the list is contrained to the window width. Holding tokens will no longer be pushed off-screen by other tokens with long names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5909)
<!-- Reviewable:end -->
