### PR TITLE
markdownToHTML() - add flexmark's MacrosExtension as an option

### DIFF
--- a/src/main/java/net/rptools/maptool/client/functions/MarkDownFunctions.java
+++ b/src/main/java/net/rptools/maptool/client/functions/MarkDownFunctions.java
@@ -22,6 +22,7 @@ import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtensio
 import com.vladsch.flexmark.ext.gfm.strikethrough.SubscriptExtension;
 import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
 import com.vladsch.flexmark.ext.ins.InsExtension;
+import com.vladsch.flexmark.ext.macros.MacrosExtension;
 import com.vladsch.flexmark.ext.superscript.SuperscriptExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.ext.toc.TocExtension;
@@ -63,6 +64,7 @@ public class MarkDownFunctions extends AbstractFunction {
     ATTRIBUTES("ATTRIBUTES", AttributesExtension.create()),
     DEFINITION("DEFINITION", DefinitionExtension.create()),
     INS("INS", InsExtension.create()),
+    MACROS("MACROS", MacrosExtension.create()),
     STRIKETHROUGH("STRIKETHROUGH", StrikethroughExtension.create()),
     STRIKETHROUGHSUBSCRIPT("STRIKETHROUGHSUBSCRIPT", StrikethroughSubscriptExtension.create()),
     SUBSCRIPT("SUBSCRIPT", SubscriptExtension.create()),


### PR DESCRIPTION
### Identify the Bug or Feature request
closes #5945

### Description of the Change
Adds support for:
https://github.com/vsch/flexmark-java/wiki/Extensions#macros
https://github.com/vsch/flexmark-java/wiki/Macros-Extension

Not to be confused of course with MapTool's very own macros and macronames! :)

### Possible Drawbacks
None expected.

### Documentation Notes
Add `MACROS` and [flexmark's wiki link](https://github.com/vsch/flexmark-java/wiki/Macros-Extension) to the `optionalExtension` list here: https://wiki.rptools.info/index.php/markdownToHTML

### Release Notes
Added optional extension for `markdownToHTML()` to insert markdown block elements inline

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5946)
<!-- Reviewable:end -->
