### PR TITLE
Better defaults for MAPTOOL_DATADIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ out/
 \${sys:appHome}/
 build-resources/wikiDocExtraction/*.txt
 build-resources/wikiDocExtraction/*.xml
+/run/
 
 
 # Automatically Generated

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ def javaArgs = [
         "-Xss8M", "-Dsun.java2d.d3d=false",
         "-Dpolyglot.engine.WarnInterpreterOnly=false",
         "-Djava.util.Arrays.useLegacyMergeSort=true",
-        "-DMAPTOOL_DATADIR=.maptool-" + vendor.toLowerCase(),
         "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
         "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",

--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -125,11 +125,16 @@ public class AppUtil {
     if (dataDirPath == null) {
       String path = System.getProperty(DATADIR_PROPERTY_NAME);
       if (StringUtils.isEmpty(path)) {
-        path = DEFAULT_DATADIR_NAME;
-      }
-      if (!path.contains("/") && !path.contains("\\")) {
+        // This should only happen for test runs that don't go through application initialization.
+        // So use a local directory rather than the user's home directory.
+        var cwd = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+        var dataDir = cwd.resolve("run/data");
+        path = dataDir.toString();
+      } else if (!path.contains("/") && !path.contains("\\")) {
+        // Plain file names should be resolved under the home directory.
         path = getUserHome() + "/" + path;
       }
+
       // Now we need to check for characters that are known to cause problems in
       // path names. We want to allow the local platform to make this decision, but
       // the built-in "jar://" URL uses the "!" as a separator between the archive name

--- a/src/main/java/net/rptools/maptool/client/AppUtil.java
+++ b/src/main/java/net/rptools/maptool/client/AppUtil.java
@@ -50,7 +50,7 @@ public class AppUtil {
 
   private static Logger log;
 
-  private static File dataDirPath;
+  private static Path dataDirPath;
   private static String packagerCfgFileName =
       getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) != null
           ? getAttributeFromJarManifest("Implementation-Title", AppConstants.APP_NAME) + ".cfg"
@@ -66,12 +66,12 @@ public class AppUtil {
   }
 
   /**
-   * Returns a File object for USER_HOME if USER_HOME is non-null, otherwise null.
+   * Returns an absolute path to the user's home directory.
    *
-   * @return the users home directory as a File object
+   * @return the user's home directory absolute path
    */
-  private static File getUserHome() {
-    return new File(System.getProperty("user.home"));
+  private static Path getUserHome() {
+    return Paths.get(System.getProperty("user.home")).toAbsolutePath();
   }
 
   /**
@@ -88,29 +88,28 @@ public class AppUtil {
    * @see AppUtil#getAppHome
    */
   public static File getAppHome(String subdir) {
-    File path = getDataDir();
+    Path path = getDataDir();
     if (!StringUtils.isEmpty(subdir)) {
-      path = new File(path.getAbsolutePath(), subdir);
+      path = path.resolve(subdir).toAbsolutePath();
     }
     // Now check for characters known to cause problems. See getDataDir() for details.
-    if (path.getAbsolutePath().matches("!")) {
-      throw new RuntimeException(I18N.getText("msg.error.unusableDir", path.getAbsolutePath()));
+    if (path.toString().matches("!")) {
+      throw new RuntimeException(I18N.getText("msg.error.unusableDir", path));
     }
 
-    if (!path.exists()) {
-      path.mkdirs();
-      // Now check our work
-      if (!path.exists()) {
-        RuntimeException re =
-            new RuntimeException(
-                I18N.getText("msg.error.unableToCreateDataDir", path.getAbsolutePath()));
-        if (log != null) {
-          log.info("msg.error.unableToCreateDataDir", re);
-        }
-        throw re;
+    // Ensure the path exists in the file system.
+    try {
+      Files.createDirectories(path);
+    } catch (IOException e) {
+      RuntimeException re =
+          new RuntimeException(I18N.getText("msg.error.unableToCreateDataDir", path));
+      if (log != null) {
+        log.info("msg.error.unableToCreateDataDir", re);
       }
+      throw re;
     }
-    return path;
+
+    return path.toFile();
   }
 
   /** Set the state back to uninitialized */
@@ -119,20 +118,27 @@ public class AppUtil {
     dataDirPath = null;
   }
 
-  /** Determine the actual directory to store data files, derived from the environment */
-  // Package protected for testing
-  static File getDataDir() {
+  /**
+   * Determine the actual directory to store data files, derived from the environment
+   *
+   * @return The absolute path to the selected data directory.
+   */
+  private static Path getDataDir() {
     if (dataDirPath == null) {
-      String path = System.getProperty(DATADIR_PROPERTY_NAME);
-      if (StringUtils.isEmpty(path)) {
-        // This should only happen for test runs that don't go through application initialization.
-        // So use a local directory rather than the user's home directory.
-        var cwd = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
-        var dataDir = cwd.resolve("run/data");
-        path = dataDir.toString();
-      } else if (!path.contains("/") && !path.contains("\\")) {
-        // Plain file names should be resolved under the home directory.
-        path = getUserHome() + "/" + path;
+      var dataDirProperty = System.getProperty(DATADIR_PROPERTY_NAME);
+
+      // If the data directory is not provided, that indicates a test run or other development run
+      // that didn't go through normal application startup. So make a local directory for MT data.
+      Path path =
+          StringUtils.isEmpty(dataDirProperty)
+              ? Paths.get(System.getProperty("user.dir"))
+                  .toAbsolutePath()
+                  .resolve(Paths.get("run", "data"))
+              : Paths.get(dataDirProperty);
+
+      if (!path.isAbsolute()) {
+        // Resolve relative paths against the user's home directory.
+        path = getUserHome().resolve(path);
       }
 
       // Now we need to check for characters that are known to cause problems in
@@ -140,11 +146,11 @@ public class AppUtil {
       // the built-in "jar://" URL uses the "!" as a separator between the archive name
       // and the archive member. :( Right now we're only checking for that one character
       // but the list may need to be expanded in the future.
-      if (path.matches("!")) {
+      if (path.toString().matches("!")) {
         throw new RuntimeException(I18N.getText("msg.error.unusableDataDir", path));
       }
 
-      dataDirPath = new File(path);
+      dataDirPath = path;
     }
     return dataDirPath;
   }

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -33,6 +33,9 @@ public class LaunchInstructions {
     if (System.getProperty("java.util.logging.manager") == null) {
       System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
     }
+    if (System.getProperty(AppUtil.DATADIR_PROPERTY_NAME) == null) {
+      System.setProperty(AppUtil.DATADIR_PROPERTY_NAME, ".maptool-rptools");
+    }
     ThreadContext.put("OS", System.getProperty("os.name"));
   }
 


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5974

### Description of the Change

It is no longer required to provide `-DMAPTOOL_DATADIR=.maptool-rptools` to store MT data under `~/.maptool-rptools`. The `~/.maptool` directory will never be used as a default anymore. For situations like test runs, `AppUtil` will default the data directory to be local to the developmenet directory, under `./run/`
 
The option is still supported, so users can still redirect the data directory to be in another location.

I changed some of the path handling in `AppUtil` to use `Path` rather than manipulating and joining `String`-based or `File`-based paths.

### Possible Drawbacks

Should be none.

### Documentation Notes

N/A

### Release Notes

- Changed the default value of the `MAPTOOL_DATADIR` system property to be `.maptool-rptools`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5981)
<!-- Reviewable:end -->
