### PR TITLE
Turn timer macro functions + minor editor/permissions QoL

### DIFF
--- a/src/main/java/net/rptools/maptool/client/AppPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/AppPreferences.java
@@ -738,6 +738,13 @@ public class AppPreferences {
           "Preferences.label.macros.permissions.tooltip",
           false);
 
+  public static final Preference<Boolean> trustAllPlayers =
+      store.defineBoolean(
+          "trustAllPlayers",
+          "Preferences.label.macros.trustAllPlayers",
+          "Preferences.label.macros.trustAllPlayers.tooltip",
+          false);
+
   public static final Preference<Boolean> loadMruCampaignAtStart =
       store.defineBoolean(
           "loadMRUCampaignAtStart",

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -69,6 +69,7 @@ import net.rptools.maptool.client.AppUpdate.ReleaseInfo;
 import net.rptools.maptool.client.MapToolConnection.HandshakeCompletionObserver;
 import net.rptools.maptool.client.events.ChatMessageAdded;
 import net.rptools.maptool.client.events.ServerDisconnected;
+import net.rptools.maptool.client.functions.TurnTimerFunction;
 import net.rptools.maptool.client.functions.UserDefinedMacroFunctions;
 import net.rptools.maptool.client.swing.MapToolEventQueue;
 import net.rptools.maptool.client.swing.NoteFrame;
@@ -921,6 +922,8 @@ public class MapTool {
 
   public static void setCampaign(Campaign campaign, @Nullable GUID defaultZoneId) {
     campaign = Objects.requireNonNullElseGet(campaign, Campaign::new);
+
+    TurnTimerFunction.cancelAll();
 
     // Load up the new
     client.setCampaign(campaign);

--- a/src/main/java/net/rptools/maptool/client/MapToolExpressionParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolExpressionParser.java
@@ -85,6 +85,7 @@ public class MapToolExpressionParser extends ExpressionParser {
               TokenSpeechFunctions.getInstance(),
               TokenStateFunction.getInstance(),
               TokenVisibleFunction.getInstance(),
+              TurnTimerFunction.getInstance(),
               isVisibleFunction.getInstance(),
               getInfoFunction.getInstance(),
               TokenMoveFunctions.getInstance(),

--- a/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolLineParser.java
@@ -1710,6 +1710,9 @@ public class MapToolLineParser {
    * @return if the macro context is trusted or not.
    */
   public boolean isMacroTrusted() {
+    if (AppPreferences.trustAllPlayers.get()) {
+      return true;
+    }
     return !contextStack.isEmpty() && contextStack.peek().isTrusted();
   }
 

--- a/src/main/java/net/rptools/maptool/client/functions/TurnTimerFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/TurnTimerFunction.java
@@ -1,0 +1,271 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.JsonArray;
+import java.awt.EventQueue;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.MapToolVariableResolver;
+import net.rptools.maptool.language.I18N;
+import net.rptools.maptool.util.FunctionUtil;
+import net.rptools.parser.Parser;
+import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
+import net.rptools.parser.function.AbstractFunction;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Macro functions for arbitrary-length, non-blocking turn timers. Scheduling is backed by a single
+ * dedicated thread; expiry callbacks are bounced onto the EDT and dispatched via the macro parser
+ * so they execute in the same context as any other event-driven macro (e.g. {@code
+ * onInitiativeChange}).
+ *
+ * <p>Timers live in static memory only. They are not persisted with the campaign and do not survive
+ * a restart or {@code setCampaign} call.
+ */
+public class TurnTimerFunction extends AbstractFunction {
+
+  private static final Logger LOGGER = LogManager.getLogger(TurnTimerFunction.class);
+
+  /** Reserved timer name used by the initiative auto-restart template. */
+  public static final String INITIATIVE_TIMER_NAME = "__initiative__";
+
+  private static final ThreadFactory THREAD_FACTORY =
+      new ThreadFactoryBuilder().setNameFormat("turn-timer-%d").setDaemon(true).build();
+
+  private static final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY);
+
+  private static final ConcurrentHashMap<String, TimerEntry> timers = new ConcurrentHashMap<>();
+
+  private static volatile InitiativeTemplate initiativeTemplate;
+
+  private TurnTimerFunction() {
+    super(
+        0,
+        4,
+        "startTimer",
+        "stopTimer",
+        "getTimerRemaining",
+        "getTimerStatus",
+        "getTimerNames",
+        "setInitiativeTimer",
+        "clearInitiativeTimer");
+  }
+
+  private static final TurnTimerFunction instance = new TurnTimerFunction();
+
+  public static TurnTimerFunction getInstance() {
+    return instance;
+  }
+
+  @Override
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> args)
+      throws ParserException {
+    return switch (functionName.toLowerCase()) {
+      case "starttimer" -> evalStart(args);
+      case "stoptimer" -> evalStop(args);
+      case "gettimerremaining" -> evalRemaining(args);
+      case "gettimerstatus" -> evalStatus(args);
+      case "gettimernames" -> evalNames(args);
+      case "setinitiativetimer" -> evalSetInitiative(args);
+      case "clearinitiativetimer" -> evalClearInitiative(args);
+      default ->
+          throw new ParserException(
+              I18N.getText("macro.function.general.unknownFunction", functionName));
+    };
+  }
+
+  private Object evalStart(List<Object> args) throws ParserException {
+    FunctionUtil.blockUntrustedMacro("startTimer");
+    FunctionUtil.checkNumberParam("startTimer", args, 2, 4);
+    String name = args.get(0).toString();
+    double seconds = parseSeconds("startTimer", args.get(1));
+    String callback = args.size() > 2 ? args.get(2).toString() : "";
+    String callbackArgs = args.size() > 3 ? args.get(3).toString() : "";
+    start(name, seconds, callback, callbackArgs);
+    return BigDecimal.ONE;
+  }
+
+  private Object evalStop(List<Object> args) throws ParserException {
+    FunctionUtil.blockUntrustedMacro("stopTimer");
+    FunctionUtil.checkNumberParam("stopTimer", args, 1, 1);
+    return stop(args.get(0).toString()) ? BigDecimal.ONE : BigDecimal.ZERO;
+  }
+
+  private Object evalRemaining(List<Object> args) throws ParserException {
+    FunctionUtil.checkNumberParam("getTimerRemaining", args, 1, 1);
+    return BigDecimal.valueOf(remainingSeconds(args.get(0).toString()))
+        .setScale(3, RoundingMode.HALF_UP);
+  }
+
+  private Object evalStatus(List<Object> args) throws ParserException {
+    FunctionUtil.checkNumberParam("getTimerStatus", args, 1, 1);
+    return timers.containsKey(args.get(0).toString()) ? "running" : "none";
+  }
+
+  private Object evalNames(List<Object> args) throws ParserException {
+    FunctionUtil.checkNumberParam("getTimerNames", args, 0, 0);
+    JsonArray arr = new JsonArray();
+    timers.keySet().forEach(arr::add);
+    return arr;
+  }
+
+  private Object evalSetInitiative(List<Object> args) throws ParserException {
+    FunctionUtil.blockUntrustedMacro("setInitiativeTimer");
+    FunctionUtil.checkNumberParam("setInitiativeTimer", args, 1, 3);
+    double seconds = parseSeconds("setInitiativeTimer", args.get(0));
+    if (seconds <= 0) {
+      clearInitiativeTimer();
+      return BigDecimal.ONE;
+    }
+    String callback = args.size() > 1 ? args.get(1).toString() : "";
+    String callbackArgs = args.size() > 2 ? args.get(2).toString() : "";
+    initiativeTemplate =
+        new InitiativeTemplate(Math.round(seconds * 1000.0), callback, callbackArgs);
+    start(INITIATIVE_TIMER_NAME, seconds, callback, callbackArgs);
+    return BigDecimal.ONE;
+  }
+
+  private Object evalClearInitiative(List<Object> args) throws ParserException {
+    FunctionUtil.blockUntrustedMacro("clearInitiativeTimer");
+    FunctionUtil.checkNumberParam("clearInitiativeTimer", args, 0, 0);
+    clearInitiativeTimer();
+    return BigDecimal.ONE;
+  }
+
+  private static double parseSeconds(String functionName, Object raw) throws ParserException {
+    double seconds;
+    if (raw instanceof Number n) {
+      seconds = n.doubleValue();
+    } else {
+      try {
+        seconds = Double.parseDouble(raw.toString());
+      } catch (NumberFormatException e) {
+        throw new ParserException(
+            I18N.getText("macro.function.turnTimer.invalidDuration", functionName));
+      }
+    }
+    if (Double.isNaN(seconds) || Double.isInfinite(seconds)) {
+      throw new ParserException(
+          I18N.getText("macro.function.turnTimer.invalidDuration", functionName));
+    }
+    return seconds;
+  }
+
+  /* -------- core scheduling (also reachable from tests) -------- */
+
+  static void start(String name, double seconds, String callback, String callbackArgs)
+      throws ParserException {
+    if (seconds <= 0) {
+      throw new ParserException(
+          I18N.getText("macro.function.turnTimer.invalidDuration", "startTimer"));
+    }
+    long delayMs = Math.round(seconds * 1000.0);
+    long expiresAt = System.currentTimeMillis() + delayMs;
+    ScheduledFuture<?> future =
+        scheduler.schedule(() -> fire(name), delayMs, TimeUnit.MILLISECONDS);
+    TimerEntry prior = timers.put(name, new TimerEntry(future, expiresAt, callback, callbackArgs));
+    if (prior != null) {
+      prior.future().cancel(false);
+    }
+  }
+
+  static boolean stop(String name) {
+    TimerEntry removed = timers.remove(name);
+    if (removed == null) {
+      return false;
+    }
+    removed.future().cancel(false);
+    return true;
+  }
+
+  static double remainingSeconds(String name) {
+    TimerEntry entry = timers.get(name);
+    if (entry == null) {
+      return 0.0;
+    }
+    long remaining = entry.expiresAtMillis() - System.currentTimeMillis();
+    return Math.max(0L, remaining) / 1000.0;
+  }
+
+  /**
+   * Called from {@code InitiativeList.handleInitiativeChangeCommitMacroEvent} after a successful
+   * initiative pass. Restarts the configured initiative timer, if one is set.
+   */
+  public static void onInitiativeChanged() {
+    InitiativeTemplate tpl = initiativeTemplate;
+    if (tpl == null) {
+      return;
+    }
+    long expiresAt = System.currentTimeMillis() + tpl.millis();
+    ScheduledFuture<?> future =
+        scheduler.schedule(() -> fire(INITIATIVE_TIMER_NAME), tpl.millis(), TimeUnit.MILLISECONDS);
+    TimerEntry prior =
+        timers.put(
+            INITIATIVE_TIMER_NAME, new TimerEntry(future, expiresAt, tpl.callback(), tpl.args()));
+    if (prior != null) {
+      prior.future().cancel(false);
+    }
+  }
+
+  /** Cancels every active timer and drops any initiative-timer template. */
+  public static void cancelAll() {
+    initiativeTemplate = null;
+    timers.values().forEach(entry -> entry.future().cancel(false));
+    timers.clear();
+  }
+
+  private static void clearInitiativeTimer() {
+    initiativeTemplate = null;
+    stop(INITIATIVE_TIMER_NAME);
+  }
+
+  private static void fire(String name) {
+    TimerEntry entry = timers.remove(name);
+    if (entry == null || entry.callback().isEmpty()) {
+      return;
+    }
+    EventQueue.invokeLater(
+        () -> {
+          try {
+            MapTool.getParser()
+                .runMacro(
+                    new MapToolVariableResolver(null), null, entry.callback(), entry.args(), false);
+          } catch (ParserException e) {
+            LOGGER.warn("Turn timer '{}' callback failed: {}", name, e.getMessage(), e);
+            MapTool.addLocalMessage(
+                I18N.getText("macro.function.turnTimer.callbackFailed", name, e.getMessage()));
+          }
+        });
+  }
+
+  private record TimerEntry(
+      ScheduledFuture<?> future, long expiresAtMillis, String callback, String args) {}
+
+  private record InitiativeTemplate(long millis, String callback, String args) {}
+}

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/dialog/MacroEditorDialog.java
@@ -24,6 +24,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.*;
@@ -74,6 +76,13 @@ import org.fife.ui.rtextarea.SearchResult;
 public class MacroEditorDialog extends JDialog implements SearchListener {
 
   public static final String DEFAULT_COLOR_NAME = "default";
+
+  /**
+   * Matches a "# NAME" directive on the first line. If present at save time, NAME is lifted into
+   * the macro's label and the line is stripped from the command body.
+   */
+  private static final Pattern MACRO_NAME_DIRECTIVE =
+      Pattern.compile("\\A#[ \\t]+([^\\r\\n]+)\\r?\\n?");
 
   private static final long serialVersionUID = 8228617911117087993L;
   private static final Logger log = LogManager.getLogger(MacroEditorDialog.class);
@@ -726,7 +735,30 @@ public class MacroEditorDialog extends JDialog implements SearchListener {
     }
   }
 
+  /**
+   * If the command's first line is a {@code # NAME} directive, lift NAME into the label field and
+   * strip the line from the command. Runs in-place on the dialog's UI so the save path picks up the
+   * rewritten values normally.
+   */
+  private void applyNameDirective() {
+    String command = getCommandTextArea().getText();
+    if (command == null || command.isEmpty()) {
+      return;
+    }
+    Matcher m = MACRO_NAME_DIRECTIVE.matcher(command);
+    if (!m.lookingAt()) {
+      return;
+    }
+    String name = m.group(1).trim();
+    if (name.isEmpty()) {
+      return;
+    }
+    getLabelTextField().setText(name);
+    getCommandTextArea().setText(command.substring(m.end()));
+  }
+
   private void save(boolean closeDialog) {
+    applyNameDirective();
     callback.accept(getCommandTextArea().getText());
     if (properties != null) {
       String hotKey = getHotKeyCombo().getSelectedItem().toString();

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialog.java
@@ -361,6 +361,9 @@ public class PreferencesDialog extends AbeillePanel {
   private final JCheckBox allowExternalMacroAccessCheckBox =
       getCheckBox("allowExternalMacroAccess");
 
+  /** Checkbox for trusting all players (dev/test convenience). */
+  private final JCheckBox trustAllPlayersCheckBox = getCheckBox("trustAllPlayers");
+
   // Authentication
   /** Text area for displaying the public key for authentication. */
   private final JTextArea publicKeyTextArea = (JTextArea) getComponent("publicKeyTextArea");
@@ -1057,6 +1060,8 @@ public class PreferencesDialog extends AbeillePanel {
         e ->
             AppPreferences.allowExternalMacroAccess.set(
                 allowExternalMacroAccessCheckBox.isSelected()));
+    trustAllPlayersCheckBox.addActionListener(
+        e -> AppPreferences.trustAllPlayers.set(trustAllPlayersCheckBox.isSelected()));
     showDialogOnNewToken.addActionListener(
         e -> AppPreferences.showDialogOnNewToken.set(showDialogOnNewToken.isSelected()));
     autoSaveSpinner.addChangeListener(
@@ -1756,6 +1761,7 @@ public class PreferencesDialog extends AbeillePanel {
     upnpDiscoveryTimeoutTextField.setText(
         Integer.toString(AppPreferences.upnpDiscoveryTimeout.get()));
     allowExternalMacroAccessCheckBox.setSelected(AppPreferences.allowExternalMacroAccess.get());
+    trustAllPlayersCheckBox.setSelected(AppPreferences.trustAllPlayers.get());
     fileSyncPath.setText(AppPreferences.fileSyncPath.get());
 
     // get JVM User Defaults/User override preferences

--- a/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/preferencesdialog/PreferencesDialogView.form
@@ -1787,7 +1787,7 @@
                       </component>
                     </children>
                   </grid>
-                  <grid id="d929a" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="d929a" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="0" right="0"/>
                     <constraints>
                       <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -1815,6 +1815,25 @@
                         <properties>
                           <actionCommand value="Default: Allow Players to Edit Macros"/>
                           <name value="allowExternalMacroAccess"/>
+                          <text value=""/>
+                        </properties>
+                      </component>
+                      <component id="d602d" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.macros.trustAllPlayers"/>
+                          <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="Preferences.label.macros.trustAllPlayers.tooltip"/>
+                        </properties>
+                      </component>
+                      <component id="243e5" class="javax.swing.JCheckBox">
+                        <constraints>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <actionCommand value="Trust All Players"/>
+                          <name value="trustAllPlayers"/>
                           <text value=""/>
                         </properties>
                       </component>

--- a/src/main/java/net/rptools/maptool/model/InitiativeList.java
+++ b/src/main/java/net/rptools/maptool/model/InitiativeList.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.functions.TurnTimerFunction;
 import net.rptools.maptool.language.I18N;
 import net.rptools.maptool.model.library.Library;
 import net.rptools.maptool.model.library.LibraryManager;
@@ -698,6 +699,7 @@ public class InitiativeList implements Serializable {
       int oldRound,
       int newRound,
       InitiativeChangeDirection direction) {
+    TurnTimerFunction.onInitiativeChanged();
     try {
       var libs =
           new LibraryManager()

--- a/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
+++ b/src/main/java/net/rptools/maptool/model/library/token/LibraryToken.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import net.rptools.lib.MD5Key;
+import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
 import net.rptools.maptool.client.macro.MacroManager.MacroDetails;
@@ -326,11 +327,15 @@ class LibraryToken implements Library {
                 }
               }
 
+              boolean trusted =
+                  AppPreferences.trustAllPlayers.get()
+                      || library.isOwnedByNone()
+                      || !buttonProps.getAllowPlayerEdits();
               return Optional.of(
                   new MTScriptMacroInfo(
                       macroName,
                       buttonProps.getCommand(),
-                      library.isOwnedByNone() || !buttonProps.getAllowPlayerEdits(),
+                      trusted,
                       !buttonProps.getAllowPlayerEdits() && buttonProps.getAutoExecute(),
                       buttonProps.getEvaluatedToolTip()));
             });

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -959,6 +959,8 @@ Preferences.label.upnp.timeout                    = Discovery Timeout
 Preferences.label.upnp.timeout.tooltip            = Timeout period in milliseconds to wait when looking for UPnP gateways.
 Preferences.label.macros.permissions              = Enable External Macro Access
 Preferences.label.macros.permissions.tooltip      = Enable macros to call functions that can access your drive and http services. The following functions will be enabled: getRequest, postRequest, exportData, getEnvironmentVariable.
+Preferences.label.macros.trustAllPlayers          = Trust All Players (insecure)
+Preferences.label.macros.trustAllPlayers.tooltip  = <html><b>Insecure.</b> When enabled, every macro runs in trusted context and players can create/edit macros anywhere — bypasses all macro permission checks. Intended for solo development and testing only.
 Preferences.label.chat.macrolinks                 = Suppress ToolTips for MacroLinks
 Preferences.label.chat.macrolinks.tooltip         = MacroLinks show normally tooltips that state informations about the link target. This is a anti cheating device. This options let you disable this tooltips for aesthetic reasons.
 Preference.checkbox.chat.macrolinks.tooltip       = <html>Enabled: do not show tooltips for macroLink<br>Disabled (default): show tooltips for macroLinks 
@@ -2057,6 +2059,9 @@ macro.function.MacroFunctions.outOfRange           = "{0}": Macro at index {1} d
 macro.function.TokenInit.notOnList                 = The token is not in the initiative list.
 # TokenInitFunctions
 macro.function.TokenInit.notOnListSet              = The token is not in the initiative list so no value can be set.
+# TurnTimerFunction
+macro.function.turnTimer.invalidDuration           = "{0}": Timer duration must be a positive number of seconds.
+macro.function.turnTimer.callbackFailed            = Turn timer "{0}" callback failed: {1}
 # abort Function
 # Note that I'm leaving off the double quotes on this one.  I think it
 # will look better that way.

--- a/src/test/java/net/rptools/maptool/client/functions/TurnTimerFunctionTest.java
+++ b/src/test/java/net/rptools/maptool/client/functions/TurnTimerFunctionTest.java
@@ -1,0 +1,86 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.rptools.parser.ParserException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the scheduling/lifecycle parts of {@link TurnTimerFunction} that do not require a
+ * running MapTool — registration, replacement, cancellation, remaining-time math, and the
+ * initiative auto-restart hook. Callback dispatch is intentionally not exercised here: it requires
+ * the live macro parser. Tests use empty-callback timers so {@code fire()} becomes a no-op when
+ * they elapse.
+ */
+class TurnTimerFunctionTest {
+
+  @AfterEach
+  void clearTimers() {
+    TurnTimerFunction.cancelAll();
+  }
+
+  @Test
+  void startRegistersATimerThatCountsDown() throws Exception {
+    TurnTimerFunction.start("t1", 2.0, "", "");
+    double remaining = TurnTimerFunction.remainingSeconds("t1");
+    assertTrue(remaining > 1.5 && remaining <= 2.0, "expected ~2s remaining, was " + remaining);
+  }
+
+  @Test
+  void stopRemovesTheTimer() throws Exception {
+    TurnTimerFunction.start("t2", 5.0, "", "");
+    assertTrue(TurnTimerFunction.stop("t2"));
+    assertEquals(0.0, TurnTimerFunction.remainingSeconds("t2"));
+    assertFalse(TurnTimerFunction.stop("t2"));
+  }
+
+  @Test
+  void startWithSameNameReplacesThePriorTimer() throws Exception {
+    TurnTimerFunction.start("dup", 60.0, "", "");
+    double first = TurnTimerFunction.remainingSeconds("dup");
+    TurnTimerFunction.start("dup", 2.0, "", "");
+    double second = TurnTimerFunction.remainingSeconds("dup");
+    assertTrue(first > 30, "first timer should have a long remaining; was " + first);
+    assertTrue(second <= 2.0, "replacement should shorten remaining; was " + second);
+  }
+
+  @Test
+  void invalidDurationsAreRejected() {
+    assertThrows(ParserException.class, () -> TurnTimerFunction.start("bad", 0.0, "", ""));
+    assertThrows(ParserException.class, () -> TurnTimerFunction.start("bad", -1.0, "", ""));
+  }
+
+  @Test
+  void timerElapsesToZero() throws Exception {
+    TurnTimerFunction.start("quick", 0.05, "", "");
+    Thread.sleep(120);
+    assertEquals(0.0, TurnTimerFunction.remainingSeconds("quick"));
+  }
+
+  @Test
+  void cancelAllClearsEverything() throws Exception {
+    TurnTimerFunction.start("a", 10.0, "", "");
+    TurnTimerFunction.start("b", 10.0, "", "");
+    TurnTimerFunction.cancelAll();
+    assertEquals(0.0, TurnTimerFunction.remainingSeconds("a"));
+    assertEquals(0.0, TurnTimerFunction.remainingSeconds("b"));
+  }
+}


### PR DESCRIPTION
## Summary

Three independent changes bundled into one PR for convenience. **Happy to split into three PRs if reviewers prefer** — particularly because feature 3 is a deliberate security-bypass and may be unwelcome upstream as-is.

### 1. Turn-timer macro functions (the main change)

Adds `TurnTimerFunction`, registered in `MapToolExpressionParser`, exposing:

| Function | Purpose |
|---|---|
| `startTimer(name, seconds, [callback], [args])` | Schedules a macro to run after `seconds`. Non-blocking — the calling macro returns immediately. Implements the long-missing "sleep" primitive without freezing the parser. |
| `stopTimer(name)` | Cancel a pending timer. |
| `getTimerRemaining(name)` | Seconds remaining (BigDecimal). |
| `getTimerStatus(name)` | `running` or `none`. |
| `getTimerNames()` | JSON array of active names. |
| `setInitiativeTimer(seconds, [callback], [args])` | Stores an auto-restart template; the timer re-arms on every initiative pass under reserved name `__initiative__`. Pass `0` to disable. |
| `clearInitiativeTimer()` | Drops the template and stops any pending instance. |

Backed by a single dedicated `ScheduledExecutorService` (named threads, daemon — same idiom as `DebounceExecutor`). Callbacks are bounced onto the EDT via `EventQueue.invokeLater` and dispatched through `MapTool.getParser().runMacro(...)` — same pattern `CallFunction`'s deferred path uses. Write operations require trusted-macro context.

Hooked into `InitiativeList.handleInitiativeChangeCommitMacroEvent` for the auto-restart, and into `MapTool.setCampaign` to cancel pending timers on campaign change. Timers are non-persistent (deliberate; mirrors how `HTMLFrame`/`HTMLOverlayPanel` registries behave).

Covered by `TurnTimerFunctionTest` (lifecycle: register, cancel, replace, decay-to-zero, invalid-duration, cancelAll).

**Example usage:**

```
[h: setInitiativeTimer(60, "turnExpired@Lib:Combat")]
```

Or layered (warning + expiry) by starting two named timers from an `onInitiativeChange` lib-token macro:

```
[h: startTimer("turnWarning", 50, "turnWarning@Lib:Combat")]
[h: startTimer("turnExpired", 60, "timerExpired@Lib:Combat")]
```

### 2. `# Name` macro-editor directive (small QoL)

When saving in `MacroEditorDialog`, if the command's first line is `# something`, that line is consumed and `something` becomes the macro's label. Plain regex match in `applyNameDirective()`, called from the existing `save()` entry point. Useful when bulk-pasting macros from disk where the filename has been embedded as a hint at the top. Caveat: people who *deliberately* output a literal `# Text` line at the top of a macro will be surprised — in practice, almost all macros start with `[…]`.

### 3. `Trust All Players (insecure)` preference (likely contentious)

New `AppPreferences.trustAllPlayers` checkbox in **Preferences → Application → Macro Permissions**. When on, `MapToolLineParser.isMacroTrusted()` and `LibraryToken` macro-trust both short-circuit to `true`, making every macro trusted regardless of token ownership or per-button "Allow Player Edits". The label includes `(insecure)` and the tooltip warns it's intended for solo development/testing only.

**Why include it:** Because at 99% of tables, the DM can trust all the players to not destroy the game if given power to write their own complex macros. It's a massive annoyance for my group that we can't do this.

## Test plan

- [x] `./gradlew test` — `TurnTimerFunctionTest` green; nothing else regresses.
- [x] `./gradlew spotlessCheck` — clean.
- [x] Manual end-to-end: `setInitiativeTimer(10, "ping@Lib:Combat")` arms timer; Next/Previous re-arm; setting `0` disables; campaign load cancels pending timers; macro-editor directive lifts label and strips line; trust-all preference is opt-in and persists across restart.
- [ ] Reviewer sanity-check on Windows/Linux (developed and tested on macOS).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5963)
<!-- Reviewable:end -->
