### PR TITLE
Multiple wall selection

### DIFF
--- a/src/main/java/net/rptools/maptool/client/swing/walls/WallConfigurationController.java
+++ b/src/main/java/net/rptools/maptool/client/swing/walls/WallConfigurationController.java
@@ -14,20 +14,113 @@
  */
 package net.rptools.maptool.client.swing.walls;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.swing.JComboBox;
+import net.rptools.lib.CollectionUtil;
 import net.rptools.maptool.model.topology.VisibilityType;
 import net.rptools.maptool.model.topology.Wall;
 
 public class WallConfigurationController {
+  /**
+   * Like Wall.Data, but mutable, observable, and nullable (in case of multiple selected walls not
+   * agreeing).
+   */
+  public static final class WallData {
+
+    private final @Nullable Wall.Direction direction;
+    private final @Nullable Wall.MovementDirectionModifier movementModifier;
+    // DO NOT MODIFY `modifiers`!
+    private final EnumMap<VisibilityType, Wall.DirectionModifier> modifiers;
+
+    public WallData(
+        @Nullable Wall.Direction direction,
+        @Nullable Wall.MovementDirectionModifier movementModifier,
+        Map<VisibilityType, Wall.DirectionModifier> modifiers) {
+      this.direction = direction;
+      this.movementModifier = movementModifier;
+      this.modifiers = new EnumMap<>(VisibilityType.class);
+      this.modifiers.putAll(modifiers);
+    }
+
+    public WallData(WallData other) {
+      this(other.direction, other.movementModifier, other.modifiers);
+    }
+
+    public WallData(Wall.Data data) {
+      this(
+          data.direction(),
+          data.movementModifier(),
+          CollectionUtil.newFilledEnumMap(VisibilityType.class, data::directionModifier));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof WallData other)) {
+        return false;
+      }
+
+      return this.direction == other.direction
+          && this.movementModifier == other.movementModifier
+          && this.modifiers.equals(other.modifiers);
+    }
+
+    public @Nullable Wall.Direction direction() {
+      return direction;
+    }
+
+    public WallData withDirection(@Nullable Wall.Direction direction) {
+      return new WallData(direction, this.movementModifier, this.modifiers);
+    }
+
+    public @Nullable Wall.MovementDirectionModifier movementModifier() {
+      return movementModifier;
+    }
+
+    public WallData withMovementModifier(
+        @Nullable Wall.MovementDirectionModifier movementModifier) {
+      return new WallData(this.direction, movementModifier, this.modifiers);
+    }
+
+    public @Nullable Wall.DirectionModifier directionModifier(VisibilityType visibilityType) {
+      return this.modifiers.get(visibilityType);
+    }
+
+    public WallData withDirectionModifier(
+        VisibilityType visibilityType, @Nullable Wall.DirectionModifier modifier) {
+      var newModifiers = new EnumMap<>(this.modifiers);
+      if (modifier == null) {
+        newModifiers.remove(visibilityType);
+      } else {
+        newModifiers.put(visibilityType, modifier);
+      }
+      return new WallData(this.direction, this.movementModifier, newModifiers);
+    }
+
+    public Wall.Data toWallData() {
+      return toWallData(new Wall.Data());
+    }
+
+    public Wall.Data toWallData(Wall.Data original) {
+      return new Wall.Data(
+          Objects.requireNonNullElse(direction, original.direction()),
+          Objects.requireNonNullElse(movementModifier, original.movementModifier()),
+          CollectionUtil.newFilledEnumMap(
+              VisibilityType.class,
+              type ->
+                  Objects.requireNonNullElseGet(
+                      modifiers.get(type), () -> original.directionModifier(type))));
+    }
+  }
+
   private final WallConfigurationView view;
   private final PropertyChangeListener changeListener;
