### PR TITLE
Stop timer when returning early from renderHalos

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/HaloRenderer.java
@@ -80,11 +80,13 @@ public class HaloRenderer {
 
     var tokenHalos = token.getHalos();
     if (token.getHaloColor() == null && tokenHalos.isEmpty()) {
+      timer.stop("HaloRenderer-renderHalos");
       return;
     }
 
     var grid = zone.getGrid();
     if (grid == null) {
+      timer.stop("HaloRenderer-renderHalos");
       return;
     }
 


### PR DESCRIPTION
closes #5786

### Description of the Change
Close the `HaloRenderer-renderHalos` timer if returning early from `renderHalos`.

### Possible Drawbacks
None foreseen.

### Documentation Notes
N/A

### Release Notes
- Fixed an issue where a timer would not be closed if returning early.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5913)
<!-- Reviewable:end -->
