### PR TITLE
Remove redundant JVM options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,10 +93,10 @@ ext {
 }
 
 def javaArgs = [
-        "-Xss8M", "-Dsun.java2d.d3d=false", "-Dfile.encoding=UTF-8",
+        "-Xss8M", "-Dsun.java2d.d3d=false",
         "-Dpolyglot.engine.WarnInterpreterOnly=false",
         "-Djava.util.Arrays.useLegacyMergeSort=true",
-        "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(), "-XX:+ShowCodeDetailsInExceptionMessages",
+        "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(),
         "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
         "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5971

### Description of the Change

Removes options `-Dfile.encoding=UTF-8` and `-XX:+ShowCodeDetailsInExceptionMessages` as these are already the default behaviour in recent Java versions.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Removed some unnecessary JVM arguments from the build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5979)
<!-- Reviewable:end -->