-  private @Nonnull Wall.Data wallData = new Wall.Data();
+  private @Nonnull WallData wallData = new WallData(new Wall.Data());
 
   public WallConfigurationController(PropertyChangeListener changeListener) {
     this.view = new WallConfigurationView();
@@ -38,7 +131,7 @@ public class WallConfigurationController {
         e -> {
           var newDirection = directionSelect.getItemAt(directionSelect.getSelectedIndex());
           if (newDirection != null) {
-            updateWall(newDirection, wallData.movementModifier(), wallData.modifiers());
+            updateWall(wallData.withDirection(newDirection));
           }
         });
 
@@ -48,7 +141,7 @@ public class WallConfigurationController {
           var modifier =
               movementModifierSelect.getItemAt(movementModifierSelect.getSelectedIndex());
           if (modifier != null) {
-            updateWall(wallData.direction(), modifier, wallData.modifiers());
+            updateWall(wallData.withMovementModifier(modifier));
           }
         });
 
@@ -58,34 +151,19 @@ public class WallConfigurationController {
           e -> {
             var modifier = input.getItemAt(input.getSelectedIndex());
             if (modifier != null) {
-              var newModifiers =
-                  new EnumMap<VisibilityType, Wall.DirectionModifier>(VisibilityType.class);
-              newModifiers.putAll(wallData.modifiers());
-              newModifiers.put(visibilityType, modifier);
-
-              updateWall(
-                  wallData.direction(),
-                  wallData.movementModifier(),
-                  Maps.immutableEnumMap(newModifiers));
+              updateWall(wallData.withDirectionModifier(visibilityType, modifier));
             }
           });
     }
   }
 
