### PR TITLE
Lock Player Context Menus

### DIFF
--- a/messages/src/main/proto/data_transfer_objects.proto
+++ b/messages/src/main/proto/data_transfer_objects.proto
@@ -31,6 +31,7 @@ message ServerPolicyDto {
   bool vbl_blocks_move = 15;
   bool hide_map_select_ui = 16;
   bool lock_player_library = 17;
+  bool is_token_context_locked = 18;
 }
 
 message CampaignDto {

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1949,7 +1949,9 @@ public class AppActions {
       new TranslatedClientAction("action.toggleTokenContextMenuLock") {
 
         @Override
-        public boolean isAvailable() { return MapTool.getPlayer().isGM(); }
+        public boolean isAvailable() {
+          return MapTool.getPlayer().isGM();
+        }
 
         @Override
         public boolean isSelected() {

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1944,31 +1944,29 @@ public class AppActions {
           client.getServerCommand().setServerPolicy(policy);
         }
       };
-    /** Toggle to enable / disable player use of the token context menu. */
-    public static final Action TOGGLE_TOKEN_CONTEXT_LOCK =
-            new TranslatedClientAction("action.toggleTokenContextMenuLock") {
 
-                @Override
-                public boolean isAvailable() {
-                    return MapTool.getPlayer().isGM();
-                }
+  public static final Action TOGGLE_TOKEN_CONTEXT_LOCK =
+      new TranslatedClientAction("action.toggleTokenContextMenuLock") {
 
-                @Override
-                public boolean isSelected() {
-                    return MapTool.getServerPolicy().isTokenContextLocked();
-                }
+        @Override
+        public boolean isAvailable() { return MapTool.getPlayer().isGM(); }
 
-                @Override
-                protected void executeAction() {
-                    var client = MapTool.getClient();
+        @Override
+        public boolean isSelected() {
+          return MapTool.getServerPolicy().isTokenContextLocked();
+        }
 
-                    ServerPolicy policy = client.getServerPolicy();
-                    policy.setIsTokenContextLocked(!policy.isTokenContextLocked());
+        @Override
+        protected void executeAction() {
+          var client = MapTool.getClient();
 
-                    client.setServerPolicy(policy);
-                    client.getServerCommand().setServerPolicy(policy);
-                }
-            };
+          ServerPolicy policy = client.getServerPolicy();
+          policy.setIsTokenContextLocked(!policy.isTokenContextLocked());
+
+          client.setServerPolicy(policy);
+          client.getServerCommand().setServerPolicy(policy);
+        }
+      };
   public static final Action START_SERVER =
       new TranslatedClientAction("action.serverStart") {
 

--- a/src/main/java/net/rptools/maptool/client/AppActions.java
+++ b/src/main/java/net/rptools/maptool/client/AppActions.java
@@ -1944,7 +1944,31 @@ public class AppActions {
           client.getServerCommand().setServerPolicy(policy);
         }
       };
+    /** Toggle to enable / disable player use of the token context menu. */
+    public static final Action TOGGLE_TOKEN_CONTEXT_LOCK =
+            new TranslatedClientAction("action.toggleTokenContextMenuLock") {
 
+                @Override
+                public boolean isAvailable() {
+                    return MapTool.getPlayer().isGM();
+                }
+
+                @Override
+                public boolean isSelected() {
+                    return MapTool.getServerPolicy().isTokenContextLocked();
+                }
+
+                @Override
+                protected void executeAction() {
+                    var client = MapTool.getClient();
+
+                    ServerPolicy policy = client.getServerPolicy();
+                    policy.setIsTokenContextLocked(!policy.isTokenContextLocked());
+
+                    client.setServerPolicy(policy);
+                    client.getServerCommand().setServerPolicy(policy);
+                }
+            };
   public static final Action START_SERVER =
       new TranslatedClientAction("action.serverStart") {
 
@@ -1985,6 +2009,7 @@ public class AppActions {
           policy.setPlayersReceiveCampaignMacros(serverProps.getPlayersReceiveCampaignMacros());
           policy.setHiddenMapSelectUI(serverProps.getMapSelectUIHidden());
           policy.setIsTokenEditorLocked(serverProps.getLockTokenEditOnStart());
+          policy.setIsTokenContextLocked(serverProps.getLockTokenContextOnStart());
           policy.setIsMovementLocked(serverProps.getLockPlayerMovementOnStart());
           policy.setDisablePlayerAssetPanel(serverProps.getPlayerLibraryLock());
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -281,7 +281,9 @@ public class PointerTool extends DefaultTool {
       }
       if (SwingUtilities.isRightMouseButton(event)) {
         Token token = getTokenAt(event.getX(), event.getY());
-        if (token == null || !AppUtil.playerOwns(token)) {
+        if (token == null
+            || !AppUtil.playerOwns(token)
+            || (!MapTool.getPlayer().isGM() && MapTool.getServerPolicy().isTokenContextLocked())) {
           return;
         }
         tokenUnderMouse = token;
@@ -568,6 +570,9 @@ public class PointerTool extends DefaultTool {
 
     // POPUP MENU
     if (SwingUtilities.isRightMouseButton(e) && tokenDragOp == null && !isDraggingMap) {
+      if (!MapTool.getPlayer().isGM() && MapTool.getServerPolicy().isTokenContextLocked()) {
+        return;
+      }
       final var selectionModel = renderer.getSelectionModel();
       if (tokenUnderMouse != null && !selectionModel.isSelected(tokenUnderMouse.getId())) {
         if (!SwingUtil.isShiftDown(e)) {

--- a/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
+++ b/src/main/java/net/rptools/maptool/client/ui/AppMenuBar.java
@@ -191,6 +191,7 @@ public class AppMenuBar extends JMenuBar {
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_LINK_PLAYER_VIEW, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_MOVEMENT_LOCK, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_TOKEN_EDITOR_LOCK, menu));
+    menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_TOKEN_CONTEXT_LOCK, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_ZOOM_LOCK, menu));
     menu.add(new RPCheckBoxMenuItem(AppActions.TOGGLE_ENFORCE_NOTIFICATION, menu));
 

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1399,6 +1399,10 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
                       }
                     }
                     if (!selectedTokenSet.isEmpty()) {
+                      if (!MapTool.getPlayer().isGM()
+                          && MapTool.getServerPolicy().isTokenContextLocked()) {
+                        return;
+                      }
                       try {
                         if (firstToken.getLayer().isStampLayer()) {
                           new StampPopupMenu(

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AbstractButtonGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AbstractButtonGroup.java
@@ -185,7 +185,9 @@ public abstract class AbstractButtonGroup extends JPanel
   public void mouseReleased(MouseEvent event) {
     Token token = getToken();
     if (SwingUtilities.isRightMouseButton(event)) {
-      if (getPanelClass().equals("CampaignPanel") && !MapTool.getPlayer().isGM()) {
+      if (!MapTool.getPlayer().isGM()
+          && ("CampaignPanel".equals(getPanelClass())
+              || MapTool.getServerPolicy().isTokenContextLocked())) {
         return;
       }
       // open button group menu
@@ -280,6 +282,9 @@ public abstract class AbstractButtonGroup extends JPanel
             MapTool.getFrame()
                 .showTokenPropertiesDialog(token, MapTool.getFrame().getCurrentZoneRenderer());
           } else if (SwingUtilities.isRightMouseButton(event)) {
+            if (!MapTool.getPlayer().isGM() && MapTool.getServerPolicy().isTokenContextLocked()) {
+              return;
+            }
             // open token popup menu
             Set<GUID> GUIDSet = new HashSet<GUID>();
             GUIDSet.add(tokenId);

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AreaGroup.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttongroups/AreaGroup.java
@@ -145,7 +145,9 @@ public class AreaGroup extends AbstractButtonGroup {
   public void mouseReleased(MouseEvent event) {
     Token token = getToken();
     if (SwingUtilities.isRightMouseButton(event)) {
-      if ("CampaignPanel".equals(getPanelClass()) && !MapTool.getPlayer().isGM()) {
+      if (!MapTool.getPlayer().isGM()
+          && ("CampaignPanel".equals(getPanelClass())
+              || MapTool.getServerPolicy().isTokenContextLocked())) {
         return;
       }
       // open button group menu

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButton.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/buttons/MacroButton.java
@@ -204,6 +204,9 @@ public class MacroButton extends JButton implements MouseListener {
         properties.executeMacro();
       }
     } else if (SwingUtilities.isRightMouseButton(event)) {
+      if (!MapTool.getPlayer().isGM() && MapTool.getServerPolicy().isTokenContextLocked()) {
+        return;
+      }
       if (getPanelClass().equals("GlobalPanel")) {
         new MacroButtonPopupMenu(this, panelClass, false).show(this, event.getX(), event.getY());
       } else if (getPanelClass().equals("CampaignPanel")) {

--- a/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/macrobuttons/panels/AbstractMacroPanel.java
@@ -173,7 +173,9 @@ public abstract class AbstractMacroPanel extends JPanel implements Scrollable, M
 
   public void mouseReleased(MouseEvent event) {
     if (SwingUtilities.isRightMouseButton(event)) {
-      if ("CampaignPanel".equals(getPanelClass()) && !MapTool.getPlayer().isGM()) {
+      if (!MapTool.getPlayer().isGM()
+          && ("CampaignPanel".equals(getPanelClass())
+              || MapTool.getServerPolicy().isTokenContextLocked())) {
         return;
       }
       // open button group menu

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialog.java
@@ -49,6 +49,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
   private JCheckBox playersCanRevealVision;
   private JCheckBox hideMapSelectUI;
   private JCheckBox lockTokenEditOnStartup;
+  private JCheckBox lockTokenContextOnStartup;
   private JCheckBox lockPlayerMoveOnStartup;
   private JCheckBox lockPlayerLibrary;
   private JButton generateGMPassword;
@@ -92,6 +93,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
     usePasswordFile = (JCheckBox) getComponent("@usePasswordFile");
     hideMapSelectUI = (JCheckBox) getComponent("@hideMapSelectUI");
     lockTokenEditOnStartup = (JCheckBox) getComponent("@lockTokenEditOnStartup");
+    lockTokenContextOnStartup = (JCheckBox) getComponent("@lockTokenContextOnStartup");
     lockPlayerMoveOnStartup = (JCheckBox) getComponent("@lockPlayerMovementOnStartup");
     lockPlayerLibrary = (JCheckBox) getComponent("@disablePlayerLibrary");
 
@@ -143,6 +145,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
         });
     hideMapSelectUI.setSelected(prefs.getMapSelectUIHidden());
     lockTokenEditOnStartup.setSelected(prefs.getLockTokenEditOnStart());
+    lockTokenContextOnStartup.setSelected(prefs.getLockTokenContextOnStart());
     lockPlayerMoveOnStartup.setSelected(prefs.getLockPlayerMovementOnStart());
     lockPlayerLibrary.setSelected(prefs.getPlayerLibraryLock());
 
@@ -265,6 +268,7 @@ public class StartServerDialog extends AbeillePanel<StartServerDialogPreferences
                 prefs.setUseEasyConnect(useEasyConnect.isSelected());
                 prefs.setMapSelectUIHidden(hideMapSelectUI.isSelected());
                 prefs.setLockTokenEditOnStart(lockTokenEditOnStartup.isSelected());
+                prefs.setLockTokenContextOnStart(lockTokenContextOnStartup.isSelected());
                 prefs.setLockPlayerMovementOnStart(lockPlayerMoveOnStartup.isSelected());
                 prefs.setPlayerLibraryLock(lockPlayerLibrary.isSelected());
 

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
@@ -14,265 +14,269 @@
  */
 package net.rptools.maptool.client.ui.startserverdialog;
 
-import java.util.Objects;
-import java.util.prefs.Preferences;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.model.player.Player;
 import net.rptools.maptool.server.ServerConfig;
 
+import java.util.Objects;
+import java.util.prefs.Preferences;
+
 public class StartServerDialogPreferences {
-  private static Preferences prefs =
-      Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs/server");
+    private static Preferences prefs =
+            Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs/server");
 
-  private static final String KEY_USERNAME = "name";
-  private static final String KEY_ROLE = "playerRole";
-  private static final String KEY_PORT = "port";
-  private static final String KEY_GM_PASSWORD = "gmPassword";
-  private static final String KEY_PLAYER_PASSWORD = "playerPassword";
-  private static final String KEY_STRICT_TOKEN_OWNERSHIP = "strictTokenOwnership";
-  private static final String KEY_REGISTER_SERVER = "registerServer";
-  private static final String KEY_RPTOOLS_NAME = "rptoolsName";
-  private static final String KEY_RPTOOLS_PRIVATE = "rptoolsPrivate";
-  private static final String KEY_PLAYERS_CAN_REVEAL_VISION = "playersCanRevealVisionCheckbox";
-  private static final String KEY_GM_REVEALS_VISION = "gmRevealsVisionForUnownedTokens";
-  private static final String KEY_USE_INDIVIDUAL_VIEWS = "useIndividualViews";
-  private static final String KEY_USE_UPNP = "useUPnP";
-  private static final String KEY_RESTRICTED_IMPERSONATION = "restrictedImpersonation";
-  private static final String KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS = "playersReceiveCampaignMacros";
-  private static final String KEY_WALKER_METRIC = "movementMetric";
-  private static final String KEY_USE_INDIVIDUAL_FOW = "useIndividualFOW";
-  private static final String KEY_AUTO_REVEAL_ON_MOVE = "autoRevealOnMovement";
+    private static final String KEY_USERNAME = "name";
+    private static final String KEY_ROLE = "playerRole";
+    private static final String KEY_PORT = "port";
+    private static final String KEY_GM_PASSWORD = "gmPassword";
+    private static final String KEY_PLAYER_PASSWORD = "playerPassword";
+    private static final String KEY_STRICT_TOKEN_OWNERSHIP = "strictTokenOwnership";
+    private static final String KEY_REGISTER_SERVER = "registerServer";
+    private static final String KEY_RPTOOLS_NAME = "rptoolsName";
+    private static final String KEY_RPTOOLS_PRIVATE = "rptoolsPrivate";
+    private static final String KEY_PLAYERS_CAN_REVEAL_VISION = "playersCanRevealVisionCheckbox";
+    private static final String KEY_GM_REVEALS_VISION = "gmRevealsVisionForUnownedTokens";
+    private static final String KEY_USE_INDIVIDUAL_VIEWS = "useIndividualViews";
+    private static final String KEY_USE_UPNP = "useUPnP";
+    private static final String KEY_RESTRICTED_IMPERSONATION = "restrictedImpersonation";
+    private static final String KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS = "playersReceiveCampaignMacros";
+    private static final String KEY_WALKER_METRIC = "movementMetric";
+    private static final String KEY_USE_INDIVIDUAL_FOW = "useIndividualFOW";
+    private static final String KEY_AUTO_REVEAL_ON_MOVE = "autoRevealOnMovement";
 
-  private static final String KEY_USE_EASY_CONNECT = "useEasyConnect";
-  private static final String KEY_USE_PASSWORD_FILE = "usePasswordFile";
-  private static final String KEY_HIDE_MAP_SELECT_UI = "hideMapSelectUI";
-  private static final String KEY_START_LOCKED_TOKEN_EDIT = "lockTokenEditOnStartup";
-  private static final String KEY_START_LOCKED_TOKEN_CONTEXT = "lockTokenContextOnStartup";
-  private static final String KEY_START_LOCKED_PLAYER_MOVEMENT = "lockPlayerMovementOnStartup";
-  private static final String KEY_LOCK_PLAYER_LIBRARY = "lockPlayerLibrary";
+    private static final String KEY_USE_EASY_CONNECT = "useEasyConnect";
+    private static final String KEY_USE_PASSWORD_FILE = "usePasswordFile";
+    private static final String KEY_HIDE_MAP_SELECT_UI = "hideMapSelectUI";
+    private static final String KEY_START_LOCKED_TOKEN_EDIT = "lockTokenEditOnStartup";
+    private static final String KEY_START_LOCKED_TOKEN_CONTEXT = "lockTokenContextOnStartup";
+    private static final String KEY_START_LOCKED_PLAYER_MOVEMENT = "lockPlayerMovementOnStartup";
+    private static final String KEY_LOCK_PLAYER_LIBRARY = "lockPlayerLibrary";
 
-  private static final String KEY_USE_WEBRTC = "useWebRTC";
+    private static final String KEY_USE_WEBRTC = "useWebRTC";
 
-  private static Boolean useToolTipsForUnformattedRolls = null;
+    private static Boolean useToolTipsForUnformattedRolls = null;
 
-  public Player.Role getRole() {
-    return Player.Role.valueOf(prefs.get(KEY_ROLE, Player.Role.GM.name()));
-  }
+    public Player.Role getRole() {
+        return Player.Role.valueOf(prefs.get(KEY_ROLE, Player.Role.GM.name()));
+    }
 
-  public void setRole(Player.Role role) {
-    prefs.put(KEY_ROLE, role.name());
-  }
+    public void setRole(Player.Role role) {
+        prefs.put(KEY_ROLE, role.name());
+    }
 
-  public String getUsername() {
-    return prefs.get(KEY_USERNAME, "");
-  }
+    public String getUsername() {
+        return prefs.get(KEY_USERNAME, "");
+    }
 
-  public void setUsername(String name) {
-    prefs.put(KEY_USERNAME, name.trim());
-  }
+    public void setUsername(String name) {
+        prefs.put(KEY_USERNAME, name.trim());
+    }
 
-  public void setGMPassword(String password) {
-    prefs.put(KEY_GM_PASSWORD, password.trim());
-  }
+    public void setGMPassword(String password) {
+        prefs.put(KEY_GM_PASSWORD, password.trim());
+    }
 
-  public String getGMPassword() {
-    return prefs.get(KEY_GM_PASSWORD, "");
-  }
+    public String getGMPassword() {
+        return prefs.get(KEY_GM_PASSWORD, "");
+    }
 
-  public void setPlayerPassword(String password) {
-    prefs.put(KEY_PLAYER_PASSWORD, password.trim());
-  }
+    public void setPlayerPassword(String password) {
+        prefs.put(KEY_PLAYER_PASSWORD, password.trim());
+    }
 
-  public String getPlayerPassword() {
-    return prefs.get(KEY_PLAYER_PASSWORD, "");
-  }
+    public String getPlayerPassword() {
+        return prefs.get(KEY_PLAYER_PASSWORD, "");
+    }
 
-  public int getPort() {
-    return prefs.getInt(KEY_PORT, ServerConfig.DEFAULT_PORT);
-  }
+    public int getPort() {
+        return prefs.getInt(KEY_PORT, ServerConfig.DEFAULT_PORT);
+    }
 
-  public void setPort(int port) {
-    prefs.putInt(KEY_PORT, port);
-  }
+    public void setPort(int port) {
+        prefs.putInt(KEY_PORT, port);
+    }
 
-  public boolean getUseStrictTokenOwnership() {
-    return prefs.getBoolean(KEY_STRICT_TOKEN_OWNERSHIP, false);
-  }
+    public boolean getUseStrictTokenOwnership() {
+        return prefs.getBoolean(KEY_STRICT_TOKEN_OWNERSHIP, false);
+    }
 
-  public void setUseStrictTokenOwnership(boolean use) {
-    prefs.putBoolean(KEY_STRICT_TOKEN_OWNERSHIP, use);
-  }
+    public void setUseStrictTokenOwnership(boolean use) {
+        prefs.putBoolean(KEY_STRICT_TOKEN_OWNERSHIP, use);
+    }
 
-  // my addition
-  public boolean getRestrictedImpersonation() {
-    return prefs.getBoolean(KEY_RESTRICTED_IMPERSONATION, false);
-  }
+    // my addition
+    public boolean getRestrictedImpersonation() {
+        return prefs.getBoolean(KEY_RESTRICTED_IMPERSONATION, false);
+    }
 
-  public void setRestrictedImpersonation(boolean impersonation) {
-    prefs.putBoolean(KEY_RESTRICTED_IMPERSONATION, impersonation);
-  }
+    public void setRestrictedImpersonation(boolean impersonation) {
+        prefs.putBoolean(KEY_RESTRICTED_IMPERSONATION, impersonation);
+    }
 
-  public boolean registerServer() {
-    return prefs.getBoolean(KEY_REGISTER_SERVER, false);
-  }
+    public boolean registerServer() {
+        return prefs.getBoolean(KEY_REGISTER_SERVER, false);
+    }
 
-  public void setRegisterServer(boolean register) {
-    prefs.putBoolean(KEY_REGISTER_SERVER, register);
-  }
+    public void setRegisterServer(boolean register) {
+        prefs.putBoolean(KEY_REGISTER_SERVER, register);
+    }
 
-  public void setRPToolsName(String name) {
-    prefs.put(KEY_RPTOOLS_NAME, name.trim());
-  }
+    public void setRPToolsName(String name) {
+        prefs.put(KEY_RPTOOLS_NAME, name.trim());
+    }
 
-  public String getRPToolsName() {
-    return prefs.get(KEY_RPTOOLS_NAME, "");
-  }
+    public String getRPToolsName() {
+        return prefs.get(KEY_RPTOOLS_NAME, "");
+    }
 
-  public void setRPToolsPrivate(boolean flag) {
-    prefs.putBoolean(KEY_RPTOOLS_PRIVATE, flag);
-  }
+    public void setRPToolsPrivate(boolean flag) {
+        prefs.putBoolean(KEY_RPTOOLS_PRIVATE, flag);
+    }
 
-  public boolean getRPToolsPrivate() {
-    return prefs.getBoolean(KEY_RPTOOLS_PRIVATE, false);
-  }
+    public boolean getRPToolsPrivate() {
+        return prefs.getBoolean(KEY_RPTOOLS_PRIVATE, false);
+    }
 
-  public void setPlayersCanRevealVision(boolean flag) {
-    prefs.putBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, flag);
-  }
+    public void setPlayersCanRevealVision(boolean flag) {
+        prefs.putBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, flag);
+    }
 
-  public boolean getPlayersCanRevealVision() {
-    return prefs.getBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, false);
-  }
+    public boolean getPlayersCanRevealVision() {
+        return prefs.getBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, false);
+    }
 
-  public void setGmRevealsVisionForUnownedTokens(boolean flag) {
-    prefs.putBoolean(KEY_GM_REVEALS_VISION, flag);
-  }
+    public void setGmRevealsVisionForUnownedTokens(boolean flag) {
+        prefs.putBoolean(KEY_GM_REVEALS_VISION, flag);
+    }
 
-  public boolean getGmRevealsVisionForUnownedTokens() {
-    return prefs.getBoolean(KEY_GM_REVEALS_VISION, false);
-  }
+    public boolean getGmRevealsVisionForUnownedTokens() {
+        return prefs.getBoolean(KEY_GM_REVEALS_VISION, false);
+    }
 
-  public void setUseIndividualViews(boolean flag) {
-    prefs.putBoolean(KEY_USE_INDIVIDUAL_VIEWS, flag);
-  }
+    public void setUseIndividualViews(boolean flag) {
+        prefs.putBoolean(KEY_USE_INDIVIDUAL_VIEWS, flag);
+    }
 
-  public boolean getUseIndividualViews() {
-    return prefs.getBoolean(KEY_USE_INDIVIDUAL_VIEWS, false);
-  }
+    public boolean getUseIndividualViews() {
+        return prefs.getBoolean(KEY_USE_INDIVIDUAL_VIEWS, false);
+    }
 
-  public void setUseUPnP(boolean op) {
-    prefs.putBoolean(KEY_USE_UPNP, op);
-  }
+    public void setUseUPnP(boolean op) {
+        prefs.putBoolean(KEY_USE_UPNP, op);
+    }
 
-  public boolean getUseUPnP() {
-    return prefs.getBoolean(KEY_USE_UPNP, false);
-  }
+    public boolean getUseUPnP() {
+        return prefs.getBoolean(KEY_USE_UPNP, false);
+    }
 
-  public void setPlayersReceiveCampaignMacros(boolean flag) {
-    prefs.putBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, flag);
-  }
+    public void setPlayersReceiveCampaignMacros(boolean flag) {
+        prefs.putBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, flag);
+    }
 
-  public boolean getPlayersReceiveCampaignMacros() {
-    return prefs.getBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, false);
-  }
+    public boolean getPlayersReceiveCampaignMacros() {
+        return prefs.getBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, false);
+    }
 
-  public boolean getUseToolTipsForUnformattedRolls() {
-    // Tool tips works slightly differently as its a setting that has to be available
-    // to the user to configure before the start server dialog. So if it has not been
-    // specified we default to the users preferences.
-    return Objects.requireNonNullElseGet(
-        useToolTipsForUnformattedRolls, AppPreferences.useToolTipForInlineRoll::get);
-  }
+    public boolean getUseToolTipsForUnformattedRolls() {
+        // Tool tips works slightly differently as its a setting that has to be available
+        // to the user to configure before the start server dialog. So if it has not been
+        // specified we default to the users preferences.
+        return Objects.requireNonNullElseGet(
+                useToolTipsForUnformattedRolls, AppPreferences.useToolTipForInlineRoll::get);
+    }
 
-  public void setUseToolTipsForUnformattedRolls(boolean flag) {
-    useToolTipsForUnformattedRolls = flag;
-  }
+    public void setUseToolTipsForUnformattedRolls(boolean flag) {
+        useToolTipsForUnformattedRolls = flag;
+    }
 
-  public WalkerMetric getMovementMetric() {
-    String metric = prefs.get(KEY_WALKER_METRIC, "ONE_ONE_ONE");
-    return WalkerMetric.valueOf(metric);
-  }
+    public WalkerMetric getMovementMetric() {
+        String metric = prefs.get(KEY_WALKER_METRIC, "ONE_ONE_ONE");
+        return WalkerMetric.valueOf(metric);
+    }
 
-  public void setMovementMetric(WalkerMetric metric) {
-    prefs.put(KEY_WALKER_METRIC, metric.name());
-  }
+    public void setMovementMetric(WalkerMetric metric) {
+        prefs.put(KEY_WALKER_METRIC, metric.name());
+    }
 
-  public boolean getUseIndividualFOW() {
-    return prefs.getBoolean(KEY_USE_INDIVIDUAL_FOW, false);
-  }
+    public boolean getUseIndividualFOW() {
+        return prefs.getBoolean(KEY_USE_INDIVIDUAL_FOW, false);
+    }
 
-  public void setUseIndividualFOW(boolean flag) {
-    prefs.putBoolean(KEY_USE_INDIVIDUAL_FOW, flag);
-  }
+    public void setUseIndividualFOW(boolean flag) {
+        prefs.putBoolean(KEY_USE_INDIVIDUAL_FOW, flag);
+    }
 
-  public boolean isAutoRevealOnMovement() {
-    return prefs.getBoolean(KEY_AUTO_REVEAL_ON_MOVE, false);
-  }
+    public boolean isAutoRevealOnMovement() {
+        return prefs.getBoolean(KEY_AUTO_REVEAL_ON_MOVE, false);
+    }
 
-  public void setAutoRevealOnMovement(boolean flag) {
-    prefs.putBoolean(KEY_AUTO_REVEAL_ON_MOVE, flag);
-  }
+    public void setAutoRevealOnMovement(boolean flag) {
+        prefs.putBoolean(KEY_AUTO_REVEAL_ON_MOVE, flag);
+    }
 
-  public boolean getUsePasswordFile() {
-    return prefs.getBoolean(KEY_USE_PASSWORD_FILE, false);
-  }
+    public boolean getUsePasswordFile() {
+        return prefs.getBoolean(KEY_USE_PASSWORD_FILE, false);
+    }
 
-  public void setUsePasswordFile(boolean flag) {
-    prefs.putBoolean(KEY_USE_PASSWORD_FILE, flag);
-  }
+    public void setUsePasswordFile(boolean flag) {
+        prefs.putBoolean(KEY_USE_PASSWORD_FILE, flag);
+    }
 
-  public boolean getUseEasyConnect() {
-    return prefs.getBoolean(KEY_USE_EASY_CONNECT, false);
-  }
+    public boolean getUseEasyConnect() {
+        return prefs.getBoolean(KEY_USE_EASY_CONNECT, false);
+    }
 
-  public void setUseEasyConnect(boolean flag) {
-    prefs.putBoolean(KEY_USE_EASY_CONNECT, flag);
-  }
+    public void setUseEasyConnect(boolean flag) {
+        prefs.putBoolean(KEY_USE_EASY_CONNECT, flag);
+    }
 
-  public boolean getMapSelectUIHidden() {
-    return prefs.getBoolean(KEY_HIDE_MAP_SELECT_UI, false);
-  }
+    public boolean getMapSelectUIHidden() {
+        return prefs.getBoolean(KEY_HIDE_MAP_SELECT_UI, false);
+    }
 
-  public void setMapSelectUIHidden(boolean flag) {
-    prefs.putBoolean(KEY_HIDE_MAP_SELECT_UI, flag);
-  }
+    public void setMapSelectUIHidden(boolean flag) {
+        prefs.putBoolean(KEY_HIDE_MAP_SELECT_UI, flag);
+    }
 
-  public boolean getLockTokenEditOnStart() {
-    return prefs.getBoolean(KEY_START_LOCKED_TOKEN_EDIT, false);
-  }
+    public boolean getLockTokenEditOnStart() {
+        return prefs.getBoolean(KEY_START_LOCKED_TOKEN_EDIT, false);
+    }
 
-  public boolean getLockTokenContextOnStart() {
-    return prefs.getBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, false);
-  }
-  public void setLockTokenEditOnStart(boolean flag) {
-    prefs.putBoolean(KEY_START_LOCKED_TOKEN_EDIT, flag);
-  }
-  public void setLockTokenContextOnStart(boolean flag) {
-    prefs.putBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, flag);
-  }
-  public boolean getLockPlayerMovementOnStart() {
-    return prefs.getBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, false);
-  }
+    public boolean getLockTokenContextOnStart() {
+        return prefs.getBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, false);
+    }
 
-  public void setLockPlayerMovementOnStart(boolean flag) {
-    prefs.putBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, flag);
-  }
+    public void setLockTokenEditOnStart(boolean flag) {
+        prefs.putBoolean(KEY_START_LOCKED_TOKEN_EDIT, flag);
+    }
 
-  public boolean getPlayerLibraryLock() {
-    return prefs.getBoolean(KEY_LOCK_PLAYER_LIBRARY, false);
-  }
+    public void setLockTokenContextOnStart(boolean flag) {
+        prefs.putBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, flag);
+    }
 
-  public void setPlayerLibraryLock(boolean flag) {
-    prefs.putBoolean(KEY_LOCK_PLAYER_LIBRARY, flag);
-  }
+    public boolean getLockPlayerMovementOnStart() {
+        return prefs.getBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, false);
+    }
 
-  public boolean getUseWebRtc() {
-    return prefs.getBoolean(KEY_USE_WEBRTC, false);
-  }
+    public void setLockPlayerMovementOnStart(boolean flag) {
+        prefs.putBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, flag);
+    }
 
-  public void setKeyUseWebrtc(boolean flag) {
-    prefs.putBoolean(KEY_USE_WEBRTC, flag);
-  }
+    public boolean getPlayerLibraryLock() {
+        return prefs.getBoolean(KEY_LOCK_PLAYER_LIBRARY, false);
+    }
+
+    public void setPlayerLibraryLock(boolean flag) {
+        prefs.putBoolean(KEY_LOCK_PLAYER_LIBRARY, flag);
+    }
+
+    public boolean getUseWebRtc() {
+        return prefs.getBoolean(KEY_USE_WEBRTC, false);
+    }
+
+    public void setKeyUseWebrtc(boolean flag) {
+        prefs.putBoolean(KEY_USE_WEBRTC, flag);
+    }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
@@ -14,269 +14,268 @@
  */
 package net.rptools.maptool.client.ui.startserverdialog;
 
+import java.util.Objects;
+import java.util.prefs.Preferences;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.walker.WalkerMetric;
 import net.rptools.maptool.model.player.Player;
 import net.rptools.maptool.server.ServerConfig;
 
-import java.util.Objects;
-import java.util.prefs.Preferences;
-
 public class StartServerDialogPreferences {
-    private static Preferences prefs =
-            Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs/server");
+  private static Preferences prefs =
+      Preferences.userRoot().node(AppConstants.APP_NAME + "/prefs/server");
 
-    private static final String KEY_USERNAME = "name";
-    private static final String KEY_ROLE = "playerRole";
-    private static final String KEY_PORT = "port";
-    private static final String KEY_GM_PASSWORD = "gmPassword";
-    private static final String KEY_PLAYER_PASSWORD = "playerPassword";
-    private static final String KEY_STRICT_TOKEN_OWNERSHIP = "strictTokenOwnership";
-    private static final String KEY_REGISTER_SERVER = "registerServer";
-    private static final String KEY_RPTOOLS_NAME = "rptoolsName";
-    private static final String KEY_RPTOOLS_PRIVATE = "rptoolsPrivate";
-    private static final String KEY_PLAYERS_CAN_REVEAL_VISION = "playersCanRevealVisionCheckbox";
-    private static final String KEY_GM_REVEALS_VISION = "gmRevealsVisionForUnownedTokens";
-    private static final String KEY_USE_INDIVIDUAL_VIEWS = "useIndividualViews";
-    private static final String KEY_USE_UPNP = "useUPnP";
-    private static final String KEY_RESTRICTED_IMPERSONATION = "restrictedImpersonation";
-    private static final String KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS = "playersReceiveCampaignMacros";
-    private static final String KEY_WALKER_METRIC = "movementMetric";
-    private static final String KEY_USE_INDIVIDUAL_FOW = "useIndividualFOW";
-    private static final String KEY_AUTO_REVEAL_ON_MOVE = "autoRevealOnMovement";
+  private static final String KEY_USERNAME = "name";
+  private static final String KEY_ROLE = "playerRole";
+  private static final String KEY_PORT = "port";
+  private static final String KEY_GM_PASSWORD = "gmPassword";
+  private static final String KEY_PLAYER_PASSWORD = "playerPassword";
+  private static final String KEY_STRICT_TOKEN_OWNERSHIP = "strictTokenOwnership";
+  private static final String KEY_REGISTER_SERVER = "registerServer";
+  private static final String KEY_RPTOOLS_NAME = "rptoolsName";
+  private static final String KEY_RPTOOLS_PRIVATE = "rptoolsPrivate";
+  private static final String KEY_PLAYERS_CAN_REVEAL_VISION = "playersCanRevealVisionCheckbox";
+  private static final String KEY_GM_REVEALS_VISION = "gmRevealsVisionForUnownedTokens";
+  private static final String KEY_USE_INDIVIDUAL_VIEWS = "useIndividualViews";
+  private static final String KEY_USE_UPNP = "useUPnP";
+  private static final String KEY_RESTRICTED_IMPERSONATION = "restrictedImpersonation";
+  private static final String KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS = "playersReceiveCampaignMacros";
+  private static final String KEY_WALKER_METRIC = "movementMetric";
+  private static final String KEY_USE_INDIVIDUAL_FOW = "useIndividualFOW";
+  private static final String KEY_AUTO_REVEAL_ON_MOVE = "autoRevealOnMovement";
 
-    private static final String KEY_USE_EASY_CONNECT = "useEasyConnect";
-    private static final String KEY_USE_PASSWORD_FILE = "usePasswordFile";
-    private static final String KEY_HIDE_MAP_SELECT_UI = "hideMapSelectUI";
-    private static final String KEY_START_LOCKED_TOKEN_EDIT = "lockTokenEditOnStartup";
-    private static final String KEY_START_LOCKED_TOKEN_CONTEXT = "lockTokenContextOnStartup";
-    private static final String KEY_START_LOCKED_PLAYER_MOVEMENT = "lockPlayerMovementOnStartup";
-    private static final String KEY_LOCK_PLAYER_LIBRARY = "lockPlayerLibrary";
+  private static final String KEY_USE_EASY_CONNECT = "useEasyConnect";
+  private static final String KEY_USE_PASSWORD_FILE = "usePasswordFile";
+  private static final String KEY_HIDE_MAP_SELECT_UI = "hideMapSelectUI";
+  private static final String KEY_START_LOCKED_TOKEN_EDIT = "lockTokenEditOnStartup";
+  private static final String KEY_START_LOCKED_TOKEN_CONTEXT = "lockTokenContextOnStartup";
+  private static final String KEY_START_LOCKED_PLAYER_MOVEMENT = "lockPlayerMovementOnStartup";
+  private static final String KEY_LOCK_PLAYER_LIBRARY = "lockPlayerLibrary";
 
-    private static final String KEY_USE_WEBRTC = "useWebRTC";
+  private static final String KEY_USE_WEBRTC = "useWebRTC";
 
-    private static Boolean useToolTipsForUnformattedRolls = null;
+  private static Boolean useToolTipsForUnformattedRolls = null;
 
-    public Player.Role getRole() {
-        return Player.Role.valueOf(prefs.get(KEY_ROLE, Player.Role.GM.name()));
-    }
+  public Player.Role getRole() {
+    return Player.Role.valueOf(prefs.get(KEY_ROLE, Player.Role.GM.name()));
+  }
 
-    public void setRole(Player.Role role) {
-        prefs.put(KEY_ROLE, role.name());
-    }
+  public void setRole(Player.Role role) {
+    prefs.put(KEY_ROLE, role.name());
+  }
 
-    public String getUsername() {
-        return prefs.get(KEY_USERNAME, "");
-    }
+  public String getUsername() {
+    return prefs.get(KEY_USERNAME, "");
+  }
 
-    public void setUsername(String name) {
-        prefs.put(KEY_USERNAME, name.trim());
-    }
+  public void setUsername(String name) {
+    prefs.put(KEY_USERNAME, name.trim());
+  }
 
-    public void setGMPassword(String password) {
-        prefs.put(KEY_GM_PASSWORD, password.trim());
-    }
+  public void setGMPassword(String password) {
+    prefs.put(KEY_GM_PASSWORD, password.trim());
+  }
 
-    public String getGMPassword() {
-        return prefs.get(KEY_GM_PASSWORD, "");
-    }
+  public String getGMPassword() {
+    return prefs.get(KEY_GM_PASSWORD, "");
+  }
 
-    public void setPlayerPassword(String password) {
-        prefs.put(KEY_PLAYER_PASSWORD, password.trim());
-    }
+  public void setPlayerPassword(String password) {
+    prefs.put(KEY_PLAYER_PASSWORD, password.trim());
+  }
 
-    public String getPlayerPassword() {
-        return prefs.get(KEY_PLAYER_PASSWORD, "");
-    }
+  public String getPlayerPassword() {
+    return prefs.get(KEY_PLAYER_PASSWORD, "");
+  }
 
-    public int getPort() {
-        return prefs.getInt(KEY_PORT, ServerConfig.DEFAULT_PORT);
-    }
+  public int getPort() {
+    return prefs.getInt(KEY_PORT, ServerConfig.DEFAULT_PORT);
+  }
 
-    public void setPort(int port) {
-        prefs.putInt(KEY_PORT, port);
-    }
+  public void setPort(int port) {
+    prefs.putInt(KEY_PORT, port);
+  }
 
-    public boolean getUseStrictTokenOwnership() {
-        return prefs.getBoolean(KEY_STRICT_TOKEN_OWNERSHIP, false);
-    }
+  public boolean getUseStrictTokenOwnership() {
+    return prefs.getBoolean(KEY_STRICT_TOKEN_OWNERSHIP, false);
+  }
 
-    public void setUseStrictTokenOwnership(boolean use) {
-        prefs.putBoolean(KEY_STRICT_TOKEN_OWNERSHIP, use);
-    }
+  public void setUseStrictTokenOwnership(boolean use) {
+    prefs.putBoolean(KEY_STRICT_TOKEN_OWNERSHIP, use);
+  }
 
-    // my addition
-    public boolean getRestrictedImpersonation() {
-        return prefs.getBoolean(KEY_RESTRICTED_IMPERSONATION, false);
-    }
+  // my addition
+  public boolean getRestrictedImpersonation() {
+    return prefs.getBoolean(KEY_RESTRICTED_IMPERSONATION, false);
+  }
 
-    public void setRestrictedImpersonation(boolean impersonation) {
-        prefs.putBoolean(KEY_RESTRICTED_IMPERSONATION, impersonation);
-    }
+  public void setRestrictedImpersonation(boolean impersonation) {
+    prefs.putBoolean(KEY_RESTRICTED_IMPERSONATION, impersonation);
+  }
 
-    public boolean registerServer() {
-        return prefs.getBoolean(KEY_REGISTER_SERVER, false);
-    }
+  public boolean registerServer() {
+    return prefs.getBoolean(KEY_REGISTER_SERVER, false);
+  }
 
-    public void setRegisterServer(boolean register) {
-        prefs.putBoolean(KEY_REGISTER_SERVER, register);
-    }
+  public void setRegisterServer(boolean register) {
+    prefs.putBoolean(KEY_REGISTER_SERVER, register);
+  }
 
-    public void setRPToolsName(String name) {
-        prefs.put(KEY_RPTOOLS_NAME, name.trim());
-    }
+  public void setRPToolsName(String name) {
+    prefs.put(KEY_RPTOOLS_NAME, name.trim());
+  }
 
-    public String getRPToolsName() {
-        return prefs.get(KEY_RPTOOLS_NAME, "");
-    }
+  public String getRPToolsName() {
+    return prefs.get(KEY_RPTOOLS_NAME, "");
+  }
 
-    public void setRPToolsPrivate(boolean flag) {
-        prefs.putBoolean(KEY_RPTOOLS_PRIVATE, flag);
-    }
+  public void setRPToolsPrivate(boolean flag) {
+    prefs.putBoolean(KEY_RPTOOLS_PRIVATE, flag);
+  }
 
-    public boolean getRPToolsPrivate() {
-        return prefs.getBoolean(KEY_RPTOOLS_PRIVATE, false);
-    }
+  public boolean getRPToolsPrivate() {
+    return prefs.getBoolean(KEY_RPTOOLS_PRIVATE, false);
+  }
 
-    public void setPlayersCanRevealVision(boolean flag) {
-        prefs.putBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, flag);
-    }
+  public void setPlayersCanRevealVision(boolean flag) {
+    prefs.putBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, flag);
+  }
 
-    public boolean getPlayersCanRevealVision() {
-        return prefs.getBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, false);
-    }
+  public boolean getPlayersCanRevealVision() {
+    return prefs.getBoolean(KEY_PLAYERS_CAN_REVEAL_VISION, false);
+  }
 
-    public void setGmRevealsVisionForUnownedTokens(boolean flag) {
-        prefs.putBoolean(KEY_GM_REVEALS_VISION, flag);
-    }
+  public void setGmRevealsVisionForUnownedTokens(boolean flag) {
+    prefs.putBoolean(KEY_GM_REVEALS_VISION, flag);
+  }
 
-    public boolean getGmRevealsVisionForUnownedTokens() {
-        return prefs.getBoolean(KEY_GM_REVEALS_VISION, false);
-    }
+  public boolean getGmRevealsVisionForUnownedTokens() {
+    return prefs.getBoolean(KEY_GM_REVEALS_VISION, false);
+  }
 
-    public void setUseIndividualViews(boolean flag) {
-        prefs.putBoolean(KEY_USE_INDIVIDUAL_VIEWS, flag);
-    }
+  public void setUseIndividualViews(boolean flag) {
+    prefs.putBoolean(KEY_USE_INDIVIDUAL_VIEWS, flag);
+  }
 
-    public boolean getUseIndividualViews() {
-        return prefs.getBoolean(KEY_USE_INDIVIDUAL_VIEWS, false);
-    }
+  public boolean getUseIndividualViews() {
+    return prefs.getBoolean(KEY_USE_INDIVIDUAL_VIEWS, false);
+  }
 
-    public void setUseUPnP(boolean op) {
-        prefs.putBoolean(KEY_USE_UPNP, op);
-    }
+  public void setUseUPnP(boolean op) {
+    prefs.putBoolean(KEY_USE_UPNP, op);
+  }
 
-    public boolean getUseUPnP() {
-        return prefs.getBoolean(KEY_USE_UPNP, false);
-    }
+  public boolean getUseUPnP() {
+    return prefs.getBoolean(KEY_USE_UPNP, false);
+  }
 
-    public void setPlayersReceiveCampaignMacros(boolean flag) {
-        prefs.putBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, flag);
-    }
+  public void setPlayersReceiveCampaignMacros(boolean flag) {
+    prefs.putBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, flag);
+  }
 
