### PR TITLE
Fix NPE for SocketConnection

### DIFF
--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/AbstractConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/AbstractConnection.java
@@ -15,7 +15,6 @@
 package net.rptools.clientserver.simple.connection;
 
 import java.io.*;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -123,95 +122,6 @@ public abstract class AbstractConnection implements Connection {
   protected final void dispatchCompressedMessage(byte[] compressedMessage) {
     var message = inflate(compressedMessage);
     dispatchMessage(message);
-  }
-
-  protected final void writeMessage(OutputStream out, byte[] message) throws IOException {
-    int length = message.length;
-
-    notifyListeners(ActivityListener.Direction.Outbound, ActivityListener.State.Start, length, 0);
-
-    out.write(length >> 24);
-    out.write(length >> 16);
-    out.write(length >> 8);
-    out.write(length);
-
-    for (int i = 0; i < message.length; i++) {
-      out.write(message[i]);
-
-      if (i != 0 && i % ActivityListener.CHUNK_SIZE == 0) {
-        notifyListeners(
-            ActivityListener.Direction.Outbound, ActivityListener.State.Progress, length, i);
-      }
-    }
-    out.flush();
-    notifyListeners(
-        ActivityListener.Direction.Outbound, ActivityListener.State.Complete, length, length);
-  }
-
-  protected final byte[] readMessage(InputStream in) throws IOException {
-    int b32 = in.read();
-    int b24 = in.read();
-    int b16 = in.read();
-    int b8 = in.read();
-
-    if (b32 < 0) {
-      throw new IOException("Stream closed");
-    }
-    int length = (b32 << 24) + (b24 << 16) + (b16 << 8) + b8;
-
-    notifyListeners(ActivityListener.Direction.Inbound, ActivityListener.State.Start, length, 0);
-
-    byte[] ret = new byte[length];
-    for (int i = 0; i < length; i++) {
-      ret[i] = (byte) in.read();
-
-      if (i != 0 && i % ActivityListener.CHUNK_SIZE == 0) {
-        notifyListeners(
-            ActivityListener.Direction.Inbound, ActivityListener.State.Progress, length, i);
-      }
-    }
-    notifyListeners(
-        ActivityListener.Direction.Inbound, ActivityListener.State.Complete, length, length);
-    return ret;
-  }
-
-  private ByteBuffer messageBuffer = null;
-
-  protected final byte[] readMessage(ByteBuffer part) {
-    if (messageBuffer == null) {
-      int length = part.getInt();
-      notifyListeners(ActivityListener.Direction.Inbound, ActivityListener.State.Start, length, 0);
-
-      if (part.remaining() == length) {
-        var ret = new byte[length];
-        part.get(ret);
-        notifyListeners(
-            ActivityListener.Direction.Inbound, ActivityListener.State.Complete, length, length);
-        return ret;
-      }
-
-      messageBuffer = ByteBuffer.allocate(length);
-    }
-
-    messageBuffer.put(part);
-    notifyListeners(
-        ActivityListener.Direction.Inbound,
-        ActivityListener.State.Progress,
-        messageBuffer.capacity(),
-        messageBuffer.position());
-
-    if (messageBuffer.capacity() == messageBuffer.position()) {
-      notifyListeners(
-          ActivityListener.Direction.Inbound,
-          ActivityListener.State.Complete,
-          messageBuffer.capacity(),
-          messageBuffer.capacity());
-      var ret = messageBuffer.array();
-      messageBuffer = null;
-      return ret;
-    }
-
-    return null;
   }
 
   protected final void fireDisconnect() {

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/AbstractConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/AbstractConnection.java
@@ -33,12 +33,22 @@ import org.apache.logging.log4j.Logger;
 public abstract class AbstractConnection implements Connection {
   private static final Logger log = LogManager.getLogger(AbstractConnection.class);
 
+  private final String id;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final BlockingQueue<byte[]> outQueue = new LinkedBlockingQueue<>();
 
   private final List<DisconnectHandler> disconnectHandlers = new CopyOnWriteArrayList<>();
   private final List<ActivityListener> listeners = new CopyOnWriteArrayList<>();
   private final List<MessageHandler> messageHandlers = new CopyOnWriteArrayList<>();
+
+  protected AbstractConnection(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public final String getId() {
+    return id;
+  }
 
   @Override
   public final void close() {

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/DirectConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/DirectConnection.java
@@ -40,7 +40,6 @@ public class DirectConnection extends AbstractConnection {
   }
 
   private final AtomicBoolean sharedClosedFlag;
-  private final String id;
   private final BlockingQueue<byte[]> writeQueue;
   private final ReceiveThread receiveThread;
 
@@ -49,8 +48,8 @@ public class DirectConnection extends AbstractConnection {
       String id,
       BlockingQueue<byte[]> writeQueue,
       BlockingQueue<byte[]> readQueue) {
+    super(id);
     this.sharedClosedFlag = sharedClosedFlag;
-    this.id = id;
     this.writeQueue = writeQueue;
     this.receiveThread = new ReceiveThread(readQueue);
   }
@@ -87,11 +86,6 @@ public class DirectConnection extends AbstractConnection {
   @Override
   public boolean isAlive() {
     return !sharedClosedFlag.get();
-  }
-
-  @Override
-  public String getId() {
-    return id;
   }
 
   @Override

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
@@ -28,9 +28,12 @@ public class SocketConnection extends AbstractConnection implements Connection {
   /** Instance used for log messages. */
   private static final Logger log = LogManager.getLogger(SocketConnection.class);
 
+  // Only valid for open connections.
   private SendThread send;
   private ReceiveThread receive;
   private Socket socket;
+
+  // Only valid for pending connections before #open() is called.
   private String hostName;
   private int port;
 
@@ -42,12 +45,12 @@ public class SocketConnection extends AbstractConnection implements Connection {
 
   public SocketConnection(String id, Socket socket) {
     super(id);
-    this.socket = socket;
-
-    initialize(socket);
+    connect(socket);
   }
 
-  private void initialize(Socket socket) {
+  private void connect(Socket socket) {
+    assert this.socket != null : "Should only call #connect() not already open";
+
     this.socket = socket;
     this.send = new SendThread(socket);
     this.receive = new ReceiveThread(socket);
@@ -58,7 +61,11 @@ public class SocketConnection extends AbstractConnection implements Connection {
 
   @Override
   public void open() throws IOException {
-    initialize(new Socket(hostName, port));
+    if (this.socket != null) {
+      throw new IOException("The connection has already been opened.");
+    }
+
+    connect(new Socket(hostName, port));
   }
 
   @Override
@@ -68,6 +75,11 @@ public class SocketConnection extends AbstractConnection implements Connection {
 
   @Override
   protected void onClose() {
+    if (socket == null) {
+      // Not open, so nothing to do.
+      return;
+    }
+
     receive.interrupt();
     send.interrupt();
 
@@ -80,7 +92,7 @@ public class SocketConnection extends AbstractConnection implements Connection {
 
   @Override
   public boolean isAlive() {
-    return !socket.isClosed();
+    return socket != null && !socket.isClosed();
   }
 
   @Override

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
@@ -27,7 +27,6 @@ public class SocketConnection extends AbstractConnection implements Connection {
   /** Instance used for log messages. */
   private static final Logger log = LogManager.getLogger(SocketConnection.class);
 
-  private final String id;
   private SendThread send;
   private ReceiveThread receive;
   private Socket socket;
@@ -35,21 +34,16 @@ public class SocketConnection extends AbstractConnection implements Connection {
   private int port;
 
   public SocketConnection(String id, String hostName, int port) {
-    this.id = id;
+    super(id);
     this.hostName = hostName;
     this.port = port;
   }
 
   public SocketConnection(String id, Socket socket) {
-    this.id = id;
+    super(id);
     this.socket = socket;
 
     initialize(socket);
-  }
-
-  @Override
-  public String getId() {
-    return id;
   }
 
   private void initialize(Socket socket) {

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/SocketConnection.java
@@ -17,6 +17,7 @@ package net.rptools.clientserver.simple.connection;
 import java.io.*;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import net.rptools.clientserver.ActivityListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -118,7 +119,7 @@ public class SocketConnection extends AbstractConnection implements Connection {
           }
 
           try {
-            SocketConnection.this.writeMessage(out, message);
+            writeMessage(out, message);
           } catch (IOException e) {
             log.error("Error while writing message. Closing connection.", e);
             return;
@@ -127,6 +128,29 @@ public class SocketConnection extends AbstractConnection implements Connection {
       } finally {
         SocketConnection.this.close();
       }
+    }
+
+    protected final void writeMessage(OutputStream out, byte[] message) throws IOException {
+      int length = message.length;
+
+      notifyListeners(ActivityListener.Direction.Outbound, ActivityListener.State.Start, length, 0);
+
+      out.write(length >> 24);
+      out.write(length >> 16);
+      out.write(length >> 8);
+      out.write(length);
+
+      for (int i = 0; i < message.length; i++) {
+        out.write(message[i]);
+
+        if (i != 0 && i % ActivityListener.CHUNK_SIZE == 0) {
+          notifyListeners(
+              ActivityListener.Direction.Outbound, ActivityListener.State.Progress, length, i);
+        }
+      }
+      out.flush();
+      notifyListeners(
+          ActivityListener.Direction.Outbound, ActivityListener.State.Complete, length, length);
     }
   }
 
@@ -154,7 +178,7 @@ public class SocketConnection extends AbstractConnection implements Connection {
 
         while (!SocketConnection.this.isClosed() && SocketConnection.this.isAlive()) {
           try {
-            byte[] message = SocketConnection.this.readMessage(in);
+            byte[] message = readMessage(in);
             SocketConnection.this.dispatchCompressedMessage(message);
           } catch (SocketTimeoutException e) {
             log.warn("Lost client {}", SocketConnection.this.getId(), e);
@@ -171,6 +195,33 @@ public class SocketConnection extends AbstractConnection implements Connection {
         SocketConnection.this.close();
         fireDisconnect();
       }
+    }
+
+    private byte[] readMessage(InputStream in) throws IOException {
+      int b32 = in.read();
+      int b24 = in.read();
+      int b16 = in.read();
+      int b8 = in.read();
+
+      if (b32 < 0) {
+        throw new IOException("Stream closed");
+      }
+      int length = (b32 << 24) + (b24 << 16) + (b16 << 8) + b8;
+
+      notifyListeners(ActivityListener.Direction.Inbound, ActivityListener.State.Start, length, 0);
+
+      byte[] ret = new byte[length];
+      for (int i = 0; i < length; i++) {
+        ret[i] = (byte) in.read();
+
+        if (i != 0 && i % ActivityListener.CHUNK_SIZE == 0) {
+          notifyListeners(
+              ActivityListener.Direction.Inbound, ActivityListener.State.Progress, length, i);
+        }
+      }
+      notifyListeners(
+          ActivityListener.Direction.Inbound, ActivityListener.State.Complete, length, length);
+      return ret;
     }
   }
 }

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/WebRTCConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/WebRTCConnection.java
@@ -39,7 +39,6 @@ public class WebRTCConnection extends AbstractConnection implements Connection {
   private final RTCDataChannelObserver rtcDataChannelObserver = new RTCDataChannelObserverImpl();
   private final PeerConnectionFactory factory = new PeerConnectionFactory();
   private final String serverName;
-  private final String id;
   private final Gson gson = new Gson();
   private final Listener listener;
   private WebSocketClient signalingClient;
@@ -57,7 +56,7 @@ public class WebRTCConnection extends AbstractConnection implements Connection {
 
   // used from client side
   public WebRTCConnection(String id, String serverName, Listener listener) {
-    this.id = id;
+    super(id);
     this.serverName = serverName;
     this.listener = listener;
     init();
@@ -65,7 +64,7 @@ public class WebRTCConnection extends AbstractConnection implements Connection {
 
   // this is used from the server side
   public WebRTCConnection(OfferMessageDto message, WebRTCServer webRTCServer) {
-    this.id = message.source;
+    super(message.source);
     this.server = webRTCServer;
     this.serverName = server.getName();
     this.listener = () -> {};
@@ -223,11 +222,6 @@ public class WebRTCConnection extends AbstractConnection implements Connection {
       case CONNECTED, DISCONNECTED -> true;
       default -> false;
     };
-  }
-
-  @Override
-  public String getId() {
-    return id;
   }
 
   @Override

--- a/clientserver/src/main/java/net/rptools/clientserver/simple/connection/WebRTCConnection.java
+++ b/clientserver/src/main/java/net/rptools/clientserver/simple/connection/WebRTCConnection.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import net.rptools.clientserver.ActivityListener;
 import net.rptools.clientserver.simple.server.WebRTCServer;
 import net.rptools.clientserver.simple.webrtc.*;
 import org.apache.logging.log4j.LogManager;
@@ -565,6 +566,46 @@ public class WebRTCConnection extends AbstractConnection implements Connection {
       if (message != null) {
         dispatchCompressedMessage(message);
       }
+    }
+
+    private ByteBuffer messageBuffer = null;
+
+    private byte[] readMessage(ByteBuffer part) {
+      if (messageBuffer == null) {
+        int length = part.getInt();
+        notifyListeners(
+            ActivityListener.Direction.Inbound, ActivityListener.State.Start, length, 0);
+
+        if (part.remaining() == length) {
+          var ret = new byte[length];
+          part.get(ret);
+          notifyListeners(
+              ActivityListener.Direction.Inbound, ActivityListener.State.Complete, length, length);
+          return ret;
+        }
+
+        messageBuffer = ByteBuffer.allocate(length);
+      }
+
+      messageBuffer.put(part);
+      notifyListeners(
+          ActivityListener.Direction.Inbound,
+          ActivityListener.State.Progress,
+          messageBuffer.capacity(),
+          messageBuffer.position());
+
+      if (messageBuffer.capacity() == messageBuffer.position()) {
+        notifyListeners(
+            ActivityListener.Direction.Inbound,
+            ActivityListener.State.Complete,
+            messageBuffer.capacity(),
+            messageBuffer.capacity());
+        var ret = messageBuffer.array();
+        messageBuffer = null;
+        return ret;
+      }
+
+      return null;
     }
   }
 }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #5558 

### Description of the Change

More clearly distinguishes the "connected" state from other states for `SocketConnection`. `socket`, `send`, and `receive` are only accessed if `socket` is first checked to not be `null`. `hostName` and `port` are only accessed if `socket` is first checked to be `null`.

Also refactored `AbstractConnection` a bit:
- Require the ID to be provided in the constructor (guarantees it is a constant value, and one less method for child classes to implement)
- Moved the `readMessage()` and `writeMessage()` out of `AbstractConnection` into `SocketConnection` and `WebRTCConnection` since each one is specific to one of those.

### Possible Drawbacks

Shouldn't be any.

### Documentation Notes

N/A

### Release Notes

- Fixed a null pointer exception in socket connections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5976)
<!-- Reviewable:end -->
