### PR TITLE
Open com.sun.java.swing.plaf.windows again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ def modulesToOpen = [
         'java.desktop/sun.java2d',
         'java.desktop/javax.swing',
         'java.desktop/sun.awt.shell',
+        'java.desktop/com.sun.java.swing.plaf.windows'
 ]
 def jarManifestAttributes = [
         'Implementation-Title': project.name + developerRelease,


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes issue with PR #5982 

### Description of the Change

Despite being discouraged, the `java.desktop/com.sun.java.swing.plaf.windows` module is required for proper theming of JIDE components (perhaps others as well) on Windws. The removal of this module prevented things like the EditTokenDialog from being initialized properly.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/6007)
<!-- Reviewable:end -->
