### PR TITLE
shape.properties output string fix

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -605,13 +605,13 @@ public class ShapeFunctions extends AbstractFunction {
             ? ":"
             : FunctionUtil.paramAsString(functionName, parameters, 3, false);
     if (delimiter1.equals(delimiter2)) {
-      throw new RuntimeException(
+      throw new ParserException(
           I18N.getText("macro.function.general.argumentTypeB", functionName, 3, 2));
     } else if (delimiter2.equals(delimiter3)) {
-      throw new RuntimeException(
+      throw new ParserException(
           I18N.getText("macro.function.general.argumentTypeB", functionName, 4, 3));
     } else if (delimiter3.equals(delimiter1)) {
-      throw new RuntimeException(
+      throw new ParserException(
           I18N.getText("macro.function.general.argumentTypeB", functionName, 4, 2));
     }
     if (!CACHED_SHAPES.containsKey(name)) {

--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -17,16 +17,13 @@ package net.rptools.maptool.client.functions;
 // @formatter:off
 
 import com.google.common.primitives.Floats;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import java.awt.*;
 import java.awt.geom.*;
 import java.util.*;
 import java.util.List;
 import java.util.function.BiFunction;
 import net.rptools.maptool.client.MapTool;
-import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Zone;
@@ -78,22 +75,23 @@ public class ShapeFunctions extends AbstractFunction {
   public static final Map<String, String> SOURCE_LINKS =
       Map.of(
           "arc",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Arc2D.Double.html#Double-double-double-double-double-double-double-int-",
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Arc2D.Double.html#Double-double-double-double-double-double-double-int-",
           "cubicCurve",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/CubicCurve2D.Double.html#Double-double-double-double-double-double-double-double-double-",
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/CubicCurve2D.Double.html#Double-double-double-double-double-double-double-double-double-",
           "ellipse",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Ellipse2D.Double.html#Double-double-double-double-double-",
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Ellipse2D.Double.html#Double-double-double-double-double-",
           "line",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Line2D.Double.html#Double-double-double-double-double-",
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Line2D.Double.html#Double-double-double-double-double-",
           "polygon",
-              "https://xmlgraphics.apache.org/batik/javadoc/org/apache/batik/ext/awt/geom/Polygon2D.html#Polygon2D-float:A-float:A-int-",
+          "https://xmlgraphics.apache.org/batik/javadoc/org/apache/batik/ext/awt/geom/Polygon2D.html#Polygon2D-float:A-float:A-int-",
           "quadCurve",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/QuadCurve2D.Double.html#Double-double-double-double-double-double-double-",
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/QuadCurve2D.Double.html#Double-double-double-double-double-double-double-",
           "rectangle",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Double.html#Double-double-double-double-double-",
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/Rectangle2D.Double.html#Double-double-double-double-double-",
           "roundRectangle",
-              "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/RoundRectangle2D.Double.html#Double-double-double-double-double-double-double-",
-          "svgPath", "https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths");
+          "https://docs.oracle.com/javase/8/docs/api/java/awt/geom/RoundRectangle2D.Double.html#Double-double-double-double-double-double-double-",
+          "svgPath",
+          "https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths");
   public static final String[] SHAPE_TYPES =
       new String[] {
         "arc",
@@ -592,12 +590,30 @@ public class ShapeFunctions extends AbstractFunction {
   private Object getProperties(
       Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
-    /* name, delimiter */
+    /* name, delimiter, nested delimiter */
     String name = FunctionUtil.paramAsString(functionName, parameters, 0, false);
-    String delimiter =
+    String delimiter1 =
         parameters.size() < 2
             ? ";"
             : FunctionUtil.paramAsString(functionName, parameters, 1, false);
+    String delimiter2 =
+        parameters.size() < 3
+            ? ","
+            : FunctionUtil.paramAsString(functionName, parameters, 2, false);
+    String delimiter3 =
+        parameters.size() < 4
+            ? ":"
+            : FunctionUtil.paramAsString(functionName, parameters, 3, false);
+    if (delimiter1.equals(delimiter2)) {
+      throw new RuntimeException(
+          I18N.getText("macro.function.general.argumentTypeB", functionName, 3, 2));
+    } else if (delimiter2.equals(delimiter3)) {
+      throw new RuntimeException(
+          I18N.getText("macro.function.general.argumentTypeB", functionName, 4, 3));
+    } else if (delimiter3.equals(delimiter1)) {
+      throw new RuntimeException(
+          I18N.getText("macro.function.general.argumentTypeB", functionName, 4, 2));
+    }
     if (!CACHED_SHAPES.containsKey(name)) {
       return false;
     }
@@ -614,23 +630,17 @@ public class ShapeFunctions extends AbstractFunction {
               seg, coords[0], coords[1], coords[2], coords[3], coords[4], coords[5], coords[6]));
       pi.next();
     }
-    StringBuilder stringBuilder = new StringBuilder(sd.toNonLocalisedString());
-    stringBuilder.append("segments=").append(String.join(",", segments)).append(";");
 
-    if (delimiter.equalsIgnoreCase("json")) {
-      JsonObject jsonObject =
-          JSONMacroFunctions.getInstance()
-              .getJsonObjectFunctions()
-              .fromStrProp(stringBuilder.toString(), ";");
-      jsonObject.add(
-          "segments",
-          JSONMacroFunctions.getInstance()
-              .getJsonArrayFunctions()
-              .fromStringList(String.join("##", segments), "##"));
+    if (delimiter1.equalsIgnoreCase("json")) {
+      JsonObject jsonObject = sd.toJson();
+      jsonObject.add("segments", new Gson().toJsonTree(segments));
       return jsonObject;
     } else {
-      stringBuilder.append("segments=\"").append(String.join("\",\"", segments)).append("\";");
-      return stringBuilder.toString();
+      return sd.toNonLocalisedString().replaceAll(";", delimiter1)
+          + delimiter1
+          + "segments="
+          + String.join(
+              delimiter2, segments.stream().map(s -> s.replaceAll(",", delimiter3)).toList());
     }
   }
 

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -15,6 +15,8 @@
 package net.rptools.maptool.model.drawing;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import java.awt.*;
 import java.awt.image.ImageObserver;
 import net.rptools.maptool.client.MapTool;
@@ -150,6 +152,14 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
 
   public String toNonLocalisedString() {
     return "name=" + getName() + ";" + "layer=" + getLayer().name() + ";" + "id=" + getId() + ";";
+  }
+
+  public JsonObject toJson() {
+    JsonObject jo = new JsonObject();
+    jo.add("name", new JsonPrimitive(getName()));
+    jo.add("layer", new JsonPrimitive(getLayer().name()));
+    jo.add("id", new JsonPrimitive(getId().toString()));
+    return jo;
   }
 
   ////

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -156,7 +156,8 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
 
   public JsonObject toJson() {
     JsonObject jo = new JsonObject();
-    jo.add("name", new JsonPrimitive(getName()));
+    String nm = getName();
+    jo.add("name", new JsonPrimitive(nm == null ? "" : nm));
     jo.add("layer", new JsonPrimitive(getLayer().name()));
     jo.add("id", new JsonPrimitive(getId().toString()));
     return jo;

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -224,7 +224,7 @@ public class ShapeDrawable extends AbstractDrawing {
   @Override
   public JsonObject toJson() {
     JsonObject jo = super.toJson();
-    jo.add("antiAliasing", new JsonPrimitive(getName()));
+    jo.add("antiAliasing", new JsonPrimitive(getUseAntiAliasing()));
     jo.add("shapeType", new JsonPrimitive(getLayer().name()));
     jo.add("x", new JsonPrimitive(getBounds().x));
     jo.add("y", new JsonPrimitive(getBounds().y));

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -14,6 +14,8 @@
  */
 package net.rptools.maptool.model.drawing;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.protobuf.StringValue;
 import java.awt.*;
 import java.awt.Rectangle;
@@ -185,7 +187,6 @@ public class ShapeDrawable extends AbstractDrawing {
         + "shapeType="
         + getShapeTypeName()
         + ";"
-        + "bounds=\""
         + "x="
         + getBounds().x
         + ";"
@@ -196,8 +197,7 @@ public class ShapeDrawable extends AbstractDrawing {
         + getBounds().width
         + ";"
         + "height="
-        + getBounds().height
-        + "\";";
+        + getBounds().height;
   }
 
   public String toNonLocalisedString() {
@@ -208,7 +208,6 @@ public class ShapeDrawable extends AbstractDrawing {
         + "shapeType="
         + getShapeTypeName()
         + ";"
-        + "bounds=\""
         + "x="
         + getBounds().x
         + ";"
@@ -219,8 +218,19 @@ public class ShapeDrawable extends AbstractDrawing {
         + getBounds().width
         + ";"
         + "height="
-        + getBounds().height
-        + "\";";
+        + getBounds().height;
+  }
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject jo = super.toJson();
+    jo.add("antiAliasing", new JsonPrimitive(getName()));
+    jo.add("shapeType", new JsonPrimitive(getLayer().name()));
+    jo.add("x", new JsonPrimitive(getBounds().x));
+    jo.add("y", new JsonPrimitive(getBounds().y));
+    jo.add("width", new JsonPrimitive(getBounds().width));
+    jo.add("height", new JsonPrimitive(getBounds().height));
+    return jo;
   }
 
   private void restoreAA(Graphics2D g, Object oldAA) {

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -225,7 +225,7 @@ public class ShapeDrawable extends AbstractDrawing {
   public JsonObject toJson() {
     JsonObject jo = super.toJson();
     jo.add("antiAliasing", new JsonPrimitive(getUseAntiAliasing()));
-    jo.add("shapeType", new JsonPrimitive(getLayer().name()));
+    jo.add("shapeType", new JsonPrimitive(getShapeTypeName()));
     jo.add("x", new JsonPrimitive(getBounds().x));
     jo.add("y", new JsonPrimitive(getBounds().y));
     jo.add("width", new JsonPrimitive(getBounds().width));

--- a/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/ShapeDrawable.java
@@ -197,7 +197,21 @@ public class ShapeDrawable extends AbstractDrawing {
         + getBounds().width
         + ";"
         + "height="
-        + getBounds().height;
+        + getBounds().height
+        + ";"
+        + "bounds=\""
+        + "x="
+        + getBounds().x
+        + ";"
+        + "y="
+        + getBounds().y
+        + ";"
+        + "width="
+        + getBounds().width
+        + ";"
+        + "height="
+        + getBounds().height
+        + "\"";
   }
 
   public String toNonLocalisedString() {
@@ -218,7 +232,21 @@ public class ShapeDrawable extends AbstractDrawing {
         + getBounds().width
         + ";"
         + "height="
-        + getBounds().height;
+        + getBounds().height
+        + ";"
+        + "bounds=\""
+        + "x="
+        + getBounds().x
+        + ";"
+        + "y="
+        + getBounds().y
+        + ";"
+        + "width="
+        + getBounds().width
+        + ";"
+        + "height="
+        + getBounds().height
+        + "\"";
   }
 
   @Override

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -2084,6 +2084,7 @@ macro.function.general.argumentKeyTypeD            = Argument key "{1}" to funct
 macro.function.general.argumentKeyTypeG            = Argument key "{1}" to function "{0}" must be a GUID.
 macro.function.general.argumentKeyTypeI            = Argument key "{1}" to function "{0}" must be an integer.
 macro.function.general.argumentTypeA               = Argument number {1} to function "{0}" must be a JSON Array.
+macro.function.general.argumentTypeB               = Argument number {1} to function "{0}" cannot be the same as argument number {2}.
 macro.function.general.argumentTypeI               = Argument number {1} "{2}" to function "{0}" must be an integer.
 macro.function.general.argumentTypeInvalid         = Argument number {1} invalid argument type for function "{0}".
 macro.function.general.argumentTypeJ               = Argument number {1} to function "{0}" must be a JSON Array or Object.


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5927
closes #5927

### Description of the Change
Altered toString methods on ancestor classes to flatten structure.
Added toJson methods on ancestor classes to prevent things getting munted in conversion to JSON.
Unable to elegantly resolve nested string lists without the addition of another delimiter, so there are now three delimiter arguments available on the function
0. Shape Name
1. "json" or String-Property-List delimiter - default `;`
2. String-List delimiter - default `,`
3. Nested String-List delimiter, default `:`

### Possible Drawbacks
Users will expect to be able to access the nested string list without specifying a delimiter and will become angstful at the unexpected results.

### Documentation Notes
Fix to shape.properties output
### Release Notes
Fix to shape.properties output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5932)
<!-- Reviewable:end -->
