### PR TITLE
Show marker portraits without requiring player notes

### DIFF
--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -38,7 +38,6 @@ import javax.swing.*;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.CodeTimer;
 import net.rptools.lib.MD5Key;
-import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.*;
 import net.rptools.maptool.client.events.TokenHoverEnter;
 import net.rptools.maptool.client.events.TokenHoverExit;
@@ -49,6 +48,7 @@ import net.rptools.maptool.client.ui.*;
 import net.rptools.maptool.client.ui.theme.Images;
 import net.rptools.maptool.client.ui.theme.RessourceManager;
 import net.rptools.maptool.client.ui.zone.FogUtil;
+import net.rptools.maptool.client.ui.zone.Marker;
 import net.rptools.maptool.client.ui.zone.PlayerView;
 import net.rptools.maptool.client.ui.zone.renderer.ZoneRenderer;
 import net.rptools.maptool.events.MapToolEventBus;
@@ -88,7 +88,7 @@ public class PointerTool extends DefaultTool {
   private boolean mouseButtonDown = false;
 
   private Token tokenUnderMouse;
-  private Token markerUnderMouse;
+  private Marker markerUnderMouse;
   private int keysDown; // used to record whether Shift/Ctrl/Meta keys are down
 
   private final TokenStackPanel tokenStackPanel = new TokenStackPanel();
@@ -400,7 +400,7 @@ public class PointerTool extends DefaultTool {
     if (isShowingHover) {
       isShowingHover = false;
       hoverTokenNotes = null;
-      markerUnderMouse = renderer.getMarkerAt(e.getX(), e.getY());
+      markerUnderMouse = renderer.getViewModel().getMarkerAt(e.getX(), e.getY());
       repaint();
     }
     if (isShowingTokenStackPopup) {
@@ -668,14 +668,11 @@ public class PointerTool extends DefaultTool {
                   SwingUtil.isShiftDown(keysDown),
                   SwingUtil.isControlDown(keysDown)));
     }
-    Token marker = renderer.getMarkerAt(mouseX, mouseY);
-    if (!AppUtil.tokenIsVisible(renderer.getZone(), marker, renderer.getPlayerView())) {
-      marker = null;
-    }
+    Marker marker = renderer.getViewModel().getMarkerAt(mouseX, mouseY);
     if (marker != markerUnderMouse && marker != null) {
       markerUnderMouse = marker;
       renderer.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-      MapTool.getFrame().setStatusMessage(markerUnderMouse.getName());
+      MapTool.getFrame().setStatusMessage(markerUnderMouse.name());
     } else if (marker == null && markerUnderMouse != null) {
       markerUnderMouse = null;
       renderer.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
@@ -1678,42 +1675,36 @@ public class PointerTool extends DefaultTool {
     }
   }
 
-  private String createHoverNote(Token marker) {
-    var notes = HTMLUtil.htmlize(marker.getNotes(), marker.getNotesType());
-    var gmNotes = HTMLUtil.htmlize(marker.getGMNotes(), marker.getGmNotesType());
-
-    boolean showGMNotes = MapTool.getPlayer().isGM() && !StringUtil.isEmpty(gmNotes);
-    boolean showNotes = !StringUtil.isEmpty(notes);
+  private String createHoverNote(Marker marker) {
+    boolean showGMNotes = marker.gmNotes() != null;
+    boolean showNotes = marker.playerNotes() != null;
 
     StringBuilder builder = new StringBuilder();
 
-    if (marker.getPortraitImage() != null) {
+    if (marker.imageKey() != null) {
       builder.append("<table><tr><td valign=top>");
     }
     if (showGMNotes || showNotes) {
-      builder.append("<b><span class='title'>").append(marker.getName());
-      if (MapTool.getPlayer().isGM()
-          && !StringUtil.isEmpty(marker.getGMName())
-          && !marker.getName().equals(marker.getGMName())) {
-        builder.append(" (").append(marker.getGMName()).append(")");
+      builder.append("<b><span class='title'>").append(marker.name());
+      if (marker.gmName() != null && !marker.name().equals(marker.gmName())) {
+        builder.append(" (").append(marker.gmName()).append(")");
       }
       builder.append("</span></b><br>");
     }
+
     if (showNotes) {
-      builder.append(notes);
-      // add a gap between player and gmNotes
-      if (showGMNotes) {
-        builder.append("<br><br>");
-      }
+      builder.append(
+          HTMLUtil.htmlize(marker.playerNotes().note(), marker.playerNotes().mimeType()));
     }
     if (showGMNotes) {
       if (showNotes) {
-        builder.append("<b><span class='title'>GM Notes</span></b><br>");
+        // add a gap and heading between player and gmNotes
+        builder.append("<br><br><b><span class='title'>GM Notes</span></b><br>");
       }
-      builder.append(gmNotes);
+      builder.append(HTMLUtil.htmlize(marker.gmNotes().note(), marker.gmNotes().mimeType()));
     }
-    if (marker.getPortraitImage() != null) {
-      BufferedImage image = ImageManager.getImageAndWait(marker.getPortraitImage());
+    if (marker.imageKey() != null) {
+      BufferedImage image = ImageManager.getImageAndWait(marker.imageKey());
       Dimension imgSize = new Dimension(image.getWidth(), image.getHeight());
       if (imgSize.width > AppConstants.NOTE_PORTRAIT_SIZE
           || imgSize.height > AppConstants.NOTE_PORTRAIT_SIZE) {
@@ -1722,15 +1713,14 @@ public class PointerTool extends DefaultTool {
       builder.append("</td><td valign=top>");
       builder
           .append("<img src='asset://")
-          .append(marker.getPortraitImage())
+          .append(marker.imageKey())
           .append("' width=")
           .append(imgSize.width)
           .append(" height=")
           .append(imgSize.height)
           .append("></tr></table>");
     }
-    String hoverText = builder.toString();
-    return hoverText;
+    return builder.toString();
   }
 
   private static final class TokenDragOp {

--- a/src/main/java/net/rptools/maptool/client/ui/zone/Marker.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/Marker.java
@@ -1,0 +1,27 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone;
+
+import java.awt.geom.Area;
+import javax.annotation.Nullable;
+import net.rptools.lib.MD5Key;
+
+public record Marker(
+    Area bounds,
+    String name,
+    @Nullable String gmName,
+    @Nullable Notes playerNotes,
+    @Nullable Notes gmNotes,
+    @Nullable MD5Key imageKey) {}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/Notes.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/Notes.java
@@ -1,0 +1,17 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.zone;
+
+public record Notes(String note, String mimeType) {}

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -118,7 +118,7 @@ public class ZoneViewModel {
   private final Map<Zone.Layer, List<TokenPosition>> tokenPositionsByLayer =
       CollectionUtil.newFilledEnumMap(Zone.Layer.class, l -> new LinkedList<>());
 
-  private final List<TokenPosition> markerList = new ArrayList<>();
+  private final List<Marker> markerList = new ArrayList<>();
   private final Map<Token, Set<Token>> tokenStackMap = new HashMap<>();
 
   private final Map<Zone.Layer, Set<GUID>> visibleTokensByLayer =
@@ -229,8 +229,14 @@ public class ZoneViewModel {
         tokenPositionsByLayer.getOrDefault(layer, Collections.emptyList()));
   }
 
-  public List<TokenPosition> getMarkerPositions() {
-    return Collections.unmodifiableList(markerList);
+  public @Nullable Marker getMarkerAt(int x, int y) {
+    var zonePoint = zoneScale.toWorldSpace(x, y);
+    for (var marker : markerList.reversed()) {
+      if (marker.bounds().contains(zonePoint)) {
+        return marker;
+      }
+    }
+    return null;
   }
 
   public Map<Token, Set<Token>> getTokenStackMap() {
@@ -277,7 +283,7 @@ public class ZoneViewModel {
     updateVisibleArea();
     updateMovingTokens();
     updateTokenPositions();
-    updateMarkerPositions();
+    updateMarkerList();
     updateTokenStacks();
     updateVisibleTokens();
     updateLightPosition();
@@ -397,17 +403,47 @@ public class ZoneViewModel {
     }
   }
 
-  /** Updates {@link #markerList} based on {@link #tokenPositionsByLayer}. */
-  private void updateMarkerPositions() {
+  /**
+   * Updates {@link #markerList} based on {@link #playerView}, {@link #tokenPositionsByLayer}, and
+   * {@link #visibleTokensByLayer}
+   */
+  private void updateMarkerList() {
+    var isGM = playerView.isGMView();
+
     markerList.clear();
 
-    for (var list : tokenPositionsByLayer.values()) {
-      for (var tokenPosition : list) {
+    for (var entry : tokenPositionsByLayer.entrySet()) {
+      var layer = entry.getKey();
+      if (!layer.isMarkerLayer()) {
+        // No markers in this layer, so don't bother iterating over them.
+        continue;
+      }
+
+      for (var tokenPosition : entry.getValue()) {
         var token = tokenPosition.token();
-        var playerCanSeeMarker =
-            MapTool.getPlayer().isGM() || !StringUtil.isEmpty(token.getNotes());
-        if (tokenPosition.token().isMarker() && playerCanSeeMarker) {
-          markerList.add(tokenPosition);
+        if (!visibleTokensByLayer.get(layer).contains(token.getId())) {
+          // No value in storing markers the player can't see.
+          continue;
+        }
+
+        var marker =
+            new Marker(
+                tokenPosition.transformedBounds(),
+                token.getName(),
+                isGM && !StringUtil.isEmpty(token.getGMName()) ? token.getGMName() : null,
+                StringUtil.isEmpty(token.getNotes())
+                    ? null
+                    : new Notes(token.getNotes(), token.getNotesType()),
+                StringUtil.isEmpty(token.getGMNotes()) || !isGM
+                    ? null
+                    : new Notes(token.getGMNotes(), token.getGmNotesType()),
+                token.getPortraitImage());
+
+        // A GM sees a marker if it has any notes or a portrait.
+        // A player sees a marker only if it has player notes.
+        if (marker.playerNotes() != null
+            || (isGM && (marker.gmNotes() != null || marker.imageKey() != null))) {
+          markerList.add(marker);
         }
       }
     }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneViewModel.java
@@ -442,7 +442,8 @@ public class ZoneViewModel {
         // A GM sees a marker if it has any notes or a portrait.
         // A player sees a marker only if it has player notes.
         if (marker.playerNotes() != null
-            || (isGM && (marker.gmNotes() != null || marker.imageKey() != null))) {
+            || marker.imageKey() != null
+            || (isGM && marker.gmNotes() != null)) {
           markerList.add(marker);
         }
       }

--- a/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/renderer/ZoneRenderer.java
@@ -2162,20 +2162,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener {
     return null;
   }
 
-  public @Nullable Token getMarkerAt(int x, int y) {
-    var zonePoint = viewModel.getZoneScale().toWorldSpace(x, y);
-
-    List<ZoneViewModel.TokenPosition> positionList =
-        new ArrayList<>(viewModel.getMarkerPositions());
-    Collections.reverse(positionList);
-    for (ZoneViewModel.TokenPosition position : positionList) {
-      if (position.transformedBounds().contains(zonePoint)) {
-        return position.token();
-      }
-    }
-    return null;
-  }
-
   public List<Token> getTokenStackAt(int x, int y) {
     var tokenStackMap = viewModel.getTokenStackMap();
 

--- a/src/main/java/net/rptools/maptool/model/Token.java
+++ b/src/main/java/net/rptools/maptool/model/Token.java
@@ -43,7 +43,6 @@ import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import net.rptools.CaseInsensitiveHashMap;
 import net.rptools.lib.MD5Key;
-import net.rptools.lib.StringUtil;
 import net.rptools.lib.image.ImageUtil;
 import net.rptools.lib.transferable.TokenTransferData;
 import net.rptools.maptool.client.AppUtil;
@@ -611,11 +610,6 @@ public class Token implements Cloneable {
     } else {
       return height;
     }
-  }
-
-  public boolean isMarker() {
-    return getLayer().isMarkerLayer()
-        && (!StringUtil.isEmpty(notes) || !StringUtil.isEmpty(gmNotes) || portraitImage != null);
   }
 
   public String getPropertyType() {


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #3758

### Description of the Change

Updates the check for whether to treat stamps as markers so that a portrait is enough - player notes are not required to show a portrait to players.

I also did some refactoring to consolidate all the marker-identifying logic into `ZoneViewModel#updateMarkerList()`:
- Deciding whether a token is a marker (used to be in `Token#isMarker()`)
- Deciding whether a marker is visible (used to be checked in `PointerTool#mouseMoved()`)
- Deciding which bits should be shown in the marker notes (used to be in `PointerTool#createHoverNotes()`)
- Picking which marker to use at a given cursor position (used to be in `ZoneRenderer#getMarkerAt()`)
- Building a list of markers (was already done by `ZoneViewModel`)

As a result, markers now respect the "Show As Player" setting, e.g., GM names won't be shown when the setting is enabled. It also means there can be no inconsistency in whether a token counts as a marker to show to the current player.

A new `Marker` type has been introduced to minimially represent the marker data. This decouples marker notes rendering from tokens, most of which is not needed in the context of markers. In the future, maybe this will open the door to some non-token representations for markers. Since this type is not persisted, so it is free to change over time.

### Possible Drawbacks

Can't rely on portraits being hidden from players based on the presence of notes.

### Documentation Notes

Stamps with a portrait and no notes can be seen as markers by players.

Before (required some player notes):
<img width="444" height="357" alt="image" src="https://github.com/user-attachments/assets/43aecf36-8a10-4076-b398-ab87edb82424" />

After:
<img width="437" height="365" alt="image" src="https://github.com/user-attachments/assets/6a574630-23af-48a0-8d2e-13202f19741d" />

### Release Notes

- Changed stamps that have a portrait as markers for players, even when they don't have player notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5978)
<!-- Reviewable:end -->