-    public boolean getPlayersReceiveCampaignMacros() {
-        return prefs.getBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, false);
-    }
+  public boolean getPlayersReceiveCampaignMacros() {
+    return prefs.getBoolean(KEY_PLAYERS_RECEIVE_CAMPAIGN_MACROS, false);
+  }
 
-    public boolean getUseToolTipsForUnformattedRolls() {
-        // Tool tips works slightly differently as its a setting that has to be available
-        // to the user to configure before the start server dialog. So if it has not been
-        // specified we default to the users preferences.
-        return Objects.requireNonNullElseGet(
-                useToolTipsForUnformattedRolls, AppPreferences.useToolTipForInlineRoll::get);
-    }
+  public boolean getUseToolTipsForUnformattedRolls() {
+    // Tool tips works slightly differently as its a setting that has to be available
+    // to the user to configure before the start server dialog. So if it has not been
+    // specified we default to the users preferences.
+    return Objects.requireNonNullElseGet(
+        useToolTipsForUnformattedRolls, AppPreferences.useToolTipForInlineRoll::get);
+  }
 
-    public void setUseToolTipsForUnformattedRolls(boolean flag) {
-        useToolTipsForUnformattedRolls = flag;
-    }
+  public void setUseToolTipsForUnformattedRolls(boolean flag) {
+    useToolTipsForUnformattedRolls = flag;
+  }
 
