### PR TITLE
Close the extraction marker stream reliably

### DIFF
--- a/src/main/java/net/rptools/maptool/util/ExtractImagesFromPDF.java
+++ b/src/main/java/net/rptools/maptool/util/ExtractImagesFromPDF.java
@@ -127,12 +127,8 @@ public final class ExtractImagesFromPDF {
     imageTracker.clear();
 
     if (!isInterupted) {
-      FileOutputStream out;
-
-      try {
-        out = new FileOutputStream(pdfFileHash);
+      try (FileOutputStream out = new FileOutputStream(pdfFileHash)) {
         out.flush();
-        out.close();
       } catch (IOException e) {
         log.error("Error while writing PDF image to disk", e);
       }


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/32650814.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Used try-with-resources when writing the PDF extraction marker so failures cannot leak the stream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/6021)
<!-- Reviewable:end -->
