### PR TITLE
Fix Drawing ID not unique on shape.draw() - Mk II

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -522,6 +522,8 @@ public class ShapeFunctions extends AbstractFunction {
       throw new ParserException(I18N.getText(OBJECT_NOT_FOUND, functionName, shapeName));
     }
     ShapeDrawable shapeDrawable = CACHED_SHAPES.get(shapeName);
+    shapeDrawable.setId(
+        new GUID()); // this gives the drawn element a separate ID to the cached shape
     Rectangle bounds = shapeDrawable.getBounds();
 
     /* Sanity checks */

--- a/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/ShapeFunctions.java
@@ -521,7 +521,7 @@ public class ShapeFunctions extends AbstractFunction {
     if (!CACHED_SHAPES.containsKey(shapeName)) {
       throw new ParserException(I18N.getText(OBJECT_NOT_FOUND, functionName, shapeName));
     }
-    ShapeDrawable shapeDrawable = CACHED_SHAPES.get(shapeName);
+    ShapeDrawable shapeDrawable = new ShapeDrawable(CACHED_SHAPES.get(shapeName));
     shapeDrawable.setId(
         new GUID()); // this gives the drawn element a separate ID to the cached shape
     Rectangle bounds = shapeDrawable.getBounds();

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -46,8 +46,8 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
   }
 
   protected AbstractDrawing(AbstractDrawing other) {
-    // The only thing we don't preserve is the ID.
-    this.id = new GUID();
+    // The only thing we don't preserve is the ID. - umm except that we obviously do
+    this.id = other.id;
     this.layer = other.layer;
     this.name = other.name;
   }

--- a/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
+++ b/src/main/java/net/rptools/maptool/model/drawing/AbstractDrawing.java
@@ -46,7 +46,6 @@ public abstract class AbstractDrawing implements Drawable, ImageObserver {
   }
 
   protected AbstractDrawing(AbstractDrawing other) {
-    // The only thing we don't preserve is the ID. - umm except that we obviously do
     this.id = other.id;
     this.layer = other.layer;
     this.name = other.name;


### PR DESCRIPTION
### Identify the Bug or Feature request
Original #5920 
hopefully fixes [5926 comment](https://github.com/RPTools/maptool/pull/5926#discussion_r2807352727) without screwing up the original issue.

### Description of the Change
Revert to copying the id in the AbstractDrawing copy constructor; otherwise it breaks drawing user interactions.
Updated ShapeFunctions method drawShape to assign a new ID to the copied ShapeDrawable which should propagate its way to the new drawing ID.

### Possible Drawbacks
Who knows, obviously I can't be trusted.

### Documentation Notes

### Release Notes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5942)
<!-- Reviewable:end -->