-    public WalkerMetric getMovementMetric() {
-        String metric = prefs.get(KEY_WALKER_METRIC, "ONE_ONE_ONE");
-        return WalkerMetric.valueOf(metric);
-    }
+  public WalkerMetric getMovementMetric() {
+    String metric = prefs.get(KEY_WALKER_METRIC, "ONE_ONE_ONE");
+    return WalkerMetric.valueOf(metric);
+  }
 
-    public void setMovementMetric(WalkerMetric metric) {
-        prefs.put(KEY_WALKER_METRIC, metric.name());
-    }
+  public void setMovementMetric(WalkerMetric metric) {
+    prefs.put(KEY_WALKER_METRIC, metric.name());
+  }
 
-    public boolean getUseIndividualFOW() {
-        return prefs.getBoolean(KEY_USE_INDIVIDUAL_FOW, false);
-    }
+  public boolean getUseIndividualFOW() {
+    return prefs.getBoolean(KEY_USE_INDIVIDUAL_FOW, false);
+  }
 
-    public void setUseIndividualFOW(boolean flag) {
-        prefs.putBoolean(KEY_USE_INDIVIDUAL_FOW, flag);
-    }
+  public void setUseIndividualFOW(boolean flag) {
+    prefs.putBoolean(KEY_USE_INDIVIDUAL_FOW, flag);
+  }
 
