### PR TITLE
Fix ChatTypingPanel and ChatActionLabel notifications not displaying Take 2

### DIFF
--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -411,7 +411,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     currentRenderPanel = zoneRendererPanel;
 
     zoneRendererPanel.add(getChatTypingPanel(), PositionalLayout.Position.NW);
-    zoneRendererPanel.add(getChatActionLabel(), PositionalLayout.Position.SW);
 
     commandPanel = new CommandPanel();
 
@@ -422,6 +421,9 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
     zoneRendererPanel.add(overlayPanel, PositionalLayout.Position.CENTER, 0);
     overlayPanel.setVisible(false); // disabled by default
+
+    // chat action label should be above overlays, otherwise unclickable when overlays visible
+    zoneRendererPanel.add(getChatActionLabel(), PositionalLayout.Position.SW, 0);
 
     pointerToolOverlay = new PointerToolOverlay();
     zoneRendererPanel.add(pointerToolOverlay, PositionalLayout.Position.CENTER, 0);

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1703,8 +1703,7 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
       zoneRendererPanel.remove(currentRenderer);
     }
     if (renderer != null) {
-      zoneRendererPanel.add(
-          renderer, PositionalLayout.Position.CENTER, zoneRendererPanel.getComponentCount() - 2);
+      zoneRendererPanel.add(renderer, PositionalLayout.Position.CENTER);
       zoneRendererPanel.doLayout();
     }
     currentRenderer = renderer;

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -426,10 +426,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     pointerToolOverlay = new PointerToolOverlay();
     zoneRendererPanel.add(pointerToolOverlay, PositionalLayout.Position.CENTER, 0);
 
-    // bring chat notifications to the front
-    zoneRendererPanel.setComponentZOrder(getChatTypingPanel(), 0);
-    zoneRendererPanel.setComponentZOrder(getChatActionLabel(), 0);
-
     // Put it all together
     setJMenuBar(menuBar);
     add(BorderLayout.NORTH, toolbarPanel);
@@ -1932,10 +1928,6 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
 
     zoneRendererPanel.add(initiativePanel, PositionalLayout.Position.SE);
     zoneRendererPanel.setComponentZOrder(initiativePanel, 0);
-
-    // bring chat notifications to the front
-    zoneRendererPanel.setComponentZOrder(getChatTypingPanel(), 0);
-    zoneRendererPanel.setComponentZOrder(getChatActionLabel(), 0);
 
     zoneRendererPanel.revalidate();
     zoneRendererPanel.doLayout();

--- a/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
+++ b/src/main/java/net/rptools/maptool/client/ui/MapToolFrame.java
@@ -1981,6 +1981,11 @@ public class MapToolFrame extends DefaultDockableHolder implements WindowListene
     menuBar.setVisible(true);
     this.setVisible(true);
 
+    // hide the chat action label if the chat window is already visible in windowed mode
+    if (chatActionLabel.isShowing() && isCommandPanelVisible()) {
+      chatActionLabel.setVisible(false);
+    }
+
     fullScreenFrame.dispose();
     fullScreenFrame = null;
   }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix or Enhancement
fixes #6006
properly fixes #5907

### Description of the Change
1. Undoes changes made in #5999 for issue #5907.
2. `zoneRenderPanel` is now always added at the back.
3. Resurrects the chat action label (no one seemed to miss it however as it has been gone for a while and no-one complained about it!).  Chat action label is now added above overlays (so it remains clickable if overlays are visible)
4. If the chat action label is visible in full screen mode (where chat is not visible anyway), when exiting full screen it now checks if the chat window (the command panel) is already open and if so hide the chat action label.

Layer Order is now:
1. PointerToolOverlay (TOP)
2. JLabel (chat action)
3. HTMLOverlayPanel
4. ChatTypingNotification
5. ZoneRenderer (BOTTOM)

### Possible Drawbacks
Minor - clicking the chat action label when in full screen mode will open the chat window (if not already open) on exiting full screen mode.

### Documentation Notes
n/a

### Release Notes
- Fixed an issue where chat notifications were not being displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/6009)
<!-- Reviewable:end -->
