### PR TITLE
Remove support for -v option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,6 @@ javafx {
 }
 
 run {
-    args = ['-v=' + appSemVer]
     // Add -Dlog4j2.debug to see log4j2 details
     // Add  -Djavax.net.debug=all to debug networking issues
 

--- a/src/main/java/net/rptools/maptool/client/MapTool.java
+++ b/src/main/java/net/rptools/maptool/client/MapTool.java
@@ -1545,9 +1545,6 @@ public class MapTool {
     // Start the update check early. Will be handled after the splash screen goes away.
     var updateFuture = AppUpdate.autoUpdateCheck();
 
-    String versionImplementation = version;
-    String versionOverride = version;
-
     if (OsDetection.MAC_OS_X) {
       // On OSX the menu bar at the top of the screen can be enabled at any time, but the
       // title (ie. name of the application) has to be set before the GUI is initialized (by
@@ -1563,8 +1560,8 @@ public class MapTool {
     }
 
     if (MapTool.class.getPackage().getImplementationVersion() != null) {
-      versionImplementation = MapTool.class.getPackage().getImplementationVersion().trim();
-      log.info("getting MapTool version from manifest: " + versionImplementation);
+      version = MapTool.class.getPackage().getImplementationVersion().trim();
+      log.info("getting MapTool version from manifest: " + version);
     }
 
     if (MapTool.class.getPackage().getImplementationVendor() != null) {
@@ -1590,7 +1587,7 @@ public class MapTool {
     // -version
     Options cmdOptions = new Options();
     cmdOptions.addOption("d", "debug", false, "turn on System.out enhanced debug output");
-    cmdOptions.addOption("v", "version", true, "override MapTool version");
+    cmdOptions.addOption("v", "version", true, "override MapTool version (defunct)");
     cmdOptions.addOption("m", "monitor", true, "sets which monitor to use");
     cmdOptions.addOption("f", "fullscreen", false, "set to maximize window");
     cmdOptions.addOption("w", "width", true, "override MapTool window width");
@@ -1609,7 +1606,6 @@ public class MapTool {
       cmd = cmdParser.parse(cmdOptions, args);
 
       debug = getCommandLineOption(cmd, "debug");
-      versionOverride = getCommandLineOption(cmd, "version", version);
       graphicsMonitor = getCommandLineOption(cmd, "monitor", graphicsMonitor);
       useFullScreen = getCommandLineOption(cmd, "fullscreen");
 
@@ -1644,13 +1640,10 @@ public class MapTool {
     }
 
     if (cmd.hasOption("version")) {
-      log.info("overriding MapTool version from command line to: " + versionOverride);
-      version = versionOverride;
-    } else {
-      version = versionImplementation;
-      log.info("MapTool version: " + version);
+      log.warn("Found -v on command line, but the option is no longer used and will be ignored.");
     }
 
+    log.info("MapTool version: " + version);
     log.info("MapTool vendor: " + vendor);
 
     if (cmd.getArgs().length != 0) {
@@ -1666,9 +1659,7 @@ public class MapTool {
 
     // Set MapTool version
     Sentry.setTag("os", System.getProperty("os.name"));
-    Sentry.setTag("version", MapTool.getVersion());
-    Sentry.setTag("versionImplementation", versionImplementation);
-    Sentry.setTag("versionOverride", versionOverride);
+    Sentry.setTag("version", version);
 
     if (listMacros) {
       StringBuilder logOutput = new StringBuilder();


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5973

### Description of the Change

This removes support for the `-v` command line option that overrides the built-in version. The option itself is still registered (so that existing scripts can run new JARs), but a warning is logged to explain that the version number is no longer respected.

This has one change in behaviour for development runs (e.g., `gradlew run`). Tthe splash screen will now show the version as "DEVELOPMENT" rather than "0.0.1" since it is no longer provided in the application arguments and there is no JAR manifest from which to pull a `Implementation-Version`.

### Possible Drawbacks

Can't directly control the version details anymore.

### Documentation Notes

The `-v` command line option no longer has an effect.

### Release Notes

- Removed support for the `-v` command line parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5980)
<!-- Reviewable:end -->
