### PR TITLE
Added tests for most of the methods in FunctionUtil.

### DIFF
--- a/src/main/java/net/rptools/maptool/util/FunctionUtil.java
+++ b/src/main/java/net/rptools/maptool/util/FunctionUtil.java
@@ -14,15 +14,13 @@
  */
 package net.rptools.maptool.util;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.google.gson.*;
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -38,9 +36,7 @@ import net.rptools.maptool.client.functions.json.JSONMacroFunctions;
 import net.rptools.maptool.client.ui.theme.ThemeSupport;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.language.I18N;
-import net.rptools.maptool.model.GUID;
-import net.rptools.maptool.model.InvalidGUIDException;
-import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.*;
 import net.rptools.maptool.model.drawing.DrawableColorPaint;
 import net.rptools.maptool.model.drawing.DrawablePaint;
 import net.rptools.maptool.model.drawing.DrawableTexturePaint;
@@ -56,6 +52,8 @@ import net.rptools.parser.function.Function;
  * @since 1.5.5
  */
 public class FunctionUtil {
+  private static final MathContext MATH_CONTEXT = new MathContext(16, RoundingMode.HALF_EVEN);
+
   private static final String KEY_WRONG_NUM_PARAM = "macro.function.general.wrongNumParam";
   private static final String KEY_NOT_ENOUGH_PARAM = "macro.function.general.notEnoughParam";
   private static final String KEY_TOO_MANY_PARAM = "macro.function.general.tooManyParam";
@@ -101,11 +99,11 @@ public class FunctionUtil {
       String html =
           String.format(
               """
-  <table border=0 width=100%% cellspacing=3 cellpadding=0 style="background:%s;"><tr><td>
-  <table style="background: %s; color: %s"><tr valign=middle><td height="44px" width="48px">%s</td>
-  <td>%s</td></tr></table>
-  </td></tr></table>
-  """,
+                                            <table border=0 width=100%% cellspacing=3 cellpadding=0 style="background:%s;"><tr><td>
+                                            <table style="background: %s; color: %s"><tr valign=middle><td height="44px" width="48px">%s</td>
+                                            <td>%s</td></tr></table>
+                                            </td></tr></table>
+                                            """,
               red, white, textColour, imageText, messageText);
       MapTool.addGlobalMessage(html, List.of("self"));
     }
@@ -156,7 +154,7 @@ public class FunctionUtil {
   /**
    * Gets the token from the specified index or returns the token in context. This method will check
    * the list size before trying to retrieve the token so it is safe to use for functions that have
-   * the token as a optional argument.
+   * the token as an optional argument.
    *
    * @param functionName the function name (used for generating exception messages).
    * @param param the parameters for the function
@@ -204,7 +202,7 @@ public class FunctionUtil {
   /**
    * Gets the ZoneRender from the specified index or returns the current ZoneRender. This method
    * will check the list size before trying to retrieve the token so it is safe to use for functions
-   * that have the map as a optional argument.
+   * that have the map as an optional argument.
    *
    * @param functionName the function name (used for generating exception messages).
    * @param param the parameters for the function
@@ -267,22 +265,12 @@ public class FunctionUtil {
    * @param index the index of the parameter to return as BigDecimal
    * @param allowString should text that can be converted to BigDecimal be allowed?
    * @return the BigDecimal value of the parameter
-   * @throws ParserException if can't be converted to BigDecimal, or if disallowed text
+   * @throws ParserException when unable to convert to BigDecimal, or if disallowed text
    */
   public static BigDecimal paramAsBigDecimal(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
-    Object parameter = parameters.get(index);
-    if (parameter instanceof BigDecimal) {
-      return (BigDecimal) parameter;
-    }
-    try {
-      if (!allowString && parameter instanceof String) throw new NumberFormatException("String");
-      return new BigDecimal(parameter.toString());
-    } catch (NumberFormatException ne) {
-      throw new ParserException(
-          I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
-    }
+    return new BigDecimal(paramAsNumber(functionName, parameters, index, allowString).toString());
   }
 
   /**
@@ -294,19 +282,92 @@ public class FunctionUtil {
    * @param index the index of the parameter to return as Boolean
    * @param allowString should text parameters be allowed
    * @return the parameter as a Boolean
-   * @throws ParserException if can't be converted to BigDecimal, or if disallowed text
+   * @throws ParserException when unable to convert to BigDecimal, or if disallowed text
    */
   public static Boolean paramAsBoolean(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
     Object parameter = parameters.get(index);
+    if (parameter instanceof Boolean b) {
+      // already a boolean, return it.
+      return b;
+    } else if (allowString && parameter instanceof String string) {
+      // if it is a string of "true/false" return it as boolean
+      if (string.trim().equalsIgnoreCase("false")) {
+        return false;
+      } else if (string.trim().equalsIgnoreCase("true")) {
+        return true;
+      }
+    }
     try {
       if (!allowString && parameter instanceof String) {
         throw new NumberFormatException("String");
       }
-      BigDecimal val = new BigDecimal(parameter.toString());
+      BigDecimal val = new BigDecimal(parameter.toString().trim());
       return !val.equals(BigDecimal.ZERO); // true if any value except zero
     } catch (NumberFormatException ne) {
+      throw new ParserException(
+          I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
+    }
+  }
+
+  /**
+   * Helper function for the various getParam as numeric type. Converts numbers of various types and
+   * formats, including scientific, hex, octal, binary and their string representations. Allows for
+   * suffixes that should not appear in macro code; i.e. 1f, 2d, 3L. Only thing it doesn't cope with
+   * is returning -0, which hopefully nobody is counting on.
+   *
+   * @param functionName for error messages
+   * @param parameters containing values
+   * @param index of value to return
+   * @param allowString if string representation of number is allowed
+   * @return number value as a Number
+   * @throws ParserException if value is not a valid number.
+   */
+  private static Number paramAsNumber(
+      String functionName, List<Object> parameters, int index, boolean allowString)
+      throws ParserException {
+    Object parameter = parameters.get(index);
+
+    if (!allowString && parameter instanceof String string) {
+      throw new ParserException(I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, string));
+    }
+    String nString;
+    if (parameter instanceof Number number) {
+      if (Double.isNaN(number.doubleValue()) || Float.isNaN(number.floatValue())) {
+        throw new ParserException(
+            I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, Double.NaN));
+      } else if (number.doubleValue() == 0) {
+        return 0;
+      }
+      // this seems stupid, but it is the only way to get consistent results between floats, doubles
+      // and ints out of BigDecimal
+      nString = number.toString();
+    } else {
+      nString = parameter.toString().trim().toLowerCase();
+      if (nString.equals("nan")) {
+        throw new ParserException(
+            I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, Double.NaN));
+      }
+    }
+    if (nString.endsWith("d") || nString.endsWith("f") || nString.endsWith("l")) {
+      nString = nString.substring(0, nString.length() - 1);
+    }
+    if (nString.startsWith("#") || nString.startsWith("0x") || nString.startsWith("0b")) {
+      try {
+        if (nString.startsWith("0b")) {
+          return Integer.parseUnsignedInt(nString.substring(2), 2);
+        } else {
+          return Integer.decode(nString);
+        }
+      } catch (NumberFormatException nfe) {
+        throw new ParserException(
+            I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
+      }
+    }
+    try {
+      return new BigDecimal(nString, MATH_CONTEXT);
+    } catch (NumberFormatException nfe) {
       throw new ParserException(
           I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
     }
@@ -321,21 +382,18 @@ public class FunctionUtil {
    * @param index the index of the parameter to return as integer
    * @param allowString should text be allowed as parameter
    * @return the parameter as an integer
-   * @throws ParserException if the parameter can't be converted to BigDecimal, or if disallowed
-   *     text
+   * @throws ParserException if the parameter can't be converted to Integer, or if disallowed text
    */
   public static int paramAsInteger(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
-    Object parameter = parameters.get(index);
-    try {
-      if (!allowString && parameter instanceof String) {
-        throw new NumberFormatException("String");
-      }
-      return Integer.parseInt(parameter.toString());
-    } catch (NumberFormatException ne) {
+
+    Number number = paramAsNumber(functionName, parameters, index, allowString);
+    if (number.intValue() == number.doubleValue()) {
+      return number.intValue();
+    } else {
       throw new ParserException(
-          I18N.getText(KEY_NOT_INT, functionName, index + 1, parameter.toString()));
+          I18N.getText(KEY_NOT_INT, functionName, index + 1, parameters.get(index).toString()));
     }
   }
 
@@ -348,21 +406,12 @@ public class FunctionUtil {
    * @param index the index of the parameter to return as Double
    * @param allowString should text be allowed
    * @return the parameter as a Double
-   * @throws ParserException if can't be converted to Double, or disallowed text
+   * @throws ParserException when cannot be converted to Double, or disallowed text
    */
   public static double paramAsDouble(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
-    Object parameter = parameters.get(index);
-    try {
-      if (!allowString && parameter instanceof String) {
-        throw new NumberFormatException("String");
-      }
-      return Double.parseDouble(parameter.toString());
-    } catch (NumberFormatException ne) {
-      throw new ParserException(
-          I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
-    }
+    return paramAsNumber(functionName, parameters, index, allowString).doubleValue();
   }
 
   /**
@@ -374,30 +423,21 @@ public class FunctionUtil {
    * @param index the index of the parameter to return as Float
    * @param allowString should text be allowed
    * @return the parameter as a Float
-   * @throws ParserException if can't be converted to Float, or if disallowed text
+   * @throws ParserException when unable to convert to Float, or if disallowed text
    */
   public static float paramAsFloat(
       String functionName, List<Object> parameters, int index, boolean allowString)
       throws ParserException {
-    Object parameter = parameters.get(index);
-    try {
-      if (!allowString && parameter instanceof String) {
-        throw new NumberFormatException("String");
-      }
-      return Float.parseFloat(parameter.toString());
-    } catch (NumberFormatException ne) {
-      throw new ParserException(
-          I18N.getText(KEY_NOT_NUMBER, functionName, index + 1, parameter.toString()));
-    }
+    return paramAsNumber(functionName, parameters, index, allowString).floatValue();
   }
 
   /**
    * Return the jsonObject value of a parameter supplied as a JSON Object or StringPropList.<br>
-   * Throws a <code>ParserException</code> if the parameter can't be converted to a json.
+   * Throws a <code>ParserException</code> if the parameter can't be converted to a JSON.
    *
    * @param functionName this is used in the exception message
    * @param parameters the list of parameters
-   * @param index the index of the parameter to return as Json
+   * @param index the index of the parameter to return as JSON
    * @param delimiter the delimiter if known
    * @return the parameter as a jsonObject
    * @throws ParserException if the parameter can't be converted to jsonObject or jsonArray
@@ -405,42 +445,49 @@ public class FunctionUtil {
   public static JsonObject paramFromStrPropOrJsonAsJsonObject(
       String functionName, List<Object> parameters, int index, String delimiter)
       throws ParserException {
+
+    Object arg = parameters.get(index);
+    if (arg instanceof JsonObject jo) {
+      return jo;
+    }
+
+    if (delimiter.equalsIgnoreCase("json")) {
+      return paramAsJsonObject(functionName, parameters, index);
+    }
+    delimiter = delimiter.isEmpty() ? ";" : delimiter;
+    // just in case it is a JSON Object despite the delimiter
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
     try {
-      JsonObject json = new JsonObject();
-      if (delimiter.equalsIgnoreCase("json")) {
-        json = paramAsJsonObject(functionName, parameters, index);
-      } else if (parameters.get(index) instanceof JsonObject) {
-        json = paramAsJsonObject(functionName, parameters, index);
-      } else if (!delimiter.equalsIgnoreCase(";")) {
-        List<String> entries =
-            Arrays.stream(paramAsString(functionName, parameters, index, true).split(delimiter))
-                .toList();
-        String[] keyValue;
-        for (String entry : entries) {
-          keyValue = entry.split("=");
-          try {
-            json.add(keyValue[0].trim(), new JsonPrimitive(new BigDecimal(keyValue[1])));
-          } catch (NumberFormatException nfe) {
-            json.add(keyValue[0].trim(), new JsonPrimitive(keyValue[1].trim()));
-          }
+      JsonElement jsonElement = gson.toJsonTree(arg);
+      if (jsonElement.isJsonObject()) {
+        return jsonElement.getAsJsonObject();
+      }
+    } catch (JsonParseException ignored) {
+    }
+    String strProp = arg.toString();
+    String[] kvPairs = strProp.split(delimiter);
+    JsonObject jsonObject = new JsonObject();
+    for (String pair : kvPairs) {
+      String[] kv = pair.split("=");
+      if (kv.length != 2) {
+        throw new ParserException(
+            I18N.getText("macro.function.general.unableToParse", functionName, index));
+      }
+      String key = kv[0];
+      String value = kv[1];
+      if ((value.contains("{") && value.contains("}"))
+          || (value.contains("[") && value.contains("]"))) {
+        try {
+          JsonElement je = gson.toJsonTree(value);
+          jsonObject.add(key, je);
+        } catch (JsonParseException ignored) {
+          jsonObject.addProperty(key, value);
         }
       } else {
-        // guessing time
-        if (((String) parameters.get(index)).contains("{")) {
-          json = paramAsJsonObject(functionName, parameters, index);
-        } else if (((String) parameters.get(index)).contains(";")) {
-          json =
-              JSONMacroFunctions.getInstance()
-                  .getJsonObjectFunctions()
-                  .fromStrProp(paramAsString(functionName, parameters, index, true), ";");
-        }
+        jsonObject.addProperty(key, value);
       }
-      return json;
-    } catch (ParserException pe) {
-      throw new ParserException(
-          I18N.getText(
-              "macro.function.input.illegalArgumentType", "unknown", "JSON Object/StringProp"));
     }
+    return jsonObject;
   }
 
   /**
@@ -485,11 +532,11 @@ public class FunctionUtil {
 
   /**
    * Return the jsonObject or jsonArray value of a parameter. Throws a <code>ParserException</code>
-   * if the parameter can't be converted to a json.
+   * if the parameter can't be converted to a JSON.
    *
    * @param functionName this is used in the exception message
    * @param parameters the list of parameters
-   * @param index the index of the parameter to return as Json
+   * @param index the index of the parameter to return as JSON
    * @return the parameter as a jsonObject or jsonArray
    * @throws ParserException if the parameter can't be converted to jsonObject or jsonArray
    */
@@ -562,13 +609,13 @@ public class FunctionUtil {
   }
 
   /**
-   * Return the jsonObject or jsonArray value of a parameter. if the parameter can't be converted to
-   * a json. Then an empty json array will be returned if its an empty string, otherwise a a
-   * JsonArray containing the argument will be returned.
+   * Return the jsonObject or jsonArray value of a parameter. If the parameter can't be converted to
+   * a JSON, an empty string results in an empty JSON array, otherwise a JSON array containing the
+   * argument will be returned.
    *
    * @param functionName this is used in the exception message
    * @param parameters the list of parameters
-   * @param index the index of the parameter to return as Json
+   * @param index the index of the parameter to return as JSON
    * @return the parameter as a jsonObject or jsonArray
    * @throws ParserException if the parameter can't be converted to jsonObject or jsonArray
    */
@@ -583,8 +630,8 @@ public class FunctionUtil {
   }
 
   /**
-   * Return the jsonElement value of a parameter. Throws a <code>ParserException</code> if the
-   * parameter can't be converted to a jsonArray.
+   * Return the jsonElement value of a parameter. Where the value is not a JSON, returns an array
+   * containing the value.
    *
    * @param functionName this is used in the exception message
    * @param parameters the list of parameters
@@ -598,7 +645,7 @@ public class FunctionUtil {
     } catch (ParserException e) {
       JsonArray json = new JsonArray();
       Object val = parameters.get(index);
-      if (val.toString().length() > 0) {
+      if (!val.toString().isEmpty()) {
         if (val instanceof Number) {
           json.add((Number) val);
         } else {
@@ -618,21 +665,25 @@ public class FunctionUtil {
    * @return The boolean value of the object
    */
   public static boolean getBooleanValue(Object value) {
-    boolean set = false;
-    if (value instanceof Boolean) {
-      set = (Boolean) value;
-    } else if (value instanceof Number) {
-      set = ((Number) value).doubleValue() != 0;
-    } else if (value == null) {
-      set = false;
-    } else {
-      try {
-        set = !new BigDecimal(value.toString()).equals(BigDecimal.ZERO);
-      } catch (NumberFormatException e) {
-        set = Boolean.parseBoolean(value.toString());
-      } // endif
-    } // endif
-    return set;
+    boolean returnValue = false;
+    switch (value) {
+      case Boolean b -> returnValue = b;
+      case Number number -> returnValue = number.doubleValue() != 0;
+      case String string -> {
+        string = string.trim();
+        if (string.equalsIgnoreCase("false") || string.equalsIgnoreCase("true")) {
+          returnValue = string.equalsIgnoreCase("true");
+        } else {
+          try {
+            returnValue = !new BigDecimal(string).equals(BigDecimal.ZERO);
+          } catch (NumberFormatException e) {
+            returnValue = Boolean.parseBoolean(value.toString());
+          }
+        }
+      }
+      case null, default -> {}
+    }
+    return returnValue;
   }
 
   /**
@@ -646,7 +697,7 @@ public class FunctionUtil {
   }
 
   /**
-   * Parses a string into either a Color Paint or Texture Paint.
+   * Parses a string into either a Colour Paint or Texture Paint.
    *
    * @param paint String containing the paint description.
    * @return Pen DrawableTexturePaint or DrawableColorPaint.

--- a/src/test/java/net/rptools/maptool/client/functions/json/FunctionUtilTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/FunctionUtilTest.java
@@ -1,0 +1,585 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions.json;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import com.google.gson.*;
+import com.vladsch.flexmark.util.html.ui.Color;
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.List;
+import net.rptools.maptool.client.MapToolVariableResolver;
+import net.rptools.maptool.model.Token;
+import net.rptools.maptool.model.drawing.DrawableColorPaint;
+import net.rptools.maptool.util.FunctionUtil;
+import net.rptools.parser.Parser;
+import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
+import org.junit.jupiter.api.*;
+
+class FunctionUtilTest {
+  private final String functionName = "testFunction";
+
+  @Test
+  @Disabled // I don't know how to get these to work
+  void untestable() throws ParserException {
+    Parser parser = new Parser(true);
+    Token mockToken = mock(Token.class);
+    VariableResolver variableResolver = new MapToolVariableResolver(mockToken);
+    List<Object> parameters = List.of();
+    FunctionUtil.experimentalWarning(parser, variableResolver, functionName);
+    FunctionUtil.getTokenFromParam(variableResolver, functionName, parameters, 14, 16);
+    FunctionUtil.getZoneRendererFromParam(functionName, parameters, 16);
+    FunctionUtil.getZoneRenderer(functionName, "Grasslands");
+
+    FunctionUtil.getAssetKeyFromString(mockToken.getImageAssetId().toString());
+    FunctionUtil.blockUntrustedMacro(functionName);
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.checkNumberParam()")
+  void checkNumberParam() {
+    List<Object> params = List.of("a", "b");
+    // max < min
+    assertThrows(
+        ParserException.class, () -> FunctionUtil.checkNumberParam(functionName, params, 2, 0));
+    // length > max
+    assertThrows(
+        ParserException.class, () -> FunctionUtil.checkNumberParam(functionName, params, 0, 1));
+    // length < min
+    assertThrows(
+        ParserException.class, () -> FunctionUtil.checkNumberParam(functionName, params, 3, 4));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.getPaintFromString()")
+  void getPaintFromString() {
+    assertInstanceOf(
+        DrawableColorPaint.class, FunctionUtil.getPaintFromString(Color.black.toString()));
+    assertInstanceOf(DrawableColorPaint.class, FunctionUtil.getPaintFromString("black"));
+    assertInstanceOf(DrawableColorPaint.class, FunctionUtil.getPaintFromString("#000"));
+    assertInstanceOf(DrawableColorPaint.class, FunctionUtil.getPaintFromString("#a0a0a0a0"));
+    assertInstanceOf(DrawableColorPaint.class, FunctionUtil.getPaintFromString("0x112233"));
+    assertInstanceOf(DrawableColorPaint.class, FunctionUtil.getPaintFromString("0X111222333"));
+    assertInstanceOf(
+        DrawableColorPaint.class, FunctionUtil.getPaintFromString("0b2333")); // malformed
+  }
+
+  //
+  // Typed parameters (non-JSON)
+  //
+
+  @Test
+  @DisplayName("FunctionUtil.getDecimalForBoolean()")
+  void getDecimalForBoolean() {
+    assertEquals(BigDecimal.ZERO, FunctionUtil.getDecimalForBoolean(false));
+    assertEquals(BigDecimal.ONE, FunctionUtil.getDecimalForBoolean(true));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.getBooleanValue()")
+  void getBooleanValue() {
+    List<Object> params =
+        List.of(0, " 0 ", false, " FaLse", 1, -2, 3, true, "1 ", " true", "TRuE ");
+    for (int i = 0; i < params.size(); i++) {
+      if (i < 4) {
+        assertFalse(FunctionUtil.getBooleanValue(params.get(i)));
+      } else {
+        assertTrue(FunctionUtil.getBooleanValue(params.get(i)));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsBoolean()")
+  void paramAsBoolean() throws ParserException {
+    List<Object> params;
+
+    // Non-numeric string
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsBoolean(functionName, List.of("3.two"), 0, true));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsBoolean(functionName, List.of(emptyString), 0, true));
+
+    // numeric parameters
+    params = List.of(0, 1, -2, 3);
+    assertEquals(false, FunctionUtil.paramAsBoolean(functionName, params, 0, false));
+    assertEquals(true, FunctionUtil.paramAsBoolean(functionName, params, 1, false));
+    assertEquals(true, FunctionUtil.paramAsBoolean(functionName, params, 2, false));
+    assertEquals(true, FunctionUtil.paramAsBoolean(functionName, params, 3, false));
+
+    // Boolean parameters
+    assertEquals(false, FunctionUtil.paramAsBoolean(functionName, List.of(false), 0, true));
+    assertEquals(true, FunctionUtil.paramAsBoolean(functionName, List.of(true), 0, true));
+
+    // String parameters
+    params = List.of("-0 ", " 1.0 ", "false ", " true");
+    assertEquals(false, FunctionUtil.paramAsBoolean(functionName, params, 0, true));
+    assertEquals(true, FunctionUtil.paramAsBoolean(functionName, params, 1, true));
+    assertEquals(false, FunctionUtil.paramAsBoolean(functionName, params, 2, true));
+    assertEquals(true, FunctionUtil.paramAsBoolean(functionName, params, 3, true));
+    List<Object> finalParams = params;
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsBoolean(functionName, finalParams, 0, false));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsBoolean(functionName, finalParams, 1, false));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsBoolean(functionName, finalParams, 2, false));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsBoolean(functionName, finalParams, 3, false));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsString()")
+  void paramAsString() throws ParserException {
+    assertEquals("NaN", FunctionUtil.paramAsString(functionName, List.of(Double.NaN), 0, true));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsString(functionName, List.of(Double.NaN), 0, false));
+    assertEquals("true", FunctionUtil.paramAsString(functionName, List.of(true), 0, true));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsString(functionName, List.of(true), 0, false));
+    assertEquals("true", FunctionUtil.paramAsString(functionName, List.of("true"), 0, true));
+    assertEquals(
+        "{}", FunctionUtil.paramAsString(functionName, List.of(new JsonObject()), 0, true));
+    assertEquals(
+        "a string", FunctionUtil.paramAsString(functionName, List.of("a string"), 0, true));
+  }
+
+  private final List<Object> numbers =
+      List.of(
+          Byte.valueOf("-0"),
+          -1L,
+          2,
+          -3.3f,
+          4.4d,
+          -5e0,
+          6.6e0,
+          0x00000007,
+          0x00000008,
+          0b1001,
+          Double.NaN);
+
+  private final List<Object> numberStrings =
+      List.of(
+          "-0 ",
+          " -1L",
+          " +2 ",
+          " -3.3f",
+          "4.4d ",
+          " -5e0",
+          " 6.6e0 ",
+          "0x00000007",
+          " #8 ",
+          " 0b1001",
+          "NaN");
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsInteger()")
+  void paramAsInteger() throws ParserException {
+    List<Object> expected = List.of(-0, -1, 2, false, false, -5, false, 7, 8, 9, false);
+
+    for (int i = 0; i < expected.size(); i++) {
+      Object expect = expected.get(i);
+      if (expect instanceof Boolean) {
+        final int index = i;
+        assertThrows(
+            ParserException.class,
+            () -> FunctionUtil.paramAsInteger(functionName, numbers, index, false));
+      } else if (expect instanceof Integer result) {
+        assertEquals(result, FunctionUtil.paramAsInteger(functionName, numbers, i, false));
+        assertEquals(result, FunctionUtil.paramAsInteger(functionName, numberStrings, i, true));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsDouble()")
+  void paramAsDouble() throws ParserException {
+    List<Object> expected = List.of(0d, -1d, 2d, -3.3d, 4.4d, -5d, 6.6d, 7d, 8d, 9d, false);
+    for (int i = 0; i < expected.size(); i++) {
+      Object expect = expected.get(i);
+      if (expect instanceof Boolean) {
+        final int index = i;
+        assertThrows(
+            ParserException.class,
+            () -> FunctionUtil.paramAsDouble(functionName, numbers, index, false));
+      } else if (expect instanceof Double result) {
+        assertEquals(result, FunctionUtil.paramAsDouble(functionName, numbers, i, false));
+        assertEquals(result, FunctionUtil.paramAsDouble(functionName, numberStrings, i, true));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsFloat()")
+  void paramAsFloat() throws ParserException {
+    List<Object> expected = List.of(0f, -1f, 2f, -3.3f, 4.4f, -5f, 6.6f, 7f, 8f, 9f, false);
+
+    for (int i = 0; i < expected.size(); i++) {
+      Object expect = expected.get(i);
+      if (expect instanceof Boolean) {
+        final int index = i;
+        assertThrows(
+            ParserException.class,
+            () -> FunctionUtil.paramAsFloat(functionName, numbers, index, false));
+      } else if (expect instanceof Float result) {
+        assertEquals(result, FunctionUtil.paramAsFloat(functionName, numbers, i, false));
+        assertEquals(result, FunctionUtil.paramAsFloat(functionName, numberStrings, i, true));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsBigDecimal()")
+  void paramAsBigDecimal() throws ParserException {
+    List<Object> expected =
+        List.of(
+            new BigDecimal("-0"),
+            new BigDecimal("-1"),
+            new BigDecimal("2"),
+            new BigDecimal("-3.3"),
+            new BigDecimal("4.4"),
+            new BigDecimal("-5"),
+            new BigDecimal("6.6"),
+            new BigDecimal("7"),
+            new BigDecimal("8"),
+            new BigDecimal("9"),
+            false);
+
+    for (int i = 0; i < expected.size(); i++) {
+      Object expect = expected.get(i);
+      if (expect instanceof Boolean) {
+        final int index = i;
+        assertThrows(
+            ParserException.class,
+            () -> FunctionUtil.paramAsBigDecimal(functionName, numbers, index, false));
+      } else if (expect instanceof BigDecimal result) {
+        assertEquals(
+            0, result.compareTo(FunctionUtil.paramAsBigDecimal(functionName, numbers, i, false)));
+        assertEquals(result, FunctionUtil.paramAsBigDecimal(functionName, numberStrings, i, true));
+      }
+    }
+  }
+
+  //
+  // Typed parameters (JSON)
+  //
+  private final String emptyString = "";
+  private final JsonArray emptyJsonArray = new JsonArray();
+  private final JsonObject emptyJsonObject = new JsonObject();
+  private final List<String> listOfStrings = List.of("string", "list", "test");
+  private final String hash = "#";
+  private final String delimJson = "jSoN";
+  private final String stringList = "string,list,test";
+  private final String stringListHash = "string#list#test";
+  private final String strProp = "a=1;B=2";
+  private final String strPropHash = "a=1#B=2";
+  private final String strPropJson = "a=1;b={}";
+  private final String jsonArrayString = "[[{},{}],[]]";
+  private final String malformedStrProp = "a=1;b=2;c3";
+  private final String malformedObjectString = "{malformed:}";
+  private final String malformedArrayString = "['malformed':{";
+  private final JsonObject jsonObject = new JsonObject();
+
+  {
+    jsonObject.addProperty("a", "1");
+    jsonObject.addProperty("B", "2");
+  }
+
+  @Test
+  void paramFromStrPropOrJsonAsJsonObject() throws ParserException {
+    assertEquals(
+        jsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+            functionName, List.of(strProp), 0, emptyString));
+    assertEquals(
+        jsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(functionName, List.of(strProp), 0, ";"));
+    assertEquals(
+        jsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+            functionName, List.of(strPropHash), 0, hash));
+    assertEquals(
+        jsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+            functionName, List.of(jsonObject), 0, delimJson));
+    assertEquals(
+        jsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+            functionName, List.of(jsonObject), 0, hash));
+    assertEquals(
+        jsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+            functionName, List.of(jsonObject), 0, emptyString));
+    assertEquals(
+        "{\"a\":\"1\",\"b\":\"{}\"}",
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(strPropJson), 0, emptyString)
+            .toString());
+    assertEquals(
+        emptyJsonObject,
+        FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+            functionName, List.of(emptyJsonObject), 0, delimJson));
+
+    assertThrows(
+        ParserException.class,
+        () ->
+            FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(strPropJson), 0, delimJson));
+    assertThrows(
+        ParserException.class,
+        () ->
+            FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(stringList), 0, hash));
+    assertThrows(
+        ParserException.class,
+        () ->
+            FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(stringListHash), 0, hash));
+    assertThrows(
+        ParserException.class,
+        () ->
+            FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(malformedArrayString), 0, delimJson));
+    assertThrows(
+        ParserException.class,
+        () ->
+            FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(malformedObjectString), 0, delimJson));
+    assertThrows(
+        ParserException.class,
+        () ->
+            FunctionUtil.paramFromStrPropOrJsonAsJsonObject(
+                functionName, List.of(malformedStrProp), 0, delimJson));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsJson()")
+  void paramAsJson() throws ParserException {
+    assertInstanceOf(
+        JsonObject.class, FunctionUtil.paramAsJson(functionName, List.of(emptyJsonObject), 0));
+    assertInstanceOf(
+        JsonArray.class, FunctionUtil.paramAsJson(functionName, List.of(jsonArrayString), 0));
+
+    assertEquals(
+        emptyJsonObject, FunctionUtil.paramAsJson(functionName, List.of(emptyJsonObject), 0));
+    assertEquals(
+        emptyJsonArray, FunctionUtil.paramAsJson(functionName, List.of(emptyJsonArray), 0));
+    assertEquals(
+        jsonArrayString,
+        FunctionUtil.paramAsJson(functionName, List.of(jsonArrayString), 0).toString());
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJson(functionName, List.of(strPropJson), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJson(functionName, List.of(stringList), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJson(functionName, List.of(emptyString), 0));
+    assertThrows(
+        ParserException.class, () -> FunctionUtil.paramAsJson(functionName, List.of(1), 0));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsJsonObject()")
+  void paramAsJsonObject() throws ParserException {
+    assertEquals(
+        emptyJsonObject, FunctionUtil.paramAsJsonObject(functionName, List.of(emptyJsonObject), 0));
+    assertEquals(emptyJsonObject, FunctionUtil.paramAsJsonObject(functionName, List.of("{}"), 0));
+    assertEquals(jsonObject, FunctionUtil.paramAsJsonObject(functionName, List.of(jsonObject), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(malformedObjectString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(malformedArrayString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(emptyString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(jsonArrayString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(emptyJsonArray), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(strProp), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(strPropJson), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonObject(functionName, List.of(stringList), 0));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramAsJsonArray()")
+  void paramAsJsonArray() throws ParserException {
+    assertEquals(
+        emptyJsonArray, FunctionUtil.paramAsJsonArray(functionName, List.of(emptyJsonArray), 0));
+    assertEquals(emptyJsonArray, FunctionUtil.paramAsJsonArray(functionName, List.of("[]"), 0));
+    assertEquals(
+        jsonArrayString,
+        FunctionUtil.paramAsJsonArray(functionName, List.of(jsonArrayString), 0).toString());
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(malformedObjectString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(malformedArrayString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(emptyJsonObject), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(emptyString), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(strProp), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(strPropJson), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(stringList), 0));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramAsJsonArray(functionName, List.of(stringListHash), 0));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramConvertedToJsonArray()")
+  void paramConvertedToJsonArray() throws ParserException {
+    String pattern = "[\"%s\"]";
+    assertEquals(
+        emptyJsonArray,
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(emptyJsonArray), 0));
+    assertEquals(
+        emptyJsonArray, FunctionUtil.paramConvertedToJsonArray(functionName, List.of("[]"), 0));
+    assertEquals(
+        jsonArrayString,
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(jsonArrayString), 0)
+            .toString());
+    assertEquals(
+        emptyJsonArray,
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(emptyString), 0));
+    assertEquals(
+        String.format(pattern, malformedObjectString),
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(malformedObjectString), 0)
+            .toString());
+    assertEquals(
+        String.format(pattern, malformedArrayString),
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(malformedArrayString), 0)
+            .toString());
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.paramConvertedToJsonArray(functionName, List.of(emptyJsonObject), 0));
+    assertEquals(
+        String.format(pattern, strProp),
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(strProp), 0).toString());
+    assertEquals(
+        String.format(pattern, strPropJson),
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(strPropJson), 0).toString());
+    assertEquals(
+        String.format(pattern, stringList),
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(stringList), 0).toString());
+    assertEquals(
+        String.format(pattern, stringListHash),
+        FunctionUtil.paramConvertedToJsonArray(functionName, List.of(stringListHash), 0)
+            .toString());
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.paramConvertedToJson()")
+  void paramConvertedToJson() {
+    String pattern = "[\"%s\"]";
+    assertEquals(
+        emptyJsonArray,
+        FunctionUtil.paramConvertedToJson(functionName, List.of(emptyJsonArray), 0));
+    assertEquals(emptyJsonArray, FunctionUtil.paramConvertedToJson(functionName, List.of("[]"), 0));
+    assertEquals(
+        jsonArrayString,
+        FunctionUtil.paramConvertedToJson(functionName, List.of(jsonArrayString), 0).toString());
+    assertEquals(
+        emptyJsonArray, FunctionUtil.paramConvertedToJson(functionName, List.of(emptyString), 0));
+    assertEquals(
+        String.format(pattern, malformedObjectString),
+        FunctionUtil.paramConvertedToJson(functionName, List.of(malformedObjectString), 0)
+            .toString());
+    assertEquals(
+        String.format(pattern, malformedArrayString),
+        FunctionUtil.paramConvertedToJson(functionName, List.of(malformedArrayString), 0)
+            .toString());
+    assertEquals(
+        emptyJsonObject,
+        FunctionUtil.paramConvertedToJson(functionName, List.of(emptyJsonObject), 0));
+    assertEquals(
+        String.format(pattern, strProp),
+        FunctionUtil.paramConvertedToJson(functionName, List.of(strProp), 0).toString());
+    assertEquals(
+        String.format(pattern, strPropJson),
+        FunctionUtil.paramConvertedToJson(functionName, List.of(strPropJson), 0).toString());
+    assertEquals(
+        String.format(pattern, stringList),
+        FunctionUtil.paramConvertedToJson(functionName, List.of(stringList), 0).toString());
+    assertEquals(
+        String.format(pattern, stringListHash),
+        FunctionUtil.paramConvertedToJson(functionName, List.of(stringListHash), 0).toString());
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.delimitedResult()")
+  void delimitedResult() {
+    assertEquals("string#list#test", FunctionUtil.delimitedResult(hash, listOfStrings).toString());
+    assertEquals(
+        "[\"string\",\"list\",\"test\"]",
+        FunctionUtil.delimitedResult(delimJson, listOfStrings).toString());
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.validateKeyNames()")
+  void validateKeyNames() {
+    Set<String> keyExists = Set.of("B");
+    Set<String> keyMissing = Set.of("c");
+    assertDoesNotThrow(
+        () -> FunctionUtil.validateKeyNames(jsonObject, keyExists, 0, functionName, emptyString));
+    assertDoesNotThrow(
+        () -> FunctionUtil.validateKeyNames(strPropHash, keyExists, 0, functionName, hash));
+    assertThrows(
+        ParserException.class,
+        () -> FunctionUtil.validateKeyNames(jsonObject, keyMissing, 0, functionName, hash));
+  }
+
+  @Test
+  @DisplayName("FunctionUtil.jsonWithLowerCaseKeys()")
+  void jsonWithLowerCaseKeys() {
+    JsonObject joExpect = new JsonObject();
+    joExpect.addProperty("a", "1");
+    joExpect.addProperty("b", "2");
+    assertEquals(joExpect, FunctionUtil.jsonWithLowerCaseKeys(jsonObject));
+  }
+}

--- a/src/test/java/net/rptools/maptool/client/functions/json/FunctionUtilTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/json/FunctionUtilTest.java
@@ -309,6 +309,7 @@ class FunctionUtilTest {
   }
 
   @Test
+  @DisplayName("FunctionUtil.paramFromStrPropOrJsonAsJsonObject()")
   void paramFromStrPropOrJsonAsJsonObject() throws ParserException {
     assertEquals(
         jsonObject,


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5956 
closes #5956

### Description of the Change
**Missing tests for**: i.e. I couldn't work out how to get them to fly.
- FunctionUtil.experimentalWarning()
- FunctionUtil.getTokenFromParam()
- FunctionUtil.getZoneRendererFromParam()
- FunctionUtil.getZoneRenderer()
- FunctionUtil.getAssetKeyFromString()
- FunctionUtil.blockUntrustedMacro()

**Added tests for;**
- checkNumberParam()
 
- delimitedResult()
 
- getBooleanValue()
- getPaintFromString()

- paramAsBoolean()
- paramAsString()
- paramAsInteger()
- paramAsDouble()
- paramAsFloat()
- paramAsBigDecimal()

- paramFromStrPropOrJsonAsJsonObject()
- paramAsJson()
- paramAsJsonObject() 
- paramAsJsonArray()
- paramConvertedToJsonArray()
- paramConvertedToJson()
- jsonWithLowerCaseKeys()
- validateKeyNames() 


### Possible Drawbacks
Macros relying on dodgy flavours might fail the taste test, though unlikely.


### Release Notes
Improved macro argument processing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5957)
<!-- Reviewable:end -->
