### PR TITLE
Fix Drawing ID not unique on shape.draw()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -360,7 +360,7 @@ dependencies {
     implementation(libs.okhttp)
 
     implementation(libs.bundles.imageio)
-    implementation(libs.batik)
+    implementation(libs.bundles.batik)
     implementation(libs.bundles.pdfbox)
     implementation(libs.bcmail)
     implementation(libs.bundles.jai.imageio)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation(libs.gson)
 
     implementation(libs.bundles.imageio)
-    implementation(libs.batik)
+    implementation(libs.bundles.batik)
     implementation(libs.jsvg)
 
     implementation(libs.apache.commons.io)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,10 @@ imageio-tiff = { group = "com.twelvemonkeys.imageio", name = "imageio-tiff", ver
 imageio-batik = { group = "com.twelvemonkeys.imageio", name = "imageio-batik", version.ref = "imageio" }
 imageio-tga = { group = "com.twelvemonkeys.imageio", name = "imageio-tga", version.ref = "imageio" }
 imageio-bmp = { group = "com.twelvemonkeys.imageio", name = "imageio-bmp", version.ref = "imageio" }
-batik = { group = "org.apache.xmlgraphics", name = "batik-all", version = "1.19" }
+batik-all = { group = "org.apache.xmlgraphics", name = "batik-all", version = "1.19" }
+batik-awt = { group = "org.apache.xmlgraphics", name="batik-awt-util", version = "1.19" }
+batik-transcoder = { group = "org.apache.xmlgraphics", name="batik-transcoder", version = "1.19" }
+
 # PDF image extraction
 pdfbox = { group = "org.apache.pdfbox", name = "pdfbox", version.ref = "pdfbox" }
 pdfbox-tools = { group = "org.apache.pdfbox", name = "pdfbox-tools", version.ref = "pdfbox" }
@@ -191,6 +194,7 @@ imageio = [
   "imageio-tga",
   "imageio-bmp",
 ]
+batik = ["batik-all", "batik-awt", "batik-transcoder"]
 pdfbox = ["pdfbox", "pdfbox-tools"]
 jide = [
   "jide-common",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ imageio-tiff = { group = "com.twelvemonkeys.imageio", name = "imageio-tiff", ver
 imageio-batik = { group = "com.twelvemonkeys.imageio", name = "imageio-batik", version.ref = "imageio" }
 imageio-tga = { group = "com.twelvemonkeys.imageio", name = "imageio-tga", version.ref = "imageio" }
 imageio-bmp = { group = "com.twelvemonkeys.imageio", name = "imageio-bmp", version.ref = "imageio" }
+
 batik-all = { group = "org.apache.xmlgraphics", name = "batik-all", version = "1.19" }
 batik-awt = { group = "org.apache.xmlgraphics", name="batik-awt-util", version = "1.19" }
 batik-transcoder = { group = "org.apache.xmlgraphics", name="batik-transcoder", version = "1.19" }

--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -576,7 +576,7 @@ public class ShapeFunctions extends AbstractFunction {
         pen.setEraser(penObject.get("eraser").getAsBoolean());
       }
     }
-    DrawnElement drawnElement = new DrawnElement(CACHED_SHAPES.get(shapeName), pen);
+    DrawnElement drawnElement = new DrawnElement(shapeDrawable.copy(), pen);
     drawnElement.setPen(pen);
 
     MapTool.serverCommand()

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -47,7 +47,7 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
 
   protected AbstractDrawing(AbstractDrawing other) {
     // The only thing we don't preserve is the ID.
-    this.id = other.id;
+    this.id = new GUID();
     this.layer = other.layer;
     this.name = other.name;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5920
closes #5920

### Description of the Change
Changed `AbstractDrawing(AbstractDrawing other)` to generate a new ID.
Changed `shape.draw()` to use `... drawnElement = new DrawnElement(shapeDrawable.copy()...` to enforce a unique ID.

Test results for the same shape drawn ten times;
**lib:shapeTest:** 
1. Drawing Id: 3D6EF77ED31245029CD3D14B07879DC7
2. Drawing Id: 075888047DB34FF09810E495E09B8C3A
3. Drawing Id: 34476124167A40E7BEAE19BF117BB958
4. Drawing Id: BCC4D776184B4FA7A490DF8EBF16D372
5. Drawing Id: F3ABCFCD9AA74D9CA381A01373DCDAAE
6. Drawing Id: 45BD6B9CC88A45B6B0189C8D55CF827C
7. Drawing Id: C1F9FFB596224C1D9ED3E80D3FC37981
8. Drawing Id: 5FAECE5E51AC4F75AD3A86481165D9A4
9. Drawing Id: 8876E0B3BE2D474B99C9311CB56A0E31
10. Drawing Id: D53D4819EFEA4D16AB6A2964C09AB68A

### Possible Drawbacks
none

### Documentation Notes
BugFix: shape.draw() returning duplicate IDs on multiple calls for the same shape.
### Release Notes
BugFix: shape.draw() returning duplicate IDs on multiple calls for the same shape.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5926)
<!-- Reviewable:end -->
