### PR TITLE
Programmatically provide system property defaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,7 @@ ext {
 }
 
 def javaArgs = [
-        "-Xss8M", "-Dsun.java2d.d3d=false",
-        "-Dpolyglot.engine.WarnInterpreterOnly=false",
-        "-Djava.util.Arrays.useLegacyMergeSort=true",
+        "-Xss8M",
         "--add-opens=java.desktop/java.awt=ALL-UNNAMED", "--add-opens=java.desktop/java.awt.geom=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.awt.geom=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
         "--add-opens=javafx.web/javafx.scene.web=ALL-UNNAMED", "--add-opens=javafx.web/com.sun.webkit=ALL-UNNAMED",

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.maptool.client;
 
+import java.util.Properties;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import org.apache.logging.log4j.LogManager;
@@ -27,25 +28,26 @@ public class LaunchInstructions {
           + "MapTool will launch anyway, but it is recommended that you increase the maximum memory allocated or don't set a limit.</body></html>";
 
   static {
-    if (System.getProperty("sun.java2d.d3d") == null) {
-      System.setProperty("sun.java2d.d3d", "false");
-    }
-    if (System.getProperty("polyglot.engine.WarnInterpreterOnly") == null) {
-      System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
-    }
-    if (System.getProperty("java.util.Arrays.useLegacyMergeSort") == null) {
-      System.setProperty("java.util.Arrays.useLegacyMergeSort", "true");
+    var defaultProperties = new Properties();
+    defaultProperties.put("sun.java2d.d3d", "false");
+    defaultProperties.put("sun.java2d.opengl", "false");
+    defaultProperties.put("polyglot.engine.WarnInterpreterOnly", "false");
+    defaultProperties.put("java.util.Arrays.useLegacyMergeSort", "true");
+    // This sets up log4j to capture logging from Java logging manager
+    defaultProperties.put("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    defaultProperties.put(AppUtil.DATADIR_PROPERTY_NAME, ".maptool-rptools");
+
+    for (var entry : defaultProperties.entrySet()) {
+      var key = entry.getKey().toString();
+
+      // Allow the user to provide an alternative value.
+      if (System.getProperty(key) == null) {
+        System.setProperty(key, entry.getValue().toString());
+      }
     }
 
     // This will inject additional data tags in log4j2 which will be picked up by Sentry.io
     System.setProperty("log4j2.isThreadContextMapInheritable", "true");
-    // This sets up log4j to capture logging from Java logging manager
-    if (System.getProperty("java.util.logging.manager") == null) {
-      System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
-    }
-    if (System.getProperty(AppUtil.DATADIR_PROPERTY_NAME) == null) {
-      System.setProperty(AppUtil.DATADIR_PROPERTY_NAME, ".maptool-rptools");
-    }
     ThreadContext.put("OS", System.getProperty("os.name"));
   }
 

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -27,6 +27,16 @@ public class LaunchInstructions {
           + "MapTool will launch anyway, but it is recommended that you increase the maximum memory allocated or don't set a limit.</body></html>";
 
   static {
+    if (System.getProperty("sun.java2d.d3d") == null) {
+      System.setProperty("sun.java2d.d3d", "false");
+    }
+    if (System.getProperty("polyglot.engine.WarnInterpreterOnly") == null) {
+      System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+    }
+    if (System.getProperty("java.util.Arrays.useLegacyMergeSort") == null) {
+      System.setProperty("java.util.Arrays.useLegacyMergeSort", "true");
+    }
+
     // This will inject additional data tags in log4j2 which will be picked up by Sentry.io
     System.setProperty("log4j2.isThreadContextMapInheritable", "true");
     // This sets up log4j to capture logging from Java logging manager


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5972

### Description of the Change

Sets the `sun.java2d.d3d`, `polyglot.engine.WarnInterpreterOnly`, and `java.util.Arrays.useLegacyMergeSort` system properties immediately on application start rather than requiring them to be set on the command line. If alternative values are provided on the command line, those will be used instead of the defaults. Also added is `sun.java2d.opengl` to be explicit that it should not be used by default, though it just so happens that the JVM does disable this by default (unliked `sun.java2d.d3d`).

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

- Set `sun.java2d.d3d`, `polyglot.engine.WarnInterpreterOnly`, and `java.util.Arrays.useLegacyMergeSort` programmatically so they do not need to be provided on the command line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5982)
<!-- Reviewable:end -->