-    public boolean isAutoRevealOnMovement() {
-        return prefs.getBoolean(KEY_AUTO_REVEAL_ON_MOVE, false);
-    }
+  public boolean isAutoRevealOnMovement() {
+    return prefs.getBoolean(KEY_AUTO_REVEAL_ON_MOVE, false);
+  }
 
-    public void setAutoRevealOnMovement(boolean flag) {
-        prefs.putBoolean(KEY_AUTO_REVEAL_ON_MOVE, flag);
-    }
+  public void setAutoRevealOnMovement(boolean flag) {
+    prefs.putBoolean(KEY_AUTO_REVEAL_ON_MOVE, flag);
+  }
 
-    public boolean getUsePasswordFile() {
-        return prefs.getBoolean(KEY_USE_PASSWORD_FILE, false);
-    }
+  public boolean getUsePasswordFile() {
+    return prefs.getBoolean(KEY_USE_PASSWORD_FILE, false);
+  }
 
-    public void setUsePasswordFile(boolean flag) {
-        prefs.putBoolean(KEY_USE_PASSWORD_FILE, flag);
-    }
+  public void setUsePasswordFile(boolean flag) {
+    prefs.putBoolean(KEY_USE_PASSWORD_FILE, flag);
+  }
 
-    public boolean getUseEasyConnect() {
-        return prefs.getBoolean(KEY_USE_EASY_CONNECT, false);
-    }
+  public boolean getUseEasyConnect() {
+    return prefs.getBoolean(KEY_USE_EASY_CONNECT, false);
+  }
 
