### PR TITLE
createAsset improvements in error checking and capabilities.

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -65,9 +65,6 @@ public class TokenImage extends AbstractFunction {
   public static final String SET_IMAGE = "setImage";
   public static final String SET_PORTRAIT = "setTokenPortrait";
   public static final String SET_HANDOUT = "setTokenHandout";
-  public static final String FILE_HEADER_WEBP = "RIFF";
-  public static final String FILE_HEADER_JPG = "ÿØÿà";
-  public static final String FILE_HEADER_PNG = "‰PNG";
 
   private TokenImage() {
     super(
@@ -85,7 +82,32 @@ public class TokenImage extends AbstractFunction {
         "getTokenOpacity",
         "createAsset");
   }
+  private static boolean isPNG(byte[] b) {
+    return b.length >= 8
+            && (b[0] & 0xFF) == 0x89
+            && b[1] == 0x50
+            && b[2] == 0x4E
+            && b[3] == 0x47;
+  }
 
+  private static boolean isJPG(byte[] b) {
+    return b.length >= 3
+            && (b[0] & 0xFF) == 0xFF
+            && (b[1] & 0xFF) == 0xD8
+            && (b[2] & 0xFF) == 0xFF;
+  }
+
+  private static boolean isWEBP(byte[] b) {
+    return b.length >= 12
+            && b[0] == 'R'
+            && b[1] == 'I'
+            && b[2] == 'F'
+            && b[3] == 'F'
+            && b[8] == 'W'
+            && b[9] == 'E'
+            && b[10] == 'B'
+            && b[11] == 'P';
+  }
   /**
    * Gets the TokenImage instance.
    *
@@ -191,48 +213,61 @@ public class TokenImage extends AbstractFunction {
       String imageString = args.get(1).toString();
       if (imageName.isEmpty() || imageString.isEmpty()) {
         throw new ParserException(
-            I18N.getText("macro.function.general.paramCannotBeEmpty", functionName));
-      } else if (imageString.length() > 8) {
-        Asset asset;
-        URI uri;
+                I18N.getText("macro.function.general.paramCannotBeEmpty", functionName));
+      }
+      if (imageString.length() <= 8) {
+        throw new ParserException(
+                I18N.getText("macro.function.general.wrongParamType", functionName));
+      }
+      Asset asset;
+      boolean isBase64Image = false;
+      byte[] base64Bytes = null;
+      try {
+        base64Bytes = Base64.decode(imageString);
+        if (isPNG(base64Bytes) || isJPG(base64Bytes) || isWEBP(base64Bytes)) {
+          isBase64Image = true;
+        }
+      } catch (Exception ignore) {
+      }
+      URI uri = null;
+      if (!isBase64Image) {
         try {
           uri = new URI(imageString);
+          if (uri.getScheme() == null) {
+            uri = null;
+          }
         } catch (URISyntaxException e) {
           uri = null;
         }
-        if (uri != null && isValidAssetScheme(uri) && isValidAssetExtension(uri)) {
-          try {
-            URL url = uri.toURL();
-            BufferedImage imageRAW = ImageIO.read(url);
-            asset = Asset.createImageAsset(imageName, imageRAW);
-          } catch (MalformedURLException | IllegalArgumentException e) {
-            throw new ParserException(
-                I18N.getText("macro.function.input.illegalArgumentType", imageString));
-          } catch (IOException e1) {
-            throw new ParserException(I18N.getText("macro.function.html5.invalidURI", imageString));
-          }
-        } else {
-          byte[] imageBytes = Base64.decode(imageString);
-          String imageCheck;
-          try {
-            imageCheck = new String(imageBytes, 0, 4);
-          } catch (Exception e) {
-            throw new ParserException(I18N.getText("dragdrop.unsupportedType", functionName));
-          }
-          if (imageCheck.equals(FILE_HEADER_WEBP)
-              || imageCheck.equals(FILE_HEADER_JPG)
-              || imageCheck.equals(FILE_HEADER_PNG)) {
-            asset = Asset.createImageAsset(imageName, imageBytes);
-          } else {
-            throw new ParserException(I18N.getText("dragdrop.unsupportedType", functionName));
-          }
-        }
-        AssetManager.putAsset(asset);
-        return "asset://" + asset.getMD5Key().toString();
-      } else {
-        throw new ParserException(
-            I18N.getText("macro.function.general.wrongParamType", functionName));
       }
+      if (uri != null
+              && uri.getScheme() != null
+              && isValidAssetScheme(uri)
+              && isValidAssetExtension(uri)) {
+        try {
+          URL url = uri.toURL();
+          BufferedImage imageRAW = ImageIO.read(url);
+          asset = Asset.createImageAsset(imageName, imageRAW);
+        } catch (MalformedURLException | IllegalArgumentException e) {
+          throw new ParserException(
+                  I18N.getText("macro.function.input.illegalArgumentType", imageString));
+        } catch (IOException e) {
+          throw new ParserException(
+                  I18N.getText("macro.function.html5.invalidURI", imageString));
+        }
+      } else {
+        byte[] imageBytes = isBase64Image
+                ? base64Bytes
+                : Base64.decode(imageString);
+        if (isPNG(imageBytes) || isJPG(imageBytes) || isWEBP(imageBytes)) {
+          asset = Asset.createImageAsset(imageName, imageBytes);
+        } else {
+          throw new ParserException(
+                  I18N.getText("dragdrop.unsupportedType", functionName));
+        }
+      }
+      AssetManager.putAsset(asset);
+      return "asset://" + asset.getMD5Key().toString();
     }
 
     /* getImage, getTokenImage, getTokenPortrait, or getTokenHandout */
@@ -388,10 +423,13 @@ public class TokenImage extends AbstractFunction {
    * @param uri The URI to check.
    * @return {@code true} if the scheme is valid.
    */
-  private boolean isValidAssetScheme(URI uri) {
+  public boolean isValidAssetScheme(URI uri) {
+    if (uri == null || uri.getScheme() == null) {
+      return false;
+    }
     return uri.getScheme().equalsIgnoreCase("http")
-        || uri.getScheme().equalsIgnoreCase("https")
-        || uri.getScheme().equalsIgnoreCase("lib");
+            || uri.getScheme().equalsIgnoreCase("https")
+            || uri.getScheme().equalsIgnoreCase("asset");
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TokenImage.java
@@ -82,32 +82,27 @@ public class TokenImage extends AbstractFunction {
         "getTokenOpacity",
         "createAsset");
   }
+
   private static boolean isPNG(byte[] b) {
-    return b.length >= 8
-            && (b[0] & 0xFF) == 0x89
-            && b[1] == 0x50
-            && b[2] == 0x4E
-            && b[3] == 0x47;
+    return b.length >= 8 && (b[0] & 0xFF) == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47;
   }
 
   private static boolean isJPG(byte[] b) {
-    return b.length >= 3
-            && (b[0] & 0xFF) == 0xFF
-            && (b[1] & 0xFF) == 0xD8
-            && (b[2] & 0xFF) == 0xFF;
+    return b.length >= 3 && (b[0] & 0xFF) == 0xFF && (b[1] & 0xFF) == 0xD8 && (b[2] & 0xFF) == 0xFF;
   }
 
   private static boolean isWEBP(byte[] b) {
     return b.length >= 12
-            && b[0] == 'R'
-            && b[1] == 'I'
-            && b[2] == 'F'
-            && b[3] == 'F'
-            && b[8] == 'W'
-            && b[9] == 'E'
-            && b[10] == 'B'
-            && b[11] == 'P';
+        && b[0] == 'R'
+        && b[1] == 'I'
+        && b[2] == 'F'
+        && b[3] == 'F'
+        && b[8] == 'W'
+        && b[9] == 'E'
+        && b[10] == 'B'
+        && b[11] == 'P';
   }
+
   /**
    * Gets the TokenImage instance.
    *
@@ -213,11 +208,11 @@ public class TokenImage extends AbstractFunction {
       String imageString = args.get(1).toString();
       if (imageName.isEmpty() || imageString.isEmpty()) {
         throw new ParserException(
-                I18N.getText("macro.function.general.paramCannotBeEmpty", functionName));
+            I18N.getText("macro.function.general.paramCannotBeEmpty", functionName));
       }
       if (imageString.length() <= 8) {
         throw new ParserException(
-                I18N.getText("macro.function.general.wrongParamType", functionName));
+            I18N.getText("macro.function.general.wrongParamType", functionName));
       }
       Asset asset;
       boolean isBase64Image = false;
@@ -241,29 +236,25 @@ public class TokenImage extends AbstractFunction {
         }
       }
       if (uri != null
-              && uri.getScheme() != null
-              && isValidAssetScheme(uri)
-              && isValidAssetExtension(uri)) {
+          && uri.getScheme() != null
+          && isValidAssetScheme(uri)
+          && isValidAssetExtension(uri)) {
         try {
           URL url = uri.toURL();
           BufferedImage imageRAW = ImageIO.read(url);
           asset = Asset.createImageAsset(imageName, imageRAW);
         } catch (MalformedURLException | IllegalArgumentException e) {
           throw new ParserException(
-                  I18N.getText("macro.function.input.illegalArgumentType", imageString));
+              I18N.getText("macro.function.input.illegalArgumentType", imageString));
         } catch (IOException e) {
-          throw new ParserException(
-                  I18N.getText("macro.function.html5.invalidURI", imageString));
+          throw new ParserException(I18N.getText("macro.function.html5.invalidURI", imageString));
         }
       } else {
-        byte[] imageBytes = isBase64Image
-                ? base64Bytes
-                : Base64.decode(imageString);
+        byte[] imageBytes = isBase64Image ? base64Bytes : Base64.decode(imageString);
         if (isPNG(imageBytes) || isJPG(imageBytes) || isWEBP(imageBytes)) {
           asset = Asset.createImageAsset(imageName, imageBytes);
         } else {
-          throw new ParserException(
-                  I18N.getText("dragdrop.unsupportedType", functionName));
+          throw new ParserException(I18N.getText("dragdrop.unsupportedType", functionName));
         }
       }
       AssetManager.putAsset(asset);
@@ -428,8 +419,8 @@ public class TokenImage extends AbstractFunction {
       return false;
     }
     return uri.getScheme().equalsIgnoreCase("http")
-            || uri.getScheme().equalsIgnoreCase("https")
-            || uri.getScheme().equalsIgnoreCase("asset");
+        || uri.getScheme().equalsIgnoreCase("https")
+        || uri.getScheme().equalsIgnoreCase("asset");
   }
 
   /**


### PR DESCRIPTION

### Identify the Bug or Feature request
fixes #5917

### Description of the Change

createAsset was using strings to check for image format and could fail.  This is now using bytes.
You could not take a base64 encoded PNG string (but base64 encoded webp would work??) and use it with createAsset.

### Possible Drawbacks
There should be none.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5918)
<!-- Reviewable:end -->
