### PR TITLE
Build for both apple silicon and apple intel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-15-intel]
+        os: [windows-latest, ubuntu-latest, macos-15-intel, macos-15]
         java: [ '21' ]
         distribution: ['temurin']
       fail-fast: false
@@ -186,13 +186,22 @@ jobs:
       #    / / / / / // /_/ // /__ / /_/ /___/ /
       #   /_/ /_/ /_/ \__,_/ \___/ \____//____/
       #
+    - name: Set Mac Architecture Variable
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        ARCH=$(uname -m)
+        if [ "$ARCH" = "arm64" ]; then
+          echo "MAC_ARCH=apple-silicon" >> $GITHUB_ENV
+        else
+          echo "MAC_ARCH=intel" >> $GITHUB_ENV
+        fi
     - name: Rename Mac OS Release Files
       if: startsWith(matrix.os, 'macos')
       run: |
-        mkdir releases/renamed/
-        cp releases/MapTool*.dmg releases/renamed/MapTool-${{ github.event.release.tag_name }}.dmg
-        cp releases/MapTool*.pkg releases/renamed/MapTool-${{ github.event.release.tag_name }}.pkg
-        cp releases/MapTool*-mac.app.zip releases/renamed/MapTool-${{ github.event.release.tag_name }}-mac.app.zip
+        mkdir -p releases/renamed/
+        cp releases/MapTool*.dmg releases/renamed/MapTool-${{ github.event.release.tag_name }}-${{ env.MAC_ARCH }}.dmg
+        cp releases/MapTool*.pkg releases/renamed/MapTool-${{ github.event.release.tag_name }}-${{ env.MAC_ARCH }}.pkg
+        cp releases/MapTool*-mac*.zip releases/renamed/MapTool-${{ github.event.release.tag_name }}-mac-${{ env.MAC_ARCH }}.app.zip
       continue-on-error: true
     - name: Upload Mac DMG Release Asset
       id: upload-release-asset-dmg
@@ -202,8 +211,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}.dmg
-        asset_name: MapTool-${{ github.event.release.tag_name }}.dmg
+        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-${{ env.MAC_ARCH }}.dmg
+        asset_name: MapTool-${{ github.event.release.tag_name }}-${{ env.MAC_ARCH }}.dmg
         asset_content_type: application/octet-stream
     - name: Upload Mac PKG Release Asset
       id: upload-release-asset-pkg
@@ -213,8 +222,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}.pkg
-        asset_name: MapTool-${{ github.event.release.tag_name }}.pkg
+        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-${{ env.MAC_ARCH }}.pkg
+        asset_name: MapTool-${{ github.event.release.tag_name }}-${{ env.MAC_ARCH }}.pkg
         asset_content_type: application/octet-stream
     - name: Upload Mac Image Release Asset
       id: upload-release-asset-mac-image
@@ -224,6 +233,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-mac.app.zip
-        asset_name: MapTool-${{ github.event.release.tag_name }}-mac.app.zip
+        asset_path: releases/renamed/MapTool-${{ github.event.release.tag_name }}-mac-${{ env.MAC_ARCH }}.app.zip
+        asset_name: MapTool-${{ github.event.release.tag_name }}-mac-${{ env.MAC_ARCH }}.app.zip
         asset_content_type: application/octet-stream

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-15-intel]
+        os: [windows-latest, ubuntu-latest, macos-15-intel, macos-15]
         java: ["21"]
         distribution: ["temurin"]
       fail-fast: false