-    public void setUseEasyConnect(boolean flag) {
-        prefs.putBoolean(KEY_USE_EASY_CONNECT, flag);
-    }
+  public void setUseEasyConnect(boolean flag) {
+    prefs.putBoolean(KEY_USE_EASY_CONNECT, flag);
+  }
 
-    public boolean getMapSelectUIHidden() {
-        return prefs.getBoolean(KEY_HIDE_MAP_SELECT_UI, false);
-    }
+  public boolean getMapSelectUIHidden() {
+    return prefs.getBoolean(KEY_HIDE_MAP_SELECT_UI, false);
+  }
 
-    public void setMapSelectUIHidden(boolean flag) {
-        prefs.putBoolean(KEY_HIDE_MAP_SELECT_UI, flag);
-    }
+  public void setMapSelectUIHidden(boolean flag) {
+    prefs.putBoolean(KEY_HIDE_MAP_SELECT_UI, flag);
+  }
 
-    public boolean getLockTokenEditOnStart() {
-        return prefs.getBoolean(KEY_START_LOCKED_TOKEN_EDIT, false);
-    }
+  public boolean getLockTokenEditOnStart() {
+    return prefs.getBoolean(KEY_START_LOCKED_TOKEN_EDIT, false);
+  }
 
-    public boolean getLockTokenContextOnStart() {
-        return prefs.getBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, false);
-    }
+  public boolean getLockTokenContextOnStart() {
+    return prefs.getBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, false);
+  }
 
