### PR TITLE
Fix `ChatTypingPanel` and `ChatActionLabel` notifications not displaying

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -426,6 +426,10 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     pointerToolOverlay = new PointerToolOverlay();
     zoneRendererPanel.add(pointerToolOverlay, PositionalLayout.Position.CENTER, 0);
 
+    // bring chat notifications to the front
+    zoneRendererPanel.setComponentZOrder(getChatTypingPanel(), 0);
+    zoneRendererPanel.setComponentZOrder(getChatActionLabel(), 0);
+
     // Put it all together
     setJMenuBar(menuBar);
     add(BorderLayout.NORTH, toolbarPanel);
@@ -1928,6 +1932,10 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
     zoneRendererPanel.add(initiativePanel, PositionalLayout.Position.SE);
     zoneRendererPanel.setComponentZOrder(initiativePanel, 0);
+
+    // bring chat notifications to the front
+    zoneRendererPanel.setComponentZOrder(getChatTypingPanel(), 0);
+    zoneRendererPanel.setComponentZOrder(getChatActionLabel(), 0);
 
     zoneRendererPanel.revalidate();
     zoneRendererPanel.doLayout();


### PR DESCRIPTION
### Identify the Bug or Feature request
fixes #5907

### Description of the Change
Set the Z-Order for the `ChatTypingPanel` and `ChatActionLabel` components so they both now appear on top of maps.   In full screen mode, when they appear they will appear over the top of any full screen tools (rather than under them as it was previously).  

### Possible Drawbacks
none anticipated

### Documentation Notes
none

### Release Notes
fixed an issue with chat typing and action notifications not displaying over the top of maps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/5999)
<!-- Reviewable:end -->