-  private void updateWall(
-      Wall.Direction direction,
-      Wall.MovementDirectionModifier movementModifier,
-      ImmutableMap<VisibilityType, Wall.DirectionModifier> modifiers) {
-    var newWallData = new Wall.Data(direction, movementModifier, modifiers);
-
-    if (wallData.equals(newWallData)) {
-      return;
+  private void updateWall(WallData newWallData) {
+    if (!wallData.equals(newWallData)) {
+      var oldWallData = wallData;
+      wallData = newWallData;
+      changeListener.propertyChange(
+          new PropertyChangeEvent(this, "wallData", oldWallData, wallData));
     }
-
-    var oldWallData = wallData;
-    wallData = newWallData;
-
-    changeListener.propertyChange(new PropertyChangeEvent(this, "wallData", oldWallData, wallData));
   }
 
   public WallConfigurationView getView() {
@@ -101,7 +179,11 @@ public class WallConfigurationController {
   }
 
   public void bind(@Nonnull Wall.Data model) {
-    this.wallData = model;
+    bind(new WallData(model));
+  }
+
+  public void bind(@Nonnull WallData model) {
+    this.wallData = new WallData(model);
 
     this.view.getDirectionSelect().setSelectedItem(this.wallData.direction());
     this.view.getMovementModifier().setSelectedItem(this.wallData.movementModifier());
@@ -111,7 +193,7 @@ public class WallConfigurationController {
     }
   }
 
-  public @Nonnull Wall.Data getModel() {
-    return wallData;
+  public @Nonnull WallData getModel() {
+    return new WallData(wallData);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client.tool;
 
+import com.github.weisj.jsvg.util.ColorUtil;
 import com.google.common.eventbus.Subscribe;
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
@@ -29,6 +30,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.geom.RoundRectangle2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -616,7 +618,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
               wallStroke.getLineJoin());
       var decorationStroke =
           new BasicStroke(1.5f, wallStroke.getEndCap(), wallStroke.getLineJoin());
-      var walls = rig.getWallsWithin(bounds);
+      var walls = rig.getWallsIntersecting(bounds);
       for (var wall : walls) {
         var asSegment = wall.asLineSegment();
         var asVector = Vector2D.create(asSegment.p0, asSegment.p1);
@@ -790,8 +792,9 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
       if (SwingUtilities.isLeftMouseButton(event)) {
         switch (potentialDragElement) {
           case null -> {
-            // TODO Selection box!
             // Do nothing.
+            tool.changeToolMode(new DrawSelectionBoxToolMode(tool, rig, potentialDragPoint));
+            handled = true;
           }
           case WallTopologyRig.MovableVertex movableVertex -> {
             tool.changeToolMode(
@@ -836,11 +839,17 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
               movableWall.delete();
               MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
-            } else {
-              if (!SwingUtil.isShiftDown(event)) {
-                // Not holding shift, so replace the selection instead of adding to it.
-                tool.clearSelectedWalls();
+            } else if (SwingUtil.isShiftDown(event)) {
+              // Toggle the selection status of the wall.
+              var isSelected = tool.isSelectedWall(movableWall);
+              if (isSelected) {
+                tool.removeWallsFromSelectionIf(movableWall::isForSameElement);
+              } else {
+                tool.addSelectedWall(movableWall);
               }
+            } else {
+              // Not holding shift, so replace the selection instead of adding to it.
+              tool.clearSelectedWalls();
               tool.addSelectedWall(movableWall);
             }
           }
@@ -1227,6 +1236,83 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
         return Color.green;
       }
       return super.getHandleFill(handle);
+    }
+  }
+
+  /**
+   * Tool mode for drawing a wall selection box.
+   *
+   * <p>This mode supports the following actions:
+   *
+   * <ol>
+   *   <li>Canceling leaves the selection as-is and transitions to {@link BasicToolMode}.
+   *   <li>Left-dragging the mouse will adjust the selection box accordingly.
+   *   <li>Releasing the left mouse button will commit the selection. Any walls contained within the
+   *       selection box will become the new selection. If the <kbd>Shift</kbd> key is held when
+   *       releasing the left mouse button, the newly selected walls will be added to the selection;
+   *       otherwise, they will replace the selection.
+   * </ol>
+   */
+  private static final class DrawSelectionBoxToolMode extends ToolModeBase {
+    private final Point2D.Double startPoint;
+    private final Point2D.Double endPoint;
+    private final RoundRectangle2D.Double box;
+
+    public DrawSelectionBoxToolMode(
+        WallTopologyTool tool, WallTopologyRig rig, Point2D startPoint) {
+      super(tool, rig);
+      this.startPoint = new Point2D.Double(startPoint.getX(), startPoint.getY());
+      this.endPoint = new Point2D.Double(startPoint.getX(), startPoint.getY());
+      this.box =
+          new RoundRectangle2D.Double(this.startPoint.getX(), this.startPoint.getY(), 0, 0, 10, 10);
+    }
+
+    @Override
+    public final boolean cancel() {
+      // Revert to the original.
+      rig.setWalls(tool.getZone().getWalls());
+      tool.changeToolMode(new BasicToolMode(tool, rig));
+      return true;
+    }
+
+    @Override
+    public boolean mouseDragged(Point2D point, Snap snapMode, MouseEvent event) {
+      if (SwingUtilities.isLeftMouseButton(event)) {
+        endPoint.setLocation(point.getX(), point.getY());
+        box.x = Math.min(startPoint.getX(), endPoint.getX());
+        box.y = Math.min(startPoint.getY(), endPoint.getY());
+        box.width = Math.max(startPoint.getX(), endPoint.getX()) - box.x;
+        box.height = Math.max(startPoint.getY(), endPoint.getY()) - box.y;
+      }
+
+      return false;
+    }
+
+    @Override
+    public void mouseReleased(Point2D point, Snap snapMode, MouseEvent event) {
+      if (SwingUtilities.isLeftMouseButton(event)) {
+        tool.changeToolMode(new BasicToolMode(tool, rig));
+
+        var wallsToSelect = rig.getWallsWithin(box.getBounds2D());
+        if (!SwingUtil.isShiftDown(event)) {
+          // Not holding shift, so replace the selection instead of adding to it.
+          tool.clearSelectedWalls();
+        }
+        for (var wall : wallsToSelect) {
+          tool.addSelectedWall(wall);
+        }
+      }
+    }
+
+    @Override
+    public void paint(Graphics2D g2) {
+      super.paint(g2);
+
+      g2.setPaint(ColorUtil.withAlpha(AppStyle.selectionBoxFill, 0.25f));
+      g2.fill(box);
+
+      g2.setColor(AppStyle.selectionBoxOutline);
+      g2.draw(box);
     }
   }
 }

--- a/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/WallTopologyTool.java
@@ -29,13 +29,18 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
+import net.rptools.lib.CollectionUtil;
 import net.rptools.maptool.client.AppStyle;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.swing.SwingUtil;
@@ -49,6 +54,7 @@ import net.rptools.maptool.client.ui.zone.ZoneOverlay;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.events.MapToolEventBus;
 import net.rptools.maptool.model.topology.Vertex;
+import net.rptools.maptool.model.topology.VisibilityType;
 import net.rptools.maptool.model.topology.Wall;
 import net.rptools.maptool.model.zones.WallTopologyChanged;
 import org.locationtech.jts.math.Vector2D;
@@ -58,7 +64,8 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
       new Point2D.Double(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
   private final WallConfigurationController controlPanel;
-  private @Nullable WallTopologyRig.MovableWall selectedWall;
+  private final CopyOnWriteArrayList<WallTopologyRig.MovableWall> selectedWalls =
+      new CopyOnWriteArrayList<>();
 
   /** The current tool behaviour. Each operation enters a distinct mode so we don't cross-talk. */
   private ToolMode mode = new NilToolMode();
@@ -71,11 +78,10 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     controlPanel =
         new WallConfigurationController(
             event -> {
-              var newData = (Wall.Data) event.getNewValue();
-
-              if (selectedWall != null) {
-                selectedWall.getSource().setData(newData);
-                mode.onWallChanged(selectedWall);
+              var newData = (WallConfigurationController.WallData) event.getNewValue();
+              for (var wall : selectedWalls) {
+                wall.getSource().setData(newData.toWallData(wall.getSource().data()));
+                mode.onWallChanged(wall);
               }
             });
   }
@@ -209,20 +215,57 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     return getWallHalfWidth() * 1.5;
   }
 
-  private void setSelectedWall(@Nullable WallTopologyRig.MovableWall wall) {
-    selectedWall = wall;
-    if (selectedWall != null) {
-      controlPanel.bind(selectedWall.getSource().data());
+  private void rebindSelection() {
+    if (!this.selectedWalls.isEmpty()) {
+      // For each field, need to check if we have agreement or not. If not, null the field.
+      // Otherwise set it to the elemnt's field.
+      var firstData = this.selectedWalls.getFirst().getSource().data();
+      var direction = firstData.direction();
+      var movementModifier = firstData.movementModifier();
+      var modifiers =
+          CollectionUtil.newFilledEnumMap(VisibilityType.class, firstData::directionModifier);
+
+      for (var wall : this.selectedWalls) {
+        var data = wall.getSource().data();
+        if (data.direction() != direction) {
+          direction = null;
+        }
+        if (data.movementModifier() != movementModifier) {
+          movementModifier = null;
+        }
+        for (var type : VisibilityType.values()) {
+          if (data.directionModifier(type) != modifiers.get(type)) {
+            modifiers.put(type, null);
+          }
+        }
+      }
+
+      controlPanel.bind(
+          new WallConfigurationController.WallData(direction, movementModifier, modifiers));
     }
   }
 
-  private boolean isSelectedWall(WallTopologyRig.MovableWall wall) {
-    var selected = getSelectedWall();
-    return selected.isPresent() && wall.isForSameElement(selected.get());
+  private void clearSelectedWalls() {
+    this.selectedWalls.clear();
+    rebindSelection();
   }
 
-  private Optional<WallTopologyRig.MovableWall> getSelectedWall() {
-    return Optional.ofNullable(selectedWall);
+  private void addSelectedWall(WallTopologyRig.MovableWall wall) {
+    this.selectedWalls.add(wall);
+    rebindSelection();
+  }
+
+  private void removeWallsFromSelectionIf(Predicate<WallTopologyRig.MovableWall> predicate) {
+    this.selectedWalls.removeIf(predicate);
+    rebindSelection();
+  }
+
+  private boolean isSelectedWall(WallTopologyRig.MovableWall wall) {
+    return getSelectedWalls().stream().anyMatch(wall::isForSameElement);
+  }
+
+  public List<WallTopologyRig.MovableWall> getSelectedWalls() {
+    return Collections.unmodifiableList(selectedWalls);
   }
 
   private void changeToolMode(ToolMode newMode) {
@@ -273,16 +316,17 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
   @Subscribe
   private void onTopologyChanged(WallTopologyChanged event) {
-    var selected = getSelectedWall();
+    var selected = new ArrayList<>(getSelectedWalls());
 
     var rig = new WallTopologyRig(this::getHandleSelectDistance, this::getWallSelectDistance);
     rig.setWalls(getZone().getWalls());
     changeToolMode(new BasicToolMode(this, rig));
 
-    // If the selected wall still exists, rebind it.
-    var newSelectedWall =
-        selected.flatMap(s -> rig.getWall(s.getSource().from(), s.getSource().to())).orElse(null);
-    setSelectedWall(newSelectedWall);
+    // Rebind any selected walls that still exist, in case any of them have changed.
+    clearSelectedWalls();
+    selected.stream()
+        .flatMap(s -> rig.getWall(s.getSource().from(), s.getSource().to()).stream())
+        .forEach(this::addSelectedWall);
   }
 
   /**
@@ -461,14 +505,13 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     @Override
     public void delete() {}
 
-    protected void deleteSelectedWall() {
-      tool.getSelectedWall()
-          .ifPresent(
-              wall -> {
-                tool.setSelectedWall(null);
-                wall.delete();
-                MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
-              });
+    protected void deleteSelectedWalls() {
+      var toBeDeleted = new ArrayList<>(tool.getSelectedWalls());
+      tool.clearSelectedWalls();
+      for (var wall : toBeDeleted) {
+        wall.delete();
+      }
+      MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
     }
 
     /**
@@ -732,7 +775,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
     @Override
     public void delete() {
-      deleteSelectedWall();
+      deleteSelectedWalls();
     }
 
     @Override
@@ -747,6 +790,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
       if (SwingUtilities.isLeftMouseButton(event)) {
         switch (potentialDragElement) {
           case null -> {
+            // TODO Selection box!
             // Do nothing.
           }
           case WallTopologyRig.MovableVertex movableVertex -> {
@@ -775,16 +819,11 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
           }
           case WallTopologyRig.MovableVertex movableVertex -> {
             if (event.getClickCount() == 2) {
-              var selectionToBeDeleted =
-                  tool.getSelectedWall()
-                      .filter(
-                          s ->
-                              s.getFrom().isForSameElement(movableVertex)
-                                  || s.getTo().isForSameElement(movableVertex))
-                      .isPresent();
-              if (selectionToBeDeleted) {
-                tool.setSelectedWall(null);
-              }
+              // Remove any affected walls from the selection.
+              tool.removeWallsFromSelectionIf(
+                  wall ->
+                      wall.getFrom().isForSameElement(movableVertex)
+                          || wall.getTo().isForSameElement(movableVertex));
 
               movableVertex.delete();
               MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
@@ -792,15 +831,17 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
           }
           case WallTopologyRig.MovableWall movableWall -> {
             if (event.getClickCount() == 2) {
-              var isSelected = tool.isSelectedWall(movableWall);
-              if (isSelected) {
-                tool.setSelectedWall(null);
-              }
+              // Remove any affected walls from the selection.
+              tool.removeWallsFromSelectionIf(movableWall::isForSameElement);
 
               movableWall.delete();
               MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
             } else {
-              tool.setSelectedWall(movableWall);
+              if (!SwingUtil.isShiftDown(event)) {
+                // Not holding shift, so replace the selection instead of adding to it.
+                tool.clearSelectedWalls();
+              }
+              tool.addSelectedWall(movableWall);
             }
           }
         }
@@ -877,8 +918,9 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
     @Override
     public void activate() {
-      wall.getSource().setData(tool.controlPanel.getModel());
-      tool.setSelectedWall(wall);
+      wall.getSource().setData(tool.controlPanel.getModel().toWallData());
+      tool.clearSelectedWalls();
+      tool.addSelectedWall(wall);
     }
 
     private void findConnectToHandle(InputEvent event) {
@@ -894,7 +936,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     public boolean cancel() {
       // Revert to the original.
       rig.setWalls(tool.getZone().getWalls());
-      tool.setSelectedWall(null);
+      tool.clearSelectedWalls();
       tool.changeToolMode(new BasicToolMode(tool, rig));
       return true;
     }
@@ -937,8 +979,9 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
         }
         wall = newWall;
 
-        newWall.getSource().setData(tool.controlPanel.getModel());
-        tool.setSelectedWall(newWall);
+        newWall.getSource().setData(tool.controlPanel.getModel().toWallData());
+        tool.clearSelectedWalls();
+        tool.addSelectedWall(newWall);
       }
       if (SwingUtilities.isLeftMouseButton(event)) {
         // Like a right-click, but we're done drawing.
@@ -958,7 +1001,10 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
                   .flatMap(vertex -> rig.getWall(wall.getSource().from(), vertex.getSource().id()))
                   .orElse(null);
         }
-        tool.setSelectedWall(lastWall);
+        tool.clearSelectedWalls();
+        if (lastWall != null) {
+          tool.addSelectedWall(lastWall);
+        }
 
         MapTool.serverCommand().replaceWalls(tool.getZone(), rig.commit());
         tool.changeToolMode(new BasicToolMode(tool, rig));
@@ -1015,7 +1061,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     public final boolean cancel() {
       // Revert to the original.
       rig.setWalls(tool.getZone().getWalls());
-      tool.setSelectedWall(null);
+      tool.clearSelectedWalls();
       tool.changeToolMode(new BasicToolMode(tool, rig));
       return true;
     }
@@ -1074,7 +1120,10 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
     @Override
     public void activate() {
       this.rig.bringToFront(this.movable);
-      this.tool.setSelectedWall(this.movable);
+      this.tool.clearSelectedWalls();
+      // TODO We need to be able to drag multiple walls. For now we collapse the selection to a
+      //  single wall, but this is not ideal.
+      this.tool.addSelectedWall(this.movable);
     }
 
     @Override
@@ -1136,7 +1185,7 @@ public class WallTopologyTool extends DefaultTool implements ZoneOverlay {
 
     @Override
     public void activate() {
-      tool.setSelectedWall(null);
+      tool.clearSelectedWalls();
       this.rig.bringToFront(this.movable);
     }
 

--- a/src/main/java/net/rptools/maptool/client/tool/rig/WallTopologyRig.java
+++ b/src/main/java/net/rptools/maptool/client/tool/rig/WallTopologyRig.java
@@ -85,7 +85,7 @@ public final class WallTopologyRig implements Rig<WallTopologyRig.Element<?>> {
     return results;
   }
 
-  public List<WallTopologyRig.MovableWall> getWallsWithin(Rectangle2D bounds) {
+  public List<WallTopologyRig.MovableWall> getWallsIntersecting(Rectangle2D bounds) {
     var envelope =
         new Envelope(
             bounds.getMinX(), bounds.getMaxX(),
@@ -102,6 +102,30 @@ public final class WallTopologyRig implements Rig<WallTopologyRig.Element<?>> {
                       GeometryUtil.point2DToCoordinate(movableWall.getFrom().getPosition()),
                       GeometryUtil.point2DToCoordinate(movableWall.getTo().getPosition()));
               if (wallEnvelope.intersects(envelope)) {
+                results.add(movableWall);
+              }
+            });
+    results.sort(Comparator.comparingInt(wall -> walls.getZIndex(wall.getSource())));
+    return results;
+  }
+
+  public List<WallTopologyRig.MovableWall> getWallsWithin(Rectangle2D bounds) {
+    var envelope =
+        new Envelope(
+            bounds.getMinX(), bounds.getMaxX(),
+            bounds.getMinY(), bounds.getMaxY());
+
+    var results = new ArrayList<WallTopologyRig.MovableWall>();
+    walls
+        .getWalls()
+        .forEach(
+            wall -> {
+              var movableWall = new WallTopologyRig.MovableWall(this, walls, wall);
+              var wallEnvelope =
+                  new Envelope(
+                      GeometryUtil.point2DToCoordinate(movableWall.getFrom().getPosition()),
+                      GeometryUtil.point2DToCoordinate(movableWall.getTo().getPosition()));
+              if (envelope.covers(wallEnvelope)) {
                 results.add(movableWall);
               }
             });
@@ -159,7 +183,7 @@ public final class WallTopologyRig implements Rig<WallTopologyRig.Element<?>> {
             point.getY() - selectDistance,
             2 * selectDistance,
             2 * selectDistance);
-    var candidateWalls = getWallsWithin(bounds);
+    var candidateWalls = getWallsIntersecting(bounds);
 
     // Reverse so we pick the highest-z-index candidate.
     for (var wall : candidateWalls.reversed()) {

--- a/src/main/java/net/rptools/maptool/model/topology/WallTopology.java
+++ b/src/main/java/net/rptools/maptool/model/topology/WallTopology.java
@@ -369,11 +369,11 @@ public final class WallTopology implements Topology {
 
     var firstIsForeign = !graph.containsVertex(first.id());
     if (firstIsForeign) {
-      throw new RuntimeException("Unable unable vertices: first vertex does not exist!");
+      throw new RuntimeException("Unable to merge vertices: first vertex does not exist!");
     }
     var secondIsForeign = !graph.containsVertex(second.id());
     if (secondIsForeign) {
-      throw new RuntimeException("Unable unable vertices: second vertex does not exist!");
+      throw new RuntimeException("Unable to merge vertices: second vertex does not exist!");
     }
 
     if (first.equals(second)) {


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5324

### Description of the Change

Adds support to `WallTopologyTool` for selecting multiple walls at one time. There are two ways to modify the selection:
1. Left clicking. Without holding shift, this is the same behaviour as before (selecting one wall). Holding shift will toggle whether the clicked wall is selected.
2. Left-dragging. This draws a selection box similar to other tools. When the mouse is released, walls within the selection box will become the new selection. If shift is held, the walls will instead be added to the existing selection instead of replacing the selection.

When multiple walls are selected, the configuration panel will blank out any options that don't have a common value for all walls. When changing any option, including a blanked out option, the new value will be applied to all selected walls.

### Possible Drawbacks

Should be none

### Documentation Notes

The wall topology tool supports these new actions:
- Shift+left click will add or remove the clicked wall from the current selection.
- Dragging with the left mouse button will draw a selection box. Releasing the left mouse button will set the walls inside the selection box as the selected walls. If the shift key is held, the newly selected walls will be added to the existing selection instead of replacing the selection.

### Release Notes

- Add ability to select multiple walls using shift+left clicking or left-dragging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5912)
<!-- Reviewable:end -->