--- a/build.gradle
+++ b/build.gradle
@@ -307,13 +307,19 @@ runtime {
 
         if (osdetector.os.is('osx')) {
             println "Setting MacOS installer options"
-            targetPlatformName = "mac"
+            def isArm = osdetector.arch.equals('aarch_64') || osdetector.arch.contains('arm') || osdetector.arch.contains('aarch')
+            def macArch = isArm ? 'apple-silicon' : 'intel'
+            def macJdkUrl = isArm ?
+                    'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz' :
+                    'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz'
+
+            targetPlatformName = "mac-" + macArch
             imageOptions += ['--icon', 'package/macosx/' + project.name + developerRelease + '.icns']
             installerOptions += [
                     '--mac-package-name', project.name + developerRelease
             ]
-            targetPlatform('mac') {
-                jdkHome = jdkDownload('https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz')
+            targetPlatform("mac-${macArch}") {
+                jdkHome = jdkDownload(macJdkUrl)
                 jvmArgs += [ '-Xdock:name=' + project.name + developerRelease ]
             }
         }

--- a/clientserver/build.gradle
+++ b/clientserver/build.gradle
@@ -22,7 +22,7 @@ dependencies {
         implementation(variantOf(libs.webrtc) { classifier('windows-x86_64')})
     else if (osdetector.os.is('osx')) {
         def isArm = osdetector.arch.equals('aarch_64') || osdetector.arch.contains('arm') || osdetector.arch.contains('aarch')
-        def webrtcClassifier = isArm ? 'macos-arm64' : 'macos-x86_64'
+        def webrtcClassifier = isArm ? 'macos-aarch64' : 'macos-x86_64'
         implementation(variantOf(libs.webrtc) { classifier(webrtcClassifier) })
     }
     else if (osdetector.os.is('linux'))

--- a/clientserver/build.gradle
+++ b/clientserver/build.gradle
@@ -20,8 +20,11 @@ dependencies {
     implementation(libs.webrtc)
     if (osdetector.os.is('windows'))
         implementation(variantOf(libs.webrtc) { classifier('windows-x86_64')})
-    else if (osdetector.os.is('osx'))
-        implementation(variantOf(libs.webrtc) { classifier('macos-x86_64')})
+    else if (osdetector.os.is('osx')) {
+        def isArm = osdetector.arch.equals('aarch_64') || osdetector.arch.contains('arm') || osdetector.arch.contains('aarch')
+        def webrtcClassifier = isArm ? 'macos-arm64' : 'macos-x86_64'
+        implementation(variantOf(libs.webrtc) { classifier(webrtcClassifier) })
+    }
     else if (osdetector.os.is('linux'))
         implementation(variantOf(libs.webrtc) { classifier('linux-x86_64')})
 


### PR DESCRIPTION

### Identify the Bug or Feature request
Resolves #5987


### Description of the Change
Adds native Apple Silicon (ARM64/macOS) builds to the CI pipeline, producing architecture-specific artifacts alongside the existing Intel builds. No Rosetta emulation needed on Apple Silicon Macs.


### Possible Drawbacks

Should be none


### Documentation Notes
#### CI Workflows
- .github/workflows/publish.yml — Added macos-15 (ARM64 native) runner to the release matrix alongside macos-15-intel (X86_64). macOS artifacts are now named with -mac-intel and -mac-apple-silicon suffixes respectively (DMG, PKG, and .app.zip).
- .github/workflows/verify-build.yml — Added macos-15 runner to the build verification matrix.

#### Gradle Build
- build.gradle — The macOS jpackage target platform now conditionally downloads the aarch64 Temurin JDK (OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz) when building on Apple Silicon, instead of the x64 JDK.
- clientserver/build.gradle — Added a macos-aarch64 classifier branch for the WebRTC native library (webrtc-java 0.11.0 already publishes this classifier).
Native Dependency Compatibility
All existing native dependencies already support Apple Silicon natively — no version bumps were needed:
- LibGDX 1.13.5 — natives-desktop includes libgdxarm64.dylib (for when we add back in)
- JOGL 2.5.0 — ships universal binaries (natives-macosx-universal) (for when we add back in)
- Zstd-JNI — auto-detects osx-aarch64
- WebP ImageIO — supports ARM64
- JavaFX 22 — plugin auto-resolves mac-aarch64
- JAI ImageIO — pure Java, no native code


### Release Notes
#### Artifact naming (for future releases after this is applied)
|Artifact|Architecture|
|---|---|
|MapTool-1.2.3-mac-intel.dmg | Intel (x86_64)|
|MapTool-1.2.3-mac-intel.pkg |	Intel (x86_64)|
|MapTool-1.2.3-mac-intel.app.zip |	Intel (x86_64)|
|MapTool-1.2.3-mac-apple-silicon.dmg |	Apple Silicon (ARM64)|
|MapTool-1.2.3-mac-apple-silicon.pkg |	Apple Silicon (ARM64)|
|MapTool-1.2.3-mac-apple-silicon.app.zip |	Apple Silicon (ARM64)|

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/maptool/6027)
<!-- Reviewable:end -->
