### PR TITLE
Add more output info to build log and upload test results to artifacts

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: "21"
       - name: spotlessCheck
         run: ./gradlew spotlessCheck
@@ -38,12 +38,12 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.os }} w/JDK ${{ matrix.java }}
-    runs-on:  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-15-intel]
-        java: [ '21' ]
-        distribution: [ 'temurin']
+        java: ["21"]
+        distribution: ["temurin"]
       fail-fast: false
     steps:
       - name: Git checkout
@@ -60,9 +60,15 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      #- name: Junit Report to Annotations
-      #  uses: ashley-taylor/junit-report-annotations-action@v1.0
       - name: Build with Gradle
         uses: GabrielBB/xvfb-action@v1.0
-        with: 
-          run: ./gradlew build --no-daemon
+        with:
+          run: ./gradlew build --no-daemon --info
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.os }}-jdk${{ matrix.java }}
+          path: |
+            build/reports/tests/test/**
+            build/test-results/test/**

--- a/build.gradle
+++ b/build.gradle
@@ -508,3 +508,13 @@ javadoc {
 task createWrapper(type: Wrapper) {
     gradleVersion = '8.2.1'
 }
+
+tasks.withType(Test).configureEach {
+    testLogging {
+        events "failed", "skipped"
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
+}


### PR DESCRIPTION

### Identify the Bug or Feature request
resolves #6016 


### Description of the Change
- Added logging to the build tasks
- Added the --info flag to the build to output more information
- Uploaded the generated junit test results as an artifact to the build

### Possible Drawbacks
- Builds may take a little bit longer, but it's worth it
- The build log is a LOT noiser, but when things pass you won't even see it, and when they fail in some cases you need that extra information.

### Documentation Notes
- Added logging to the build tasks
- Added the --info flag to the build to output more information
- Uploaded the generated junit test results as an artifact to the build

The test results can be found by expanding the "Upload test reports" in the build log, the download link then appers at the bottom of that section.
<img width="1677" height="710" alt="image" src="https://github.com/user-attachments/assets/cee61045-5027-4906-9e9b-901ccdfe6257" />


### Release Notes
Add more information for debuging failing builds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/6017)
<!-- Reviewable:end -->