-    public void setLockTokenEditOnStart(boolean flag) {
-        prefs.putBoolean(KEY_START_LOCKED_TOKEN_EDIT, flag);
-    }
+  public void setLockTokenEditOnStart(boolean flag) {
+    prefs.putBoolean(KEY_START_LOCKED_TOKEN_EDIT, flag);
+  }
 
-    public void setLockTokenContextOnStart(boolean flag) {
-        prefs.putBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, flag);
-    }
+  public void setLockTokenContextOnStart(boolean flag) {
+    prefs.putBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, flag);
+  }
 
-    public boolean getLockPlayerMovementOnStart() {
-        return prefs.getBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, false);
-    }
+  public boolean getLockPlayerMovementOnStart() {
+    return prefs.getBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, false);
+  }
 
-    public void setLockPlayerMovementOnStart(boolean flag) {
-        prefs.putBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, flag);
-    }
+  public void setLockPlayerMovementOnStart(boolean flag) {
+    prefs.putBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, flag);
+  }
 
-    public boolean getPlayerLibraryLock() {
-        return prefs.getBoolean(KEY_LOCK_PLAYER_LIBRARY, false);
-    }
+  public boolean getPlayerLibraryLock() {
+    return prefs.getBoolean(KEY_LOCK_PLAYER_LIBRARY, false);
+  }
 
