### PR TITLE
Fix for missing state image assets in campaign files

### DIFF
--- a/src/main/java/net/rptools/maptool/client/MapToolUtil.java
+++ b/src/main/java/net/rptools/maptool/client/MapToolUtil.java
@@ -16,6 +16,7 @@ package net.rptools.maptool.client;
 
 import java.awt.Color;
 import java.security.SecureRandom;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -24,6 +25,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.rptools.lib.MD5Key;
 import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.utilities.RandomSuffixFactory;
 import net.rptools.maptool.language.I18N;
@@ -263,6 +265,15 @@ public class MapToolUtil {
 
   public static Set<String> getColorNames() {
     return COLOR_MAP.keySet();
+  }
+
+  public static void uploadAssetIds(Collection<MD5Key> assetIds) {
+    for (var assetId : assetIds) {
+      var asset = AssetManager.getAsset(assetId);
+      if (asset != null) {
+        uploadAsset(asset);
+      }
+    }
   }
 
   public static void uploadTexture(DrawablePaint paint) {

--- a/src/main/java/net/rptools/maptool/client/functions/BarImageFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/BarImageFunction.java
@@ -68,34 +68,29 @@ public class BarImageFunction extends AbstractFunction {
 
     StringBuilder assetId = new StringBuilder("asset://");
 
-    if (over instanceof SingleImageBarTokenOverlay) {
-      assetId.append(((SingleImageBarTokenOverlay) over).getAssetId().toString());
-
-    } else if (over instanceof TwoImageBarTokenOverlay) {
-      if (value != null) {
-        if (value.doubleValue() > 0.5) {
-          assetId.append(((TwoImageBarTokenOverlay) over).getTopAssetId().toString());
-        } else {
-          assetId.append(((TwoImageBarTokenOverlay) over).getBottomAssetId().toString());
-        }
+    if (over instanceof SingleImageBarTokenOverlay one) {
+      assetId.append(one.getAssetId().toString());
+    } else if (over instanceof TwoImageBarTokenOverlay two) {
+      if (value != null && value.doubleValue() > 0.5) {
+        assetId.append(two.getTopAssetId().toString());
       } else {
-        assetId.append(((TwoImageBarTokenOverlay) over).getBottomAssetId().toString());
+        assetId.append(two.getBottomAssetId().toString());
       }
-    } else if (over instanceof MultipleImageBarTokenOverlay) {
+    } else if (over instanceof MultipleImageBarTokenOverlay many) {
       int increment = 0;
-      int max_increments = ((MultipleImageBarTokenOverlay) over).getAssetIds().length;
+      int max_increments = many.getAssets().size();
       if (value != null) {
-        increment = Math.max(Math.min(over.findIncrement(value.doubleValue()), max_increments), 0);
+        increment = Math.clamp(over.findIncrement(value.doubleValue()), 0, max_increments);
       }
-      assetId.append(((MultipleImageBarTokenOverlay) over).getAssetIds()[increment].toString());
+      assetId.append(many.getAssets().get(increment).toString());
     } else {
       throw new ParserException(
           I18N.getText("macro.function.barImage.notImage", functionName, barName));
     }
-    // control flow should be the same with this code being outside of the if statement
+
     if (size != null && size.intValue() != 0) {
       assetId.append("-");
-      int i = Math.max(Math.min(size.intValue(), 500), 1);
+      int i = Math.clamp(size.intValue(), 1, 500);
       assetId.append(i);
     }
     return assetId.toString();

--- a/src/main/java/net/rptools/maptool/client/functions/BarImageFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/BarImageFunction.java
@@ -78,11 +78,11 @@ public class BarImageFunction extends AbstractFunction {
       }
     } else if (over instanceof MultipleImageBarTokenOverlay many) {
       int increment = 0;
-      int max_increments = many.getAssets().size();
+      int max_increments = many.getAssetIds().size();
       if (value != null) {
         increment = Math.clamp(over.findIncrement(value.doubleValue()), 0, max_increments);
       }
-      assetId.append(many.getAssets().get(increment).toString());
+      assetId.append(many.getAssetIds().get(increment).toString());
     } else {
       throw new ParserException(
           I18N.getText("macro.function.barImage.notImage", functionName, barName));

--- a/src/main/java/net/rptools/maptool/client/functions/StateImageFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/StateImageFunction.java
@@ -17,8 +17,8 @@ package net.rptools.maptool.client.functions;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.maptool.client.MapTool;
+import net.rptools.maptool.client.ui.token.AbstractImageTokenOverlay;
 import net.rptools.maptool.client.ui.token.BooleanTokenOverlay;
-import net.rptools.maptool.client.ui.token.ImageTokenOverlay;
 import net.rptools.maptool.language.I18N;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -59,9 +59,9 @@ public class StateImageFunction extends AbstractFunction {
       throw new ParserException(
           I18N.getText("macro.function.stateImage.unknownState", "getStateImage()", stateName));
     }
-    if (over instanceof ImageTokenOverlay) {
+    if (over instanceof AbstractImageTokenOverlay imageOverlay) {
       StringBuilder assetId = new StringBuilder("asset://");
-      assetId.append(((ImageTokenOverlay) over).getAssetId().toString());
+      assetId.append(imageOverlay.getAssetId().toString());
       if (size != null && size.intValue() != 0) {
         assetId.append("-");
         // Constrain it slightly, so its between 1 and 500 :)

--- a/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
+++ b/src/main/java/net/rptools/maptool/client/functions/getInfoFunction.java
@@ -411,15 +411,20 @@ public class getInfoFunction extends AbstractFunction {
       state.addProperty("isShowOwner", bto.isShowOwner() ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty("isShowOthers", bto.isShowOthers() ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty(
-          "isImageOverlay", (bto instanceof ImageTokenOverlay) ? BigDecimal.ONE : BigDecimal.ZERO);
+          "isImageOverlay",
+          (bto instanceof AbstractImageTokenOverlay) ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty("mouseOver", bto.isMouseover() ? BigDecimal.ONE : BigDecimal.ZERO);
       state.addProperty("opacity", bto.getOpacity());
       state.addProperty("order", bto.getOrder());
-      if (bto instanceof FlowColorDotTokenOverlay) {
-        state.addProperty("gridSize", ((FlowColorDotTokenOverlay) bto).getGrid());
+
+      if (bto instanceof AbstractFlowShapeTokenOverlay flow) {
+        state.addProperty("gridSize", flow.getGrid());
       }
-      if (bto instanceof CornerImageTokenOverlay) {
-        state.addProperty("corner", ((CornerImageTokenOverlay) bto).getCorner().name());
+      if (bto instanceof FlowImageTokenOverlay flow) {
+        state.addProperty("gridSize", flow.getGrid());
+      }
+      if (bto instanceof CornerImageTokenOverlay cornerImage) {
+        state.addProperty("corner", cornerImage.getCorner().name());
       }
 
       sgroup.add(state);

--- a/src/main/java/net/rptools/maptool/client/macro/impl/AddTokenStateMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/AddTokenStateMacro.java
@@ -118,7 +118,9 @@ public class AddTokenStateMacro implements Macro {
       MapTool.addLocalMessage(e.getMessage());
       return;
     }
+    MapToolUtil.uploadAssetIds(tokenOverlay.getAssetIds());
     MapTool.getCampaign().getTokenStatesMap().put(tokenOverlay.getName(), tokenOverlay);
+
     MapTool.addLocalMessage(I18N.getText("addtokenstate.added", tokenOverlay.getName()));
   }
 

--- a/src/main/java/net/rptools/maptool/client/macro/impl/LoadTokenStatesMacro.java
+++ b/src/main/java/net/rptools/maptool/client/macro/impl/LoadTokenStatesMacro.java
@@ -23,6 +23,7 @@ import java.util.List;
 import javax.swing.JFileChooser;
 import net.rptools.maptool.client.MapTool;
 import net.rptools.maptool.client.MapToolMacroContext;
+import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.macro.Macro;
 import net.rptools.maptool.client.macro.MacroContext;
 import net.rptools.maptool.client.macro.MacroDefinition;
@@ -72,6 +73,7 @@ public class LoadTokenStatesMacro implements Macro {
       List<BooleanTokenOverlay> overlays = (List<BooleanTokenOverlay>) decoder.readObject();
       decoder.close();
       for (BooleanTokenOverlay overlay : overlays) {
+        MapToolUtil.uploadAssetIds(overlay.getAssetIds());
         MapTool.getCampaign().getTokenStatesMap().put(overlay.getName(), overlay);
       } // endfor
       MapTool.addLocalMessage(I18N.getText("loadtokenstates.loaded", overlays.size()));

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
@@ -603,19 +603,12 @@ public class TokenBarController
         } // endif
 
         // Handle images
-        MD5Key[] assetIds = null;
-        if (bar instanceof TwoImageBarTokenOverlay) {
-          assetIds =
-              new MD5Key[] {
-                ((TwoImageBarTokenOverlay) bar).getBottomAssetId(),
-                ((TwoImageBarTokenOverlay) bar).getTopAssetId()
-              };
+        var assetIds = bar.getAssets();
+        if (bar instanceof TwoImageBarTokenOverlay two) {
           type = 0;
-        } else if (bar instanceof SingleImageBarTokenOverlay) {
-          assetIds = new MD5Key[] {((SingleImageBarTokenOverlay) bar).getAssetId()};
+        } else if (bar instanceof SingleImageBarTokenOverlay one) {
           type = 1;
-        } else if (bar instanceof MultipleImageBarTokenOverlay) {
-          assetIds = ((MultipleImageBarTokenOverlay) bar).getAssetIds();
+        } else if (bar instanceof MultipleImageBarTokenOverlay many) {
           type = 2;
         }
         DefaultListModel<MD5Key> model = new DefaultListModel<>();

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
@@ -42,6 +42,7 @@ import javax.swing.filechooser.FileFilter;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.ColorWell;
 import net.rptools.maptool.client.ui.PreviewPanelFileChooser;
@@ -731,6 +732,8 @@ public class TokenBarController
       BarTokenOverlay overlay = model.getElementAt(i);
       overlay.setOrder(i);
       states.put(overlay.getName(), overlay);
+
+      MapToolUtil.uploadAssetIds(overlay.getAssetIds());
     }
     campaign.getTokenBarsMap().clear();
     campaign.getTokenBarsMap().putAll(states);

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenBarController.java
@@ -603,7 +603,7 @@ public class TokenBarController
         } // endif
 
         // Handle images
-        var assetIds = bar.getAssets();
+        var assetIds = bar.getAssetIds();
         if (bar instanceof TwoImageBarTokenOverlay two) {
           type = 0;
         } else if (bar instanceof SingleImageBarTokenOverlay one) {

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -31,6 +31,7 @@ import net.rptools.lib.MD5Key;
 import net.rptools.lib.StringUtil;
 import net.rptools.maptool.client.AppConstants;
 import net.rptools.maptool.client.AppPreferences;
+import net.rptools.maptool.client.MapToolUtil;
 import net.rptools.maptool.client.swing.AbeillePanel;
 import net.rptools.maptool.client.swing.ColorWell;
 import net.rptools.maptool.client.ui.PreviewPanelFileChooser;
@@ -679,6 +680,8 @@ public class TokenStatesController
       BooleanTokenOverlay overlay = (BooleanTokenOverlay) model.getElementAt(i);
       overlay.setOrder(i);
       states.put(overlay.getName(), overlay);
+
+      MapToolUtil.uploadAssetIds(overlay.getAssetIds());
     }
     campaign.getTokenStatesMap().clear();
     campaign.getTokenStatesMap().putAll(states);

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -513,69 +513,79 @@ public class TokenStatesController
 
       // Get most of the colors and all of the widths from the XTokenOverlay
       OverlayType type;
-      // Handle the
       switch (s) {
-        case CornerImageTokenOverlay cornerImageTokenOverlay -> {
-          type = OverlayType.CornerImage;
-          formPanel
-              .getComboBox(CORNER)
-              .setSelectedIndex(cornerImageTokenOverlay.getCorner().ordinal());
-        }
-        case FlowImageTokenOverlay flowImageTokenOverlay -> {
-          type = OverlayType.GridImage;
-          int size = flowImageTokenOverlay.getGrid(); // Still need grid size
-          formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
-        }
-        case ImageTokenOverlay imageTokenOverlay -> {
-          type = OverlayType.Image;
-        }
         case ColorDotTokenOverlay colorDotTokenOverlay -> {
           type = OverlayType.Dot;
+          ((ColorWell) formPanel.getComponent(COLOR)).setColor(colorDotTokenOverlay.getColor());
           formPanel
               .getComboBox(CORNER)
               .setSelectedIndex(colorDotTokenOverlay.getCorner().ordinal());
-        }
-        case OTokenOverlay oTokenOverlay -> {
-          type = OverlayType.Circle;
         }
         case ShadedTokenOverlay shadedTokenOverlay -> {
           type = OverlayType.Shaded;
           ((ColorWell) formPanel.getComponent(COLOR)).setColor(shadedTokenOverlay.getColor());
         }
-        case CrossTokenOverlay crossTokenOverlay -> {
-          type = OverlayType.Cross;
+
+        // region AbstractImageTokenOverlay
+
+        case AbstractImageTokenOverlay imageTokenOverlay0 -> {
+          switch (imageTokenOverlay0) {
+            case ImageTokenOverlay imageTokenOverlay -> {
+              type = OverlayType.Image;
+            }
+            case CornerImageTokenOverlay cornerImageTokenOverlay -> {
+              type = OverlayType.CornerImage;
+              formPanel
+                  .getComboBox(CORNER)
+                  .setSelectedIndex(cornerImageTokenOverlay.getCorner().ordinal());
+            }
+            case FlowImageTokenOverlay flowImageTokenOverlay -> {
+              type = OverlayType.GridImage;
+              int size = flowImageTokenOverlay.getGrid(); // Still need grid size
+              formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
+            }
+          }
         }
-        case DiamondTokenOverlay diamondTokenOverlay -> {
-          type = OverlayType.Diamond;
-        }
-        case FlowDiamondTokenOverlay flowDiamondTokenOverlay -> {
-          type = OverlayType.GridDiamond;
-        }
-        case YieldTokenOverlay yieldTokenOverlay -> {
-          type = OverlayType.Yield;
-        }
-        case FlowYieldTokenOverlay flowYieldTokenOverlay -> {
-          type = OverlayType.GridYield;
-        }
-        case TriangleTokenOverlay triangleTokenOverlay -> {
-          type = OverlayType.Triangle;
-        }
-        case FlowTriangleTokenOverlay flowTriangleTokenOverlay -> {
-          type = OverlayType.GridTriangle;
-        }
-        case FlowColorSquareTokenOverlay flowColorSquareTokenOverlay -> {
-          type = OverlayType.GridSquare;
-        }
-        case FlowColorDotTokenOverlay flowColorDotTokenOverlay -> {
-          type = OverlayType.GridDot;
-          int size = flowColorDotTokenOverlay.getGrid();
+
+        // endregion
+
+        // region AbstractFlowShapeTokenOverlay
+
+        case AbstractFlowShapeTokenOverlay flowShapeTokenOverlay -> {
+          int size = flowShapeTokenOverlay.getGrid();
           formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
+
+          type =
+              switch (flowShapeTokenOverlay) {
+                case FlowColorDotTokenOverlay flowColorDotTokenOverlay -> OverlayType.GridDot;
+                case FlowColorSquareTokenOverlay flowColorSquareTokenOverlay ->
+                    OverlayType.GridSquare;
+                case FlowDiamondTokenOverlay flowDiamondTokenOverlay -> OverlayType.GridDiamond;
+                case FlowTriangleTokenOverlay flowTriangleTokenOverlay -> OverlayType.GridTriangle;
+                case FlowYieldTokenOverlay flowYieldTokenOverlay -> OverlayType.GridYield;
+              };
         }
-        case XTokenOverlay xTokenOverlay -> {
-          type = OverlayType.X;
-          formPanel.getSpinner(WIDTH).setValue(xTokenOverlay.getWidth());
-          ((ColorWell) formPanel.getComponent(COLOR)).setColor(xTokenOverlay.getColor());
+
+        // endregion
+
+        // region AbstractShapeTokenOverlay
+
+        case AbstractShapeTokenOverlay shapeTokenOverlay -> {
+          formPanel.getSpinner(WIDTH).setValue(shapeTokenOverlay.getWidth());
+          ((ColorWell) formPanel.getComponent(COLOR)).setColor(shapeTokenOverlay.getColor());
+
+          type =
+              switch (shapeTokenOverlay) {
+                case CrossTokenOverlay crossTokenOverlay -> OverlayType.Cross;
+                case DiamondTokenOverlay diamondTokenOverlay -> OverlayType.Diamond;
+                case OTokenOverlay oTokenOverlay -> OverlayType.Circle;
+                case TriangleTokenOverlay triangleTokenOverlay -> OverlayType.Triangle;
+                case YieldTokenOverlay yieldTokenOverlay -> OverlayType.Yield;
+                case XTokenOverlay xTokenOverlay -> OverlayType.X;
+              };
         }
+
+          // endregion
       }
 
       // Set the type and change components

--- a/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
+++ b/src/main/java/net/rptools/maptool/client/ui/campaignproperties/TokenStatesController.java
@@ -511,57 +511,71 @@ public class TokenStatesController
       formPanel.getCheckBox(SHOW_OTHERS).setSelected(s.isShowOthers());
 
       // Get most of the colors and all of the widths from the XTokenOverlay
-      OverlayType type = OverlayType.Image;
-      if (s instanceof XTokenOverlay xTokenOverlay) {
-        type = OverlayType.X;
-        formPanel.getSpinner(WIDTH).setValue(xTokenOverlay.getWidth());
-        ((ColorWell) formPanel.getComponent(COLOR)).setColor(xTokenOverlay.getColor());
-      } // endif
-
-      // Get the the flow grid for most components from FlowColorDotTokenOverlay
-      if (s instanceof FlowColorDotTokenOverlay flowColorDotTokenOverlay) {
-        type = OverlayType.GridDot;
-        int size = flowColorDotTokenOverlay.getGrid();
-        formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
-      } // endif
-
+      OverlayType type;
       // Handle the
-      if (s instanceof CornerImageTokenOverlay cornerImageTokenOverlay) {
-        type = OverlayType.CornerImage;
-        formPanel
-            .getComboBox(CORNER)
-            .setSelectedIndex(cornerImageTokenOverlay.getCorner().ordinal());
-      } else if (s instanceof FlowImageTokenOverlay flowImageTokenOverlay) {
-        type = OverlayType.GridImage;
-        int size = flowImageTokenOverlay.getGrid(); // Still need grid size
-        formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
-      } else if (s instanceof ImageTokenOverlay) {
-        type = OverlayType.Image;
-      } else if (s instanceof ColorDotTokenOverlay colorDotTokenOverlay) {
-        type = OverlayType.Dot;
-        formPanel.getComboBox(CORNER).setSelectedIndex(colorDotTokenOverlay.getCorner().ordinal());
-      } else if (s instanceof OTokenOverlay) {
-        type = OverlayType.Circle;
-      } else if (s instanceof ShadedTokenOverlay shadedTokenOverlay) {
-        type = OverlayType.Shaded;
-        ((ColorWell) formPanel.getComponent(COLOR)).setColor(shadedTokenOverlay.getColor());
-      } else if (s instanceof CrossTokenOverlay) {
-        type = OverlayType.Cross;
-      } else if (s instanceof DiamondTokenOverlay) {
-        type = OverlayType.Diamond;
-      } else if (s instanceof FlowDiamondTokenOverlay) {
-        type = OverlayType.GridDiamond;
-      } else if (s instanceof YieldTokenOverlay) {
-        type = OverlayType.Yield;
-      } else if (s instanceof FlowYieldTokenOverlay) {
-        type = OverlayType.GridYield;
-      } else if (s instanceof TriangleTokenOverlay) {
-        type = OverlayType.Triangle;
-      } else if (s instanceof FlowTriangleTokenOverlay) {
-        type = OverlayType.GridTriangle;
-      } else if (s instanceof FlowColorSquareTokenOverlay) {
-        type = OverlayType.GridSquare;
-      } // endif
+      switch (s) {
+        case CornerImageTokenOverlay cornerImageTokenOverlay -> {
+          type = OverlayType.CornerImage;
+          formPanel
+              .getComboBox(CORNER)
+              .setSelectedIndex(cornerImageTokenOverlay.getCorner().ordinal());
+        }
+        case FlowImageTokenOverlay flowImageTokenOverlay -> {
+          type = OverlayType.GridImage;
+          int size = flowImageTokenOverlay.getGrid(); // Still need grid size
+          formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
+        }
+        case ImageTokenOverlay imageTokenOverlay -> {
+          type = OverlayType.Image;
+        }
+        case ColorDotTokenOverlay colorDotTokenOverlay -> {
+          type = OverlayType.Dot;
+          formPanel
+              .getComboBox(CORNER)
+              .setSelectedIndex(colorDotTokenOverlay.getCorner().ordinal());
+        }
+        case OTokenOverlay oTokenOverlay -> {
+          type = OverlayType.Circle;
+        }
+        case ShadedTokenOverlay shadedTokenOverlay -> {
+          type = OverlayType.Shaded;
+          ((ColorWell) formPanel.getComponent(COLOR)).setColor(shadedTokenOverlay.getColor());
+        }
+        case CrossTokenOverlay crossTokenOverlay -> {
+          type = OverlayType.Cross;
+        }
+        case DiamondTokenOverlay diamondTokenOverlay -> {
+          type = OverlayType.Diamond;
+        }
+        case FlowDiamondTokenOverlay flowDiamondTokenOverlay -> {
+          type = OverlayType.GridDiamond;
+        }
+        case YieldTokenOverlay yieldTokenOverlay -> {
+          type = OverlayType.Yield;
+        }
+        case FlowYieldTokenOverlay flowYieldTokenOverlay -> {
+          type = OverlayType.GridYield;
+        }
+        case TriangleTokenOverlay triangleTokenOverlay -> {
+          type = OverlayType.Triangle;
+        }
+        case FlowTriangleTokenOverlay flowTriangleTokenOverlay -> {
+          type = OverlayType.GridTriangle;
+        }
+        case FlowColorSquareTokenOverlay flowColorSquareTokenOverlay -> {
+          type = OverlayType.GridSquare;
+        }
+        case FlowColorDotTokenOverlay flowColorDotTokenOverlay -> {
+          type = OverlayType.GridDot;
+          int size = flowColorDotTokenOverlay.getGrid();
+          formPanel.getSpinner(FLOW_GRID).setValue(size + "x" + size);
+        }
+        case XTokenOverlay xTokenOverlay -> {
+          type = OverlayType.X;
+          formPanel.getSpinner(WIDTH).setValue(xTokenOverlay.getWidth());
+          ((ColorWell) formPanel.getComponent(COLOR)).setColor(xTokenOverlay.getColor());
+        }
+      }
 
       // Set the type and change components
       formPanel.getComboBox(TYPE).setSelectedIndex(type.ordinal());
@@ -747,9 +761,8 @@ public class TokenStatesController
       fName = fName.length() == 0 ? null : fName;
       if (updatedOverlay == null || fName != null) {
         assetId = loadAsssetFile(fName, formPanel);
-      } else {
-        if (updatedOverlay instanceof ImageTokenOverlay)
-          assetId = ((ImageTokenOverlay) updatedOverlay).getAssetId();
+      } else if (updatedOverlay instanceof AbstractImageTokenOverlay imageOverlay) {
+        assetId = imageOverlay.getAssetId();
       } // endif
 
       // Create all of the image overlays

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractImageTokenOverlay.java
@@ -1,0 +1,49 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.maptool.client.ui.token;
+
+import java.util.List;
+import net.rptools.lib.MD5Key;
+
+public abstract sealed class AbstractImageTokenOverlay extends BooleanTokenOverlay
+    permits ImageTokenOverlay, CornerImageTokenOverlay, FlowImageTokenOverlay {
+  /** ID of the image displayed in the overlay. */
+  private MD5Key assetId;
+
+  /**
+   * Create new image overlay.
+   *
+   * @param name Name of the new token overlay
+   * @param assetId ID of the image displayed in the new token overlay.
+   */
+  public AbstractImageTokenOverlay(String name, MD5Key assetId) {
+    super(name);
+    this.assetId = assetId;
+  }
+
+  public AbstractImageTokenOverlay(AbstractImageTokenOverlay other) {
+    super(other.name);
+    this.assetId = other.assetId;
+  }
+
+  public MD5Key getAssetId() {
+    return assetId;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(assetId);
+  }
+}

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractImageTokenOverlay.java
@@ -43,7 +43,7 @@ public abstract sealed class AbstractImageTokenOverlay extends BooleanTokenOverl
   }
 
   @Override
-  public List<MD5Key> getAssets() {
+  public List<MD5Key> getAssetIds() {
     return List.of(assetId);
   }
 }

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractTokenOverlay.java
@@ -18,6 +18,8 @@ import com.google.protobuf.StringValue;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.util.Comparator;
+import java.util.List;
+import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.player.Player;
 import net.rptools.maptool.server.proto.TokenOverlayDto;
@@ -256,6 +258,13 @@ public abstract class AbstractTokenOverlay implements Cloneable {
    * @see java.lang.Object#clone()
    */
   public abstract Object clone();
+
+  /**
+   * @return The keys for all assets required by the overlay.
+   */
+  public List<MD5Key> getAssets() {
+    return List.of();
+  }
 
   protected void fillFrom(TokenOverlayDto dto) {
     name = dto.getName();

--- a/src/main/java/net/rptools/maptool/client/ui/token/AbstractTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/AbstractTokenOverlay.java
@@ -262,7 +262,7 @@ public abstract class AbstractTokenOverlay implements Cloneable {
   /**
    * @return The keys for all assets required by the overlay.
    */
-  public List<MD5Key> getAssets() {
+  public List<MD5Key> getAssetIds() {
     return List.of();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/BooleanTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/BooleanTokenOverlay.java
@@ -31,10 +31,8 @@ import org.apache.logging.log4j.Logger;
 public abstract sealed class BooleanTokenOverlay extends AbstractTokenOverlay
     permits AbstractShapeTokenOverlay,
         AbstractFlowShapeTokenOverlay,
+        AbstractImageTokenOverlay,
         ColorDotTokenOverlay,
-        ImageTokenOverlay,
-        CornerImageTokenOverlay,
-        FlowImageTokenOverlay,
         ShadedTokenOverlay {
   private static final Logger log = LogManager.getLogger(BooleanTokenOverlay.class);
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
@@ -18,7 +18,6 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -32,10 +31,7 @@ import net.rptools.maptool.util.ImageManager;
  *
  * @author Jay
  */
-public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
-
-  /** ID of the image displayed in the overlay. */
-  private MD5Key assetId;
+public final class CornerImageTokenOverlay extends AbstractImageTokenOverlay {
 
   /** The corner where the image is placed */
   private Quadrant corner;
@@ -48,29 +44,18 @@ public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
    * @param corner Corner that contains the image.
    */
   public CornerImageTokenOverlay(String name, MD5Key assetId, Quadrant corner) {
-    super(name);
-    this.assetId = assetId;
+    super(name, assetId);
     this.corner = corner;
   }
 
   public CornerImageTokenOverlay(CornerImageTokenOverlay other) {
     super(other);
-    this.assetId = other.assetId;
     this.corner = other.corner;
   }
 
   @Override
   public CornerImageTokenOverlay clone() {
     return new CornerImageTokenOverlay(this);
-  }
-
-  public MD5Key getAssetId() {
-    return assetId;
-  }
-
-  @Override
-  public List<MD5Key> getAssets() {
-    return List.of(assetId);
   }
 
   /**
@@ -108,7 +93,7 @@ public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    BufferedImage image = ImageManager.getImageAndWait(assetId);
+    BufferedImage image = ImageManager.getImageAndWait(getAssetId());
     Rectangle2D imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
     AwtUtil.fitInto(imageBounds, bounds);
     imageBounds = getBounds(imageBounds);
@@ -124,7 +109,7 @@ public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
 
   public CornerImageTokenOverlayDto toCornerImageDto() {
     var dto = CornerImageTokenOverlayDto.newBuilder();
-    dto.setAssetId(assetId.toString());
+    dto.setAssetId(getAssetId().toString());
     dto.setQuadrant(QuadrantDto.valueOf(corner.name()));
     return dto.build();
   }

--- a/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/CornerImageTokenOverlay.java
@@ -18,6 +18,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -65,6 +66,11 @@ public final class CornerImageTokenOverlay extends BooleanTokenOverlay {
 
   public MD5Key getAssetId() {
     return assetId;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(assetId);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
@@ -18,6 +18,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -74,6 +75,11 @@ public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
 
   public MD5Key getAssetId() {
     return assetId;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(assetId);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/FlowImageTokenOverlay.java
@@ -18,7 +18,6 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -31,11 +30,8 @@ import net.rptools.maptool.util.ImageManager;
  *
  * @author Jay
  */
-public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
+public final class FlowImageTokenOverlay extends AbstractImageTokenOverlay {
   private static final int DEFAULT_GRID_SIZE = 3;
-
-  /** ID of the image displayed in the overlay. */
-  private MD5Key assetId;
 
   /** Size of the grid used to place a token with this state. */
   private int grid;
@@ -52,9 +48,7 @@ public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
    *     share the same overlay.
    */
   public FlowImageTokenOverlay(String name, MD5Key assetId, int gridSize) {
-    super(name);
-
-    this.assetId = assetId;
+    super(name, assetId);
 
     if (gridSize <= 0) {
       gridSize = DEFAULT_GRID_SIZE;
@@ -64,22 +58,12 @@ public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
 
   public FlowImageTokenOverlay(FlowImageTokenOverlay other) {
     super(other);
-    this.assetId = other.assetId;
     this.grid = other.grid;
   }
 
   @Override
   public FlowImageTokenOverlay clone() {
     return new FlowImageTokenOverlay(this);
-  }
-
-  public MD5Key getAssetId() {
-    return assetId;
-  }
-
-  @Override
-  public List<MD5Key> getAssets() {
-    return List.of(assetId);
   }
 
   /**
@@ -96,7 +80,7 @@ public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
 
   @Override
   public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    BufferedImage image = ImageManager.getImageAndWait(assetId);
+    BufferedImage image = ImageManager.getImageAndWait(getAssetId());
 
     var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
     AwtUtil.fitInto(imageBounds, bounds);
@@ -121,7 +105,7 @@ public final class FlowImageTokenOverlay extends BooleanTokenOverlay {
 
   public FlowImageTokenOverlayDto toFlowImageDto() {
     var dto = FlowImageTokenOverlayDto.newBuilder();
-    dto.setAssetId(assetId.toString());
+    dto.setAssetId(getAssetId().toString());
     dto.setGridSize(grid);
     return dto.build();
   }

--- a/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
@@ -17,7 +17,6 @@ package net.rptools.maptool.client.ui.token;
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -29,10 +28,7 @@ import net.rptools.maptool.util.ImageManager;
  *
  * @author Jay
  */
-public final class ImageTokenOverlay extends BooleanTokenOverlay {
-
-  /** ID of the image displayed in the overlay. */
-  private MD5Key assetId;
+public final class ImageTokenOverlay extends AbstractImageTokenOverlay {
 
   /**
    * Create the complete image overlay.
@@ -41,13 +37,11 @@ public final class ImageTokenOverlay extends BooleanTokenOverlay {
    * @param assetId ID of the image displayed in the new token overlay.
    */
   public ImageTokenOverlay(String name, MD5Key assetId) {
-    super(name);
-    this.assetId = assetId;
+    super(name, assetId);
   }
 
   public ImageTokenOverlay(ImageTokenOverlay other) {
     super(other);
-    this.assetId = other.assetId;
   }
 
   @Override
@@ -55,21 +49,9 @@ public final class ImageTokenOverlay extends BooleanTokenOverlay {
     return new ImageTokenOverlay(this);
   }
 
-  /**
-   * @return Getter for assetId
-   */
-  public MD5Key getAssetId() {
-    return assetId;
-  }
-
-  @Override
-  public List<MD5Key> getAssets() {
-    return List.of(assetId);
-  }
-
   @Override
   public void paintOverlay(Graphics2D g, Token token, Rectangle bounds) {
-    BufferedImage image = ImageManager.getImageAndWait(assetId);
+    BufferedImage image = ImageManager.getImageAndWait(getAssetId());
 
     var imageBounds = new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight());
     AwtUtil.fitInto(imageBounds, bounds);
@@ -85,7 +67,7 @@ public final class ImageTokenOverlay extends BooleanTokenOverlay {
 
   public ImageTokenOverlayDto toImageDto() {
     var dto = ImageTokenOverlayDto.newBuilder();
-    dto.setAssetId(assetId.toString());
+    dto.setAssetId(getAssetId().toString());
     return dto.build();
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/ImageTokenOverlay.java
@@ -17,6 +17,7 @@ package net.rptools.maptool.client.ui.token;
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -59,6 +60,11 @@ public final class ImageTokenOverlay extends BooleanTokenOverlay {
    */
   public MD5Key getAssetId() {
     return assetId;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(assetId);
   }
 
   @Override

--- a/src/main/java/net/rptools/maptool/client/ui/token/MultipleImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/MultipleImageBarTokenOverlay.java
@@ -21,6 +21,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
@@ -119,6 +120,11 @@ public class MultipleImageBarTokenOverlay extends BarTokenOverlay {
    */
   public void setAssetIds(MD5Key[] theAssetIds) {
     this.assetIds = theAssetIds;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(assetIds);
   }
 
   public static BarTokenOverlay fromDto(BarTokenOverlayDto dto) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/MultipleImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/MultipleImageBarTokenOverlay.java
@@ -108,23 +108,16 @@ public class MultipleImageBarTokenOverlay extends BarTokenOverlay {
     g.setComposite(tempComposite);
   }
 
-  /**
-   * @return Getter for bottomAssetId
-   */
-  public MD5Key[] getAssetIds() {
-    return assetIds;
+  @Override
+  public List<MD5Key> getAssetIds() {
+    return List.of(assetIds);
   }
 
   /**
    * @param theAssetIds Setter for bottomAssetId
    */
-  public void setAssetIds(MD5Key[] theAssetIds) {
-    this.assetIds = theAssetIds;
-  }
-
-  @Override
-  public List<MD5Key> getAssets() {
-    return List.of(assetIds);
+  public void setAssetIds(List<MD5Key> theAssetIds) {
+    this.assetIds = theAssetIds.toArray(MD5Key[]::new);
   }
 
   public static BarTokenOverlay fromDto(BarTokenOverlayDto dto) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/SingleImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/SingleImageBarTokenOverlay.java
@@ -20,6 +20,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -137,6 +138,11 @@ public class SingleImageBarTokenOverlay extends BarTokenOverlay {
    */
   public MD5Key getAssetId() {
     return assetId;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(assetId);
   }
 
   /**

--- a/src/main/java/net/rptools/maptool/client/ui/token/SingleImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/SingleImageBarTokenOverlay.java
@@ -141,7 +141,7 @@ public class SingleImageBarTokenOverlay extends BarTokenOverlay {
   }
 
   @Override
-  public List<MD5Key> getAssets() {
+  public List<MD5Key> getAssetIds() {
     return List.of(assetId);
   }
 

--- a/src/main/java/net/rptools/maptool/client/ui/token/TwoImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TwoImageBarTokenOverlay.java
@@ -20,6 +20,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import net.rptools.lib.AwtUtil;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.model.Token;
@@ -170,6 +171,11 @@ public class TwoImageBarTokenOverlay extends BarTokenOverlay {
    */
   public void setTopAssetId(MD5Key topAssetId) {
     this.topAssetId = topAssetId;
+  }
+
+  @Override
+  public List<MD5Key> getAssets() {
+    return List.of(this.topAssetId, this.bottomAssetId);
   }
 
   public static BarTokenOverlay fromDto(BarTokenOverlayDto dto) {

--- a/src/main/java/net/rptools/maptool/client/ui/token/TwoImageBarTokenOverlay.java
+++ b/src/main/java/net/rptools/maptool/client/ui/token/TwoImageBarTokenOverlay.java
@@ -174,7 +174,7 @@ public class TwoImageBarTokenOverlay extends BarTokenOverlay {
   }
 
   @Override
-  public List<MD5Key> getAssets() {
+  public List<MD5Key> getAssetIds() {
     return List.of(this.topAssetId, this.bottomAssetId);
   }
 

--- a/src/main/java/net/rptools/maptool/model/Campaign.java
+++ b/src/main/java/net/rptools/maptool/model/Campaign.java
@@ -29,10 +29,6 @@ import net.rptools.maptool.client.ui.ToolbarPanel;
 import net.rptools.maptool.client.ui.macrobuttons.panels.AbstractMacroPanel;
 import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.client.ui.token.BooleanTokenOverlay;
-import net.rptools.maptool.client.ui.token.ImageTokenOverlay;
-import net.rptools.maptool.client.ui.token.MultipleImageBarTokenOverlay;
-import net.rptools.maptool.client.ui.token.SingleImageBarTokenOverlay;
-import net.rptools.maptool.client.ui.token.TwoImageBarTokenOverlay;
 import net.rptools.maptool.model.sheet.stats.StatSheetProperties;
 import net.rptools.maptool.server.proto.CampaignDto;
 
@@ -610,34 +606,12 @@ public class Campaign implements Serializable {
   public Set<MD5Key> getAllAssetIds() {
 
     // Maps (tokens are implicit)
-    Set<MD5Key> assetSet = new HashSet<MD5Key>();
+    Set<MD5Key> assetSet = new HashSet<>();
     for (Zone zone : getZones()) {
       assetSet.addAll(zone.getAllAssetIds());
     }
 
-    // States
-    for (BooleanTokenOverlay overlay : getCampaignProperties().getTokenStatesMap().values()) {
-      if (overlay instanceof ImageTokenOverlay) {
-        assetSet.add(((ImageTokenOverlay) overlay).getAssetId());
-      }
-    }
-
-    // Bars
-    for (BarTokenOverlay overlay : getCampaignProperties().getTokenBarsMap().values()) {
-      if (overlay instanceof SingleImageBarTokenOverlay) {
-        assetSet.add(((SingleImageBarTokenOverlay) overlay).getAssetId());
-      } else if (overlay instanceof TwoImageBarTokenOverlay) {
-        assetSet.add(((TwoImageBarTokenOverlay) overlay).getTopAssetId());
-        assetSet.add(((TwoImageBarTokenOverlay) overlay).getBottomAssetId());
-      } else if (overlay instanceof MultipleImageBarTokenOverlay) {
-        assetSet.addAll(Arrays.asList(((MultipleImageBarTokenOverlay) overlay).getAssetIds()));
-      } // endif
-    }
-
-    // Tables
-    for (LookupTable table : getCampaignProperties().getLookupTableMap().values()) {
-      assetSet.addAll(table.getAllAssetIds());
-    }
+    assetSet.addAll(getCampaignProperties().getAllImageAssets());
 
     return assetSet;
   }

--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -33,18 +33,13 @@ import javax.annotation.Nonnull;
 import net.rptools.lib.MD5Key;
 import net.rptools.maptool.client.AppPreferences;
 import net.rptools.maptool.client.MapToolUtil;
-import net.rptools.maptool.client.ui.token.AbstractTokenOverlay;
 import net.rptools.maptool.client.ui.token.BarTokenOverlay;
 import net.rptools.maptool.client.ui.token.BooleanTokenOverlay;
 import net.rptools.maptool.client.ui.token.ColorDotTokenOverlay;
 import net.rptools.maptool.client.ui.token.DiamondTokenOverlay;
-import net.rptools.maptool.client.ui.token.ImageTokenOverlay;
-import net.rptools.maptool.client.ui.token.MultipleImageBarTokenOverlay;
 import net.rptools.maptool.client.ui.token.OTokenOverlay;
 import net.rptools.maptool.client.ui.token.ShadedTokenOverlay;
-import net.rptools.maptool.client.ui.token.SingleImageBarTokenOverlay;
 import net.rptools.maptool.client.ui.token.TriangleTokenOverlay;
-import net.rptools.maptool.client.ui.token.TwoImageBarTokenOverlay;
 import net.rptools.maptool.client.ui.token.TwoToneBarTokenOverlay;
 import net.rptools.maptool.client.ui.token.XTokenOverlay;
 import net.rptools.maptool.client.ui.token.YieldTokenOverlay;
@@ -669,20 +664,13 @@ public class CampaignProperties implements Serializable {
     }
 
     // States have images as well
-    for (AbstractTokenOverlay overlay : getTokenStatesMap().values()) {
-      if (overlay instanceof ImageTokenOverlay) set.add(((ImageTokenOverlay) overlay).getAssetId());
+    for (BooleanTokenOverlay overlay : getTokenStatesMap().values()) {
+      set.addAll(overlay.getAssets());
     }
 
     // Bars
     for (BarTokenOverlay overlay : getTokenBarsMap().values()) {
-      if (overlay instanceof SingleImageBarTokenOverlay) {
-        set.add(((SingleImageBarTokenOverlay) overlay).getAssetId());
-      } else if (overlay instanceof TwoImageBarTokenOverlay) {
-        set.add(((TwoImageBarTokenOverlay) overlay).getTopAssetId());
-        set.add(((TwoImageBarTokenOverlay) overlay).getBottomAssetId());
-      } else if (overlay instanceof MultipleImageBarTokenOverlay) {
-        set.addAll(Arrays.asList(((MultipleImageBarTokenOverlay) overlay).getAssetIds()));
-      }
+      set.addAll(overlay.getAssets());
     }
     return set;
   }

--- a/src/main/java/net/rptools/maptool/model/CampaignProperties.java
+++ b/src/main/java/net/rptools/maptool/model/CampaignProperties.java
@@ -665,12 +665,12 @@ public class CampaignProperties implements Serializable {
 
     // States have images as well
     for (BooleanTokenOverlay overlay : getTokenStatesMap().values()) {
-      set.addAll(overlay.getAssets());
+      set.addAll(overlay.getAssetIds());
     }
 
     // Bars
     for (BarTokenOverlay overlay : getTokenBarsMap().values()) {
-      set.addAll(overlay.getAssets());
+      set.addAll(overlay.getAssetIds());
     }
     return set;
   }


### PR DESCRIPTION
### Identify the Bug or Feature request

Fixes #6004

Fixes #5933, introduced in PR #5829

### Description of the Change

First of all, updates the various places that states and bars are added to a campaign so that they also upload the asset to the server if needed. The places are the states and bar controllers of the Campaign Properties dialog, and the `addtokenstate` and `loadtokenstates` macro definitions. This fixes #6004

Supporting that, and fixing #5933, all token overlays (states and bars) have a general `#getAssetIds()` method that returns the IDs of all assets required by the overlay. This replaces most previous checks for `ImageTokenOverlay` as that was no longer the base class for all image-bearing states since #5829. This is especially important when serializing the campaign, as all state and bar assets are now guaranteed to be included.

There are a few places where checking for image-bearing states is still useful, particular some macro functions and UI code. A new `AbstractImageTokenOverlay` class has been introduced to fill that role without mixing up the individual concrete classes.

Misc notes:
- For `getInfo("campaign")`, there is still a need to check concrete types to provide the `"corner"` and `"gridSize"` keys for associated states. As these are specific to this macro function, I haven't added any kind of generic way of expressing these.
- In `TokenStatesController`, an exhaustive switch is now used to make sure we handle all the possible cases.

### Possible Drawbacks

None

### Documentation Notes

N/A

### Release Notes

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/6008)
<!-- Reviewable:end -->
