### PR TITLE
Remove unused LibGDX dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -419,11 +419,6 @@ dependencies {
     implementation(libs.rptools.maptool.addons)
     implementation(libs.rptools.dice.roller)
     implementation(libs.noiselib)
-
-    // libgdx
-    implementation(libs.bundles.gdx)
-    implementation(variantOf(libs.gdx.platform) { classifier('natives-desktop')})
-    implementation(variantOf(libs.gdx.freetype.platform) { classifier('natives-desktop')})
 }
 
 processResources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ jai-imageio = "1.4.0"
 graalvm-js = "21.2.0"
 pdfbox = "3.0.0"
 protoc = "4.31.1"
-gdx = "1.13.5"
 
 [libraries]
 findbugs-jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version = "3.0.2" }
@@ -154,16 +153,6 @@ intellij-forms-runtime = { group = "com.jetbrains.intellij.java", name = "java-g
 # layout for forms created in code
 miglayout-swing = { group = "com.miglayout", name = "miglayout-swing", version = "11.4.2" }
 
-gdx = { group = "com.badlogicgames.gdx", name = "gdx", version.ref = "gdx" }
-gdx-backend-lwjgl = { group = "com.badlogicgames.gdx", name = "gdx-backend-lwjgl", version.ref = "gdx" }
-gdx-platform = { group = "com.badlogicgames.gdx", name = "gdx-platform", version.ref = "gdx" }
-gdx-freetype = { group = "com.badlogicgames.gdx", name = "gdx-freetype", version.ref = "gdx" }
-gdx-freetype-platform = { group = "com.badlogicgames.gdx", name = "gdx-freetype-platform", version.ref = "gdx" }
-gdx-video = { group = "com.badlogicgames.gdx-video", name = "gdx-video", version = "1.3.3" }
-gdx-video-lwjgl3 = { group = "com.badlogicgames.gdx-video", name = "gdx-video-lwjgl3", version = "1.3.3" }
-libgdx-jogl-backend = { group = "com.github.thelsing", name = "libgdx-jogl-backend", version = "becdde406e" }
-earlygrey-shapedrawer = { group = "space.earlygrey", name = "shapedrawer", version = "2.6.0" }
-
 # RPTools libs
 # default resources (token, textures etc.)
 rptools-maptool-resources = { group = "com.github.RPTools", name = "maptool-resources", version = "1.6.0" }
@@ -217,8 +206,6 @@ handlebars = ["handlebars", "handlebars-helpers"]
 junit = ["junit-api", "junit-engine", "junit-params"]
 jai-imageio = ["jai-imageio-core", "jai-imageio-jpeg"]
 graalvm-js = ["graalvm-js", "graalvm-js-scriptengine"]
-gdx = ["gdx", "gdx-backend-lwjgl", "gdx-platform", "gdx-freetype", "gdx-freetype-platform",
-       "gdx-video", "gdx-video-lwjgl3", "libgdx-jogl-backend", "earlygrey-shapedrawer"]
 
 [plugins]
 git-version = { id = "com.palantir.git-version", version = "4.0.0" }


### PR DESCRIPTION
### Identify the Bug or Feature request

Resolves #5995

### Description of the Change

Removes the unused LibGDX dependencies from `build.gradle` and `libs.versions.toml`

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5996)
<!-- Reviewable:end -->