-    public void setPlayerLibraryLock(boolean flag) {
-        prefs.putBoolean(KEY_LOCK_PLAYER_LIBRARY, flag);
-    }
+  public void setPlayerLibraryLock(boolean flag) {
+    prefs.putBoolean(KEY_LOCK_PLAYER_LIBRARY, flag);
+  }
 
-    public boolean getUseWebRtc() {
-        return prefs.getBoolean(KEY_USE_WEBRTC, false);
-    }
+  public boolean getUseWebRtc() {
+    return prefs.getBoolean(KEY_USE_WEBRTC, false);
+  }
 
-    public void setKeyUseWebrtc(boolean flag) {
-        prefs.putBoolean(KEY_USE_WEBRTC, flag);
-    }
+  public void setKeyUseWebrtc(boolean flag) {
+    prefs.putBoolean(KEY_USE_WEBRTC, flag);
+  }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogPreferences.java
@@ -49,6 +49,7 @@ public class StartServerDialogPreferences {
   private static final String KEY_USE_PASSWORD_FILE = "usePasswordFile";
   private static final String KEY_HIDE_MAP_SELECT_UI = "hideMapSelectUI";
   private static final String KEY_START_LOCKED_TOKEN_EDIT = "lockTokenEditOnStartup";
+  private static final String KEY_START_LOCKED_TOKEN_CONTEXT = "lockTokenContextOnStartup";
   private static final String KEY_START_LOCKED_PLAYER_MOVEMENT = "lockPlayerMovementOnStartup";
   private static final String KEY_LOCK_PLAYER_LIBRARY = "lockPlayerLibrary";
 
@@ -242,10 +243,15 @@ public class StartServerDialogPreferences {
     return prefs.getBoolean(KEY_START_LOCKED_TOKEN_EDIT, false);
   }
 
+  public boolean getLockTokenContextOnStart() {
+    return prefs.getBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, false);
+  }
   public void setLockTokenEditOnStart(boolean flag) {
     prefs.putBoolean(KEY_START_LOCKED_TOKEN_EDIT, flag);
   }
