### PR TITLE
Fix for localised string being unhelpful in shape.getProperties()

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -614,7 +614,7 @@ public class ShapeFunctions extends AbstractFunction {
               seg, coords[0], coords[1], coords[2], coords[3], coords[4], coords[5], coords[6]));
       pi.next();
     }
-    StringBuilder stringBuilder = new StringBuilder(sd.toString());
+    StringBuilder stringBuilder = new StringBuilder(sd.toString(false));
     stringBuilder.append("segments=").append(String.join(",", segments)).append(";");
 
     if (delimiter.equalsIgnoreCase("json")) {

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -145,9 +145,17 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
 
   @Override
   public String toString() {
+    return toString(true);
+  }
+
+  public String toString(boolean localised) {
     StringBuilder sb = new StringBuilder();
     sb.append("name=").append(getName()).append(";");
-    sb.append("layer=").append(getLayer()).append(";");
+    if(localised) {
+      sb.append("layer=").append(getLayer()).append(";");
+    } else {
+      sb.append("layer=").append(getLayer().name()).append(";");
+    }
     sb.append("id=").append(getId()).append(";");
     return sb.toString();
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -151,7 +151,7 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
   public String toString(boolean localised) {
     StringBuilder sb = new StringBuilder();
     sb.append("name=").append(getName()).append(";");
-    if(localised) {
+    if (localised) {
       sb.append("layer=").append(getLayer()).append(";");
     } else {
       sb.append("layer=").append(getLayer().name()).append(";");

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -178,7 +178,10 @@ public class ShapeDrawable extends AbstractDrawing {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder(super.toString());
+    return toString(true);
+  }
+  public String toString(boolean localised) {
+    StringBuilder sb = new StringBuilder(super.toString(localised));
     sb.append("antiAliasing=").append(getUseAntiAliasing()).append(";");
     sb.append("shapeType=").append(getShapeTypeName()).append(";");
     sb.append("bounds=\"");

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -180,6 +180,7 @@ public class ShapeDrawable extends AbstractDrawing {
   public String toString() {
     return toString(true);
   }
+
   public String toString(boolean localised) {
     StringBuilder sb = new StringBuilder(super.toString(localised));
     sb.append("antiAliasing=").append(getUseAntiAliasing()).append(";");

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetContext.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetContext.java
@@ -15,20 +15,15 @@
 package net.rptools.maptool.model.sheet.stats;
 
 import java.awt.Dimension;
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
-import net.rptools.maptool.client.ui.token.AbstractTokenOverlay;
-import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.player.Player;
 import net.rptools.maptool.util.HTMLUtil;
@@ -144,12 +139,6 @@ public class StatSheetContext {
   /** The properties of the token. */
   private final List<Property> properties = new ArrayList<>();
 
-  /** The bars shown on the token. */
-  private final List<Map<String, Object>> bars = new ArrayList<>();
-
-  /** The states set on the token. */
-  private final List<Map<String, Object>> states = new ArrayList<>();
-
   /** The notes of the token. */
   private final String notes;
 
@@ -179,20 +168,9 @@ public class StatSheetContext {
    * @param location The location of the stat sheet.
    */
   public StatSheetContext(Token token, Player player, StatSheetLocation location) {
-    boolean playerOwns = AppUtil.playerOwns(token);
+
     name = token.getName();
     tokenType = token.getType().name();
-
-    List<String> stateOverlayNames = new ArrayList<>();
-    stateOverlayNames.addAll(MapTool.getCampaign().getTokenBarsMap().keySet());
-    stateOverlayNames.addAll(MapTool.getCampaign().getTokenStatesMap().keySet());
-
-    for (String stateName : stateOverlayNames) {
-      Object stateValue = token.getState(stateName);
-      if (stateValue != null) {
-        addBarState(stateName, stateValue, playerOwns, player);
-      }
-    }
 
     if (player.isGM()) {
       gmName = token.getGMName();
@@ -205,8 +183,8 @@ public class StatSheetContext {
       gmNotesType = null;
       gm = false;
     }
-    notes = playerOwns ? token.getNotes() : null;
-    notesType = playerOwns ? token.getNotesType() : null;
+    notes = AppUtil.playerOwns(token) ? token.getNotes() : null;
+    notesType = AppUtil.playerOwns(token) ? token.getNotesType() : null;
     speechName = token.getSpeechName();
 
     if (AppPreferences.showPortrait.get()) {
@@ -228,7 +206,7 @@ public class StatSheetContext {
                   return;
                 }
 
-                if (tp.isOwnerOnly() && !playerOwns) {
+                if (tp.isOwnerOnly() && !AppUtil.playerOwns(token)) {
                   return;
                 }
 
@@ -275,48 +253,6 @@ public class StatSheetContext {
           case LEFT -> "statSheet-left";
           case RIGHT -> "statSheet-right";
         };
-  }
-
-  private void addBarState(String stateName, Object stateValue, boolean playerOwns, Player player) {
-    AbstractTokenOverlay ato = null;
-    if (MapTool.getCampaign().getTokenBarsMap().containsKey(stateName)) {
-      ato = MapTool.getCampaign().getTokenBarsMap().get(stateName);
-    } else {
-      ato = MapTool.getCampaign().getTokenStatesMap().get(stateName);
-    }
-    if (ato.isShowOthers() || (playerOwns && ato.isShowOwner()) || player.isGM()) {
-      Map<String, Object> featureMap = new HashMap<>();
-      featureMap.put("value", stateValue);
-      featureMap.put("type", ato.getClass().getSimpleName());
-      String mName;
-
-      try {
-        BeanInfo beanInfo = Introspector.getBeanInfo(ato.getClass());
-        PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
-        for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-          if (!"class".equals(propertyDescriptor.getName())) {
-            if (propertyDescriptor.getReadMethod().canAccess(ato)) {
-              mName = propertyDescriptor.getReadMethod().getName();
-              if (mName.startsWith("is")) {
-                mName = mName.substring(2);
-              } else if (mName.startsWith("get") || mName.startsWith("has")) {
-                mName = mName.substring(3);
-              }
-              featureMap.put(
-                  Introspector.decapitalize(mName), propertyDescriptor.getReadMethod().invoke(ato));
-            }
-          }
-        }
-      } catch (IntrospectionException | InvocationTargetException | IllegalAccessException e) {
-        throw new RuntimeException(e);
-      }
-
-      if (ato instanceof BarTokenOverlay) {
-        bars.add(featureMap);
-      } else {
-        states.add(featureMap);
-      }
-    }
   }
 
   /**
@@ -392,9 +328,9 @@ public class StatSheetContext {
   }
 
   /**
-   * Returns the CSS class for the location of the stat sheet.
+   * Returns the css class for the location of the stat sheet.
    *
-   * @return The CSS class for the location of the stat sheet.
+   * @return The css class for the location of the stat sheet.
    */
   public String getStatSheetLocation() {
     return statSheetLocation;
@@ -451,19 +387,5 @@ public class StatSheetContext {
    */
   public boolean isGm() {
     return gm;
-  }
-
-  /**
-   * @return States set on the token.
-   */
-  public List<Map<String, Object>> getStates() {
-    return states;
-  }
-
-  /**
-   * @return Bars available on the token.
-   */
-  public List<Map<String, Object>> getBars() {
-    return bars;
   }
 }

--- a/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetContext.java
+++ b/src/main/java/net/rptools/maptool/model/sheet/stats/StatSheetContext.java
@@ -15,15 +15,20 @@
 package net.rptools.maptool.model.sheet.stats;
 
 import java.awt.Dimension;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.AppUtil;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolVariableResolver;
+import net.rptools.maptool.client.ui.token.AbstractTokenOverlay;
+import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.player.Player;
 import net.rptools.maptool.util.HTMLUtil;
@@ -139,6 +144,12 @@ public class StatSheetContext {
   /** The properties of the token. */
   private final List<Property> properties = new ArrayList<>();
 
+  /** The bars shown on the token. */
+  private final List<Map<String, Object>> bars = new ArrayList<>();
+
+  /** The states set on the token. */
+  private final List<Map<String, Object>> states = new ArrayList<>();
+
   /** The notes of the token. */
   private final String notes;
 
@@ -168,9 +179,20 @@ public class StatSheetContext {
    * @param location The location of the stat sheet.
    */
   public StatSheetContext(Token token, Player player, StatSheetLocation location) {
-
+    boolean playerOwns = AppUtil.playerOwns(token);
     name = token.getName();
     tokenType = token.getType().name();
+
+    List<String> stateOverlayNames = new ArrayList<>();
+    stateOverlayNames.addAll(MapTool.getCampaign().getTokenBarsMap().keySet());
+    stateOverlayNames.addAll(MapTool.getCampaign().getTokenStatesMap().keySet());
+
+    for (String stateName : stateOverlayNames) {
+      Object stateValue = token.getState(stateName);
+      if (stateValue != null) {
+        addBarState(stateName, stateValue, playerOwns, player);
+      }
+    }
 
     if (player.isGM()) {
       gmName = token.getGMName();
@@ -183,8 +205,8 @@ public class StatSheetContext {
       gmNotesType = null;
       gm = false;
     }
-    notes = AppUtil.playerOwns(token) ? token.getNotes() : null;
-    notesType = AppUtil.playerOwns(token) ? token.getNotesType() : null;
+    notes = playerOwns ? token.getNotes() : null;
+    notesType = playerOwns ? token.getNotesType() : null;
     speechName = token.getSpeechName();
 
     if (AppPreferences.showPortrait.get()) {
@@ -206,7 +228,7 @@ public class StatSheetContext {
                   return;
                 }
 
-                if (tp.isOwnerOnly() && !AppUtil.playerOwns(token)) {
+                if (tp.isOwnerOnly() && !playerOwns) {
                   return;
                 }
 
@@ -253,6 +275,48 @@ public class StatSheetContext {
           case LEFT -> "statSheet-left";
           case RIGHT -> "statSheet-right";
         };
+  }
+
+  private void addBarState(String stateName, Object stateValue, boolean playerOwns, Player player) {
+    AbstractTokenOverlay ato = null;
+    if (MapTool.getCampaign().getTokenBarsMap().containsKey(stateName)) {
+      ato = MapTool.getCampaign().getTokenBarsMap().get(stateName);
+    } else {
+      ato = MapTool.getCampaign().getTokenStatesMap().get(stateName);
+    }
+    if (ato.isShowOthers() || (playerOwns && ato.isShowOwner()) || player.isGM()) {
+      Map<String, Object> featureMap = new HashMap<>();
+      featureMap.put("value", stateValue);
+      featureMap.put("type", ato.getClass().getSimpleName());
+      String mName;
+
+      try {
+        BeanInfo beanInfo = Introspector.getBeanInfo(ato.getClass());
+        PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
+        for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+          if (!"class".equals(propertyDescriptor.getName())) {
+            if (propertyDescriptor.getReadMethod().canAccess(ato)) {
+              mName = propertyDescriptor.getReadMethod().getName();
+              if (mName.startsWith("is")) {
+                mName = mName.substring(2);
+              } else if (mName.startsWith("get") || mName.startsWith("has")) {
+                mName = mName.substring(3);
+              }
+              featureMap.put(
+                  Introspector.decapitalize(mName), propertyDescriptor.getReadMethod().invoke(ato));
+            }
+          }
+        }
+      } catch (IntrospectionException | InvocationTargetException | IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+
+      if (ato instanceof BarTokenOverlay) {
+        bars.add(featureMap);
+      } else {
+        states.add(featureMap);
+      }
+    }
   }
 
   /**
@@ -328,9 +392,9 @@ public class StatSheetContext {
   }
 
   /**
-   * Returns the css class for the location of the stat sheet.
+   * Returns the CSS class for the location of the stat sheet.
    *
-   * @return The css class for the location of the stat sheet.
+   * @return The CSS class for the location of the stat sheet.
    */
   public String getStatSheetLocation() {
     return statSheetLocation;
@@ -387,5 +451,19 @@ public class StatSheetContext {
    */
   public boolean isGm() {
     return gm;
+  }
+
+  /**
+   * @return States set on the token.
+   */
+  public List<Map<String, Object>> getStates() {
+    return states;
+  }
+
+  /**
+   * @return Bars available on the token.
+   */
+  public List<Map<String, Object>> getBars() {
+    return bars;
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5922
closes #5922

### Description of the Change
## Problem
Stems from shape.properties() calling _toString()_ on **ShapeDrawable**
https://github.com/RPTools/maptool/issues/5922#issuecomment-3762888092

##Fix
- Created new methods 
  - _ShapeDrawable.toString(boolean localisation)_, and
  - _AbstractDrawing.toString(boolean localisation)_ 
- On `localisation = FALSE`, Zone.Layer.name() is used instead of Zone.Layer.value()
- Changed _ShapeDrawable.toString()_ & _AbstractDrawing.toString()_ to call _toString(true)_ instead, i.e. defaults to true, leaving previous uses unaffected.

Token used for testing [lib_shapeTest.rptok.zip](https://github.com/user-attachments/files/24686159/lib_shapeTest.rptok.zip)

### Possible Drawbacks
none

### Documentation Notes
Fixed localisation string issue with shape.properties()

### Release Notes
Fixed localisation string issue with shape.properties()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5923)
<!-- Reviewable:end -->
