### PR TITLE
Fix blank token name in variable prompt when GM name is empty

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolVariableResolver.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import javax.swing.JOptionPane;
 import net.rptools.CaseInsensitiveHashMap;
+import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.functions.*;
 import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.language.I18N;
@@ -272,12 +273,12 @@ public class MapToolVariableResolver implements VariableResolver {
     if ((result == null && autoPrompt) || mods == VariableModifiers.Prompt) {
       String DialogTitle = I18N.getText("lineParser.dialogTitleNoToken");
       if (tokenInContext != null
-          && tokenInContext.getGMName() != null
+          && !StringUtil.isEmpty(tokenInContext.getGMName())
           && MapTool.getPlayer().isGM()) {
         DialogTitle = I18N.getText("lineParser.dialogTitle", tokenInContext.getGMName());
       }
       if (tokenInContext != null
-          && (tokenInContext.getGMName() == null || !MapTool.getPlayer().isGM())) {
+          && (StringUtil.isEmpty(tokenInContext.getGMName()) || !MapTool.getPlayer().isGM())) {
         DialogTitle = I18N.getText("lineParser.dialogTitle", tokenInContext.getName());
       }
       result =


### PR DESCRIPTION
Fixes #5339

When a token's GM name is cleared (set to `""` instead of `null`), the variable prompt dialog shows a blank name or just a period. This is because `getGMName() != null` doesn't catch empty strings.

Replaced the `null` checks with `StringUtil.isEmpty()` so both `null` and `""` are handled consistently, falling back to the token's regular name when the GM name is empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5955)
<!-- Reviewable:end -->