-
+  public void setLockTokenContextOnStart(boolean flag) {
+    prefs.putBoolean(KEY_START_LOCKED_TOKEN_CONTEXT, flag);
+  }
   public boolean getLockPlayerMovementOnStart() {
     return prefs.getBoolean(KEY_START_LOCKED_PLAYER_MOVEMENT, false);
   }

--- a/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogView.form
+++ b/src/main/java/net/rptools/maptool/client/ui/startserverdialog/StartServerDialogView.form
@@ -117,7 +117,7 @@
           <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.label.gmpassword"/>
         </properties>
       </component>
-      <grid id="fc9cf" layout-manager="GridLayoutManager" row-count="15" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fc9cf" layout-manager="GridLayoutManager" row-count="16" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -196,7 +196,7 @@
           </component>
           <component id="bdee" class="javax.swing.JLabel">
             <constraints>
-              <grid row="14" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="15" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="net/rptools/maptool/language/i18n" key="ServerDialog.label.metric"/>
@@ -249,7 +249,7 @@
           </component>
           <component id="cd443" class="javax.swing.JCheckBox">
             <constraints>
-              <grid row="11" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <actionCommand value="Lock Play Movement"/>
@@ -260,7 +260,7 @@
           </component>
           <component id="860" class="javax.swing.JCheckBox">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="13" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <actionCommand value="Lock Player Library"/>
@@ -282,7 +282,7 @@
           </component>
           <component id="3eea1" class="javax.swing.JComboBox">
             <constraints>
-              <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="15" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <actionCommand value="comboBoxChanged"/>
@@ -292,9 +292,21 @@
           </component>
           <hspacer id="6c8b3">
             <constraints>
-              <grid row="13" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <component id="e67f" class="javax.swing.JCheckBox">
+            <constraints>
+              <grid row="11" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="Lock Token Context Menu"/>
+              <name value="@lockTokenContextOnStartup"/>
+              <selected value="false"/>
+              <text resource-bundle="net/rptools/maptool/language/i18n" key="action.toggleTokenContextMenuLock"/>
+              <toolTipText resource-bundle="net/rptools/maptool/language/i18n" key="action.toggleTokenContextMenuLock.description"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <grid id="67b44" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/net/rptools/maptool/server/ServerPolicy.java
+++ b/src/main/java/net/rptools/maptool/server/ServerPolicy.java
@@ -30,6 +30,7 @@ public class ServerPolicy {
   private boolean strictTokenMovement;
   private boolean isMovementLocked;
   private boolean isTokenEditorLocked;
+  private boolean isTokenContextLocked;
   private boolean playersCanRevealVision;
   private boolean gmRevealsVisionForUnownedTokens;
   private boolean useIndividualViews;
@@ -57,6 +58,7 @@ public class ServerPolicy {
     this.strictTokenMovement = other.strictTokenMovement;
     this.isMovementLocked = other.isMovementLocked;
     this.isTokenEditorLocked = other.isTokenEditorLocked;
+    this.isTokenContextLocked = other.isTokenContextLocked;
     this.playersCanRevealVision = other.playersCanRevealVision;
     this.gmRevealsVisionForUnownedTokens = other.gmRevealsVisionForUnownedTokens;
     this.useIndividualViews = other.useIndividualViews;
@@ -98,8 +100,16 @@ public class ServerPolicy {
     return isTokenEditorLocked;
   }
 
+  public boolean isTokenContextLocked() {
+    return isTokenContextLocked;
+  }
+
   public void setIsTokenEditorLocked(boolean locked) {
     isTokenEditorLocked = locked;
+  }
+
+  public void setIsTokenContextLocked(boolean locked) {
+    isTokenContextLocked = locked;
   }
 
   public void setPlayersCanRevealVision(boolean flag) {
@@ -274,6 +284,8 @@ public class ServerPolicy {
     sinfo.addProperty(
         "token editor locked", isTokenEditorLocked() ? BigDecimal.ONE : BigDecimal.ZERO);
     sinfo.addProperty(
+        "token context locked", isTokenContextLocked() ? BigDecimal.ONE : BigDecimal.ZERO);
+    sinfo.addProperty(
         "restricted impersonation", isRestrictedImpersonation() ? BigDecimal.ONE : BigDecimal.ZERO);
     sinfo.addProperty(
         "individual views", isUseIndividualViews() ? BigDecimal.ONE : BigDecimal.ZERO);
@@ -325,6 +337,7 @@ public class ServerPolicy {
     policy.strictTokenMovement = dto.getUseStrictTokenManagement();
     policy.isMovementLocked = dto.getIsMovementLocked();
     policy.isTokenEditorLocked = dto.getIsTokenEditorLocked();
+    policy.isTokenContextLocked = dto.getIsTokenContextLocked();
     policy.playersCanRevealVision = dto.getPlayersCanRevealVision();
     policy.gmRevealsVisionForUnownedTokens = dto.getGmRevealsVisionForUnownedTokens();
     policy.useIndividualViews = dto.getUseIndividualViews();
@@ -347,6 +360,7 @@ public class ServerPolicy {
     dto.setUseStrictTokenManagement(strictTokenMovement);
     dto.setIsMovementLocked(isMovementLocked);
     dto.setIsTokenEditorLocked(isTokenEditorLocked);
+    dto.setIsTokenContextLocked(isTokenContextLocked);
     dto.setPlayersCanRevealVision(playersCanRevealVision);
     dto.setGmRevealsVisionForUnownedTokens(gmRevealsVisionForUnownedTokens);
     dto.setUseIndividualViews(useIndividualViews);

--- a/src/main/resources/net/rptools/maptool/language/i18n.properties
+++ b/src/main/resources/net/rptools/maptool/language/i18n.properties
@@ -1645,6 +1645,8 @@ action.toggleMovementLock                     = &Lock Player Movement
 action.toggleMovementLock.description         = Locks movement for player-owned tokens.
 action.toggleTokenEditorLock                  = Lock Player Token Editor
 action.toggleTokenEditorLock.description      = Locks access to the Token Editor.
+action.toggleTokenContextMenuLock             = Lock Player Token Context Menu
+action.toggleTokenContextMenuLock.description = Locks access to the Context Menu.
 action.toggleNewZonesHaveFOW                  = New Maps have Fog of War
 action.toggleTokensStartSnapToGrid            = Tokens Start Snap to Grid
 # Edit Menu


### PR DESCRIPTION
### Identify the Bug or Feature request
Implements #5966

This a broader approach mentioned in #1762 #1909 #2002 

### Description of the Change
Provides a feature similar to the Lock Token Editor option.  This locks the player out of all right click context menus.
Tools menu:
<img width="359" height="76" alt="image" src="https://github.com/user-attachments/assets/d3df2de0-5e36-4ec4-8c95-4d1cebbcf75d" />
Start Server:
<img width="283" height="102" alt="image" src="https://github.com/user-attachments/assets/7b75f469-41a0-4347-b59c-b5fa19744f4e" />

This effectively blocks all right click context menus from players.

### Possible Drawbacks
None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5967)
<!-- Reviewable:end -->
